### PR TITLE
Alpha: [A07] Implement ExpandTerritory use case

### DIFF
--- a/src/application/war/ExpandTerritory.js
+++ b/src/application/war/ExpandTerritory.js
@@ -1,0 +1,64 @@
+function normalizeText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+export class ExpandTerritory {
+  execute({ factionId, sourceProvinceId, targetProvinceId, provinces, capturedAt = new Date() }) {
+    const normalizedFactionId = normalizeText(factionId, 'ExpandTerritory factionId');
+    const normalizedSourceProvinceId = normalizeText(
+      sourceProvinceId,
+      'ExpandTerritory sourceProvinceId',
+    );
+    const normalizedTargetProvinceId = normalizeText(
+      targetProvinceId,
+      'ExpandTerritory targetProvinceId',
+    );
+
+    if (!Array.isArray(provinces)) {
+      throw new TypeError('ExpandTerritory provinces must be an array.');
+    }
+
+    const provinceById = new Map(provinces.map((province) => [province.id, province]));
+    const sourceProvince = provinceById.get(normalizedSourceProvinceId);
+    const targetProvince = provinceById.get(normalizedTargetProvinceId);
+
+    if (!sourceProvince) {
+      throw new RangeError('ExpandTerritory sourceProvinceId must reference an existing province.');
+    }
+
+    if (!targetProvince) {
+      throw new RangeError('ExpandTerritory targetProvinceId must reference an existing province.');
+    }
+
+    if (sourceProvince.controllingFactionId !== normalizedFactionId) {
+      throw new RangeError('ExpandTerritory source province must be controlled by the expanding faction.');
+    }
+
+    if (
+      !sourceProvince.neighborIds.includes(targetProvince.id) ||
+      !targetProvince.neighborIds.includes(sourceProvince.id)
+    ) {
+      throw new RangeError('ExpandTerritory target province must be adjacent to the source province.');
+    }
+
+    if (targetProvince.controllingFactionId === normalizedFactionId) {
+      return {
+        expanded: false,
+        province: targetProvince,
+        reason: 'already-controlled',
+      };
+    }
+
+    return {
+      expanded: true,
+      province: targetProvince.withControllingFaction(normalizedFactionId, capturedAt),
+      reason: 'captured',
+    };
+  }
+}

--- a/test/application/war/ExpandTerritory.test.js
+++ b/test/application/war/ExpandTerritory.test.js
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ExpandTerritory } from '../../../src/application/war/ExpandTerritory.js';
+import { Province } from '../../../src/domain/war/Province.js';
+
+function createProvince(overrides) {
+  return new Province({
+    id: 'prov-a',
+    name: 'Province',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    neighborIds: [],
+    ...overrides,
+  });
+}
+
+test('ExpandTerritory captures an adjacent enemy province', () => {
+  const expandTerritory = new ExpandTerritory();
+  const capturedAt = new Date('2026-04-18T12:25:00.000Z');
+  const provinces = [
+    createProvince({ id: 'prov-a', neighborIds: ['prov-b'] }),
+    createProvince({
+      id: 'prov-b',
+      ownerFactionId: 'faction-b',
+      controllingFactionId: 'faction-b',
+      neighborIds: ['prov-a'],
+    }),
+  ];
+
+  const result = expandTerritory.execute({
+    factionId: 'faction-a',
+    sourceProvinceId: 'prov-a',
+    targetProvinceId: 'prov-b',
+    provinces,
+    capturedAt,
+  });
+
+  assert.equal(result.expanded, true);
+  assert.equal(result.reason, 'captured');
+  assert.equal(result.province.controllingFactionId, 'faction-a');
+  assert.equal(result.province.contested, true);
+  assert.equal(result.province.capturedAt?.toISOString(), capturedAt.toISOString());
+
+  assert.equal(provinces[1].controllingFactionId, 'faction-b');
+  assert.equal(provinces[1].capturedAt, null);
+});
+
+test('ExpandTerritory returns a no-op when the target is already controlled', () => {
+  const expandTerritory = new ExpandTerritory();
+  const provinces = [
+    createProvince({ id: 'prov-a', neighborIds: ['prov-b'] }),
+    createProvince({ id: 'prov-b', neighborIds: ['prov-a'] }),
+  ];
+
+  const result = expandTerritory.execute({
+    factionId: 'faction-a',
+    sourceProvinceId: 'prov-a',
+    targetProvinceId: 'prov-b',
+    provinces,
+  });
+
+  assert.equal(result.expanded, false);
+  assert.equal(result.reason, 'already-controlled');
+  assert.equal(result.province, provinces[1]);
+});
+
+test('ExpandTerritory rejects invalid province references and expansion attempts', () => {
+  const expandTerritory = new ExpandTerritory();
+  const provinces = [
+    createProvince({ id: 'prov-a', neighborIds: ['prov-b'] }),
+    createProvince({
+      id: 'prov-b',
+      ownerFactionId: 'faction-b',
+      controllingFactionId: 'faction-b',
+      neighborIds: ['prov-c'],
+    }),
+  ];
+
+  assert.throws(
+    () =>
+      expandTerritory.execute({
+        factionId: 'faction-c',
+        sourceProvinceId: 'prov-a',
+        targetProvinceId: 'prov-b',
+        provinces,
+      }),
+    /source province must be controlled by the expanding faction/,
+  );
+
+  assert.throws(
+    () =>
+      expandTerritory.execute({
+        factionId: 'faction-a',
+        sourceProvinceId: 'prov-a',
+        targetProvinceId: 'prov-b',
+        provinces: [provinces[0]],
+      }),
+    /targetProvinceId must reference an existing province/,
+  );
+
+  assert.throws(
+    () =>
+      expandTerritory.execute({
+        factionId: 'faction-a',
+        sourceProvinceId: 'prov-a',
+        targetProvinceId: 'prov-b',
+        provinces,
+      }),
+    /target province must be adjacent to the source province/,
+  );
+});


### PR DESCRIPTION
## Summary

- Alpha: add a first `ExpandTerritory` use case for capturing adjacent hostile provinces
- Alpha: validate faction control, province existence, and bidirectional adjacency before expansion
- Alpha: add node:test coverage for successful captures, no-op captures, and invalid expansion attempts

## Related issue

- Alpha: closes #7

## Changes

- Alpha: add `src/application/war/ExpandTerritory.js` with capture orchestration based on Province transitions
- Alpha: add `test/application/war/ExpandTerritory.test.js` for success, guard rails, and immutable behavior
- Alpha: keep the use case compatible with the Province entity already present on `main`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?