### PR TITLE
Epsilon: Define ClimateState entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Historia strategy/simulation prototype",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/domain/climate/ClimateState.js
+++ b/src/domain/climate/ClimateState.js
@@ -1,0 +1,110 @@
+class ClimateState {
+  constructor({
+    regionId,
+    season,
+    temperatureC,
+    precipitationLevel,
+    droughtIndex = 0,
+    anomaly = null,
+    activeCatastropheIds = [],
+    updatedAt = new Date().toISOString(),
+  }) {
+    if (!regionId || typeof regionId !== 'string') {
+      throw new Error('ClimateState requires a non-empty regionId');
+    }
+
+    if (!season || typeof season !== 'string') {
+      throw new Error('ClimateState requires a season');
+    }
+
+    if (!Number.isFinite(temperatureC)) {
+      throw new Error('ClimateState temperatureC must be a finite number');
+    }
+
+    if (!Number.isFinite(precipitationLevel) || precipitationLevel < 0 || precipitationLevel > 100) {
+      throw new Error('ClimateState precipitationLevel must be between 0 and 100');
+    }
+
+    if (!Number.isFinite(droughtIndex) || droughtIndex < 0 || droughtIndex > 100) {
+      throw new Error('ClimateState droughtIndex must be between 0 and 100');
+    }
+
+    this.regionId = regionId;
+    this.season = season;
+    this.temperatureC = temperatureC;
+    this.precipitationLevel = precipitationLevel;
+    this.droughtIndex = droughtIndex;
+    this.anomaly = anomaly;
+    this.activeCatastropheIds = Array.from(new Set(activeCatastropheIds));
+    this.updatedAt = updatedAt;
+  }
+
+  withSeason(season, updatedAt = new Date().toISOString()) {
+    return new ClimateState({
+      ...this.toJSON(),
+      season,
+      updatedAt,
+    });
+  }
+
+  withReadings({
+    temperatureC = this.temperatureC,
+    precipitationLevel = this.precipitationLevel,
+    droughtIndex = this.droughtIndex,
+    anomaly = this.anomaly,
+  }, updatedAt = new Date().toISOString()) {
+    return new ClimateState({
+      ...this.toJSON(),
+      temperatureC,
+      precipitationLevel,
+      droughtIndex,
+      anomaly,
+      updatedAt,
+    });
+  }
+
+  activateCatastrophe(catastropheId, updatedAt = new Date().toISOString()) {
+    if (!catastropheId || typeof catastropheId !== 'string') {
+      throw new Error('ClimateState catastropheId must be a non-empty string');
+    }
+
+    return new ClimateState({
+      ...this.toJSON(),
+      activeCatastropheIds: [...this.activeCatastropheIds, catastropheId],
+      updatedAt,
+    });
+  }
+
+  resolveCatastrophe(catastropheId, updatedAt = new Date().toISOString()) {
+    return new ClimateState({
+      ...this.toJSON(),
+      activeCatastropheIds: this.activeCatastropheIds.filter((id) => id !== catastropheId),
+      updatedAt,
+    });
+  }
+
+  hasAnomaly() {
+    return this.anomaly !== null;
+  }
+
+  isStable() {
+    return this.droughtIndex < 60 && this.precipitationLevel >= 20 && !this.hasAnomaly();
+  }
+
+  toJSON() {
+    return {
+      regionId: this.regionId,
+      season: this.season,
+      temperatureC: this.temperatureC,
+      precipitationLevel: this.precipitationLevel,
+      droughtIndex: this.droughtIndex,
+      anomaly: this.anomaly,
+      activeCatastropheIds: [...this.activeCatastropheIds],
+      updatedAt: this.updatedAt,
+    };
+  }
+}
+
+module.exports = {
+  ClimateState,
+};

--- a/src/domain/climate/index.js
+++ b/src/domain/climate/index.js
@@ -1,0 +1,5 @@
+const { ClimateState } = require('./ClimateState');
+
+module.exports = {
+  ClimateState,
+};

--- a/test/domain/climate/ClimateState.test.js
+++ b/test/domain/climate/ClimateState.test.js
@@ -1,0 +1,90 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ClimateState } = require('../../../src/domain/climate/ClimateState');
+
+test('creates a climate state for a region', () => {
+  const state = new ClimateState({
+    regionId: 'region-north',
+    season: 'spring',
+    temperatureC: 13,
+    precipitationLevel: 57,
+    droughtIndex: 18,
+  });
+
+  assert.deepEqual(state.toJSON(), {
+    regionId: 'region-north',
+    season: 'spring',
+    temperatureC: 13,
+    precipitationLevel: 57,
+    droughtIndex: 18,
+    anomaly: null,
+    activeCatastropheIds: [],
+    updatedAt: state.updatedAt,
+  });
+  assert.equal(state.isStable(), true);
+});
+
+test('updates seasonal readings immutably', () => {
+  const original = new ClimateState({
+    regionId: 'region-delta',
+    season: 'summer',
+    temperatureC: 28,
+    precipitationLevel: 44,
+    droughtIndex: 31,
+  });
+
+  const updated = original
+    .withSeason('autumn', '2026-04-18T12:00:00.000Z')
+    .withReadings({ precipitationLevel: 61, anomaly: 'cold-front' }, '2026-04-19T12:00:00.000Z');
+
+  assert.equal(original.season, 'summer');
+  assert.equal(updated.season, 'autumn');
+  assert.equal(updated.precipitationLevel, 61);
+  assert.equal(updated.anomaly, 'cold-front');
+  assert.equal(updated.updatedAt, '2026-04-19T12:00:00.000Z');
+  assert.equal(updated.isStable(), false);
+});
+
+test('tracks active catastrophes without duplicates', () => {
+  const base = new ClimateState({
+    regionId: 'region-ash',
+    season: 'winter',
+    temperatureC: -4,
+    precipitationLevel: 80,
+    droughtIndex: 5,
+  });
+
+  const active = base
+    .activateCatastrophe('blizzard', '2026-04-20T10:00:00.000Z')
+    .activateCatastrophe('blizzard', '2026-04-20T11:00:00.000Z')
+    .activateCatastrophe('famine', '2026-04-20T12:00:00.000Z');
+
+  assert.deepEqual(active.activeCatastropheIds, ['blizzard', 'famine']);
+
+  const resolved = active.resolveCatastrophe('blizzard', '2026-04-21T10:00:00.000Z');
+  assert.deepEqual(resolved.activeCatastropheIds, ['famine']);
+});
+
+test('rejects invalid climate values', () => {
+  assert.throws(() => new ClimateState({
+    regionId: '',
+    season: 'spring',
+    temperatureC: 10,
+    precipitationLevel: 50,
+  }), /regionId/);
+
+  assert.throws(() => new ClimateState({
+    regionId: 'region-bad',
+    season: 'spring',
+    temperatureC: Number.NaN,
+    precipitationLevel: 50,
+  }), /temperatureC/);
+
+  assert.throws(() => new ClimateState({
+    regionId: 'region-bad',
+    season: 'spring',
+    temperatureC: 10,
+    precipitationLevel: 101,
+  }), /precipitationLevel/);
+});


### PR DESCRIPTION
Epsilon: implements #81.\n\n## Summary\n- add a first climate domain entity with validation and immutable update helpers\n- export the climate domain entry point\n- add node:test coverage for creation, updates, catastrophe tracking, and validation\n\n## Testing\n- npm test\n\n## Notes for Zeta\nEpsilon: please validate this PR before merge.