### PR TITLE
Alpha: [A04] Define FactionTerritory read model

### DIFF
--- a/src/domain/war/FactionTerritory.js
+++ b/src/domain/war/FactionTerritory.js
@@ -1,0 +1,145 @@
+function normalizeText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeProvinceIds(provinceIds, label) {
+  if (!Array.isArray(provinceIds)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedIds = [...new Set(provinceIds.map((provinceId) => normalizeText(provinceId, 'FactionTerritory provinceId')))];
+
+  return normalizedIds.sort();
+}
+
+function normalizeNonNegativeInteger(value, label) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${label} must be a non-negative integer.`);
+  }
+
+  return value;
+}
+
+function normalizeUpdatedAt(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new RangeError('FactionTerritory updatedAt must be a valid date.');
+  }
+
+  return date;
+}
+
+export class FactionTerritory {
+  constructor({
+    factionId,
+    provinceIds = [],
+    occupiedProvinceIds = [],
+    contestedProvinceIds = [],
+    frontlineProvinceIds = [],
+    capitalProvinceId = null,
+    totalStrategicValue = null,
+    updatedAt = null,
+  }) {
+    this.factionId = normalizeText(factionId, 'FactionTerritory factionId');
+    this.provinceIds = normalizeProvinceIds(provinceIds, 'FactionTerritory provinceIds');
+    this.occupiedProvinceIds = normalizeProvinceIds(
+      occupiedProvinceIds,
+      'FactionTerritory occupiedProvinceIds',
+    );
+    this.contestedProvinceIds = normalizeProvinceIds(
+      contestedProvinceIds,
+      'FactionTerritory contestedProvinceIds',
+    );
+    this.frontlineProvinceIds = normalizeProvinceIds(
+      frontlineProvinceIds,
+      'FactionTerritory frontlineProvinceIds',
+    );
+    this.capitalProvinceId =
+      capitalProvinceId === null ? null : normalizeText(capitalProvinceId, 'FactionTerritory capitalProvinceId');
+    this.provinceCount = this.provinceIds.length;
+    this.occupiedProvinceCount = this.occupiedProvinceIds.length;
+    this.contestedProvinceCount = this.contestedProvinceIds.length;
+    this.frontlineProvinceCount = this.frontlineProvinceIds.length;
+    this.totalStrategicValue =
+      totalStrategicValue === null
+        ? this.provinceCount
+        : normalizeNonNegativeInteger(totalStrategicValue, 'FactionTerritory totalStrategicValue');
+    this.updatedAt = normalizeUpdatedAt(updatedAt);
+
+    this.#assertSubset(this.occupiedProvinceIds, 'occupiedProvinceIds');
+    this.#assertSubset(this.contestedProvinceIds, 'contestedProvinceIds');
+    this.#assertSubset(this.frontlineProvinceIds, 'frontlineProvinceIds');
+
+    if (this.capitalProvinceId !== null && !this.provinceIds.includes(this.capitalProvinceId)) {
+      throw new RangeError('FactionTerritory capitalProvinceId must belong to provinceIds.');
+    }
+  }
+
+  get controlRatio() {
+    if (this.provinceCount === 0) {
+      return 0;
+    }
+
+    return (this.provinceCount - this.occupiedProvinceCount) / this.provinceCount;
+  }
+
+  hasProvince(provinceId) {
+    return this.provinceIds.includes(normalizeText(provinceId, 'FactionTerritory provinceId'));
+  }
+
+  withProvinceSnapshot({
+    provinceIds = this.provinceIds,
+    occupiedProvinceIds = this.occupiedProvinceIds,
+    contestedProvinceIds = this.contestedProvinceIds,
+    frontlineProvinceIds = this.frontlineProvinceIds,
+    totalStrategicValue = null,
+    updatedAt = new Date(),
+  }) {
+    return new FactionTerritory({
+      ...this.toJSON(),
+      provinceIds,
+      occupiedProvinceIds,
+      contestedProvinceIds,
+      frontlineProvinceIds,
+      totalStrategicValue,
+      updatedAt,
+    });
+  }
+
+  toJSON() {
+    return {
+      factionId: this.factionId,
+      provinceIds: [...this.provinceIds],
+      occupiedProvinceIds: [...this.occupiedProvinceIds],
+      contestedProvinceIds: [...this.contestedProvinceIds],
+      frontlineProvinceIds: [...this.frontlineProvinceIds],
+      capitalProvinceId: this.capitalProvinceId,
+      provinceCount: this.provinceCount,
+      occupiedProvinceCount: this.occupiedProvinceCount,
+      contestedProvinceCount: this.contestedProvinceCount,
+      frontlineProvinceCount: this.frontlineProvinceCount,
+      totalStrategicValue: this.totalStrategicValue,
+      controlRatio: this.controlRatio,
+      updatedAt: this.updatedAt?.toISOString() ?? null,
+    };
+  }
+
+  #assertSubset(provinceIds, label) {
+    const missingProvinceId = provinceIds.find((provinceId) => !this.provinceIds.includes(provinceId));
+
+    if (missingProvinceId) {
+      throw new RangeError(`FactionTerritory ${label} must be a subset of provinceIds.`);
+    }
+  }
+}

--- a/test/domain/war/FactionTerritory.test.js
+++ b/test/domain/war/FactionTerritory.test.js
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { FactionTerritory } from '../../../src/domain/war/FactionTerritory.js';
+
+test('FactionTerritory builds a normalized territory snapshot', () => {
+  const territory = new FactionTerritory({
+    factionId: ' faction-a ',
+    provinceIds: ['prov-03', ' prov-01 ', 'prov-02', 'prov-02'],
+    occupiedProvinceIds: ['prov-03'],
+    contestedProvinceIds: ['prov-02'],
+    frontlineProvinceIds: ['prov-02', 'prov-03'],
+    capitalProvinceId: 'prov-01',
+    totalStrategicValue: 9,
+  });
+
+  assert.deepEqual(territory.toJSON(), {
+    factionId: 'faction-a',
+    provinceIds: ['prov-01', 'prov-02', 'prov-03'],
+    occupiedProvinceIds: ['prov-03'],
+    contestedProvinceIds: ['prov-02'],
+    frontlineProvinceIds: ['prov-02', 'prov-03'],
+    capitalProvinceId: 'prov-01',
+    provinceCount: 3,
+    occupiedProvinceCount: 1,
+    contestedProvinceCount: 1,
+    frontlineProvinceCount: 2,
+    totalStrategicValue: 9,
+    controlRatio: 2 / 3,
+    updatedAt: null,
+  });
+
+  assert.equal(territory.hasProvince('prov-02'), true);
+  assert.equal(territory.hasProvince('prov-99'), false);
+});
+
+test('FactionTerritory updates snapshots immutably and derives default strategic value', () => {
+  const territory = new FactionTerritory({
+    factionId: 'faction-a',
+    provinceIds: ['prov-01', 'prov-02'],
+    capitalProvinceId: 'prov-01',
+  });
+  const updatedAt = new Date('2026-04-18T12:15:00.000Z');
+
+  const updatedTerritory = territory.withProvinceSnapshot({
+    provinceIds: ['prov-01', 'prov-02', 'prov-03'],
+    contestedProvinceIds: ['prov-03'],
+    frontlineProvinceIds: ['prov-02', 'prov-03'],
+    updatedAt,
+  });
+
+  assert.notEqual(updatedTerritory, territory);
+  assert.equal(updatedTerritory.provinceCount, 3);
+  assert.equal(updatedTerritory.totalStrategicValue, 3);
+  assert.equal(updatedTerritory.contestedProvinceCount, 1);
+  assert.equal(updatedTerritory.frontlineProvinceCount, 2);
+  assert.equal(updatedTerritory.updatedAt?.toISOString(), updatedAt.toISOString());
+
+  assert.equal(territory.provinceCount, 2);
+  assert.equal(territory.updatedAt, null);
+});
+
+test('FactionTerritory rejects invalid subsets and invalid aggregate values', () => {
+  assert.throws(
+    () =>
+      new FactionTerritory({
+        factionId: 'faction-a',
+        provinceIds: ['prov-01'],
+        occupiedProvinceIds: ['prov-02'],
+      }),
+    /FactionTerritory occupiedProvinceIds must be a subset of provinceIds/,
+  );
+
+  assert.throws(
+    () =>
+      new FactionTerritory({
+        factionId: 'faction-a',
+        provinceIds: ['prov-01'],
+        capitalProvinceId: 'prov-02',
+      }),
+    /FactionTerritory capitalProvinceId must belong to provinceIds/,
+  );
+
+  assert.throws(
+    () =>
+      new FactionTerritory({
+        factionId: 'faction-a',
+        provinceIds: ['prov-01'],
+        totalStrategicValue: -1,
+      }),
+    /FactionTerritory totalStrategicValue must be a non-negative integer/,
+  );
+});


### PR DESCRIPTION
## Summary

- Alpha: add a `FactionTerritory` read model for territory ownership snapshots
- Alpha: track province membership, occupied and contested subsets, frontline provinces, capital, and aggregate counts
- Alpha: add node:test coverage for normalization, immutable snapshot updates, and invalid subset rules

## Related issue

- Alpha: closes #4

## Changes

- Alpha: add `src/domain/war/FactionTerritory.js` with normalized territory snapshot state and derived metrics
- Alpha: add `test/domain/war/FactionTerritory.test.js` for serialization, updates, and validation rules
- Alpha: keep the model compatible with the existing minimal Node test setup already on `main`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?