### PR TITLE
Delta: [D01] Define Cellule entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/domain/intrigue/Cellule.js
+++ b/src/domain/intrigue/Cellule.js
@@ -1,0 +1,121 @@
+const DEFAULT_SECRECY = 50;
+const DEFAULT_LOYALTY = 50;
+const DEFAULT_EXPOSURE = 0;
+const ACTIVE_STATUS = 'active';
+const ALLOWED_STATUSES = new Set(['active', 'dormant', 'compromised', 'dismantled']);
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+export class Cellule {
+  constructor({
+    id,
+    factionId,
+    codename,
+    locationId,
+    memberIds = [],
+    assetIds = [],
+    operationIds = [],
+    secrecy = DEFAULT_SECRECY,
+    loyalty = DEFAULT_LOYALTY,
+    exposure = DEFAULT_EXPOSURE,
+    status = ACTIVE_STATUS,
+    sleeper = false,
+  }) {
+    this.id = Cellule.#requireText(id, 'Cellule id');
+    this.factionId = Cellule.#requireText(factionId, 'Cellule factionId');
+    this.codename = Cellule.#requireText(codename, 'Cellule codename');
+    this.locationId = Cellule.#requireText(locationId, 'Cellule locationId');
+    this.memberIds = normalizeUniqueTexts(memberIds, 'Cellule memberIds');
+    this.assetIds = normalizeUniqueTexts(assetIds, 'Cellule assetIds');
+    this.operationIds = normalizeUniqueTexts(operationIds, 'Cellule operationIds');
+    this.secrecy = Cellule.#requireIntegerInRange(secrecy, 'Cellule secrecy', 0, 100);
+    this.loyalty = Cellule.#requireIntegerInRange(loyalty, 'Cellule loyalty', 0, 100);
+    this.exposure = Cellule.#requireIntegerInRange(exposure, 'Cellule exposure', 0, 100);
+    this.status = Cellule.#normalizeStatus(status);
+    this.sleeper = Boolean(sleeper);
+  }
+
+  get operationalReadiness() {
+    return Math.max(0, Math.round((this.secrecy + this.loyalty + (100 - this.exposure)) / 3));
+  }
+
+  get isExposed() {
+    return this.exposure >= 70 || this.status === 'compromised';
+  }
+
+  withExposure(exposure) {
+    const nextExposure = Cellule.#requireIntegerInRange(exposure, 'Cellule exposure', 0, 100);
+
+    return new Cellule({
+      ...this.toJSON(),
+      exposure: nextExposure,
+      status: nextExposure >= 70 ? 'compromised' : this.status,
+    });
+  }
+
+  assignOperation(operationId) {
+    return new Cellule({
+      ...this.toJSON(),
+      operationIds: [...this.operationIds, operationId],
+      sleeper: false,
+      status: this.status === 'dismantled' ? this.status : ACTIVE_STATUS,
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      factionId: this.factionId,
+      codename: this.codename,
+      locationId: this.locationId,
+      memberIds: [...this.memberIds],
+      assetIds: [...this.assetIds],
+      operationIds: [...this.operationIds],
+      secrecy: this.secrecy,
+      loyalty: this.loyalty,
+      exposure: this.exposure,
+      status: this.status,
+      sleeper: this.sleeper,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+
+  static #normalizeStatus(value) {
+    const normalizedValue = Cellule.#requireText(value, 'Cellule status');
+
+    if (!ALLOWED_STATUSES.has(normalizedValue)) {
+      throw new RangeError(`Cellule status must be one of: ${[...ALLOWED_STATUSES].join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+}

--- a/test/domain/intrigue/Cellule.test.js
+++ b/test/domain/intrigue/Cellule.test.js
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Cellule } from '../../../src/domain/intrigue/Cellule.js';
+
+test('Cellule normalizes intrigue fields and computes readiness', () => {
+  const cellule = new Cellule({
+    id: '  cellule-ombre ',
+    factionId: ' faction-nocturne ',
+    codename: ' Les Lanternes ',
+    locationId: ' district-cendre ',
+    memberIds: ['agent-2', ' agent-1 ', 'agent-2'],
+    assetIds: ['safehouse-3', ' safehouse-1 ', 'safehouse-3'],
+    operationIds: ['op-rumeur', ' op-filature ', 'op-rumeur'],
+    secrecy: 72,
+    loyalty: 81,
+    exposure: 15,
+    sleeper: 1,
+  });
+
+  assert.deepEqual(cellule.toJSON(), {
+    id: 'cellule-ombre',
+    factionId: 'faction-nocturne',
+    codename: 'Les Lanternes',
+    locationId: 'district-cendre',
+    memberIds: ['agent-1', 'agent-2'],
+    assetIds: ['safehouse-1', 'safehouse-3'],
+    operationIds: ['op-filature', 'op-rumeur'],
+    secrecy: 72,
+    loyalty: 81,
+    exposure: 15,
+    status: 'active',
+    sleeper: true,
+  });
+
+  assert.equal(cellule.operationalReadiness, 79);
+  assert.equal(cellule.isExposed, false);
+});
+
+test('Cellule supports immutable exposure and operation updates', () => {
+  const cellule = new Cellule({
+    id: 'cellule-ombre',
+    factionId: 'faction-nocturne',
+    codename: 'Les Lanternes',
+    locationId: 'district-cendre',
+    secrecy: 72,
+    loyalty: 81,
+    exposure: 15,
+    status: 'dormant',
+    sleeper: true,
+  });
+
+  const assignedCellule = cellule.assignOperation('op-rumeur');
+  const compromisedCellule = assignedCellule.withExposure(74);
+
+  assert.notEqual(assignedCellule, cellule);
+  assert.notEqual(compromisedCellule, assignedCellule);
+  assert.deepEqual(assignedCellule.operationIds, ['op-rumeur']);
+  assert.equal(assignedCellule.status, 'active');
+  assert.equal(assignedCellule.sleeper, false);
+  assert.equal(compromisedCellule.status, 'compromised');
+  assert.equal(compromisedCellule.isExposed, true);
+
+  assert.deepEqual(cellule.operationIds, []);
+  assert.equal(cellule.status, 'dormant');
+  assert.equal(cellule.sleeper, true);
+});
+
+test('Cellule rejects invalid intrigue invariants', () => {
+  assert.throws(
+    () =>
+      new Cellule({
+        id: '',
+        factionId: 'faction-nocturne',
+        codename: 'Les Lanternes',
+        locationId: 'district-cendre',
+      }),
+    /Cellule id is required/,
+  );
+
+  assert.throws(
+    () =>
+      new Cellule({
+        id: 'cellule-ombre',
+        factionId: 'faction-nocturne',
+        codename: 'Les Lanternes',
+        locationId: 'district-cendre',
+        memberIds: ['agent-1', ''],
+      }),
+    /Cellule memberIds cannot contain empty values/,
+  );
+
+  assert.throws(
+    () =>
+      new Cellule({
+        id: 'cellule-ombre',
+        factionId: 'faction-nocturne',
+        codename: 'Les Lanternes',
+        locationId: 'district-cendre',
+        secrecy: 101,
+      }),
+    /Cellule secrecy must be an integer between 0 and 100/,
+  );
+
+  assert.throws(
+    () =>
+      new Cellule({
+        id: 'cellule-ombre',
+        factionId: 'faction-nocturne',
+        codename: 'Les Lanternes',
+        locationId: 'district-cendre',
+        status: 'unknown',
+      }),
+    /Cellule status must be one of: active, dormant, compromised, dismantled/,
+  );
+});


### PR DESCRIPTION
## Summary

- Delta: add the first intrigue domain entity, `Cellule`
- Delta: model normalized members, assets, operations, secrecy, loyalty, exposure, and status
- Delta: cover invariants and immutable state transitions with node tests

## Related issue

- Delta: closes #61

## Changes

- Delta: add `src/domain/intrigue/Cellule.js`
- Delta: add `test/domain/intrigue/Cellule.test.js`
- Delta: add minimal `package.json` test script so the repository can execute `node --test`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Delta: `operationalReadiness` gives a simple derived score for future intrigue use cases.
- Delta: Please review for validation before merge, Zeta.