### PR TITLE
Beta: define TradeRoute model

### DIFF
--- a/src/domain/economy/TradeRoute.js
+++ b/src/domain/economy/TradeRoute.js
@@ -1,0 +1,146 @@
+function normalizeStops(stops) {
+  if (!Array.isArray(stops)) {
+    throw new TypeError('TradeRoute stopCityIds must be an array.');
+  }
+
+  const normalizedStops = stops.map((stopId) => String(stopId).trim());
+
+  if (normalizedStops.length < 2) {
+    throw new RangeError('TradeRoute stopCityIds must contain at least two cities.');
+  }
+
+  if (normalizedStops.some((stopId) => stopId.length === 0)) {
+    throw new RangeError('TradeRoute stopCityIds cannot contain empty values.');
+  }
+
+  if (new Set(normalizedStops).size !== normalizedStops.length) {
+    throw new RangeError('TradeRoute stopCityIds cannot contain duplicates.');
+  }
+
+  return normalizedStops;
+}
+
+function normalizeCapacityByResource(capacityByResource) {
+  if (capacityByResource === null || typeof capacityByResource !== 'object' || Array.isArray(capacityByResource)) {
+    throw new TypeError('TradeRoute capacityByResource must be an object.');
+  }
+
+  return Object.fromEntries(
+    Object.entries(capacityByResource)
+      .map(([resourceId, capacity]) => {
+        const normalizedResourceId = String(resourceId).trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError('TradeRoute capacityByResource cannot contain an empty resource id.');
+        }
+
+        if (!Number.isInteger(capacity) || capacity < 0) {
+          throw new RangeError('TradeRoute capacities must be integers greater than or equal to 0.');
+        }
+
+        return [normalizedResourceId, capacity];
+      })
+      .sort(([leftId], [rightId]) => leftId.localeCompare(rightId)),
+  );
+}
+
+export class TradeRoute {
+  constructor({
+    id,
+    name,
+    stopCityIds,
+    distance,
+    capacityByResource = {},
+    transportMode = 'land',
+    riskLevel = 0,
+    active = true,
+  }) {
+    this.id = TradeRoute.#requireText(id, 'TradeRoute id');
+    this.name = TradeRoute.#requireText(name, 'TradeRoute name');
+    this.stopCityIds = normalizeStops(stopCityIds);
+    this.distance = TradeRoute.#requireIntegerInRange(
+      distance,
+      'TradeRoute distance',
+      1,
+      Number.MAX_SAFE_INTEGER,
+    );
+    this.capacityByResource = normalizeCapacityByResource(capacityByResource);
+    this.transportMode = TradeRoute.#requireText(transportMode, 'TradeRoute transportMode');
+    this.riskLevel = TradeRoute.#requireIntegerInRange(riskLevel, 'TradeRoute riskLevel', 0, 100);
+    this.active = Boolean(active);
+  }
+
+  get originCityId() {
+    return this.stopCityIds[0];
+  }
+
+  get destinationCityId() {
+    return this.stopCityIds[this.stopCityIds.length - 1];
+  }
+
+  get totalCapacity() {
+    return Object.values(this.capacityByResource).reduce((sum, capacity) => sum + capacity, 0);
+  }
+
+  connects(cityId) {
+    const normalizedCityId = TradeRoute.#requireText(cityId, 'TradeRoute cityId');
+
+    return this.stopCityIds.includes(normalizedCityId);
+  }
+
+  withCapacity(resourceId, capacity) {
+    const normalizedResourceId = TradeRoute.#requireText(resourceId, 'TradeRoute resourceId');
+    const normalizedCapacity = TradeRoute.#requireIntegerInRange(
+      capacity,
+      'TradeRoute capacity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+
+    return new TradeRoute({
+      ...this.toJSON(),
+      capacityByResource: {
+        ...this.capacityByResource,
+        [normalizedResourceId]: normalizedCapacity,
+      },
+    });
+  }
+
+  withActive(active) {
+    return new TradeRoute({
+      ...this.toJSON(),
+      active,
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      name: this.name,
+      stopCityIds: [...this.stopCityIds],
+      distance: this.distance,
+      capacityByResource: { ...this.capacityByResource },
+      transportMode: this.transportMode,
+      riskLevel: this.riskLevel,
+      active: this.active,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+}

--- a/test/domain/economy/TradeRoute.test.js
+++ b/test/domain/economy/TradeRoute.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TradeRoute } from '../../../src/domain/economy/TradeRoute.js';
+
+test('TradeRoute normalizes route structure and capacities', () => {
+  const route = new TradeRoute({
+    id: ' route-north ',
+    name: ' Northern Grain Road ',
+    stopCityIds: [' city-harbor ', 'city-ford', 'city-capital'],
+    distance: 18,
+    capacityByResource: {
+      ' grain ': 120,
+      wood: 50,
+    },
+    transportMode: ' river ',
+    riskLevel: 12,
+    active: 1,
+  });
+
+  assert.deepEqual(route.toJSON(), {
+    id: 'route-north',
+    name: 'Northern Grain Road',
+    stopCityIds: ['city-harbor', 'city-ford', 'city-capital'],
+    distance: 18,
+    capacityByResource: { grain: 120, wood: 50 },
+    transportMode: 'river',
+    riskLevel: 12,
+    active: true,
+  });
+
+  assert.equal(route.originCityId, 'city-harbor');
+  assert.equal(route.destinationCityId, 'city-capital');
+  assert.equal(route.totalCapacity, 170);
+  assert.equal(route.connects('city-ford'), true);
+  assert.equal(route.connects('city-mine'), false);
+});
+
+test('TradeRoute supports immutable capacity and status updates', () => {
+  const route = new TradeRoute({
+    id: 'route-north',
+    name: 'Northern Grain Road',
+    stopCityIds: ['city-harbor', 'city-capital'],
+    distance: 18,
+    capacityByResource: {
+      grain: 120,
+    },
+  });
+
+  const expanded = route.withCapacity('wood', 40);
+  const suspended = expanded.withActive(false);
+
+  assert.notEqual(expanded, route);
+  assert.notEqual(suspended, expanded);
+  assert.deepEqual(route.capacityByResource, { grain: 120 });
+  assert.deepEqual(expanded.capacityByResource, { grain: 120, wood: 40 });
+  assert.equal(suspended.active, false);
+});
+
+test('TradeRoute rejects invalid topology and capacities', () => {
+  assert.throws(
+    () => new TradeRoute({ id: 'route', name: 'Road', stopCityIds: ['city-a'], distance: 10 }),
+    /TradeRoute stopCityIds must contain at least two cities/,
+  );
+
+  assert.throws(
+    () => new TradeRoute({ id: 'route', name: 'Road', stopCityIds: ['city-a', 'city-a'], distance: 10 }),
+    /TradeRoute stopCityIds cannot contain duplicates/,
+  );
+
+  assert.throws(
+    () => new TradeRoute({ id: 'route', name: 'Road', stopCityIds: ['city-a', 'city-b'], distance: 0 }),
+    /TradeRoute distance must be an integer between 1 and/,
+  );
+
+  assert.throws(
+    () => new TradeRoute({ id: 'route', name: 'Road', stopCityIds: ['city-a', 'city-b'], distance: 10, capacityByResource: { grain: -1 } }),
+    /TradeRoute capacities must be integers greater than or equal to 0/,
+  );
+});


### PR DESCRIPTION
## Summary
- add the Beta `TradeRoute` model for logistics links between cities
- normalize route stops and per-resource capacities with helper accessors
- cover invariants and immutable updates with node tests

## Testing
- npm test

Closes #24