### PR TITLE
Delta: [D03] Define OperationClandestine model

### DIFF
--- a/src/domain/intrigue/OperationClandestine.js
+++ b/src/domain/intrigue/OperationClandestine.js
@@ -1,0 +1,162 @@
+const DEFAULT_DIFFICULTY = 50;
+const DEFAULT_DETECTION_RISK = 25;
+const DEFAULT_PROGRESS = 0;
+const DEFAULT_PHASE = 'planning';
+const ALLOWED_PHASES = new Set(['planning', 'infiltration', 'execution', 'exfiltration', 'completed', 'failed']);
+const ALLOWED_TYPES = new Set(['sabotage', 'rumor', 'intelligence', 'assassination', 'subversion']);
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+export class OperationClandestine {
+  constructor({
+    id,
+    celluleId,
+    targetFactionId,
+    type,
+    objective,
+    theaterId,
+    assignedAgentIds = [],
+    requiredAssetIds = [],
+    difficulty = DEFAULT_DIFFICULTY,
+    detectionRisk = DEFAULT_DETECTION_RISK,
+    progress = DEFAULT_PROGRESS,
+    phase = DEFAULT_PHASE,
+    heat = 0,
+  }) {
+    this.id = OperationClandestine.#requireText(id, 'OperationClandestine id');
+    this.celluleId = OperationClandestine.#requireText(celluleId, 'OperationClandestine celluleId');
+    this.targetFactionId = OperationClandestine.#requireText(
+      targetFactionId,
+      'OperationClandestine targetFactionId',
+    );
+    this.type = OperationClandestine.#normalizeType(type);
+    this.objective = OperationClandestine.#requireText(objective, 'OperationClandestine objective');
+    this.theaterId = OperationClandestine.#requireText(theaterId, 'OperationClandestine theaterId');
+    this.assignedAgentIds = normalizeUniqueTexts(
+      assignedAgentIds,
+      'OperationClandestine assignedAgentIds',
+    );
+    this.requiredAssetIds = normalizeUniqueTexts(
+      requiredAssetIds,
+      'OperationClandestine requiredAssetIds',
+    );
+    this.difficulty = OperationClandestine.#requireIntegerInRange(
+      difficulty,
+      'OperationClandestine difficulty',
+      0,
+      100,
+    );
+    this.detectionRisk = OperationClandestine.#requireIntegerInRange(
+      detectionRisk,
+      'OperationClandestine detectionRisk',
+      0,
+      100,
+    );
+    this.progress = OperationClandestine.#requireIntegerInRange(
+      progress,
+      'OperationClandestine progress',
+      0,
+      100,
+    );
+    this.phase = OperationClandestine.#normalizePhase(phase);
+    this.heat = OperationClandestine.#requireIntegerInRange(
+      heat,
+      'OperationClandestine heat',
+      0,
+      100,
+    );
+  }
+
+  get successWindow() {
+    return Math.max(0, 100 - this.difficulty - this.detectionRisk + this.progress);
+  }
+
+  get isResolved() {
+    return this.phase === 'completed' || this.phase === 'failed';
+  }
+
+  advance({ phase = this.phase, progress = this.progress, detectionRisk = this.detectionRisk, heat = this.heat }) {
+    return new OperationClandestine({
+      ...this.toJSON(),
+      phase,
+      progress,
+      detectionRisk,
+      heat,
+    });
+  }
+
+  assignAgent(agentId) {
+    return new OperationClandestine({
+      ...this.toJSON(),
+      assignedAgentIds: [...this.assignedAgentIds, agentId],
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      celluleId: this.celluleId,
+      targetFactionId: this.targetFactionId,
+      type: this.type,
+      objective: this.objective,
+      theaterId: this.theaterId,
+      assignedAgentIds: [...this.assignedAgentIds],
+      requiredAssetIds: [...this.requiredAssetIds],
+      difficulty: this.difficulty,
+      detectionRisk: this.detectionRisk,
+      progress: this.progress,
+      phase: this.phase,
+      heat: this.heat,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+
+  static #normalizeType(value) {
+    const normalizedValue = OperationClandestine.#requireText(value, 'OperationClandestine type');
+
+    if (!ALLOWED_TYPES.has(normalizedValue)) {
+      throw new RangeError(`OperationClandestine type must be one of: ${[...ALLOWED_TYPES].join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #normalizePhase(value) {
+    const normalizedValue = OperationClandestine.#requireText(value, 'OperationClandestine phase');
+
+    if (!ALLOWED_PHASES.has(normalizedValue)) {
+      throw new RangeError(`OperationClandestine phase must be one of: ${[...ALLOWED_PHASES].join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+}

--- a/test/domain/intrigue/OperationClandestine.test.js
+++ b/test/domain/intrigue/OperationClandestine.test.js
@@ -1,0 +1,130 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { OperationClandestine } from '../../../src/domain/intrigue/OperationClandestine.js';
+
+test('OperationClandestine normalizes operation planning fields', () => {
+  const operation = new OperationClandestine({
+    id: ' op-cendre ',
+    celluleId: ' cellule-ombre ',
+    targetFactionId: ' faction-aube ',
+    type: 'sabotage',
+    objective: ' saboter les arsenaux côtiers ',
+    theaterId: ' port-nord ',
+    assignedAgentIds: ['agent-b', ' agent-a ', 'agent-b'],
+    requiredAssetIds: ['asset-dock', ' asset-guild ', 'asset-dock'],
+    difficulty: 63,
+    detectionRisk: 28,
+    progress: 17,
+    phase: 'planning',
+    heat: 12,
+  });
+
+  assert.deepEqual(operation.toJSON(), {
+    id: 'op-cendre',
+    celluleId: 'cellule-ombre',
+    targetFactionId: 'faction-aube',
+    type: 'sabotage',
+    objective: 'saboter les arsenaux côtiers',
+    theaterId: 'port-nord',
+    assignedAgentIds: ['agent-a', 'agent-b'],
+    requiredAssetIds: ['asset-dock', 'asset-guild'],
+    difficulty: 63,
+    detectionRisk: 28,
+    progress: 17,
+    phase: 'planning',
+    heat: 12,
+  });
+
+  assert.equal(operation.successWindow, 26);
+  assert.equal(operation.isResolved, false);
+});
+
+test('OperationClandestine supports immutable phase and staffing updates', () => {
+  const operation = new OperationClandestine({
+    id: 'op-cendre',
+    celluleId: 'cellule-ombre',
+    targetFactionId: 'faction-aube',
+    type: 'intelligence',
+    objective: 'cartographier le réseau de messagers',
+    theaterId: 'port-nord',
+    phase: 'infiltration',
+    progress: 24,
+    detectionRisk: 34,
+    heat: 9,
+  });
+
+  const staffedOperation = operation.assignAgent('agent-corbeau');
+  const advancedOperation = staffedOperation.advance({
+    phase: 'execution',
+    progress: 61,
+    detectionRisk: 47,
+    heat: 31,
+  });
+
+  assert.notEqual(staffedOperation, operation);
+  assert.notEqual(advancedOperation, staffedOperation);
+  assert.deepEqual(staffedOperation.assignedAgentIds, ['agent-corbeau']);
+  assert.equal(advancedOperation.phase, 'execution');
+  assert.equal(advancedOperation.progress, 61);
+  assert.equal(advancedOperation.detectionRisk, 47);
+  assert.equal(advancedOperation.heat, 31);
+  assert.equal(operation.phase, 'infiltration');
+  assert.deepEqual(operation.assignedAgentIds, []);
+});
+
+test('OperationClandestine rejects invalid planning invariants', () => {
+  assert.throws(
+    () =>
+      new OperationClandestine({
+        id: '',
+        celluleId: 'cellule-ombre',
+        targetFactionId: 'faction-aube',
+        type: 'sabotage',
+        objective: 'saboter les arsenaux côtiers',
+        theaterId: 'port-nord',
+      }),
+    /OperationClandestine id is required/,
+  );
+
+  assert.throws(
+    () =>
+      new OperationClandestine({
+        id: 'op-cendre',
+        celluleId: 'cellule-ombre',
+        targetFactionId: 'faction-aube',
+        type: 'espionage',
+        objective: 'saboter les arsenaux côtiers',
+        theaterId: 'port-nord',
+      }),
+    /OperationClandestine type must be one of: sabotage, rumor, intelligence, assassination, subversion/,
+  );
+
+  assert.throws(
+    () =>
+      new OperationClandestine({
+        id: 'op-cendre',
+        celluleId: 'cellule-ombre',
+        targetFactionId: 'faction-aube',
+        type: 'sabotage',
+        objective: 'saboter les arsenaux côtiers',
+        theaterId: 'port-nord',
+        assignedAgentIds: ['agent-a', ''],
+      }),
+    /OperationClandestine assignedAgentIds cannot contain empty values/,
+  );
+
+  assert.throws(
+    () =>
+      new OperationClandestine({
+        id: 'op-cendre',
+        celluleId: 'cellule-ombre',
+        targetFactionId: 'faction-aube',
+        type: 'sabotage',
+        objective: 'saboter les arsenaux côtiers',
+        theaterId: 'port-nord',
+        phase: 'escaping',
+      }),
+    /OperationClandestine phase must be one of: planning, infiltration, execution, exfiltration, completed, failed/,
+  );
+});


### PR DESCRIPTION
## Summary

- Delta: add the core intrigue mission model, `OperationClandestine`
- Delta: model targets, assigned agents, required assets, difficulty, detection risk, progress, phase, and heat
- Delta: cover invariants and immutable staffing/progress transitions with node tests

## Related issue

- Delta: closes #63

## Changes

- Delta: add `src/domain/intrigue/OperationClandestine.js`
- Delta: add `test/domain/intrigue/OperationClandestine.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Delta: `successWindow` gives a simple derived score for future intrigue resolution use cases.
- Delta: Please review for validation before merge, Zeta.
