### PR TITLE
Alpha: [A06] Implement DetectFronts use case

### DIFF
--- a/src/application/war/DetectFronts.js
+++ b/src/application/war/DetectFronts.js
@@ -1,0 +1,77 @@
+function pairKey(leftFactionId, rightFactionId) {
+  return [String(leftFactionId).trim(), String(rightFactionId).trim()].sort().join('::');
+}
+
+function segmentId(leftProvinceId, rightProvinceId) {
+  return [String(leftProvinceId).trim(), String(rightProvinceId).trim()].sort().join('::');
+}
+
+export class DetectFronts {
+  execute({ provinces }) {
+    if (!Array.isArray(provinces)) {
+      throw new TypeError('DetectFronts provinces must be an array.');
+    }
+
+    const provinceById = new Map(provinces.map((province) => [province.id, province]));
+    const frontMap = new Map();
+    const seenSegments = new Set();
+
+    for (const province of provinces) {
+      for (const neighborId of province.neighborIds) {
+        const neighbor = provinceById.get(neighborId);
+
+        if (!neighbor) {
+          continue;
+        }
+
+        const currentSegmentId = segmentId(province.id, neighbor.id);
+
+        if (seenSegments.has(currentSegmentId)) {
+          continue;
+        }
+
+        seenSegments.add(currentSegmentId);
+
+        if (province.controllingFactionId === neighbor.controllingFactionId) {
+          continue;
+        }
+
+        const currentPairKey = pairKey(
+          province.controllingFactionId,
+          neighbor.controllingFactionId,
+        );
+        const existingFront = frontMap.get(currentPairKey) ?? {
+          id: currentPairKey,
+          factionIds: currentPairKey.split('::'),
+          provinceIds: [],
+          segmentIds: [],
+          contestedProvinceIds: [],
+        };
+
+        existingFront.segmentIds = [...new Set([...existingFront.segmentIds, currentSegmentId])].sort();
+        existingFront.provinceIds = [...new Set([...existingFront.provinceIds, province.id, neighbor.id])].sort();
+
+        if (province.contested) {
+          existingFront.contestedProvinceIds = [
+            ...new Set([...existingFront.contestedProvinceIds, province.id]),
+          ].sort();
+        }
+
+        if (neighbor.contested) {
+          existingFront.contestedProvinceIds = [
+            ...new Set([...existingFront.contestedProvinceIds, neighbor.id]),
+          ].sort();
+        }
+
+        frontMap.set(currentPairKey, existingFront);
+      }
+    }
+
+    return [...frontMap.values()]
+      .map((front) => ({
+        ...front,
+        pressure: front.contestedProvinceIds.length,
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id));
+  }
+}

--- a/test/application/war/DetectFronts.test.js
+++ b/test/application/war/DetectFronts.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DetectFronts } from '../../../src/application/war/DetectFronts.js';
+import { Province } from '../../../src/domain/war/Province.js';
+
+function createProvince(overrides) {
+  return new Province({
+    id: 'prov-1',
+    name: 'Province',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    neighborIds: [],
+    ...overrides,
+  });
+}
+
+test('DetectFronts groups hostile neighboring provinces into fronts', () => {
+  const detectFronts = new DetectFronts();
+  const provinces = [
+    createProvince({ id: 'a-1', neighborIds: ['b-1'], contested: true }),
+    createProvince({
+      id: 'b-1',
+      ownerFactionId: 'faction-b',
+      controllingFactionId: 'faction-b',
+      neighborIds: ['a-1', 'a-2'],
+      contested: true,
+    }),
+    createProvince({ id: 'a-2', neighborIds: ['b-1'] }),
+  ];
+
+  assert.deepEqual(detectFronts.execute({ provinces }), [
+    {
+      id: 'faction-a::faction-b',
+      factionIds: ['faction-a', 'faction-b'],
+      provinceIds: ['a-1', 'a-2', 'b-1'],
+      segmentIds: ['a-1::b-1', 'a-2::b-1'],
+      contestedProvinceIds: ['a-1', 'b-1'],
+      pressure: 2,
+    },
+  ]);
+});
+
+test('DetectFronts ignores internal borders, missing neighbors, and duplicate segments', () => {
+  const detectFronts = new DetectFronts();
+  const provinces = [
+    createProvince({ id: 'a-1', neighborIds: ['a-2', 'b-1', 'missing'] }),
+    createProvince({ id: 'a-2', neighborIds: ['a-1', 'b-1'] }),
+    createProvince({
+      id: 'b-1',
+      ownerFactionId: 'faction-b',
+      controllingFactionId: 'faction-b',
+      neighborIds: ['a-1', 'a-2'],
+    }),
+  ];
+
+  assert.deepEqual(detectFronts.execute({ provinces }), [
+    {
+      id: 'faction-a::faction-b',
+      factionIds: ['faction-a', 'faction-b'],
+      provinceIds: ['a-1', 'a-2', 'b-1'],
+      segmentIds: ['a-1::b-1', 'a-2::b-1'],
+      contestedProvinceIds: [],
+      pressure: 0,
+    },
+  ]);
+});
+
+test('DetectFronts rejects invalid inputs', () => {
+  const detectFronts = new DetectFronts();
+
+  assert.throws(() => detectFronts.execute({ provinces: null }), /DetectFronts provinces must be an array/);
+});


### PR DESCRIPTION
## Summary

- Alpha: add a first `DetectFronts` use case for scanning hostile province borders
- Alpha: group neighboring enemy-controlled provinces into front snapshots with segments and contested pressure
- Alpha: add node:test coverage for hostile borders, ignored internal borders, and invalid inputs

## Related issue

- Alpha: closes #6

## Changes

- Alpha: add `src/application/war/DetectFronts.js` with front detection logic based on neighboring provinces
- Alpha: add `test/application/war/DetectFronts.test.js` for grouping, deduplication, and guard rails
- Alpha: keep the use case compatible with the current Province entity already on `main`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?