### PR TITLE
Delta: [D04] Define Rumeur model

### DIFF
--- a/src/domain/intrigue/Rumeur.js
+++ b/src/domain/intrigue/Rumeur.js
@@ -1,0 +1,157 @@
+const DEFAULT_CREDIBILITY = 50;
+const DEFAULT_PROPAGATION = 0;
+const DEFAULT_TENSION = 0;
+const DEFAULT_STATUS = 'circulating';
+const ALLOWED_STATUSES = new Set(['circulating', 'contained', 'amplified', 'debunked']);
+const ALLOWED_CATEGORIES = new Set(['military', 'political', 'economic', 'religious', 'social']);
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+export class Rumeur {
+  constructor({
+    id,
+    sourceCelluleId,
+    targetFactionId,
+    category,
+    narrative,
+    originLocationId,
+    relayIds = [],
+    affectedPopulationIds = [],
+    credibility = DEFAULT_CREDIBILITY,
+    propagation = DEFAULT_PROPAGATION,
+    tension = DEFAULT_TENSION,
+    status = DEFAULT_STATUS,
+    truthValue = null,
+  }) {
+    this.id = Rumeur.#requireText(id, 'Rumeur id');
+    this.sourceCelluleId = Rumeur.#requireText(sourceCelluleId, 'Rumeur sourceCelluleId');
+    this.targetFactionId = Rumeur.#requireText(targetFactionId, 'Rumeur targetFactionId');
+    this.category = Rumeur.#normalizeCategory(category);
+    this.narrative = Rumeur.#requireText(narrative, 'Rumeur narrative');
+    this.originLocationId = Rumeur.#requireText(originLocationId, 'Rumeur originLocationId');
+    this.relayIds = normalizeUniqueTexts(relayIds, 'Rumeur relayIds');
+    this.affectedPopulationIds = normalizeUniqueTexts(
+      affectedPopulationIds,
+      'Rumeur affectedPopulationIds',
+    );
+    this.credibility = Rumeur.#requireIntegerInRange(
+      credibility,
+      'Rumeur credibility',
+      0,
+      100,
+    );
+    this.propagation = Rumeur.#requireIntegerInRange(
+      propagation,
+      'Rumeur propagation',
+      0,
+      100,
+    );
+    this.tension = Rumeur.#requireIntegerInRange(tension, 'Rumeur tension', 0, 100);
+    this.status = Rumeur.#normalizeStatus(status);
+    this.truthValue = Rumeur.#normalizeTruthValue(truthValue);
+  }
+
+  get influenceScore() {
+    return Math.max(0, Math.round((this.credibility + this.propagation + this.tension) / 3));
+  }
+
+  get isNeutralized() {
+    return this.status === 'contained' || this.status === 'debunked';
+  }
+
+  amplify({ propagation = this.propagation, tension = this.tension, status = 'amplified' }) {
+    return new Rumeur({
+      ...this.toJSON(),
+      propagation,
+      tension,
+      status,
+    });
+  }
+
+  addRelay(relayId) {
+    return new Rumeur({
+      ...this.toJSON(),
+      relayIds: [...this.relayIds, relayId],
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      sourceCelluleId: this.sourceCelluleId,
+      targetFactionId: this.targetFactionId,
+      category: this.category,
+      narrative: this.narrative,
+      originLocationId: this.originLocationId,
+      relayIds: [...this.relayIds],
+      affectedPopulationIds: [...this.affectedPopulationIds],
+      credibility: this.credibility,
+      propagation: this.propagation,
+      tension: this.tension,
+      status: this.status,
+      truthValue: this.truthValue,
+    };
+  }
+
+  static #requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+
+  static #normalizeCategory(value) {
+    const normalizedValue = Rumeur.#requireText(value, 'Rumeur category');
+
+    if (!ALLOWED_CATEGORIES.has(normalizedValue)) {
+      throw new RangeError(`Rumeur category must be one of: ${[...ALLOWED_CATEGORIES].join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #normalizeStatus(value) {
+    const normalizedValue = Rumeur.#requireText(value, 'Rumeur status');
+
+    if (!ALLOWED_STATUSES.has(normalizedValue)) {
+      throw new RangeError(`Rumeur status must be one of: ${[...ALLOWED_STATUSES].join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static #normalizeTruthValue(value) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value !== 'boolean') {
+      throw new TypeError('Rumeur truthValue must be a boolean or null.');
+    }
+
+    return value;
+  }
+}

--- a/test/domain/intrigue/Rumeur.test.js
+++ b/test/domain/intrigue/Rumeur.test.js
@@ -1,0 +1,125 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Rumeur } from '../../../src/domain/intrigue/Rumeur.js';
+
+test('Rumeur normalizes rumor spread fields', () => {
+  const rumeur = new Rumeur({
+    id: ' rumeur-cendre ',
+    sourceCelluleId: ' cellule-ombre ',
+    targetFactionId: ' faction-aube ',
+    category: 'political',
+    narrative: ' le conseil prépare une purge des guildes ',
+    originLocationId: ' port-nord ',
+    relayIds: ['relay-b', ' relay-a ', 'relay-b'],
+    affectedPopulationIds: ['dockers', ' guildes ', 'dockers'],
+    credibility: 67,
+    propagation: 54,
+    tension: 71,
+    truthValue: false,
+  });
+
+  assert.deepEqual(rumeur.toJSON(), {
+    id: 'rumeur-cendre',
+    sourceCelluleId: 'cellule-ombre',
+    targetFactionId: 'faction-aube',
+    category: 'political',
+    narrative: 'le conseil prépare une purge des guildes',
+    originLocationId: 'port-nord',
+    relayIds: ['relay-a', 'relay-b'],
+    affectedPopulationIds: ['dockers', 'guildes'],
+    credibility: 67,
+    propagation: 54,
+    tension: 71,
+    status: 'circulating',
+    truthValue: false,
+  });
+
+  assert.equal(rumeur.influenceScore, 64);
+  assert.equal(rumeur.isNeutralized, false);
+});
+
+test('Rumeur supports immutable relay and amplification updates', () => {
+  const rumeur = new Rumeur({
+    id: 'rumeur-cendre',
+    sourceCelluleId: 'cellule-ombre',
+    targetFactionId: 'faction-aube',
+    category: 'social',
+    narrative: 'des agents étrangers recrutent dans les tavernes',
+    originLocationId: 'port-nord',
+    propagation: 22,
+    tension: 31,
+    status: 'circulating',
+  });
+
+  const relayedRumeur = rumeur.addRelay('relay-guilde');
+  const amplifiedRumeur = relayedRumeur.amplify({
+    propagation: 64,
+    tension: 58,
+  });
+
+  assert.notEqual(relayedRumeur, rumeur);
+  assert.notEqual(amplifiedRumeur, relayedRumeur);
+  assert.deepEqual(relayedRumeur.relayIds, ['relay-guilde']);
+  assert.equal(amplifiedRumeur.status, 'amplified');
+  assert.equal(amplifiedRumeur.propagation, 64);
+  assert.equal(amplifiedRumeur.tension, 58);
+  assert.deepEqual(rumeur.relayIds, []);
+  assert.equal(rumeur.status, 'circulating');
+});
+
+test('Rumeur rejects invalid rumor invariants', () => {
+  assert.throws(
+    () =>
+      new Rumeur({
+        id: '',
+        sourceCelluleId: 'cellule-ombre',
+        targetFactionId: 'faction-aube',
+        category: 'political',
+        narrative: 'le conseil prépare une purge des guildes',
+        originLocationId: 'port-nord',
+      }),
+    /Rumeur id is required/,
+  );
+
+  assert.throws(
+    () =>
+      new Rumeur({
+        id: 'rumeur-cendre',
+        sourceCelluleId: 'cellule-ombre',
+        targetFactionId: 'faction-aube',
+        category: 'arcane',
+        narrative: 'le conseil prépare une purge des guildes',
+        originLocationId: 'port-nord',
+      }),
+    /Rumeur category must be one of: military, political, economic, religious, social/,
+  );
+
+  assert.throws(
+    () =>
+      new Rumeur({
+        id: 'rumeur-cendre',
+        sourceCelluleId: 'cellule-ombre',
+        targetFactionId: 'faction-aube',
+        category: 'political',
+        narrative: 'le conseil prépare une purge des guildes',
+        originLocationId: 'port-nord',
+        relayIds: ['relay-a', ''],
+      }),
+    /Rumeur relayIds cannot contain empty values/,
+  );
+
+  assert.throws(
+    () =>
+      new Rumeur({
+        id: 'rumeur-cendre',
+        sourceCelluleId: 'cellule-ombre',
+        targetFactionId: 'faction-aube',
+        category: 'political',
+        narrative: 'le conseil prépare une purge des guildes',
+        originLocationId: 'port-nord',
+        truthValue: 'unknown',
+      }),
+    /Rumeur truthValue must be a boolean or null/,
+  );
+});


### PR DESCRIPTION
## Summary

- Delta: add the intrigue rumor model, `Rumeur`
- Delta: model source cellule, target faction, category, relay network, affected populations, credibility, propagation, tension, and truth value
- Delta: cover invariants and immutable relay/amplification updates with node tests

## Related issue

- Delta: closes #64

## Changes

- Delta: add `src/domain/intrigue/Rumeur.js`
- Delta: add `test/domain/intrigue/Rumeur.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Delta: `influenceScore` gives a simple derived score for future rumor diffusion and counter-intelligence use cases.
- Delta: Please review for validation before merge, Zeta.
