### PR TITLE
Alpha: [A02] Define BorderSegment model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/domain/war/BorderSegment.js
+++ b/src/domain/war/BorderSegment.js
@@ -1,0 +1,96 @@
+function normalizeProvinceId(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizePressure(value) {
+  if (!Number.isInteger(value) || value < -100 || value > 100) {
+    throw new RangeError('BorderSegment pressure must be an integer between -100 and 100.');
+  }
+
+  return value;
+}
+
+function normalizePosition(value) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError('BorderSegment position must be a non-negative integer.');
+  }
+
+  return value;
+}
+
+export class BorderSegment {
+  constructor({
+    id,
+    provinceAId,
+    provinceBId,
+    terrainType,
+    pressure = 0,
+    contested = false,
+    chokepoint = false,
+    length = 1,
+    position = 0,
+  }) {
+    this.provinceAId = normalizeProvinceId(provinceAId, 'BorderSegment provinceAId');
+    this.provinceBId = normalizeProvinceId(provinceBId, 'BorderSegment provinceBId');
+
+    if (this.provinceAId === this.provinceBId) {
+      throw new RangeError('BorderSegment provinces must be different.');
+    }
+
+    const [leftProvinceId, rightProvinceId] = [this.provinceAId, this.provinceBId].sort();
+
+    this.provinceAId = leftProvinceId;
+    this.provinceBId = rightProvinceId;
+    this.id = normalizeProvinceId(
+      id ?? `${this.provinceAId}::${this.provinceBId}`,
+      'BorderSegment id',
+    );
+    this.terrainType = normalizeProvinceId(terrainType, 'BorderSegment terrainType');
+    this.pressure = normalizePressure(pressure);
+    this.contested = Boolean(contested);
+    this.chokepoint = Boolean(chokepoint);
+    this.length = normalizePosition(length);
+
+    if (this.length === 0) {
+      throw new RangeError('BorderSegment length must be greater than 0.');
+    }
+
+    this.position = normalizePosition(position);
+  }
+
+  get dominantProvinceId() {
+    if (this.pressure === 0) {
+      return null;
+    }
+
+    return this.pressure > 0 ? this.provinceAId : this.provinceBId;
+  }
+
+  withPressure(pressure) {
+    return new BorderSegment({
+      ...this.toJSON(),
+      pressure,
+      contested: pressure !== 0,
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      provinceAId: this.provinceAId,
+      provinceBId: this.provinceBId,
+      terrainType: this.terrainType,
+      pressure: this.pressure,
+      contested: this.contested,
+      chokepoint: this.chokepoint,
+      length: this.length,
+      position: this.position,
+    };
+  }
+}

--- a/test/domain/war/BorderSegment.test.js
+++ b/test/domain/war/BorderSegment.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BorderSegment } from '../../../src/domain/war/BorderSegment.js';
+
+test('BorderSegment normalizes province order and derives a stable id', () => {
+  const segment = new BorderSegment({
+    provinceAId: 'province-west',
+    provinceBId: 'province-east',
+    terrainType: 'river',
+    pressure: 12,
+    length: 3,
+    position: 1,
+  });
+
+  assert.deepEqual(segment.toJSON(), {
+    id: 'province-east::province-west',
+    provinceAId: 'province-east',
+    provinceBId: 'province-west',
+    terrainType: 'river',
+    pressure: 12,
+    contested: false,
+    chokepoint: false,
+    length: 3,
+    position: 1,
+  });
+
+  assert.equal(segment.dominantProvinceId, 'province-east');
+});
+
+test('BorderSegment tracks contested pressure through immutable updates', () => {
+  const segment = new BorderSegment({
+    id: 'custom-segment',
+    provinceAId: 'province-a',
+    provinceBId: 'province-b',
+    terrainType: 'forest',
+    chokepoint: true,
+  });
+
+  const contestedSegment = segment.withPressure(-25);
+  const neutralSegment = contestedSegment.withPressure(0);
+
+  assert.notEqual(contestedSegment, segment);
+  assert.equal(contestedSegment.contested, true);
+  assert.equal(contestedSegment.dominantProvinceId, 'province-b');
+  assert.equal(contestedSegment.chokepoint, true);
+
+  assert.equal(neutralSegment.contested, false);
+  assert.equal(neutralSegment.dominantProvinceId, null);
+  assert.equal(segment.pressure, 0);
+});
+
+test('BorderSegment rejects invalid borders and invalid metrics', () => {
+  assert.throws(
+    () =>
+      new BorderSegment({
+        provinceAId: 'province-a',
+        provinceBId: 'province-a',
+        terrainType: 'plain',
+      }),
+    /BorderSegment provinces must be different/,
+  );
+
+  assert.throws(
+    () =>
+      new BorderSegment({
+        provinceAId: 'province-a',
+        provinceBId: 'province-b',
+        terrainType: 'plain',
+        pressure: 101,
+      }),
+    /BorderSegment pressure must be an integer between -100 and 100/,
+  );
+
+  assert.throws(
+    () =>
+      new BorderSegment({
+        provinceAId: 'province-a',
+        provinceBId: 'province-b',
+        terrainType: 'plain',
+        length: 0,
+      }),
+    /BorderSegment length must be greater than 0/,
+  );
+});


### PR DESCRIPTION
## Summary

- Alpha: add a `BorderSegment` model for the war border slice
- Alpha: normalize province ordering, stable IDs, pressure, terrain, and chokepoint metadata
- Alpha: add node:test coverage for normalization, immutable pressure updates, and invalid borders

## Related issue

- Alpha: closes #2

## Changes

- Alpha: bootstrap the repository with a minimal Node test setup
- Alpha: add `src/domain/war/BorderSegment.js` with normalization and transition helpers
- Alpha: add `test/domain/war/BorderSegment.test.js` for segment behavior and validation rules

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?