### PR TITLE
Delta: [D02] Define Agent entity

### DIFF
--- a/src/domain/intrigue/Agent.js
+++ b/src/domain/intrigue/Agent.js
@@ -1,0 +1,137 @@
+const DEFAULT_DISCRETION = 50;
+const DEFAULT_INFLUENCE = 50;
+const DEFAULT_HEALTH = 100;
+const DEFAULT_COVER_STRENGTH = 50;
+const ACTIVE_STATUS = 'active';
+const ALLOWED_STATUSES = new Set(['active', 'undercover', 'captured', 'retired', 'missing']);
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+export class Agent {
+  constructor({
+    id,
+    codename,
+    factionId,
+    celluleId,
+    specialtyIds = [],
+    contactIds = [],
+    coverIdentity = null,
+    discretion = DEFAULT_DISCRETION,
+    influence = DEFAULT_INFLUENCE,
+    health = DEFAULT_HEALTH,
+    coverStrength = DEFAULT_COVER_STRENGTH,
+    status = ACTIVE_STATUS,
+    compromised = false,
+  }) {
+    this.id = Agent.#requireText(id, 'Agent id');
+    this.codename = Agent.#requireText(codename, 'Agent codename');
+    this.factionId = Agent.#requireText(factionId, 'Agent factionId');
+    this.celluleId = Agent.#requireText(celluleId, 'Agent celluleId');
+    this.specialtyIds = normalizeUniqueTexts(specialtyIds, 'Agent specialtyIds');
+    this.contactIds = normalizeUniqueTexts(contactIds, 'Agent contactIds');
+    this.coverIdentity = Agent.#normalizeOptionalText(coverIdentity);
+    this.discretion = Agent.#requireIntegerInRange(discretion, 'Agent discretion', 0, 100);
+    this.influence = Agent.#requireIntegerInRange(influence, 'Agent influence', 0, 100);
+    this.health = Agent.#requireIntegerInRange(health, 'Agent health', 0, 100);
+    this.coverStrength = Agent.#requireIntegerInRange(
+      coverStrength,
+      'Agent coverStrength',
+      0,
+      100,
+    );
+    this.status = Agent.#normalizeStatus(status);
+    this.compromised = Boolean(compromised);
+  }
+
+  get operationalValue() {
+    return Math.max(0, Math.round((this.discretion + this.influence + this.health + this.coverStrength) / 4));
+  }
+
+  get isOperational() {
+    return this.health > 0 && !this.compromised && this.status !== 'captured' && this.status !== 'retired';
+  }
+
+  withCompromise({ compromised, coverStrength = this.coverStrength, status = this.status }) {
+    const nextCompromised = Boolean(compromised);
+
+    return new Agent({
+      ...this.toJSON(),
+      compromised: nextCompromised,
+      coverStrength,
+      status: nextCompromised ? 'missing' : status,
+    });
+  }
+
+  assignContact(contactId) {
+    return new Agent({
+      ...this.toJSON(),
+      contactIds: [...this.contactIds, contactId],
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      codename: this.codename,
+      factionId: this.factionId,
+      celluleId: this.celluleId,
+      specialtyIds: [...this.specialtyIds],
+      contactIds: [...this.contactIds],
+      coverIdentity: this.coverIdentity,
+      discretion: this.discretion,
+      influence: this.influence,
+      health: this.health,
+      coverStrength: this.coverStrength,
+      status: this.status,
+      compromised: this.compromised,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #normalizeOptionalText(value) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    return Agent.#requireText(value, 'Agent coverIdentity');
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+
+  static #normalizeStatus(value) {
+    const normalizedValue = Agent.#requireText(value, 'Agent status');
+
+    if (!ALLOWED_STATUSES.has(normalizedValue)) {
+      throw new RangeError(`Agent status must be one of: ${[...ALLOWED_STATUSES].join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+}

--- a/test/domain/intrigue/Agent.test.js
+++ b/test/domain/intrigue/Agent.test.js
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Agent } from '../../../src/domain/intrigue/Agent.js';
+
+test('Agent normalizes intrigue operative fields', () => {
+  const agent = new Agent({
+    id: '  agent-corbeau ',
+    codename: ' La Cendre ',
+    factionId: ' faction-nocturne ',
+    celluleId: ' cellule-ombre ',
+    specialtyIds: ['infiltration', ' sabotage ', 'infiltration'],
+    contactIds: ['contact-b', ' contact-a ', 'contact-b'],
+    coverIdentity: '  archiviste itinérant ',
+    discretion: 88,
+    influence: 61,
+    health: 93,
+    coverStrength: 77,
+  });
+
+  assert.deepEqual(agent.toJSON(), {
+    id: 'agent-corbeau',
+    codename: 'La Cendre',
+    factionId: 'faction-nocturne',
+    celluleId: 'cellule-ombre',
+    specialtyIds: ['infiltration', 'sabotage'],
+    contactIds: ['contact-a', 'contact-b'],
+    coverIdentity: 'archiviste itinérant',
+    discretion: 88,
+    influence: 61,
+    health: 93,
+    coverStrength: 77,
+    status: 'active',
+    compromised: false,
+  });
+
+  assert.equal(agent.operationalValue, 80);
+  assert.equal(agent.isOperational, true);
+});
+
+test('Agent supports immutable compromise and contact updates', () => {
+  const agent = new Agent({
+    id: 'agent-corbeau',
+    codename: 'La Cendre',
+    factionId: 'faction-nocturne',
+    celluleId: 'cellule-ombre',
+    status: 'undercover',
+    coverStrength: 72,
+  });
+
+  const networkedAgent = agent.assignContact('contact-zeta');
+  const compromisedAgent = networkedAgent.withCompromise({
+    compromised: true,
+    coverStrength: 18,
+  });
+
+  assert.notEqual(networkedAgent, agent);
+  assert.notEqual(compromisedAgent, networkedAgent);
+  assert.deepEqual(networkedAgent.contactIds, ['contact-zeta']);
+  assert.equal(compromisedAgent.compromised, true);
+  assert.equal(compromisedAgent.status, 'missing');
+  assert.equal(compromisedAgent.coverStrength, 18);
+  assert.equal(compromisedAgent.isOperational, false);
+
+  assert.deepEqual(agent.contactIds, []);
+  assert.equal(agent.status, 'undercover');
+  assert.equal(agent.compromised, false);
+});
+
+test('Agent rejects invalid operative invariants', () => {
+  assert.throws(
+    () =>
+      new Agent({
+        id: '',
+        codename: 'La Cendre',
+        factionId: 'faction-nocturne',
+        celluleId: 'cellule-ombre',
+      }),
+    /Agent id is required/,
+  );
+
+  assert.throws(
+    () =>
+      new Agent({
+        id: 'agent-corbeau',
+        codename: 'La Cendre',
+        factionId: 'faction-nocturne',
+        celluleId: 'cellule-ombre',
+        specialtyIds: ['infiltration', ''],
+      }),
+    /Agent specialtyIds cannot contain empty values/,
+  );
+
+  assert.throws(
+    () =>
+      new Agent({
+        id: 'agent-corbeau',
+        codename: 'La Cendre',
+        factionId: 'faction-nocturne',
+        celluleId: 'cellule-ombre',
+        coverStrength: 101,
+      }),
+    /Agent coverStrength must be an integer between 0 and 100/,
+  );
+
+  assert.throws(
+    () =>
+      new Agent({
+        id: 'agent-corbeau',
+        codename: 'La Cendre',
+        factionId: 'faction-nocturne',
+        celluleId: 'cellule-ombre',
+        status: 'legendary',
+      }),
+    /Agent status must be one of: active, undercover, captured, retired, missing/,
+  );
+});


### PR DESCRIPTION
## Summary

- Delta: add the intrigue operative entity, `Agent`
- Delta: model specialties, contacts, cover identity, discretion, influence, health, and cover strength
- Delta: cover invariants and immutable compromise/contact transitions with node tests

## Related issue

- Delta: closes #62

## Changes

- Delta: add `src/domain/intrigue/Agent.js`
- Delta: add `test/domain/intrigue/Agent.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Delta: `operationalValue` gives a simple derived score for future intrigue actions.
- Delta: Please review for validation before merge, Zeta.
