### PR TITLE
Beta: define ResourceStock value object

### DIFF
--- a/src/domain/economy/ResourceStock.js
+++ b/src/domain/economy/ResourceStock.js
@@ -1,0 +1,129 @@
+function normalizeEntries(entries) {
+  if (entries === null || typeof entries !== 'object' || Array.isArray(entries)) {
+    throw new TypeError('ResourceStock entries must be an object.');
+  }
+
+  return Object.fromEntries(
+    Object.entries(entries)
+      .map(([resourceId, quantity]) => {
+        const normalizedResourceId = String(resourceId).trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError('ResourceStock cannot contain an empty resource id.');
+        }
+
+        if (!Number.isInteger(quantity) || quantity < 0) {
+          throw new RangeError('ResourceStock quantities must be integers greater than or equal to 0.');
+        }
+
+        return [normalizedResourceId, quantity];
+      })
+      .sort(([leftId], [rightId]) => leftId.localeCompare(rightId)),
+  );
+}
+
+export class ResourceStock {
+  constructor(entries = {}) {
+    this.entries = normalizeEntries(entries);
+  }
+
+  get totalQuantity() {
+    return Object.values(this.entries).reduce((sum, quantity) => sum + quantity, 0);
+  }
+
+  has(resourceId, minimumQuantity = 1) {
+    const normalizedResourceId = ResourceStock.#requireText(resourceId, 'ResourceStock resourceId');
+    const normalizedMinimum = ResourceStock.#requireIntegerInRange(
+      minimumQuantity,
+      'ResourceStock minimumQuantity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+
+    return (this.entries[normalizedResourceId] ?? 0) >= normalizedMinimum;
+  }
+
+  get(resourceId) {
+    const normalizedResourceId = ResourceStock.#requireText(resourceId, 'ResourceStock resourceId');
+
+    return this.entries[normalizedResourceId] ?? 0;
+  }
+
+  with(resourceId, quantity) {
+    const normalizedResourceId = ResourceStock.#requireText(resourceId, 'ResourceStock resourceId');
+    const normalizedQuantity = ResourceStock.#requireIntegerInRange(
+      quantity,
+      'ResourceStock quantity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+
+    return new ResourceStock({
+      ...this.entries,
+      [normalizedResourceId]: normalizedQuantity,
+    });
+  }
+
+  add(resourceId, quantity) {
+    const normalizedResourceId = ResourceStock.#requireText(resourceId, 'ResourceStock resourceId');
+    const normalizedQuantity = ResourceStock.#requireIntegerInRange(
+      quantity,
+      'ResourceStock quantity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+
+    return this.with(normalizedResourceId, this.get(normalizedResourceId) + normalizedQuantity);
+  }
+
+  subtract(resourceId, quantity) {
+    const normalizedResourceId = ResourceStock.#requireText(resourceId, 'ResourceStock resourceId');
+    const normalizedQuantity = ResourceStock.#requireIntegerInRange(
+      quantity,
+      'ResourceStock quantity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+    const currentQuantity = this.get(normalizedResourceId);
+
+    if (normalizedQuantity > currentQuantity) {
+      throw new RangeError('ResourceStock cannot subtract more than the available quantity.');
+    }
+
+    return this.with(normalizedResourceId, currentQuantity - normalizedQuantity);
+  }
+
+  merge(otherStock) {
+    const stock = otherStock instanceof ResourceStock ? otherStock : new ResourceStock(otherStock);
+
+    let mergedStock = new ResourceStock(this.entries);
+
+    for (const [resourceId, quantity] of Object.entries(stock.entries)) {
+      mergedStock = mergedStock.add(resourceId, quantity);
+    }
+
+    return mergedStock;
+  }
+
+  toJSON() {
+    return { ...this.entries };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+}

--- a/test/domain/economy/ResourceStock.test.js
+++ b/test/domain/economy/ResourceStock.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ResourceStock } from '../../../src/domain/economy/ResourceStock.js';
+
+test('ResourceStock normalizes and exposes resource quantities', () => {
+  const stock = new ResourceStock({
+    ' grain ': 120,
+    wood: 45,
+    stone: 0,
+  });
+
+  assert.deepEqual(stock.toJSON(), {
+    grain: 120,
+    stone: 0,
+    wood: 45,
+  });
+  assert.equal(stock.get('grain'), 120);
+  assert.equal(stock.get('iron'), 0);
+  assert.equal(stock.totalQuantity, 165);
+  assert.equal(stock.has('wood', 40), true);
+  assert.equal(stock.has('wood', 46), false);
+});
+
+test('ResourceStock supports immutable updates and merging', () => {
+  const stock = new ResourceStock({ grain: 120, wood: 45 });
+
+  const replenished = stock.add('grain', 30);
+  const consumed = replenished.subtract('wood', 20);
+  const merged = consumed.merge({ stone: 10, wood: 5 });
+
+  assert.notEqual(replenished, stock);
+  assert.notEqual(consumed, replenished);
+  assert.notEqual(merged, consumed);
+
+  assert.deepEqual(stock.toJSON(), { grain: 120, wood: 45 });
+  assert.deepEqual(replenished.toJSON(), { grain: 150, wood: 45 });
+  assert.deepEqual(consumed.toJSON(), { grain: 150, wood: 25 });
+  assert.deepEqual(merged.toJSON(), { grain: 150, stone: 10, wood: 30 });
+});
+
+test('ResourceStock rejects invalid resource ids and quantities', () => {
+  assert.throws(() => new ResourceStock(null), /ResourceStock entries must be an object/);
+
+  assert.throws(
+    () => new ResourceStock({ ' ': 1 }),
+    /ResourceStock cannot contain an empty resource id/,
+  );
+
+  assert.throws(
+    () => new ResourceStock({ grain: -1 }),
+    /ResourceStock quantities must be integers greater than or equal to 0/,
+  );
+
+  const stock = new ResourceStock({ grain: 5 });
+
+  assert.throws(
+    () => stock.subtract('grain', 6),
+    /ResourceStock cannot subtract more than the available quantity/,
+  );
+});


### PR DESCRIPTION
## Summary
- add the Beta `ResourceStock` value object for city inventories and logistics
- normalize resource entries and expose immutable add, subtract, merge, and query helpers
- cover normalization, updates, and invariants with node tests

## Testing
- npm test

Closes #22