### PR TITLE
Alpha: [A01] Define Province entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/domain/war/Province.js
+++ b/src/domain/war/Province.js
@@ -1,0 +1,116 @@
+const DEFAULT_LOYALTY = 50;
+
+function normalizeNeighborIds(neighborIds) {
+  if (!Array.isArray(neighborIds)) {
+    throw new TypeError('Province neighborIds must be an array.');
+  }
+
+  const normalizedIds = [...new Set(neighborIds.map((neighborId) => String(neighborId).trim()))];
+
+  if (normalizedIds.some((neighborId) => neighborId.length === 0)) {
+    throw new RangeError('Province neighborIds cannot contain empty values.');
+  }
+
+  return normalizedIds.sort();
+}
+
+export class Province {
+  constructor({
+    id,
+    name,
+    ownerFactionId,
+    controllingFactionId = ownerFactionId,
+    supplyLevel,
+    loyalty = DEFAULT_LOYALTY,
+    strategicValue = 1,
+    neighborIds = [],
+    contested = false,
+    capturedAt = null,
+  }) {
+    this.id = Province.#requireText(id, 'Province id');
+    this.name = Province.#requireText(name, 'Province name');
+    this.ownerFactionId = Province.#requireText(ownerFactionId, 'Province ownerFactionId');
+    this.controllingFactionId = Province.#requireText(
+      controllingFactionId,
+      'Province controllingFactionId',
+    );
+    this.supplyLevel = Province.#requireText(supplyLevel, 'Province supplyLevel');
+    this.loyalty = Province.#requireIntegerInRange(loyalty, 'Province loyalty', 0, 100);
+    this.strategicValue = Province.#requireIntegerInRange(
+      strategicValue,
+      'Province strategicValue',
+      1,
+      10,
+    );
+    this.neighborIds = normalizeNeighborIds(neighborIds);
+    this.contested = Boolean(contested);
+    this.capturedAt = Province.#normalizeDate(capturedAt);
+  }
+
+  get isOccupied() {
+    return this.ownerFactionId !== this.controllingFactionId;
+  }
+
+  withControllingFaction(controllingFactionId, capturedAt = new Date()) {
+    return new Province({
+      ...this.toJSON(),
+      controllingFactionId,
+      contested: this.ownerFactionId !== String(controllingFactionId).trim(),
+      capturedAt,
+    });
+  }
+
+  withSupplyLevel(supplyLevel) {
+    return new Province({
+      ...this.toJSON(),
+      supplyLevel,
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      name: this.name,
+      ownerFactionId: this.ownerFactionId,
+      controllingFactionId: this.controllingFactionId,
+      supplyLevel: this.supplyLevel,
+      loyalty: this.loyalty,
+      strategicValue: this.strategicValue,
+      neighborIds: [...this.neighborIds],
+      contested: this.contested,
+      capturedAt: this.capturedAt?.toISOString() ?? null,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+
+  static #normalizeDate(value) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      throw new RangeError('Province capturedAt must be a valid date.');
+    }
+
+    return date;
+  }
+}

--- a/test/domain/war/Province.test.js
+++ b/test/domain/war/Province.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Province } from '../../../src/domain/war/Province.js';
+
+test('Province keeps a normalized set of core territory fields', () => {
+  const province = new Province({
+    id: '  prov-001 ',
+    name: ' Marches of Dawn ',
+    ownerFactionId: ' faction-a ',
+    supplyLevel: 'stable',
+    loyalty: 72,
+    strategicValue: 4,
+    neighborIds: ['prov-003', ' prov-002 ', 'prov-003'],
+  });
+
+  assert.deepEqual(province.toJSON(), {
+    id: 'prov-001',
+    name: 'Marches of Dawn',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    loyalty: 72,
+    strategicValue: 4,
+    neighborIds: ['prov-002', 'prov-003'],
+    contested: false,
+    capturedAt: null,
+  });
+
+  assert.equal(province.isOccupied, false);
+});
+
+test('Province can transition to occupation while preserving immutable semantics', () => {
+  const province = new Province({
+    id: 'prov-001',
+    name: 'Marches of Dawn',
+    ownerFactionId: 'faction-a',
+    supplyLevel: 'stable',
+  });
+  const capturedAt = new Date('2026-04-18T10:15:00.000Z');
+
+  const occupiedProvince = province.withControllingFaction('faction-b', capturedAt);
+
+  assert.notEqual(occupiedProvince, province);
+  assert.equal(occupiedProvince.controllingFactionId, 'faction-b');
+  assert.equal(occupiedProvince.contested, true);
+  assert.equal(occupiedProvince.isOccupied, true);
+  assert.equal(occupiedProvince.capturedAt?.toISOString(), capturedAt.toISOString());
+
+  assert.equal(province.controllingFactionId, 'faction-a');
+  assert.equal(province.contested, false);
+  assert.equal(province.capturedAt, null);
+});
+
+test('Province rejects invalid identifiers and scores', () => {
+  assert.throws(
+    () =>
+      new Province({
+        id: '',
+        name: 'Marches of Dawn',
+        ownerFactionId: 'faction-a',
+        supplyLevel: 'stable',
+      }),
+    /Province id is required/,
+  );
+
+  assert.throws(
+    () =>
+      new Province({
+        id: 'prov-001',
+        name: 'Marches of Dawn',
+        ownerFactionId: 'faction-a',
+        supplyLevel: 'stable',
+        loyalty: 200,
+      }),
+    /Province loyalty must be an integer between 0 and 100/,
+  );
+
+  assert.throws(
+    () =>
+      new Province({
+        id: 'prov-001',
+        name: 'Marches of Dawn',
+        ownerFactionId: 'faction-a',
+        supplyLevel: 'stable',
+        strategicValue: 0,
+      }),
+    /Province strategicValue must be an integer between 1 and 10/,
+  );
+});


### PR DESCRIPTION
## Summary

- Alpha: add an initial `Province` domain entity for the war and territory slice
- Alpha: validate province identifiers, faction ownership, loyalty, strategic value, neighbors, and capture dates
- Alpha: add node:test coverage for normalization, occupation transitions, and invalid inputs

## Related issue

- Alpha: closes #1

## Changes

- Alpha: bootstrap the repository with a minimal Node test setup
- Alpha: add `src/domain/war/Province.js` with immutable transition helpers and serialization
- Alpha: add `test/domain/war/Province.test.js` for the first Alpha domain model

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?