### PR TITLE
Gamma: [G06] Implement EvolveCulture use case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/application/culture/evolveCulture.js
+++ b/src/application/culture/evolveCulture.js
@@ -1,0 +1,168 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min, max) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function normalizeDate(value, label) {
+  const normalizedValue = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(normalizedValue.getTime())) {
+    throw new RangeError(`${label} must be a valid date.`);
+  }
+
+  return normalizedValue.toISOString();
+}
+
+function clampScore(value) {
+  return Math.max(0, Math.min(100, value));
+}
+
+function normalizeCulture(culture) {
+  if (!culture || typeof culture !== 'object') {
+    throw new TypeError('evolveCulture culture must be an object.');
+  }
+
+  return {
+    ...culture,
+    id: requireText(culture.id, 'evolveCulture culture.id'),
+    name: requireText(culture.name, 'evolveCulture culture.name'),
+    archetype: requireText(culture.archetype, 'evolveCulture culture.archetype'),
+    primaryLanguage: requireText(culture.primaryLanguage, 'evolveCulture culture.primaryLanguage'),
+    valueIds: normalizeUniqueTexts(culture.valueIds ?? [], 'evolveCulture culture.valueIds'),
+    traditionIds: normalizeUniqueTexts(culture.traditionIds ?? [], 'evolveCulture culture.traditionIds'),
+    openness: requireInteger(culture.openness ?? 50, 'evolveCulture culture.openness', 0, 100),
+    cohesion: requireInteger(culture.cohesion ?? 50, 'evolveCulture culture.cohesion', 0, 100),
+    researchDrive: requireInteger(
+      culture.researchDrive ?? 50,
+      'evolveCulture culture.researchDrive',
+      0,
+      100,
+    ),
+    lastEvolvedAt: culture.lastEvolvedAt ?? null,
+  };
+}
+
+function normalizeEvolution(evolution) {
+  if (!evolution || typeof evolution !== 'object') {
+    throw new TypeError('evolveCulture evolution must be an object.');
+  }
+
+  return {
+    opennessDelta: requireInteger(
+      evolution.opennessDelta ?? 0,
+      'evolveCulture evolution.opennessDelta',
+      -100,
+      100,
+    ),
+    cohesionDelta: requireInteger(
+      evolution.cohesionDelta ?? 0,
+      'evolveCulture evolution.cohesionDelta',
+      -100,
+      100,
+    ),
+    researchDriveDelta: requireInteger(
+      evolution.researchDriveDelta ?? 0,
+      'evolveCulture evolution.researchDriveDelta',
+      -100,
+      100,
+    ),
+    addedValueIds: normalizeUniqueTexts(
+      evolution.addedValueIds ?? [],
+      'evolveCulture evolution.addedValueIds',
+    ),
+    addedTraditionIds: normalizeUniqueTexts(
+      evolution.addedTraditionIds ?? [],
+      'evolveCulture evolution.addedTraditionIds',
+    ),
+    removedValueIds: normalizeUniqueTexts(
+      evolution.removedValueIds ?? [],
+      'evolveCulture evolution.removedValueIds',
+    ),
+    removedTraditionIds: normalizeUniqueTexts(
+      evolution.removedTraditionIds ?? [],
+      'evolveCulture evolution.removedTraditionIds',
+    ),
+    evolvedAt: normalizeDate(evolution.evolvedAt ?? new Date(), 'evolveCulture evolution.evolvedAt'),
+  };
+}
+
+function applyListEvolution(currentIds, addedIds, removedIds) {
+  const nextIds = new Set(currentIds);
+
+  for (const removedId of removedIds) {
+    nextIds.delete(removedId);
+  }
+
+  for (const addedId of addedIds) {
+    nextIds.add(addedId);
+  }
+
+  return [...nextIds].sort();
+}
+
+export function evolveCulture(culture, evolution) {
+  const normalizedCulture = normalizeCulture(culture);
+  const normalizedEvolution = normalizeEvolution(evolution);
+
+  const conflictingValueIds = normalizedEvolution.addedValueIds.filter((valueId) =>
+    normalizedEvolution.removedValueIds.includes(valueId),
+  );
+  const conflictingTraditionIds = normalizedEvolution.addedTraditionIds.filter((traditionId) =>
+    normalizedEvolution.removedTraditionIds.includes(traditionId),
+  );
+
+  if (conflictingValueIds.length > 0) {
+    throw new RangeError('evolveCulture cannot add and remove the same value id in one evolution.');
+  }
+
+  if (conflictingTraditionIds.length > 0) {
+    throw new RangeError('evolveCulture cannot add and remove the same tradition id in one evolution.');
+  }
+
+  return {
+    ...normalizedCulture,
+    openness: clampScore(normalizedCulture.openness + normalizedEvolution.opennessDelta),
+    cohesion: clampScore(normalizedCulture.cohesion + normalizedEvolution.cohesionDelta),
+    researchDrive: clampScore(
+      normalizedCulture.researchDrive + normalizedEvolution.researchDriveDelta,
+    ),
+    valueIds: applyListEvolution(
+      normalizedCulture.valueIds,
+      normalizedEvolution.addedValueIds,
+      normalizedEvolution.removedValueIds,
+    ),
+    traditionIds: applyListEvolution(
+      normalizedCulture.traditionIds,
+      normalizedEvolution.addedTraditionIds,
+      normalizedEvolution.removedTraditionIds,
+    ),
+    lastEvolvedAt: normalizedEvolution.evolvedAt,
+  };
+}

--- a/test/application/culture/evolveCulture.test.js
+++ b/test/application/culture/evolveCulture.test.js
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evolveCulture } from '../../../src/application/culture/evolveCulture.js';
+
+test('evolveCulture updates scores and cultural lists immutably', () => {
+  const culture = {
+    id: 'culture-aurora',
+    name: 'Aurora Compact',
+    archetype: 'mercantile',
+    primaryLanguage: 'trade-speech',
+    valueIds: ['craft', 'curiosity'],
+    traditionIds: ['harvest-song'],
+    openness: 58,
+    cohesion: 63,
+    researchDrive: 54,
+    lastEvolvedAt: null,
+  };
+
+  const evolvedCulture = evolveCulture(culture, {
+    opennessDelta: 8,
+    cohesionDelta: -5,
+    researchDriveDelta: 11,
+    addedValueIds: ['navigation'],
+    addedTraditionIds: [' river-moot '],
+    removedTraditionIds: ['harvest-song'],
+    evolvedAt: '2026-04-18T12:40:00.000Z',
+  });
+
+  assert.notEqual(evolvedCulture, culture);
+  assert.equal(evolvedCulture.openness, 66);
+  assert.equal(evolvedCulture.cohesion, 58);
+  assert.equal(evolvedCulture.researchDrive, 65);
+  assert.deepEqual(evolvedCulture.valueIds, ['craft', 'curiosity', 'navigation']);
+  assert.deepEqual(evolvedCulture.traditionIds, ['river-moot']);
+  assert.equal(evolvedCulture.lastEvolvedAt, '2026-04-18T12:40:00.000Z');
+  assert.deepEqual(culture.valueIds, ['craft', 'curiosity']);
+  assert.deepEqual(culture.traditionIds, ['harvest-song']);
+});
+
+test('evolveCulture clamps score changes to valid bounds', () => {
+  const evolvedCulture = evolveCulture(
+    {
+      id: 'culture-aurora',
+      name: 'Aurora Compact',
+      archetype: 'mercantile',
+      primaryLanguage: 'trade-speech',
+      valueIds: [],
+      traditionIds: [],
+      openness: 95,
+      cohesion: 3,
+      researchDrive: 97,
+      lastEvolvedAt: null,
+    },
+    {
+      opennessDelta: 20,
+      cohesionDelta: -15,
+      researchDriveDelta: 12,
+      evolvedAt: '2026-04-18T12:41:00.000Z',
+    },
+  );
+
+  assert.equal(evolvedCulture.openness, 100);
+  assert.equal(evolvedCulture.cohesion, 0);
+  assert.equal(evolvedCulture.researchDrive, 100);
+});
+
+test('evolveCulture removes duplicates and supports list refreshes', () => {
+  const evolvedCulture = evolveCulture(
+    {
+      id: 'culture-aurora',
+      name: 'Aurora Compact',
+      archetype: 'mercantile',
+      primaryLanguage: 'trade-speech',
+      valueIds: ['craft'],
+      traditionIds: ['harvest-song', 'river-moot'],
+      openness: 50,
+      cohesion: 50,
+      researchDrive: 50,
+      lastEvolvedAt: null,
+    },
+    {
+      addedValueIds: ['craft', ' scholarship '],
+      removedTraditionIds: ['river-moot'],
+      addedTraditionIds: [' harbor-oath ', 'harbor-oath'],
+      evolvedAt: '2026-04-18T12:42:00.000Z',
+    },
+  );
+
+  assert.deepEqual(evolvedCulture.valueIds, ['craft', 'scholarship']);
+  assert.deepEqual(evolvedCulture.traditionIds, ['harbor-oath', 'harvest-song']);
+});
+
+test('evolveCulture rejects invalid payloads and conflicting list mutations', () => {
+  assert.throws(
+    () =>
+      evolveCulture(
+        {
+          id: 'culture-aurora',
+          name: 'Aurora Compact',
+          archetype: 'mercantile',
+          primaryLanguage: 'trade-speech',
+          valueIds: [],
+          traditionIds: [],
+          openness: 50,
+          cohesion: 50,
+          researchDrive: 50,
+        },
+        {
+          opennessDelta: 1.5,
+        },
+      ),
+    /evolveCulture evolution.opennessDelta must be an integer between -100 and 100/,
+  );
+
+  assert.throws(
+    () =>
+      evolveCulture(
+        {
+          id: 'culture-aurora',
+          name: 'Aurora Compact',
+          archetype: 'mercantile',
+          primaryLanguage: 'trade-speech',
+          valueIds: ['craft'],
+          traditionIds: [],
+          openness: 50,
+          cohesion: 50,
+          researchDrive: 50,
+        },
+        {
+          addedValueIds: ['craft'],
+          removedValueIds: [' craft '],
+        },
+      ),
+    /evolveCulture cannot add and remove the same value id in one evolution/,
+  );
+
+  assert.throws(
+    () =>
+      evolveCulture(
+        {
+          id: 'culture-aurora',
+          name: 'Aurora Compact',
+          archetype: 'mercantile',
+          primaryLanguage: 'trade-speech',
+          valueIds: [],
+          traditionIds: [],
+          openness: 50,
+          cohesion: 50,
+          researchDrive: 50,
+        },
+        {
+          evolvedAt: 'not-a-date',
+        },
+      ),
+    /evolveCulture evolution.evolvedAt must be a valid date/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add an `evolveCulture` application use case for cultural drift and adaptation
- Gamma: validate evolution payloads, clamp score changes, and apply additive or subtractive value and tradition mutations
- Gamma: cover normal evolution, clamped bounds, list refreshes, and invalid transitions with node tests

## Related issue

- Gamma: closes #46

## Changes

- Gamma: bootstrap the repository with a minimal Node test setup
- Gamma: add `src/application/culture/evolveCulture.js` with immutable cultural evolution logic and validation
- Gamma: add `test/application/culture/evolveCulture.test.js` for use case behavior

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: @Zeta, could you validate this PR before merge?
