### PR TITLE
Beta: implement ConsumeNeeds use case

### DIFF
--- a/src/application/economy/ConsumeNeeds.js
+++ b/src/application/economy/ConsumeNeeds.js
@@ -1,0 +1,86 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeResourceMap(resources, label) {
+  requireObject(resources, label);
+
+  return Object.fromEntries(
+    Object.entries(resources)
+      .map(([resourceId, quantity]) => {
+        const normalizedResourceId = String(resourceId).trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError(`${label} cannot contain an empty resource id.`);
+        }
+
+        if (!Number.isInteger(quantity) || quantity < 0) {
+          throw new RangeError(`${label} quantities must be integers greater than or equal to 0.`);
+        }
+
+        return [normalizedResourceId, quantity];
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function consumeNeeds({ city, needsByResource, stockByResource = city?.stockByResource ?? {} }) {
+  const normalizedCity = requireObject(city, 'ConsumeNeeds city');
+  const normalizedNeeds = normalizeResourceMap(needsByResource, 'ConsumeNeeds needsByResource');
+  const normalizedStock = normalizeResourceMap(stockByResource, 'ConsumeNeeds stockByResource');
+
+  const prosperity = normalizedCity.prosperity ?? 50;
+  const stability = normalizedCity.stability ?? 50;
+
+  if (!Number.isInteger(prosperity) || prosperity < 0 || prosperity > 100) {
+    throw new RangeError('ConsumeNeeds city prosperity must be an integer between 0 and 100.');
+  }
+
+  if (!Number.isInteger(stability) || stability < 0 || stability > 100) {
+    throw new RangeError('ConsumeNeeds city stability must be an integer between 0 and 100.');
+  }
+
+  const nextStockByResource = { ...normalizedStock };
+  const consumedByResource = {};
+  const shortagesByResource = {};
+
+  for (const [resourceId, requiredQuantity] of Object.entries(normalizedNeeds)) {
+    const availableQuantity = nextStockByResource[resourceId] ?? 0;
+    const consumedQuantity = Math.min(availableQuantity, requiredQuantity);
+    const shortageQuantity = requiredQuantity - consumedQuantity;
+
+    nextStockByResource[resourceId] = availableQuantity - consumedQuantity;
+    consumedByResource[resourceId] = consumedQuantity;
+
+    if (shortageQuantity > 0) {
+      shortagesByResource[resourceId] = shortageQuantity;
+    }
+  }
+
+  const totalNeeds = Object.values(normalizedNeeds).reduce((sum, quantity) => sum + quantity, 0);
+  const totalConsumed = Object.values(consumedByResource).reduce((sum, quantity) => sum + quantity, 0);
+  const satisfactionRatio = totalNeeds === 0 ? 1 : totalConsumed / totalNeeds;
+  const shortageRatio = 1 - satisfactionRatio;
+  const prosperityDelta = totalNeeds === 0 ? 0 : 0 - Math.ceil(shortageRatio * 12);
+  const stabilityDelta = totalNeeds === 0 ? 0 : 0 - Math.ceil(shortageRatio * 18);
+
+  return {
+    fullySatisfied: Object.keys(shortagesByResource).length === 0,
+    satisfactionRatio,
+    nextStockByResource,
+    consumedByResource,
+    shortagesByResource,
+    prosperityDelta,
+    stabilityDelta,
+    nextProsperity: clamp(prosperity + prosperityDelta, 0, 100),
+    nextStability: clamp(stability + stabilityDelta, 0, 100),
+  };
+}

--- a/test/application/economy/ConsumeNeeds.test.js
+++ b/test/application/economy/ConsumeNeeds.test.js
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { consumeNeeds } from '../../../src/application/economy/ConsumeNeeds.js';
+
+test('ConsumeNeeds deducts required stock when the city can satisfy all needs', () => {
+  const result = consumeNeeds({
+    city: {
+      prosperity: 64,
+      stability: 71,
+      stockByResource: {
+        grain: 20,
+        water: 12,
+      },
+    },
+    needsByResource: {
+      grain: 8,
+      water: 6,
+    },
+  });
+
+  assert.deepEqual(result, {
+    fullySatisfied: true,
+    satisfactionRatio: 1,
+    nextStockByResource: {
+      grain: 12,
+      water: 6,
+    },
+    consumedByResource: {
+      grain: 8,
+      water: 6,
+    },
+    shortagesByResource: {},
+    prosperityDelta: 0,
+    stabilityDelta: 0,
+    nextProsperity: 64,
+    nextStability: 71,
+  });
+});
+
+test('ConsumeNeeds reports shortages and applies prosperity and stability penalties', () => {
+  const result = consumeNeeds({
+    city: {
+      prosperity: 50,
+      stability: 44,
+      stockByResource: {
+        grain: 3,
+        water: 1,
+      },
+    },
+    needsByResource: {
+      grain: 8,
+      water: 4,
+    },
+  });
+
+  assert.equal(result.fullySatisfied, false);
+  assert.equal(result.satisfactionRatio, 4 / 12);
+  assert.deepEqual(result.nextStockByResource, {
+    grain: 0,
+    water: 0,
+  });
+  assert.deepEqual(result.consumedByResource, {
+    grain: 3,
+    water: 1,
+  });
+  assert.deepEqual(result.shortagesByResource, {
+    grain: 5,
+    water: 3,
+  });
+  assert.equal(result.prosperityDelta, -8);
+  assert.equal(result.stabilityDelta, -13);
+  assert.equal(result.nextProsperity, 42);
+  assert.equal(result.nextStability, 31);
+});
+
+test('ConsumeNeeds rejects invalid city state and malformed resource maps', () => {
+  assert.throws(
+    () => consumeNeeds({ city: null, needsByResource: {} }),
+    /ConsumeNeeds city must be an object/,
+  );
+
+  assert.throws(
+    () => consumeNeeds({ city: { prosperity: 101, stability: 50 }, needsByResource: {} }),
+    /ConsumeNeeds city prosperity must be an integer between 0 and 100/,
+  );
+
+  assert.throws(
+    () => consumeNeeds({ city: { prosperity: 50, stability: 50 }, needsByResource: { ' ': 1 } }),
+    /ConsumeNeeds needsByResource cannot contain an empty resource id/,
+  );
+
+  assert.throws(
+    () => consumeNeeds({ city: { prosperity: 50, stability: 50 }, needsByResource: { grain: 1 }, stockByResource: { grain: -1 } }),
+    /ConsumeNeeds stockByResource quantities must be integers greater than or equal to 0/,
+  );
+});


### PR DESCRIPTION
## Summary
- add the Beta `consumeNeeds` use case for city consumption and shortages
- deduct available stock, report unmet needs, and compute prosperity and stability penalties
- cover full satisfaction, shortages, and invalid inputs with node tests

## Testing
- npm test

Closes #26