### PR TITLE
Gamma: [G01] Define Culture entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/domain/culture/Culture.js
+++ b/src/domain/culture/Culture.js
@@ -1,0 +1,118 @@
+const DEFAULT_COHESION = 50;
+const DEFAULT_OPENNESS = 50;
+const DEFAULT_RESEARCH_DRIVE = 50;
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+export class Culture {
+  constructor({
+    id,
+    name,
+    archetype,
+    primaryLanguage,
+    valueIds = [],
+    traditionIds = [],
+    openness = DEFAULT_OPENNESS,
+    cohesion = DEFAULT_COHESION,
+    researchDrive = DEFAULT_RESEARCH_DRIVE,
+    lastEvolvedAt = null,
+  }) {
+    this.id = Culture.#requireText(id, 'Culture id');
+    this.name = Culture.#requireText(name, 'Culture name');
+    this.archetype = Culture.#requireText(archetype, 'Culture archetype');
+    this.primaryLanguage = Culture.#requireText(primaryLanguage, 'Culture primaryLanguage');
+    this.valueIds = normalizeUniqueTexts(valueIds, 'Culture valueIds');
+    this.traditionIds = normalizeUniqueTexts(traditionIds, 'Culture traditionIds');
+    this.openness = Culture.#requireIntegerInRange(openness, 'Culture openness', 0, 100);
+    this.cohesion = Culture.#requireIntegerInRange(cohesion, 'Culture cohesion', 0, 100);
+    this.researchDrive = Culture.#requireIntegerInRange(
+      researchDrive,
+      'Culture researchDrive',
+      0,
+      100,
+    );
+    this.lastEvolvedAt = Culture.#normalizeDate(lastEvolvedAt, 'Culture lastEvolvedAt');
+  }
+
+  withEvolution({
+    openness = this.openness,
+    cohesion = this.cohesion,
+    researchDrive = this.researchDrive,
+    valueIds = this.valueIds,
+    traditionIds = this.traditionIds,
+    lastEvolvedAt = new Date(),
+  } = {}) {
+    return new Culture({
+      ...this.toJSON(),
+      openness,
+      cohesion,
+      researchDrive,
+      valueIds,
+      traditionIds,
+      lastEvolvedAt,
+    });
+  }
+
+  embracesInnovation() {
+    return this.openness >= 60 && this.researchDrive >= 60;
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      name: this.name,
+      archetype: this.archetype,
+      primaryLanguage: this.primaryLanguage,
+      valueIds: [...this.valueIds],
+      traditionIds: [...this.traditionIds],
+      openness: this.openness,
+      cohesion: this.cohesion,
+      researchDrive: this.researchDrive,
+      lastEvolvedAt: this.lastEvolvedAt?.toISOString() ?? null,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+
+  static #normalizeDate(value, label) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    const normalizedValue = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(normalizedValue.getTime())) {
+      throw new RangeError(`${label} must be a valid date.`);
+    }
+
+    return normalizedValue;
+  }
+}

--- a/test/domain/culture/Culture.test.js
+++ b/test/domain/culture/Culture.test.js
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Culture } from '../../../src/domain/culture/Culture.js';
+
+test('Culture keeps normalized core culture fields', () => {
+  const culture = new Culture({
+    id: '  culture-aurora ',
+    name: ' Aurora Compact ',
+    archetype: ' mercantile ',
+    primaryLanguage: ' trade-speech ',
+    valueIds: ['curiosity', ' curiosity ', 'craft'],
+    traditionIds: ['harvest-song', ' sky-festival ', 'harvest-song'],
+    openness: 66,
+    cohesion: 58,
+    researchDrive: 71,
+  });
+
+  assert.deepEqual(culture.toJSON(), {
+    id: 'culture-aurora',
+    name: 'Aurora Compact',
+    archetype: 'mercantile',
+    primaryLanguage: 'trade-speech',
+    valueIds: ['craft', 'curiosity'],
+    traditionIds: ['harvest-song', 'sky-festival'],
+    openness: 66,
+    cohesion: 58,
+    researchDrive: 71,
+    lastEvolvedAt: null,
+  });
+
+  assert.equal(culture.embracesInnovation(), true);
+});
+
+test('Culture can evolve immutably while tracking the evolution date', () => {
+  const culture = new Culture({
+    id: 'culture-aurora',
+    name: 'Aurora Compact',
+    archetype: 'mercantile',
+    primaryLanguage: 'trade-speech',
+    valueIds: ['craft'],
+    traditionIds: ['harvest-song'],
+  });
+  const evolvedAt = new Date('2026-04-18T11:40:00.000Z');
+
+  const evolvedCulture = culture.withEvolution({
+    openness: 72,
+    cohesion: 61,
+    researchDrive: 74,
+    valueIds: ['craft', 'navigation'],
+    traditionIds: ['harvest-song', 'river-moot'],
+    lastEvolvedAt: evolvedAt,
+  });
+
+  assert.notEqual(evolvedCulture, culture);
+  assert.deepEqual(evolvedCulture.valueIds, ['craft', 'navigation']);
+  assert.deepEqual(evolvedCulture.traditionIds, ['harvest-song', 'river-moot']);
+  assert.equal(evolvedCulture.lastEvolvedAt?.toISOString(), evolvedAt.toISOString());
+  assert.equal(culture.lastEvolvedAt, null);
+  assert.deepEqual(culture.valueIds, ['craft']);
+  assert.deepEqual(culture.traditionIds, ['harvest-song']);
+});
+
+test('Culture rejects invalid text, list, score, and date inputs', () => {
+  assert.throws(
+    () =>
+      new Culture({
+        id: '',
+        name: 'Aurora Compact',
+        archetype: 'mercantile',
+        primaryLanguage: 'trade-speech',
+      }),
+    /Culture id is required/,
+  );
+
+  assert.throws(
+    () =>
+      new Culture({
+        id: 'culture-aurora',
+        name: 'Aurora Compact',
+        archetype: 'mercantile',
+        primaryLanguage: 'trade-speech',
+        valueIds: ['craft', ''],
+      }),
+    /Culture valueIds cannot contain empty values/,
+  );
+
+  assert.throws(
+    () =>
+      new Culture({
+        id: 'culture-aurora',
+        name: 'Aurora Compact',
+        archetype: 'mercantile',
+        primaryLanguage: 'trade-speech',
+        openness: 101,
+      }),
+    /Culture openness must be an integer between 0 and 100/,
+  );
+
+  assert.throws(
+    () =>
+      new Culture({
+        id: 'culture-aurora',
+        name: 'Aurora Compact',
+        archetype: 'mercantile',
+        primaryLanguage: 'trade-speech',
+        lastEvolvedAt: 'not-a-date',
+      }),
+    /Culture lastEvolvedAt must be a valid date/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add the initial `Culture` domain entity for the culture and research slice
- Gamma: normalize cultural identifiers, values, traditions, scores, and evolution timestamps
- Gamma: cover invariants, innovation heuristics, and immutable evolution helpers with node tests

## Related issue

- Gamma: closes #41

## Changes

- Gamma: bootstrap the repository with a minimal Node test setup
- Gamma: add `src/domain/culture/Culture.js` with normalization, serialization, and immutable evolution helpers
- Gamma: add `test/domain/culture/Culture.test.js` for the first Gamma domain model

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: @Zeta, could you validate this PR before merge?