### PR TITLE
Beta: implement ProduceResources use case

### DIFF
--- a/src/application/economy/ProduceResources.js
+++ b/src/application/economy/ProduceResources.js
@@ -1,0 +1,124 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeResourceMap(resources, label) {
+  requireObject(resources, label);
+
+  return Object.fromEntries(
+    Object.entries(resources)
+      .map(([resourceId, quantity]) => {
+        const normalizedResourceId = String(resourceId).trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError(`${label} cannot contain an empty resource id.`);
+        }
+
+        if (!Number.isInteger(quantity) || quantity < 0) {
+          throw new RangeError(`${label} quantities must be integers greater than or equal to 0.`);
+        }
+
+        return [normalizedResourceId, quantity];
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function getMissingRequirements(stock, requirements) {
+  return Object.entries(requirements)
+    .filter(([resourceId, quantity]) => (stock[resourceId] ?? 0) < quantity)
+    .map(([resourceId, quantity]) => ({
+      resourceId,
+      required: quantity,
+      available: stock[resourceId] ?? 0,
+    }));
+}
+
+export function produceResources({ city, rule, stockByResource = city?.stockByResource ?? {} }) {
+  const normalizedCity = requireObject(city, 'ProduceResources city');
+  const normalizedRule = requireObject(rule, 'ProduceResources rule');
+  const normalizedStock = normalizeResourceMap(stockByResource, 'ProduceResources stockByResource');
+  const workforceAvailable = normalizedCity.workforce;
+
+  if (!Number.isInteger(workforceAvailable) || workforceAvailable < 0) {
+    throw new RangeError('ProduceResources city workforce must be an integer greater than or equal to 0.');
+  }
+
+  const workforceRequired = normalizedRule.workforceRequired;
+
+  if (!Number.isInteger(workforceRequired) || workforceRequired < 0) {
+    throw new RangeError('ProduceResources rule workforceRequired must be an integer greater than or equal to 0.');
+  }
+
+  const inputByResource = normalizeResourceMap(
+    normalizedRule.inputByResource ?? {},
+    'ProduceResources rule inputByResource',
+  );
+  const outputByResource = normalizeResourceMap(
+    normalizedRule.outputByResource ?? {},
+    'ProduceResources rule outputByResource',
+  );
+
+  if (Object.keys(outputByResource).length === 0) {
+    throw new RangeError('ProduceResources rule outputByResource must define at least one produced resource.');
+  }
+
+  if (normalizedRule.enabled === false) {
+    return {
+      executed: false,
+      reason: 'rule-disabled',
+      nextStockByResource: { ...normalizedStock },
+      consumedByResource: {},
+      producedByResource: {},
+      workforceUsed: 0,
+    };
+  }
+
+  if (workforceAvailable < workforceRequired) {
+    return {
+      executed: false,
+      reason: 'insufficient-workforce',
+      nextStockByResource: { ...normalizedStock },
+      consumedByResource: {},
+      producedByResource: {},
+      workforceUsed: 0,
+    };
+  }
+
+  const missingRequirements = getMissingRequirements(normalizedStock, inputByResource);
+
+  if (missingRequirements.length > 0) {
+    return {
+      executed: false,
+      reason: 'insufficient-inputs',
+      nextStockByResource: { ...normalizedStock },
+      consumedByResource: {},
+      producedByResource: {},
+      workforceUsed: 0,
+      missingRequirements,
+    };
+  }
+
+  const nextStockByResource = { ...normalizedStock };
+
+  for (const [resourceId, quantity] of Object.entries(inputByResource)) {
+    nextStockByResource[resourceId] -= quantity;
+  }
+
+  for (const [resourceId, quantity] of Object.entries(outputByResource)) {
+    nextStockByResource[resourceId] = (nextStockByResource[resourceId] ?? 0) + quantity;
+  }
+
+  return {
+    executed: true,
+    reason: 'produced',
+    nextStockByResource,
+    consumedByResource: inputByResource,
+    producedByResource: outputByResource,
+    workforceUsed: workforceRequired,
+  };
+}

--- a/test/application/economy/ProduceResources.test.js
+++ b/test/application/economy/ProduceResources.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { produceResources } from '../../../src/application/economy/ProduceResources.js';
+
+test('ProduceResources consumes inputs and adds outputs when requirements are met', () => {
+  const result = produceResources({
+    city: {
+      id: 'city-harbor',
+      workforce: 45,
+      stockByResource: {
+        fish: 30,
+        wood: 10,
+      },
+    },
+    rule: {
+      id: 'rule-smokehouse',
+      workforceRequired: 20,
+      inputByResource: {
+        fish: 18,
+        wood: 4,
+      },
+      outputByResource: {
+        'smoked-fish': 12,
+      },
+    },
+  });
+
+  assert.deepEqual(result, {
+    executed: true,
+    reason: 'produced',
+    nextStockByResource: {
+      fish: 12,
+      wood: 6,
+      'smoked-fish': 12,
+    },
+    consumedByResource: {
+      fish: 18,
+      wood: 4,
+    },
+    producedByResource: {
+      'smoked-fish': 12,
+    },
+    workforceUsed: 20,
+  });
+});
+
+test('ProduceResources reports blocked execution for disabled rules or missing requirements', () => {
+  const disabledResult = produceResources({
+    city: { workforce: 45, stockByResource: { grain: 20 } },
+    rule: {
+      workforceRequired: 10,
+      outputByResource: { flour: 8 },
+      enabled: false,
+    },
+  });
+
+  assert.deepEqual(disabledResult, {
+    executed: false,
+    reason: 'rule-disabled',
+    nextStockByResource: { grain: 20 },
+    consumedByResource: {},
+    producedByResource: {},
+    workforceUsed: 0,
+  });
+
+  const missingInputsResult = produceResources({
+    city: { workforce: 45, stockByResource: { grain: 4 } },
+    rule: {
+      workforceRequired: 10,
+      inputByResource: { grain: 8, water: 2 },
+      outputByResource: { flour: 6 },
+    },
+  });
+
+  assert.equal(missingInputsResult.executed, false);
+  assert.equal(missingInputsResult.reason, 'insufficient-inputs');
+  assert.deepEqual(missingInputsResult.missingRequirements, [
+    { resourceId: 'grain', required: 8, available: 4 },
+    { resourceId: 'water', required: 2, available: 0 },
+  ]);
+});
+
+test('ProduceResources rejects invalid workforce and output definitions', () => {
+  assert.throws(
+    () => produceResources({ city: null, rule: {} }),
+    /ProduceResources city must be an object/,
+  );
+
+  assert.throws(
+    () => produceResources({ city: { workforce: -1 }, rule: { outputByResource: { grain: 1 } } }),
+    /ProduceResources city workforce must be an integer greater than or equal to 0/,
+  );
+
+  assert.throws(
+    () => produceResources({ city: { workforce: 1 }, rule: { workforceRequired: 1, outputByResource: {} } }),
+    /ProduceResources rule outputByResource must define at least one produced resource/,
+  );
+});


### PR DESCRIPTION
## Summary
- add the Beta `produceResources` use case for city production execution
- validate workforce and resource requirements, then return consumption and output deltas
- cover successful production, blocked execution, and invalid inputs with node tests

## Testing
- npm test

Closes #25