### PR TITLE
Beta: define ProductionRule model

### DIFF
--- a/src/domain/economy/ProductionRule.js
+++ b/src/domain/economy/ProductionRule.js
@@ -1,0 +1,143 @@
+function normalizeTextList(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function normalizeResourceMap(resources, label) {
+  if (resources === null || typeof resources !== 'object' || Array.isArray(resources)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return Object.fromEntries(
+    Object.entries(resources)
+      .map(([resourceId, quantity]) => {
+        const normalizedResourceId = String(resourceId).trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError(`${label} cannot contain an empty resource id.`);
+        }
+
+        if (!Number.isInteger(quantity) || quantity < 0) {
+          throw new RangeError(`${label} quantities must be integers greater than or equal to 0.`);
+        }
+
+        return [normalizedResourceId, quantity];
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+export class ProductionRule {
+  constructor({
+    id,
+    name,
+    workforceRequired,
+    inputByResource = {},
+    outputByResource,
+    requiredBuildingTags = [],
+    requiredCityTags = [],
+    prosperityImpact = 0,
+    stabilityImpact = 0,
+    enabled = true,
+  }) {
+    this.id = ProductionRule.#requireText(id, 'ProductionRule id');
+    this.name = ProductionRule.#requireText(name, 'ProductionRule name');
+    this.workforceRequired = ProductionRule.#requireIntegerInRange(
+      workforceRequired,
+      'ProductionRule workforceRequired',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+    this.inputByResource = normalizeResourceMap(inputByResource, 'ProductionRule inputByResource');
+    this.outputByResource = normalizeResourceMap(outputByResource, 'ProductionRule outputByResource');
+    this.requiredBuildingTags = normalizeTextList(
+      requiredBuildingTags,
+      'ProductionRule requiredBuildingTags',
+    );
+    this.requiredCityTags = normalizeTextList(requiredCityTags, 'ProductionRule requiredCityTags');
+    this.prosperityImpact = ProductionRule.#requireIntegerInRange(
+      prosperityImpact,
+      'ProductionRule prosperityImpact',
+      -100,
+      100,
+    );
+    this.stabilityImpact = ProductionRule.#requireIntegerInRange(
+      stabilityImpact,
+      'ProductionRule stabilityImpact',
+      -100,
+      100,
+    );
+    this.enabled = Boolean(enabled);
+  }
+
+  get isTransformative() {
+    return Object.keys(this.inputByResource).length > 0;
+  }
+
+  canRun({ workforceAvailable, buildingTags = [], cityTags = [] }) {
+    const normalizedWorkforce = ProductionRule.#requireIntegerInRange(
+      workforceAvailable,
+      'ProductionRule workforceAvailable',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+    const normalizedBuildingTags = new Set(normalizeTextList(buildingTags, 'ProductionRule buildingTags'));
+    const normalizedCityTags = new Set(normalizeTextList(cityTags, 'ProductionRule cityTags'));
+
+    return (
+      this.enabled
+      && normalizedWorkforce >= this.workforceRequired
+      && this.requiredBuildingTags.every((tag) => normalizedBuildingTags.has(tag))
+      && this.requiredCityTags.every((tag) => normalizedCityTags.has(tag))
+    );
+  }
+
+  withEnabled(enabled) {
+    return new ProductionRule({
+      ...this.toJSON(),
+      enabled,
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      name: this.name,
+      workforceRequired: this.workforceRequired,
+      inputByResource: { ...this.inputByResource },
+      outputByResource: { ...this.outputByResource },
+      requiredBuildingTags: [...this.requiredBuildingTags],
+      requiredCityTags: [...this.requiredCityTags],
+      prosperityImpact: this.prosperityImpact,
+      stabilityImpact: this.stabilityImpact,
+      enabled: this.enabled,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+}

--- a/test/domain/economy/ProductionRule.test.js
+++ b/test/domain/economy/ProductionRule.test.js
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ProductionRule } from '../../../src/domain/economy/ProductionRule.js';
+
+test('ProductionRule normalizes production requirements and impacts', () => {
+  const rule = new ProductionRule({
+    id: ' rule-smokehouse ',
+    name: ' Smokehouse ',
+    workforceRequired: 25,
+    inputByResource: {
+      ' fish ': 30,
+      wood: 5,
+    },
+    outputByResource: {
+      ' smoked-fish ': 20,
+    },
+    requiredBuildingTags: [' artisan ', 'food', 'artisan'],
+    requiredCityTags: [' coastal ', 'market', 'coastal'],
+    prosperityImpact: 4,
+    stabilityImpact: 2,
+    enabled: 1,
+  });
+
+  assert.deepEqual(rule.toJSON(), {
+    id: 'rule-smokehouse',
+    name: 'Smokehouse',
+    workforceRequired: 25,
+    inputByResource: { fish: 30, wood: 5 },
+    outputByResource: { 'smoked-fish': 20 },
+    requiredBuildingTags: ['artisan', 'food'],
+    requiredCityTags: ['coastal', 'market'],
+    prosperityImpact: 4,
+    stabilityImpact: 2,
+    enabled: true,
+  });
+
+  assert.equal(rule.isTransformative, true);
+});
+
+test('ProductionRule can evaluate runtime conditions immutably', () => {
+  const rule = new ProductionRule({
+    id: 'rule-quarry',
+    name: 'Quarry',
+    workforceRequired: 40,
+    outputByResource: {
+      stone: 60,
+    },
+    requiredBuildingTags: ['industry'],
+    requiredCityTags: ['hills'],
+  });
+
+  assert.equal(
+    rule.canRun({ workforceAvailable: 45, buildingTags: ['industry'], cityTags: ['hills', 'fortified'] }),
+    true,
+  );
+  assert.equal(
+    rule.canRun({ workforceAvailable: 39, buildingTags: ['industry'], cityTags: ['hills'] }),
+    false,
+  );
+  assert.equal(rule.withEnabled(false).canRun({ workforceAvailable: 60, buildingTags: ['industry'], cityTags: ['hills'] }), false);
+});
+
+test('ProductionRule rejects invalid fields and ranges', () => {
+  assert.throws(
+    () => new ProductionRule({ id: '', name: 'Quarry', workforceRequired: 10, outputByResource: { stone: 5 } }),
+    /ProductionRule id is required/,
+  );
+
+  assert.throws(
+    () => new ProductionRule({ id: 'rule', name: 'Quarry', workforceRequired: -1, outputByResource: { stone: 5 } }),
+    /ProductionRule workforceRequired must be an integer between 0 and/,
+  );
+
+  assert.throws(
+    () => new ProductionRule({ id: 'rule', name: 'Quarry', workforceRequired: 10, outputByResource: { ' ': 5 } }),
+    /ProductionRule outputByResource cannot contain an empty resource id/,
+  );
+
+  assert.throws(
+    () => new ProductionRule({ id: 'rule', name: 'Quarry', workforceRequired: 10, outputByResource: { stone: 5 }, prosperityImpact: 101 }),
+    /ProductionRule prosperityImpact must be an integer between -100 and 100/,
+  );
+});


### PR DESCRIPTION
## Summary
- add the Beta `ProductionRule` model for city production definitions
- normalize resource maps and tag requirements with runtime eligibility checks
- cover invariants and behavior with node tests

## Testing
- npm test

Closes #23