### PR TITLE
Alpha: [A08] Implement ResolveBorderPressure use case

### DIFF
--- a/src/application/war/ResolveBorderPressure.js
+++ b/src/application/war/ResolveBorderPressure.js
@@ -1,0 +1,59 @@
+function clampPressure(value) {
+  return Math.max(-100, Math.min(100, value));
+}
+
+function computeSupport(province) {
+  const occupationPenalty = province.isOccupied ? 15 : 0;
+  const contestedPenalty = province.contested ? 10 : 0;
+
+  return province.loyalty + province.strategicValue * 5 - occupationPenalty - contestedPenalty;
+}
+
+function computePressure(attackerProvince, defenderProvince) {
+  return clampPressure(computeSupport(attackerProvince) - computeSupport(defenderProvince));
+}
+
+function selectDominantProvince(leftProvince, rightProvince, pressure) {
+  if (pressure === 0) {
+    return null;
+  }
+
+  return pressure > 0 ? leftProvince.id : rightProvince.id;
+}
+
+export class ResolveBorderPressure {
+  execute({ leftProvince, rightProvince }) {
+    if (!leftProvince || !rightProvince) {
+      throw new RangeError('ResolveBorderPressure requires both leftProvince and rightProvince.');
+    }
+
+    if (leftProvince.id === rightProvince.id) {
+      throw new RangeError('ResolveBorderPressure provinces must be different.');
+    }
+
+    if (
+      !leftProvince.neighborIds.includes(rightProvince.id) ||
+      !rightProvince.neighborIds.includes(leftProvince.id)
+    ) {
+      throw new RangeError('ResolveBorderPressure provinces must be adjacent neighbors.');
+    }
+
+    if (leftProvince.controllingFactionId === rightProvince.controllingFactionId) {
+      return {
+        borderActive: false,
+        pressure: 0,
+        dominantProvinceId: null,
+        contested: false,
+      };
+    }
+
+    const pressure = computePressure(leftProvince, rightProvince);
+
+    return {
+      borderActive: true,
+      pressure,
+      dominantProvinceId: selectDominantProvince(leftProvince, rightProvince, pressure),
+      contested: Math.abs(pressure) < 20,
+    };
+  }
+}

--- a/test/application/war/ResolveBorderPressure.test.js
+++ b/test/application/war/ResolveBorderPressure.test.js
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ResolveBorderPressure } from '../../../src/application/war/ResolveBorderPressure.js';
+import { Province } from '../../../src/domain/war/Province.js';
+
+function createProvince(overrides) {
+  return new Province({
+    id: 'prov-a',
+    name: 'Province',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    loyalty: 50,
+    strategicValue: 1,
+    neighborIds: [],
+    ...overrides,
+  });
+}
+
+test('ResolveBorderPressure computes dominant pressure across an active border', () => {
+  const resolveBorderPressure = new ResolveBorderPressure();
+  const leftProvince = createProvince({
+    id: 'prov-a',
+    loyalty: 80,
+    strategicValue: 4,
+    neighborIds: ['prov-b'],
+  });
+  const rightProvince = createProvince({
+    id: 'prov-b',
+    ownerFactionId: 'faction-b',
+    controllingFactionId: 'faction-b',
+    loyalty: 30,
+    strategicValue: 1,
+    neighborIds: ['prov-a'],
+  });
+
+  assert.deepEqual(resolveBorderPressure.execute({ leftProvince, rightProvince }), {
+    borderActive: true,
+    pressure: 65,
+    dominantProvinceId: 'prov-a',
+    contested: false,
+  });
+});
+
+test('ResolveBorderPressure flags close fights as contested and neutralizes internal borders', () => {
+  const resolveBorderPressure = new ResolveBorderPressure();
+  const leftProvince = createProvince({
+    id: 'prov-a',
+    loyalty: 55,
+    strategicValue: 2,
+    contested: true,
+    neighborIds: ['prov-b'],
+  });
+  const rightProvince = createProvince({
+    id: 'prov-b',
+    ownerFactionId: 'faction-b',
+    controllingFactionId: 'faction-b',
+    loyalty: 58,
+    strategicValue: 2,
+    contested: true,
+    neighborIds: ['prov-a'],
+  });
+
+  assert.deepEqual(resolveBorderPressure.execute({ leftProvince, rightProvince }), {
+    borderActive: true,
+    pressure: -3,
+    dominantProvinceId: 'prov-b',
+    contested: true,
+  });
+
+  const alliedProvince = createProvince({ id: 'prov-c', neighborIds: ['prov-a'] });
+  const alliedBorderProvince = createProvince({
+    id: 'prov-a',
+    loyalty: 55,
+    strategicValue: 2,
+    contested: true,
+    neighborIds: ['prov-c'],
+  });
+
+  assert.deepEqual(resolveBorderPressure.execute({ leftProvince: alliedBorderProvince, rightProvince: alliedProvince }), {
+    borderActive: false,
+    pressure: 0,
+    dominantProvinceId: null,
+    contested: false,
+  });
+});
+
+test('ResolveBorderPressure rejects missing, duplicate, or non-adjacent provinces', () => {
+  const resolveBorderPressure = new ResolveBorderPressure();
+  const leftProvince = createProvince({ id: 'prov-a', neighborIds: ['prov-b'] });
+  const rightProvince = createProvince({
+    id: 'prov-b',
+    ownerFactionId: 'faction-b',
+    controllingFactionId: 'faction-b',
+    neighborIds: [],
+  });
+
+  assert.throws(
+    () => resolveBorderPressure.execute({ leftProvince: null, rightProvince }),
+    /requires both leftProvince and rightProvince/,
+  );
+
+  assert.throws(
+    () => resolveBorderPressure.execute({ leftProvince, rightProvince: leftProvince }),
+    /provinces must be different/,
+  );
+
+  assert.throws(
+    () => resolveBorderPressure.execute({ leftProvince, rightProvince }),
+    /provinces must be adjacent neighbors/,
+  );
+});


### PR DESCRIPTION
## Summary

- Alpha: add a first `ResolveBorderPressure` use case for contested province borders
- Alpha: compute border pressure from loyalty, strategic value, occupation, and contested penalties
- Alpha: add node:test coverage for dominant borders, close fights, internal borders, and invalid adjacency

## Related issue

- Alpha: closes #8

## Changes

- Alpha: add `src/application/war/ResolveBorderPressure.js` with pressure scoring and border state resolution
- Alpha: add `test/application/war/ResolveBorderPressure.test.js` for active borders, contested outcomes, and guard rails
- Alpha: keep the use case compatible with the Province entity already present on `main`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?