### PR TITLE
Gamma: [G02] Define ResearchState entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/domain/culture/ResearchState.js
+++ b/src/domain/culture/ResearchState.js
@@ -1,0 +1,164 @@
+const DEFAULT_PROGRESS = 0;
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+export class ResearchState {
+  constructor({
+    id,
+    cultureId,
+    topicId,
+    status,
+    progress = DEFAULT_PROGRESS,
+    currentTier = 0,
+    discoveredConceptIds = [],
+    blockedByIds = [],
+    lastAdvancedAt = null,
+    completedAt = null,
+  }) {
+    this.id = ResearchState.#requireText(id, 'ResearchState id');
+    this.cultureId = ResearchState.#requireText(cultureId, 'ResearchState cultureId');
+    this.topicId = ResearchState.#requireText(topicId, 'ResearchState topicId');
+    this.status = ResearchState.#requireStatus(status);
+    this.progress = ResearchState.#requireIntegerInRange(progress, 'ResearchState progress', 0, 100);
+    this.currentTier = ResearchState.#requireIntegerInRange(
+      currentTier,
+      'ResearchState currentTier',
+      0,
+      10,
+    );
+    this.discoveredConceptIds = normalizeUniqueTexts(
+      discoveredConceptIds,
+      'ResearchState discoveredConceptIds',
+    );
+    this.blockedByIds = normalizeUniqueTexts(blockedByIds, 'ResearchState blockedByIds');
+    this.lastAdvancedAt = ResearchState.#normalizeDate(lastAdvancedAt, 'ResearchState lastAdvancedAt');
+    this.completedAt = ResearchState.#normalizeDate(completedAt, 'ResearchState completedAt');
+
+    if (this.status === 'completed' && this.completedAt === null) {
+      throw new RangeError('ResearchState completedAt is required when status is completed.');
+    }
+
+    if (this.status !== 'completed' && this.completedAt !== null) {
+      throw new RangeError('ResearchState completedAt must be null unless status is completed.');
+    }
+
+    if (this.status === 'completed' && this.progress !== 100) {
+      throw new RangeError('ResearchState progress must be 100 when status is completed.');
+    }
+  }
+
+  isBlocked() {
+    return this.status === 'blocked' || this.blockedByIds.length > 0;
+  }
+
+  canAdvance() {
+    return this.status === 'active' && !this.isBlocked() && this.progress < 100;
+  }
+
+  withProgress(progress, lastAdvancedAt = new Date()) {
+    const normalizedProgress = ResearchState.#requireIntegerInRange(
+      progress,
+      'ResearchState progress',
+      0,
+      100,
+    );
+
+    if (normalizedProgress === 100) {
+      return new ResearchState({
+        ...this.toJSON(),
+        progress: normalizedProgress,
+        status: 'completed',
+        lastAdvancedAt,
+        completedAt: lastAdvancedAt,
+      });
+    }
+
+    return new ResearchState({
+      ...this.toJSON(),
+      progress: normalizedProgress,
+      lastAdvancedAt,
+    });
+  }
+
+  withStatus(status, { blockedByIds = this.blockedByIds, completedAt = this.completedAt } = {}) {
+    const normalizedStatus = ResearchState.#requireStatus(status);
+
+    return new ResearchState({
+      ...this.toJSON(),
+      status: normalizedStatus,
+      blockedByIds,
+      completedAt: normalizedStatus === 'completed' ? completedAt ?? new Date() : null,
+      progress: normalizedStatus === 'completed' ? 100 : this.progress,
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      cultureId: this.cultureId,
+      topicId: this.topicId,
+      status: this.status,
+      progress: this.progress,
+      currentTier: this.currentTier,
+      discoveredConceptIds: [...this.discoveredConceptIds],
+      blockedByIds: [...this.blockedByIds],
+      lastAdvancedAt: this.lastAdvancedAt?.toISOString() ?? null,
+      completedAt: this.completedAt?.toISOString() ?? null,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireStatus(value) {
+    const normalizedValue = ResearchState.#requireText(value, 'ResearchState status');
+    const allowedStatuses = new Set(['planned', 'active', 'blocked', 'completed']);
+
+    if (!allowedStatuses.has(normalizedValue)) {
+      throw new RangeError('ResearchState status must be one of planned, active, blocked, or completed.');
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+
+  static #normalizeDate(value, label) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    const normalizedValue = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(normalizedValue.getTime())) {
+      throw new RangeError(`${label} must be a valid date.`);
+    }
+
+    return normalizedValue;
+  }
+}

--- a/test/domain/culture/ResearchState.test.js
+++ b/test/domain/culture/ResearchState.test.js
@@ -1,0 +1,125 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
+
+test('ResearchState keeps normalized research progression fields', () => {
+  const researchState = new ResearchState({
+    id: ' research-bronze ',
+    cultureId: ' culture-aurora ',
+    topicId: ' bronze-working ',
+    status: 'active',
+    progress: 34,
+    currentTier: 2,
+    discoveredConceptIds: ['forge', ' alloy-smelting ', 'forge'],
+    blockedByIds: [],
+    lastAdvancedAt: '2026-04-18T11:55:00.000Z',
+  });
+
+  assert.deepEqual(researchState.toJSON(), {
+    id: 'research-bronze',
+    cultureId: 'culture-aurora',
+    topicId: 'bronze-working',
+    status: 'active',
+    progress: 34,
+    currentTier: 2,
+    discoveredConceptIds: ['alloy-smelting', 'forge'],
+    blockedByIds: [],
+    lastAdvancedAt: '2026-04-18T11:55:00.000Z',
+    completedAt: null,
+  });
+
+  assert.equal(researchState.canAdvance(), true);
+  assert.equal(researchState.isBlocked(), false);
+});
+
+test('ResearchState can progress to completion immutably', () => {
+  const researchState = new ResearchState({
+    id: 'research-bronze',
+    cultureId: 'culture-aurora',
+    topicId: 'bronze-working',
+    status: 'active',
+    progress: 80,
+    currentTier: 2,
+    discoveredConceptIds: ['forge'],
+  });
+  const completedAt = new Date('2026-04-18T12:00:00.000Z');
+
+  const completedResearchState = researchState.withProgress(100, completedAt);
+
+  assert.notEqual(completedResearchState, researchState);
+  assert.equal(completedResearchState.status, 'completed');
+  assert.equal(completedResearchState.progress, 100);
+  assert.equal(completedResearchState.completedAt?.toISOString(), completedAt.toISOString());
+  assert.equal(completedResearchState.lastAdvancedAt?.toISOString(), completedAt.toISOString());
+  assert.equal(researchState.status, 'active');
+  assert.equal(researchState.completedAt, null);
+});
+
+test('ResearchState can become blocked with explicit prerequisites', () => {
+  const researchState = new ResearchState({
+    id: 'research-bronze',
+    cultureId: 'culture-aurora',
+    topicId: 'bronze-working',
+    status: 'active',
+  });
+
+  const blockedResearchState = researchState.withStatus('blocked', {
+    blockedByIds: ['charcoal-production', 'tin-trade'],
+  });
+
+  assert.notEqual(blockedResearchState, researchState);
+  assert.equal(blockedResearchState.status, 'blocked');
+  assert.deepEqual(blockedResearchState.blockedByIds, ['charcoal-production', 'tin-trade']);
+  assert.equal(blockedResearchState.isBlocked(), true);
+  assert.equal(blockedResearchState.canAdvance(), false);
+});
+
+test('ResearchState rejects invalid status, score, and completion invariants', () => {
+  assert.throws(
+    () =>
+      new ResearchState({
+        id: 'research-bronze',
+        cultureId: 'culture-aurora',
+        topicId: 'bronze-working',
+        status: 'queued',
+      }),
+    /ResearchState status must be one of planned, active, blocked, or completed/,
+  );
+
+  assert.throws(
+    () =>
+      new ResearchState({
+        id: 'research-bronze',
+        cultureId: 'culture-aurora',
+        topicId: 'bronze-working',
+        status: 'active',
+        progress: 120,
+      }),
+    /ResearchState progress must be an integer between 0 and 100/,
+  );
+
+  assert.throws(
+    () =>
+      new ResearchState({
+        id: 'research-bronze',
+        cultureId: 'culture-aurora',
+        topicId: 'bronze-working',
+        status: 'completed',
+        progress: 100,
+      }),
+    /ResearchState completedAt is required when status is completed/,
+  );
+
+  assert.throws(
+    () =>
+      new ResearchState({
+        id: 'research-bronze',
+        cultureId: 'culture-aurora',
+        topicId: 'bronze-working',
+        status: 'active',
+        completedAt: '2026-04-18T12:00:00.000Z',
+      }),
+    /ResearchState completedAt must be null unless status is completed/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add the initial `ResearchState` domain entity for the research progression slice
- Gamma: normalize research ids, status, discovered concepts, blockers, and timeline fields
- Gamma: cover completion, blocking, and invariant validation with node tests

## Related issue

- Gamma: closes #42

## Changes

- Gamma: bootstrap the repository with a minimal Node test setup
- Gamma: add `src/domain/culture/ResearchState.js` with progression helpers and serialization
- Gamma: add `test/domain/culture/ResearchState.test.js` for Gamma research state behavior

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: @Zeta, could you validate this PR before merge?
