### PR TITLE
Alpha: [A03] Define Front aggregate

### DIFF
--- a/src/domain/war/Front.js
+++ b/src/domain/war/Front.js
@@ -1,0 +1,134 @@
+function normalizeText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeSegmentIds(segmentIds) {
+  if (!Array.isArray(segmentIds) || segmentIds.length === 0) {
+    throw new RangeError('Front segmentIds must be a non-empty array.');
+  }
+
+  const normalizedIds = [...new Set(segmentIds.map((segmentId) => normalizeText(segmentId, 'Front segmentId')))];
+
+  return normalizedIds.sort();
+}
+
+function normalizePressure(value) {
+  if (!Number.isInteger(value) || value < -100 || value > 100) {
+    throw new RangeError('Front pressure must be an integer between -100 and 100.');
+  }
+
+  return value;
+}
+
+function normalizeMomentum(value) {
+  if (!Number.isInteger(value) || value < 0 || value > 10) {
+    throw new RangeError('Front momentum must be an integer between 0 and 10.');
+  }
+
+  return value;
+}
+
+function normalizeUpdatedAt(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new RangeError('Front updatedAt must be a valid date.');
+  }
+
+  return date;
+}
+
+export class Front {
+  constructor({
+    id,
+    attackerFactionId,
+    defenderFactionId,
+    segmentIds,
+    pressure = 0,
+    momentum = 0,
+    status = 'stalled',
+    active = true,
+    updatedAt = null,
+  }) {
+    this.attackerFactionId = normalizeText(attackerFactionId, 'Front attackerFactionId');
+    this.defenderFactionId = normalizeText(defenderFactionId, 'Front defenderFactionId');
+
+    if (this.attackerFactionId === this.defenderFactionId) {
+      throw new RangeError('Front factions must be different.');
+    }
+
+    this.id = normalizeText(
+      id ?? `${this.attackerFactionId}::${this.defenderFactionId}`,
+      'Front id',
+    );
+    this.segmentIds = normalizeSegmentIds(segmentIds);
+    this.pressure = normalizePressure(pressure);
+    this.momentum = normalizeMomentum(momentum);
+    this.status = normalizeText(status, 'Front status');
+    this.active = Boolean(active);
+    this.updatedAt = normalizeUpdatedAt(updatedAt);
+  }
+
+  get dominantFactionId() {
+    if (this.pressure === 0) {
+      return null;
+    }
+
+    return this.pressure > 0 ? this.attackerFactionId : this.defenderFactionId;
+  }
+
+  withPressure(pressure, updatedAt = new Date()) {
+    const normalizedPressure = normalizePressure(pressure);
+
+    return new Front({
+      ...this.toJSON(),
+      pressure: normalizedPressure,
+      status: normalizedPressure === 0 ? 'stalled' : 'active',
+      active: true,
+      updatedAt,
+    });
+  }
+
+  reinforce(segmentId, momentum = this.momentum + 1, updatedAt = new Date()) {
+    return new Front({
+      ...this.toJSON(),
+      segmentIds: [...this.segmentIds, segmentId],
+      momentum,
+      active: true,
+      updatedAt,
+    });
+  }
+
+  conclude(updatedAt = new Date()) {
+    return new Front({
+      ...this.toJSON(),
+      active: false,
+      status: 'resolved',
+      updatedAt,
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      attackerFactionId: this.attackerFactionId,
+      defenderFactionId: this.defenderFactionId,
+      segmentIds: [...this.segmentIds],
+      pressure: this.pressure,
+      momentum: this.momentum,
+      status: this.status,
+      active: this.active,
+      updatedAt: this.updatedAt?.toISOString() ?? null,
+    };
+  }
+}

--- a/test/domain/war/Front.test.js
+++ b/test/domain/war/Front.test.js
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Front } from '../../../src/domain/war/Front.js';
+
+test('Front keeps a normalized aggregate view of a war line', () => {
+  const front = new Front({
+    attackerFactionId: ' faction-a ',
+    defenderFactionId: ' faction-b ',
+    segmentIds: ['seg-02', ' seg-01 ', 'seg-02'],
+    pressure: 18,
+    momentum: 3,
+    status: 'active',
+  });
+
+  assert.deepEqual(front.toJSON(), {
+    id: 'faction-a::faction-b',
+    attackerFactionId: 'faction-a',
+    defenderFactionId: 'faction-b',
+    segmentIds: ['seg-01', 'seg-02'],
+    pressure: 18,
+    momentum: 3,
+    status: 'active',
+    active: true,
+    updatedAt: null,
+  });
+
+  assert.equal(front.dominantFactionId, 'faction-a');
+});
+
+test('Front supports immutable pressure, reinforcement, and conclusion transitions', () => {
+  const front = new Front({
+    id: 'front-north',
+    attackerFactionId: 'faction-a',
+    defenderFactionId: 'faction-b',
+    segmentIds: ['seg-01'],
+  });
+  const pressureAt = new Date('2026-04-18T12:00:00.000Z');
+  const reinforceAt = new Date('2026-04-18T12:05:00.000Z');
+  const resolvedAt = new Date('2026-04-18T12:10:00.000Z');
+
+  const pressuredFront = front.withPressure(-22, pressureAt);
+  const reinforcedFront = pressuredFront.reinforce('seg-02', 4, reinforceAt);
+  const resolvedFront = reinforcedFront.conclude(resolvedAt);
+
+  assert.notEqual(pressuredFront, front);
+  assert.equal(pressuredFront.status, 'active');
+  assert.equal(pressuredFront.dominantFactionId, 'faction-b');
+  assert.equal(pressuredFront.updatedAt?.toISOString(), pressureAt.toISOString());
+
+  assert.deepEqual(reinforcedFront.segmentIds, ['seg-01', 'seg-02']);
+  assert.equal(reinforcedFront.momentum, 4);
+  assert.equal(reinforcedFront.updatedAt?.toISOString(), reinforceAt.toISOString());
+
+  assert.equal(resolvedFront.active, false);
+  assert.equal(resolvedFront.status, 'resolved');
+  assert.equal(resolvedFront.updatedAt?.toISOString(), resolvedAt.toISOString());
+
+  assert.equal(front.status, 'stalled');
+  assert.equal(front.updatedAt, null);
+});
+
+test('Front rejects invalid faction pairs and invalid combat metrics', () => {
+  assert.throws(
+    () =>
+      new Front({
+        attackerFactionId: 'faction-a',
+        defenderFactionId: 'faction-a',
+        segmentIds: ['seg-01'],
+      }),
+    /Front factions must be different/,
+  );
+
+  assert.throws(
+    () =>
+      new Front({
+        attackerFactionId: 'faction-a',
+        defenderFactionId: 'faction-b',
+        segmentIds: [],
+      }),
+    /Front segmentIds must be a non-empty array/,
+  );
+
+  assert.throws(
+    () =>
+      new Front({
+        attackerFactionId: 'faction-a',
+        defenderFactionId: 'faction-b',
+        segmentIds: ['seg-01'],
+        momentum: 11,
+      }),
+    /Front momentum must be an integer between 0 and 10/,
+  );
+});


### PR DESCRIPTION
## Summary

- Alpha: add a `Front` aggregate for the war and pressure slice
- Alpha: model attacker and defender factions, tracked border segments, pressure, momentum, and lifecycle state
- Alpha: add node:test coverage for aggregate normalization, immutable transitions, and invalid combat state

## Related issue

- Alpha: closes #3

## Changes

- Alpha: add `src/domain/war/Front.js` with pressure, reinforcement, and conclusion transitions
- Alpha: add `test/domain/war/Front.test.js` for normalization, transitions, and validation rules
- Alpha: keep the new aggregate aligned with the existing Province entity and minimal Node test setup

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?