### PR TITLE
Gamma: [G04] Define HistoricalEvent model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/domain/culture/HistoricalEvent.js
+++ b/src/domain/culture/HistoricalEvent.js
@@ -1,0 +1,152 @@
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+export class HistoricalEvent {
+  constructor({
+    id,
+    title,
+    category,
+    summary,
+    era,
+    importance,
+    triggeredAt,
+    affectedCultureIds = [],
+    divergencePointId = null,
+    discoveryIds = [],
+    tags = [],
+    resolved = false,
+    resolvedAt = null,
+  }) {
+    this.id = HistoricalEvent.#requireText(id, 'HistoricalEvent id');
+    this.title = HistoricalEvent.#requireText(title, 'HistoricalEvent title');
+    this.category = HistoricalEvent.#requireText(category, 'HistoricalEvent category');
+    this.summary = HistoricalEvent.#requireText(summary, 'HistoricalEvent summary');
+    this.era = HistoricalEvent.#requireText(era, 'HistoricalEvent era');
+    this.importance = HistoricalEvent.#requireIntegerInRange(
+      importance,
+      'HistoricalEvent importance',
+      1,
+      5,
+    );
+    this.triggeredAt = HistoricalEvent.#normalizeDate(
+      triggeredAt,
+      'HistoricalEvent triggeredAt',
+    );
+    this.affectedCultureIds = normalizeUniqueTexts(
+      affectedCultureIds,
+      'HistoricalEvent affectedCultureIds',
+    );
+    this.divergencePointId = HistoricalEvent.#normalizeOptionalText(
+      divergencePointId,
+      'HistoricalEvent divergencePointId',
+    );
+    this.discoveryIds = normalizeUniqueTexts(discoveryIds, 'HistoricalEvent discoveryIds');
+    this.tags = normalizeUniqueTexts(tags, 'HistoricalEvent tags');
+    this.resolved = Boolean(resolved);
+    this.resolvedAt = HistoricalEvent.#normalizeOptionalDate(resolvedAt, 'HistoricalEvent resolvedAt');
+
+    if (this.resolved && this.resolvedAt === null) {
+      throw new RangeError('HistoricalEvent resolvedAt is required when event is resolved.');
+    }
+
+    if (!this.resolved && this.resolvedAt !== null) {
+      throw new RangeError('HistoricalEvent resolvedAt must be null when event is unresolved.');
+    }
+  }
+
+  affectsCulture(cultureId) {
+    return this.affectedCultureIds.includes(HistoricalEvent.#requireText(cultureId, 'cultureId'));
+  }
+
+  withDiscoveries(discoveryIds) {
+    return new HistoricalEvent({
+      ...this.toJSON(),
+      discoveryIds,
+    });
+  }
+
+  resolve(resolvedAt = new Date()) {
+    return new HistoricalEvent({
+      ...this.toJSON(),
+      resolved: true,
+      resolvedAt,
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      title: this.title,
+      category: this.category,
+      summary: this.summary,
+      era: this.era,
+      importance: this.importance,
+      triggeredAt: this.triggeredAt.toISOString(),
+      affectedCultureIds: [...this.affectedCultureIds],
+      divergencePointId: this.divergencePointId,
+      discoveryIds: [...this.discoveryIds],
+      tags: [...this.tags],
+      resolved: this.resolved,
+      resolvedAt: this.resolvedAt?.toISOString() ?? null,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #normalizeOptionalText(value, label) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    return HistoricalEvent.#requireText(value, label);
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+
+  static #normalizeDate(value, label) {
+    if (value === null || value === undefined) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    const normalizedValue = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(normalizedValue.getTime())) {
+      throw new RangeError(`${label} must be a valid date.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #normalizeOptionalDate(value, label) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    return HistoricalEvent.#normalizeDate(value, label);
+  }
+}

--- a/test/domain/culture/HistoricalEvent.test.js
+++ b/test/domain/culture/HistoricalEvent.test.js
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
+
+test('HistoricalEvent keeps normalized alternate history event fields', () => {
+  const historicalEvent = new HistoricalEvent({
+    id: ' event-ashen-harbors ',
+    title: ' Ashen Harbors ',
+    category: ' catastrophe ',
+    summary: ' Coastal ports close after a season of volcanic ash and failed harvests. ',
+    era: ' late-antiquity ',
+    importance: 4,
+    triggeredAt: '2026-04-18T12:20:00.000Z',
+    affectedCultureIds: ['culture-west', ' culture-east ', 'culture-west'],
+    divergencePointId: ' divergence-fork-01 ',
+    discoveryIds: ['ash-navigation', ' harbor-rationing ', 'ash-navigation'],
+    tags: ['maritime', ' crisis ', 'maritime'],
+  });
+
+  assert.deepEqual(historicalEvent.toJSON(), {
+    id: 'event-ashen-harbors',
+    title: 'Ashen Harbors',
+    category: 'catastrophe',
+    summary: 'Coastal ports close after a season of volcanic ash and failed harvests.',
+    era: 'late-antiquity',
+    importance: 4,
+    triggeredAt: '2026-04-18T12:20:00.000Z',
+    affectedCultureIds: ['culture-east', 'culture-west'],
+    divergencePointId: 'divergence-fork-01',
+    discoveryIds: ['ash-navigation', 'harbor-rationing'],
+    tags: ['crisis', 'maritime'],
+    resolved: false,
+    resolvedAt: null,
+  });
+
+  assert.equal(historicalEvent.affectsCulture('culture-east'), true);
+  assert.equal(historicalEvent.affectsCulture('culture-south'), false);
+});
+
+test('HistoricalEvent can refresh discoveries immutably', () => {
+  const historicalEvent = new HistoricalEvent({
+    id: 'event-ashen-harbors',
+    title: 'Ashen Harbors',
+    category: 'catastrophe',
+    summary: 'Coastal ports close after a season of volcanic ash and failed harvests.',
+    era: 'late-antiquity',
+    importance: 4,
+    triggeredAt: '2026-04-18T12:20:00.000Z',
+  });
+
+  const updatedHistoricalEvent = historicalEvent.withDiscoveries([
+    'ash-navigation',
+    ' harbor-rationing ',
+    'ash-navigation',
+  ]);
+
+  assert.notEqual(updatedHistoricalEvent, historicalEvent);
+  assert.deepEqual(updatedHistoricalEvent.discoveryIds, ['ash-navigation', 'harbor-rationing']);
+  assert.deepEqual(historicalEvent.discoveryIds, []);
+});
+
+test('HistoricalEvent can resolve immutably with a resolution timestamp', () => {
+  const historicalEvent = new HistoricalEvent({
+    id: 'event-ashen-harbors',
+    title: 'Ashen Harbors',
+    category: 'catastrophe',
+    summary: 'Coastal ports close after a season of volcanic ash and failed harvests.',
+    era: 'late-antiquity',
+    importance: 4,
+    triggeredAt: '2026-04-18T12:20:00.000Z',
+  });
+  const resolvedAt = new Date('2026-04-18T12:30:00.000Z');
+
+  const resolvedHistoricalEvent = historicalEvent.resolve(resolvedAt);
+
+  assert.notEqual(resolvedHistoricalEvent, historicalEvent);
+  assert.equal(resolvedHistoricalEvent.resolved, true);
+  assert.equal(resolvedHistoricalEvent.resolvedAt?.toISOString(), resolvedAt.toISOString());
+  assert.equal(historicalEvent.resolved, false);
+  assert.equal(historicalEvent.resolvedAt, null);
+});
+
+test('HistoricalEvent rejects invalid identifiers, importance, and resolution invariants', () => {
+  assert.throws(
+    () =>
+      new HistoricalEvent({
+        id: '',
+        title: 'Ashen Harbors',
+        category: 'catastrophe',
+        summary: 'Summary',
+        era: 'late-antiquity',
+        importance: 4,
+        triggeredAt: '2026-04-18T12:20:00.000Z',
+      }),
+    /HistoricalEvent id is required/,
+  );
+
+  assert.throws(
+    () =>
+      new HistoricalEvent({
+        id: 'event-ashen-harbors',
+        title: 'Ashen Harbors',
+        category: 'catastrophe',
+        summary: 'Summary',
+        era: 'late-antiquity',
+        importance: 0,
+        triggeredAt: '2026-04-18T12:20:00.000Z',
+      }),
+    /HistoricalEvent importance must be an integer between 1 and 5/,
+  );
+
+  assert.throws(
+    () =>
+      new HistoricalEvent({
+        id: 'event-ashen-harbors',
+        title: 'Ashen Harbors',
+        category: 'catastrophe',
+        summary: 'Summary',
+        era: 'late-antiquity',
+        importance: 4,
+        triggeredAt: 'not-a-date',
+      }),
+    /HistoricalEvent triggeredAt must be a valid date/,
+  );
+
+  assert.throws(
+    () =>
+      new HistoricalEvent({
+        id: 'event-ashen-harbors',
+        title: 'Ashen Harbors',
+        category: 'catastrophe',
+        summary: 'Summary',
+        era: 'late-antiquity',
+        importance: 4,
+        triggeredAt: '2026-04-18T12:20:00.000Z',
+        resolved: true,
+      }),
+    /HistoricalEvent resolvedAt is required when event is resolved/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add the initial `HistoricalEvent` domain model for alternate history events
- Gamma: normalize cultural impact, discovery ids, tags, divergence linkage, and resolution fields
- Gamma: cover discovery updates, resolution, and invariant validation with node tests

## Related issue

- Gamma: closes #44

## Changes

- Gamma: bootstrap the repository with a minimal Node test setup
- Gamma: add `src/domain/culture/HistoricalEvent.js` with serialization and immutable update helpers
- Gamma: add `test/domain/culture/HistoricalEvent.test.js` for event lifecycle behavior

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: @Zeta, could you validate this PR before merge?
