### PR TITLE
Epsilon: Define Catastrophe model

### DIFF
--- a/src/domain/climate/Catastrophe.js
+++ b/src/domain/climate/Catastrophe.js
@@ -1,0 +1,158 @@
+const VALID_SEVERITIES = ['minor', 'major', 'critical'];
+const VALID_STATUSES = ['warning', 'active', 'resolved'];
+
+function normalizeRegionIds(regionIds) {
+  if (!Array.isArray(regionIds) || regionIds.length === 0) {
+    throw new RangeError('Catastrophe regionIds must be a non-empty array.');
+  }
+
+  const normalized = [...new Set(regionIds.map((regionId) => Catastrophe.requireText(regionId, 'Catastrophe regionId')))];
+
+  return normalized.sort();
+}
+
+export class Catastrophe {
+  constructor({
+    id,
+    type,
+    severity,
+    status = 'warning',
+    regionIds,
+    startedAt,
+    expectedEndAt = null,
+    resolvedAt = null,
+    impact = {},
+    description = null,
+  }) {
+    this.id = Catastrophe.requireText(id, 'Catastrophe id');
+    this.type = Catastrophe.requireText(type, 'Catastrophe type');
+    this.severity = Catastrophe.requireChoice(severity, 'Catastrophe severity', VALID_SEVERITIES);
+    this.status = Catastrophe.requireChoice(status, 'Catastrophe status', VALID_STATUSES);
+    this.regionIds = normalizeRegionIds(regionIds);
+    this.startedAt = Catastrophe.normalizeDate(startedAt, 'Catastrophe startedAt');
+    this.expectedEndAt = Catastrophe.normalizeOptionalDate(expectedEndAt, 'Catastrophe expectedEndAt');
+    this.resolvedAt = Catastrophe.normalizeOptionalDate(resolvedAt, 'Catastrophe resolvedAt');
+    this.impact = Catastrophe.normalizeImpact(impact);
+    this.description = description === null ? null : Catastrophe.requireText(description, 'Catastrophe description');
+
+    if (this.status === 'resolved' && this.resolvedAt === null) {
+      throw new RangeError('Catastrophe resolved status requires resolvedAt.');
+    }
+
+    if (this.resolvedAt !== null && this.resolvedAt < this.startedAt) {
+      throw new RangeError('Catastrophe resolvedAt cannot be earlier than startedAt.');
+    }
+  }
+
+  get isActive() {
+    return this.status === 'active';
+  }
+
+  get isResolved() {
+    return this.status === 'resolved';
+  }
+
+  activate() {
+    return new Catastrophe({
+      ...this.toJSON(),
+      status: 'active',
+      resolvedAt: null,
+    });
+  }
+
+  resolve(resolvedAt = new Date()) {
+    return new Catastrophe({
+      ...this.toJSON(),
+      status: 'resolved',
+      resolvedAt,
+    });
+  }
+
+  withImpact(impact) {
+    return new Catastrophe({
+      ...this.toJSON(),
+      impact: {
+        ...this.impact,
+        ...impact,
+      },
+    });
+  }
+
+  affectsRegion(regionId) {
+    const normalizedRegionId = String(regionId ?? '').trim();
+    return this.regionIds.includes(normalizedRegionId);
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      type: this.type,
+      severity: this.severity,
+      status: this.status,
+      regionIds: [...this.regionIds],
+      startedAt: this.startedAt.toISOString(),
+      expectedEndAt: this.expectedEndAt?.toISOString() ?? null,
+      resolvedAt: this.resolvedAt?.toISOString() ?? null,
+      impact: { ...this.impact },
+      description: this.description,
+    };
+  }
+
+  static requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static requireChoice(value, label, validValues) {
+    const normalizedValue = Catastrophe.requireText(value, label);
+
+    if (!validValues.includes(normalizedValue)) {
+      throw new RangeError(`${label} must be one of: ${validValues.join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static normalizeDate(value, label) {
+    const date = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      throw new RangeError(`${label} must be a valid date.`);
+    }
+
+    return date;
+  }
+
+  static normalizeOptionalDate(value, label) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    return Catastrophe.normalizeDate(value, label);
+  }
+
+  static normalizeImpact(impact) {
+    if (impact === null || typeof impact !== 'object' || Array.isArray(impact)) {
+      throw new RangeError('Catastrophe impact must be an object.');
+    }
+
+    const normalized = {};
+
+    for (const [key, value] of Object.entries(impact)) {
+      const normalizedKey = Catastrophe.requireText(key, 'Catastrophe impact key');
+
+      if (!Number.isFinite(value)) {
+        throw new RangeError(`Catastrophe impact ${normalizedKey} must be a finite number.`);
+      }
+
+      normalized[normalizedKey] = value;
+    }
+
+    return normalized;
+  }
+}

--- a/src/domain/climate/index.js
+++ b/src/domain/climate/index.js
@@ -1,0 +1,1 @@
+export { Catastrophe } from './Catastrophe.js';

--- a/test/domain/climate/Catastrophe.test.js
+++ b/test/domain/climate/Catastrophe.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Catastrophe } from '../../../src/domain/climate/Catastrophe.js';
+
+test('Catastrophe keeps normalized disaster metadata', () => {
+  const catastrophe = new Catastrophe({
+    id: ' storm-001 ',
+    type: 'great-storm',
+    severity: 'major',
+    regionIds: ['north-coast', ' north-coast ', 'riverlands'],
+    startedAt: '2026-04-18T12:00:00.000Z',
+    expectedEndAt: '2026-04-20T12:00:00.000Z',
+    impact: { harvest: -25, morale: -10 },
+    description: ' Gale-force rain and floods ',
+  });
+
+  assert.deepEqual(catastrophe.toJSON(), {
+    id: 'storm-001',
+    type: 'great-storm',
+    severity: 'major',
+    status: 'warning',
+    regionIds: ['north-coast', 'riverlands'],
+    startedAt: '2026-04-18T12:00:00.000Z',
+    expectedEndAt: '2026-04-20T12:00:00.000Z',
+    resolvedAt: null,
+    impact: { harvest: -25, morale: -10 },
+    description: 'Gale-force rain and floods',
+  });
+
+  assert.equal(catastrophe.affectsRegion('riverlands'), true);
+  assert.equal(catastrophe.isActive, false);
+});
+
+test('Catastrophe transitions from warning to active to resolved immutably', () => {
+  const warning = new Catastrophe({
+    id: 'quake-002',
+    type: 'earthquake',
+    severity: 'critical',
+    regionIds: ['highlands'],
+    startedAt: '2026-04-18T09:00:00.000Z',
+    impact: { infrastructure: -55 },
+  });
+
+  const active = warning.activate().withImpact({ population: -12 });
+  const resolved = active.resolve('2026-04-19T09:00:00.000Z');
+
+  assert.equal(warning.status, 'warning');
+  assert.equal(active.status, 'active');
+  assert.equal(active.isActive, true);
+  assert.deepEqual(active.impact, { infrastructure: -55, population: -12 });
+  assert.equal(resolved.status, 'resolved');
+  assert.equal(resolved.isResolved, true);
+  assert.equal(resolved.resolvedAt?.toISOString(), '2026-04-19T09:00:00.000Z');
+});
+
+test('Catastrophe rejects invalid values and timelines', () => {
+  assert.throws(
+    () => new Catastrophe({ id: '', type: 'storm', severity: 'major', regionIds: ['north'], startedAt: new Date(), impact: {} }),
+    /Catastrophe id is required/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'extreme', regionIds: ['north'], startedAt: new Date(), impact: {} }),
+    /Catastrophe severity must be one of/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'major', regionIds: [], startedAt: new Date(), impact: {} }),
+    /regionIds must be a non-empty array/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'major', status: 'resolved', regionIds: ['north'], startedAt: '2026-04-18T12:00:00.000Z', impact: {} }),
+    /resolved status requires resolvedAt/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'major', regionIds: ['north'], startedAt: '2026-04-18T12:00:00.000Z', resolvedAt: '2026-04-17T12:00:00.000Z', impact: {} }),
+    /resolvedAt cannot be earlier than startedAt/,
+  );
+});


### PR DESCRIPTION
Epsilon: implements #83.\n\n## Summary\n- add a Catastrophe climate model with validation for severity, status, regions, impact, and timeline consistency\n- add immutable helpers for activation, resolution, and impact updates\n- add node:test coverage for normalization, lifecycle transitions, and invalid inputs\n\n## Testing\n- npm test\n\n## Notes for Zeta\nEpsilon: please validate this PR before merge.