### PR TITLE
Alpha: [A05] Define SupplyLevel states

### DIFF
--- a/src/domain/war/Province.js
+++ b/src/domain/war/Province.js
@@ -1,3 +1,5 @@
+import { SupplyLevel } from './SupplyLevel.js';
+
 const DEFAULT_LOYALTY = 50;
 
 function normalizeNeighborIds(neighborIds) {
@@ -34,7 +36,7 @@ export class Province {
       controllingFactionId,
       'Province controllingFactionId',
     );
-    this.supplyLevel = Province.#requireText(supplyLevel, 'Province supplyLevel');
+    this.supplyLevel = SupplyLevel.normalize(supplyLevel);
     this.loyalty = Province.#requireIntegerInRange(loyalty, 'Province loyalty', 0, 100);
     this.strategicValue = Province.#requireIntegerInRange(
       strategicValue,

--- a/src/domain/war/SupplyLevel.js
+++ b/src/domain/war/SupplyLevel.js
@@ -1,0 +1,57 @@
+const SUPPLY_LEVELS = Object.freeze({
+  SECURE: 'secure',
+  STABLE: 'stable',
+  STRAINED: 'strained',
+  DISRUPTED: 'disrupted',
+  COLLAPSED: 'collapsed',
+});
+
+const SUPPLY_LEVEL_INDEX = Object.freeze({
+  [SUPPLY_LEVELS.SECURE]: 4,
+  [SUPPLY_LEVELS.STABLE]: 3,
+  [SUPPLY_LEVELS.STRAINED]: 2,
+  [SUPPLY_LEVELS.DISRUPTED]: 1,
+  [SUPPLY_LEVELS.COLLAPSED]: 0,
+});
+
+export class SupplyLevel {
+  static states() {
+    return Object.values(SUPPLY_LEVELS);
+  }
+
+  static normalize(value) {
+    const normalizedValue = String(value ?? '').trim().toLowerCase();
+
+    if (!SupplyLevel.isValid(normalizedValue)) {
+      throw new RangeError(`SupplyLevel must be one of: ${SupplyLevel.states().join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static isValid(value) {
+    return Object.hasOwn(SUPPLY_LEVEL_INDEX, value);
+  }
+
+  static compare(left, right) {
+    return SUPPLY_LEVEL_INDEX[SupplyLevel.normalize(left)] - SUPPLY_LEVEL_INDEX[SupplyLevel.normalize(right)];
+  }
+
+  static degrade(value) {
+    const normalizedValue = SupplyLevel.normalize(value);
+    const states = SupplyLevel.states();
+    const index = states.indexOf(normalizedValue);
+
+    return states[Math.min(index + 1, states.length - 1)];
+  }
+
+  static improve(value) {
+    const normalizedValue = SupplyLevel.normalize(value);
+    const states = SupplyLevel.states();
+    const index = states.indexOf(normalizedValue);
+
+    return states[Math.max(index - 1, 0)];
+  }
+}
+
+export { SUPPLY_LEVELS };

--- a/test/domain/war/Province.test.js
+++ b/test/domain/war/Province.test.js
@@ -52,7 +52,7 @@ test('Province can transition to occupation while preserving immutable semantics
   assert.equal(province.capturedAt, null);
 });
 
-test('Province rejects invalid identifiers and scores', () => {
+test('Province rejects invalid identifiers, scores, and unknown supply states', () => {
   assert.throws(
     () =>
       new Province({
@@ -86,5 +86,16 @@ test('Province rejects invalid identifiers and scores', () => {
         strategicValue: 0,
       }),
     /Province strategicValue must be an integer between 1 and 10/,
+  );
+
+  assert.throws(
+    () =>
+      new Province({
+        id: 'prov-001',
+        name: 'Marches of Dawn',
+        ownerFactionId: 'faction-a',
+        supplyLevel: 'broken',
+      }),
+    /SupplyLevel must be one of/,
   );
 });

--- a/test/domain/war/SupplyLevel.test.js
+++ b/test/domain/war/SupplyLevel.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { SupplyLevel, SUPPLY_LEVELS } from '../../../src/domain/war/SupplyLevel.js';
+
+test('SupplyLevel exposes the ordered supply state machine', () => {
+  assert.deepEqual(SupplyLevel.states(), [
+    SUPPLY_LEVELS.SECURE,
+    SUPPLY_LEVELS.STABLE,
+    SUPPLY_LEVELS.STRAINED,
+    SUPPLY_LEVELS.DISRUPTED,
+    SUPPLY_LEVELS.COLLAPSED,
+  ]);
+
+  assert.equal(SupplyLevel.normalize(' Stable '), SUPPLY_LEVELS.STABLE);
+  assert.equal(SupplyLevel.isValid('collapsed'), true);
+  assert.equal(SupplyLevel.isValid('unknown'), false);
+});
+
+test('SupplyLevel can compare, degrade, and improve supply pressure', () => {
+  assert.equal(SupplyLevel.compare('secure', 'stable') > 0, true);
+  assert.equal(SupplyLevel.compare('collapsed', 'disrupted') < 0, true);
+  assert.equal(SupplyLevel.degrade('secure'), SUPPLY_LEVELS.STABLE);
+  assert.equal(SupplyLevel.degrade('collapsed'), SUPPLY_LEVELS.COLLAPSED);
+  assert.equal(SupplyLevel.improve('disrupted'), SUPPLY_LEVELS.STRAINED);
+  assert.equal(SupplyLevel.improve('secure'), SUPPLY_LEVELS.SECURE);
+});
+
+test('SupplyLevel rejects invalid states', () => {
+  assert.throws(() => SupplyLevel.normalize(''), /SupplyLevel must be one of/);
+  assert.throws(() => SupplyLevel.compare('stable', 'broken'), /SupplyLevel must be one of/);
+});


### PR DESCRIPTION
## Summary

- Alpha: add explicit `SupplyLevel` states for territory and war systems
- Alpha: define ordered supply transitions and comparison helpers for future front and pressure logic
- Alpha: wire Province validation to the new supply state machine and cover it with tests

## Related issue

- Alpha: closes #5

## Changes

- Alpha: add `src/domain/war/SupplyLevel.js` with canonical supply states, validation, and transition helpers
- Alpha: update `src/domain/war/Province.js` to validate `supplyLevel` through the new state machine
- Alpha: add `test/domain/war/SupplyLevel.test.js` and extend Province tests for invalid supply values

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?