### PR TITLE
Alpha: [A09] Implement StabilizeCapturedProvince use case

### DIFF
--- a/src/application/war/StabilizeCapturedProvince.js
+++ b/src/application/war/StabilizeCapturedProvince.js
@@ -1,0 +1,46 @@
+import { Province } from '../../domain/war/Province.js';
+
+const SUPPLY_RECOVERY = {
+  collapsed: 'disrupted',
+  disrupted: 'strained',
+  strained: 'stable',
+  stable: 'stable',
+  secure: 'secure',
+};
+
+function clampLoyalty(value) {
+  return Math.max(0, Math.min(100, value));
+}
+
+export class StabilizeCapturedProvince {
+  execute({ province, loyaltyGain = 10, supplyRecovery = true }) {
+    if (!(province instanceof Province)) {
+      throw new TypeError('StabilizeCapturedProvince province must be a Province instance.');
+    }
+
+    if (!province.isOccupied) {
+      return {
+        stabilized: false,
+        reason: 'not-occupied',
+        province,
+      };
+    }
+
+    if (!Number.isInteger(loyaltyGain) || loyaltyGain < 0) {
+      throw new RangeError('StabilizeCapturedProvince loyaltyGain must be a non-negative integer.');
+    }
+
+    const nextProvince = new Province({
+      ...province.toJSON(),
+      loyalty: clampLoyalty(province.loyalty + loyaltyGain),
+      contested: false,
+      supplyLevel: supplyRecovery ? SUPPLY_RECOVERY[province.supplyLevel] ?? province.supplyLevel : province.supplyLevel,
+    });
+
+    return {
+      stabilized: true,
+      reason: 'stabilized',
+      province: nextProvince,
+    };
+  }
+}

--- a/test/application/war/StabilizeCapturedProvince.test.js
+++ b/test/application/war/StabilizeCapturedProvince.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { StabilizeCapturedProvince } from '../../../src/application/war/StabilizeCapturedProvince.js';
+import { Province } from '../../../src/domain/war/Province.js';
+
+function createProvince(overrides) {
+  return new Province({
+    id: 'prov-1',
+    name: 'Province',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-b',
+    supplyLevel: 'disrupted',
+    loyalty: 35,
+    contested: true,
+    neighborIds: [],
+    capturedAt: '2026-04-18T12:00:00.000Z',
+    ...overrides,
+  });
+}
+
+test('StabilizeCapturedProvince calms a captured province and improves local supply', () => {
+  const stabilizeCapturedProvince = new StabilizeCapturedProvince();
+  const province = createProvince();
+
+  const result = stabilizeCapturedProvince.execute({ province, loyaltyGain: 12 });
+
+  assert.equal(result.stabilized, true);
+  assert.equal(result.reason, 'stabilized');
+  assert.notEqual(result.province, province);
+  assert.equal(result.province.loyalty, 47);
+  assert.equal(result.province.contested, false);
+  assert.equal(result.province.supplyLevel, 'strained');
+  assert.equal(result.province.capturedAt?.toISOString(), '2026-04-18T12:00:00.000Z');
+
+  assert.equal(province.loyalty, 35);
+  assert.equal(province.contested, true);
+  assert.equal(province.supplyLevel, 'disrupted');
+});
+
+test('StabilizeCapturedProvince is a no-op for provinces that are not occupied', () => {
+  const stabilizeCapturedProvince = new StabilizeCapturedProvince();
+  const province = createProvince({
+    controllingFactionId: 'faction-a',
+    contested: false,
+    supplyLevel: 'stable',
+  });
+
+  const result = stabilizeCapturedProvince.execute({ province, loyaltyGain: 20 });
+
+  assert.equal(result.stabilized, false);
+  assert.equal(result.reason, 'not-occupied');
+  assert.equal(result.province, province);
+});
+
+test('StabilizeCapturedProvince rejects invalid inputs and clamps loyalty growth', () => {
+  const stabilizeCapturedProvince = new StabilizeCapturedProvince();
+  const province = createProvince({ loyalty: 95, supplyLevel: 'secure' });
+
+  assert.throws(
+    () => stabilizeCapturedProvince.execute({ province: null }),
+    /province must be a Province instance/,
+  );
+
+  assert.throws(
+    () => stabilizeCapturedProvince.execute({ province, loyaltyGain: -1 }),
+    /loyaltyGain must be a non-negative integer/,
+  );
+
+  const result = stabilizeCapturedProvince.execute({ province, loyaltyGain: 20, supplyRecovery: false });
+
+  assert.equal(result.province.loyalty, 100);
+  assert.equal(result.province.supplyLevel, 'secure');
+});


### PR DESCRIPTION
## Summary

- Alpha: add a first `StabilizeCapturedProvince` use case for post-capture consolidation
- Alpha: clear contested status, improve loyalty, and optionally recover supply after occupation
- Alpha: add node:test coverage for stabilization, no-op behavior, and invalid inputs

## Related issue

- Alpha: closes #9

## Changes

- Alpha: add `src/application/war/StabilizeCapturedProvince.js` with stabilization rules for occupied provinces
- Alpha: add `test/application/war/StabilizeCapturedProvince.test.js` for recovery behavior, guard rails, and immutable results
- Alpha: keep the use case compatible with the Province entity already present on `main`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?