### PR TITLE
Epsilon: Define RegionClimateProfile model

### DIFF
--- a/src/domain/climate/RegionClimateProfile.js
+++ b/src/domain/climate/RegionClimateProfile.js
@@ -1,0 +1,183 @@
+const VALID_BIOMES = ['temperate', 'arid', 'tropical', 'continental', 'polar', 'coastal', 'highland'];
+const VALID_RISK_LEVELS = ['low', 'moderate', 'high', 'extreme'];
+const VALID_SEASONS = ['spring', 'summer', 'autumn', 'winter'];
+
+function normalizeSeasonalAverages(seasonalAverages) {
+  if (seasonalAverages === null || typeof seasonalAverages !== 'object' || Array.isArray(seasonalAverages)) {
+    throw new RangeError('RegionClimateProfile seasonalAverages must be an object.');
+  }
+
+  const normalized = {};
+
+  for (const season of Object.keys(seasonalAverages)) {
+    if (!VALID_SEASONS.includes(season)) {
+      throw new RangeError(`RegionClimateProfile seasonalAverages season must be one of: ${VALID_SEASONS.join(', ')}.`);
+    }
+
+    const snapshot = seasonalAverages[season];
+
+    if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+      throw new RangeError('RegionClimateProfile seasonalAverages values must be objects.');
+    }
+
+    const averageTemperatureC = RegionClimateProfile.requireFiniteNumber(
+      snapshot.averageTemperatureC,
+      `RegionClimateProfile ${season} averageTemperatureC`,
+    );
+    const averagePrecipitationLevel = RegionClimateProfile.requireFiniteNumberInRange(
+      snapshot.averagePrecipitationLevel,
+      `RegionClimateProfile ${season} averagePrecipitationLevel`,
+      0,
+      100,
+    );
+
+    normalized[season] = {
+      averageTemperatureC,
+      averagePrecipitationLevel,
+    };
+  }
+
+  if (Object.keys(normalized).length === 0) {
+    throw new RangeError('RegionClimateProfile seasonalAverages cannot be empty.');
+  }
+
+  return normalized;
+}
+
+function normalizeCatastropheRisks(catastropheRisks) {
+  if (catastropheRisks === null || typeof catastropheRisks !== 'object' || Array.isArray(catastropheRisks)) {
+    throw new RangeError('RegionClimateProfile catastropheRisks must be an object.');
+  }
+
+  const normalized = {};
+
+  for (const [type, riskLevel] of Object.entries(catastropheRisks)) {
+    const normalizedType = RegionClimateProfile.requireText(type, 'RegionClimateProfile catastrophe risk type');
+    normalized[normalizedType] = RegionClimateProfile.requireChoice(
+      riskLevel,
+      `RegionClimateProfile catastrophe risk ${normalizedType}`,
+      VALID_RISK_LEVELS,
+    );
+  }
+
+  return normalized;
+}
+
+function normalizeTags(tags) {
+  if (!Array.isArray(tags)) {
+    throw new RangeError('RegionClimateProfile tags must be an array.');
+  }
+
+  return [...new Set(tags.map((tag) => RegionClimateProfile.requireText(tag, 'RegionClimateProfile tag')))].sort();
+}
+
+export class RegionClimateProfile {
+  constructor({
+    regionId,
+    biome,
+    altitudeMeters = 0,
+    coastal = false,
+    seasonalAverages,
+    catastropheRisks = {},
+    tags = [],
+  }) {
+    this.regionId = RegionClimateProfile.requireText(regionId, 'RegionClimateProfile regionId');
+    this.biome = RegionClimateProfile.requireChoice(biome, 'RegionClimateProfile biome', VALID_BIOMES);
+    this.altitudeMeters = RegionClimateProfile.requireFiniteNumber(
+      altitudeMeters,
+      'RegionClimateProfile altitudeMeters',
+    );
+    this.coastal = Boolean(coastal);
+    this.seasonalAverages = normalizeSeasonalAverages(seasonalAverages);
+    this.catastropheRisks = normalizeCatastropheRisks(catastropheRisks);
+    this.tags = normalizeTags(tags);
+  }
+
+  riskLevelFor(catastropheType) {
+    const normalizedType = String(catastropheType ?? '').trim();
+    return this.catastropheRisks[normalizedType] ?? 'low';
+  }
+
+  averageForSeason(season) {
+    const normalizedSeason = String(season ?? '').trim();
+    const average = this.seasonalAverages[normalizedSeason];
+
+    if (!average) {
+      throw new RangeError(`RegionClimateProfile has no average for season ${normalizedSeason}.`);
+    }
+
+    return { ...average };
+  }
+
+  withRisk(catastropheType, riskLevel) {
+    const normalizedType = RegionClimateProfile.requireText(
+      catastropheType,
+      'RegionClimateProfile catastrophe risk type',
+    );
+
+    return new RegionClimateProfile({
+      ...this.toJSON(),
+      catastropheRisks: {
+        ...this.catastropheRisks,
+        [normalizedType]: riskLevel,
+      },
+    });
+  }
+
+  addTag(tag) {
+    return new RegionClimateProfile({
+      ...this.toJSON(),
+      tags: [...this.tags, tag],
+    });
+  }
+
+  toJSON() {
+    return {
+      regionId: this.regionId,
+      biome: this.biome,
+      altitudeMeters: this.altitudeMeters,
+      coastal: this.coastal,
+      seasonalAverages: Object.fromEntries(
+        Object.entries(this.seasonalAverages).map(([season, average]) => [season, { ...average }]),
+      ),
+      catastropheRisks: { ...this.catastropheRisks },
+      tags: [...this.tags],
+    };
+  }
+
+  static requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static requireChoice(value, label, validValues) {
+    const normalizedValue = RegionClimateProfile.requireText(value, label);
+
+    if (!validValues.includes(normalizedValue)) {
+      throw new RangeError(`${label} must be one of: ${validValues.join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static requireFiniteNumber(value, label) {
+    if (!Number.isFinite(value)) {
+      throw new RangeError(`${label} must be a finite number.`);
+    }
+
+    return value;
+  }
+
+  static requireFiniteNumberInRange(value, label, min, max) {
+    if (!Number.isFinite(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be a finite number between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+}

--- a/src/domain/climate/index.js
+++ b/src/domain/climate/index.js
@@ -1,0 +1,1 @@
+export { RegionClimateProfile } from './RegionClimateProfile.js';

--- a/test/domain/climate/RegionClimateProfile.test.js
+++ b/test/domain/climate/RegionClimateProfile.test.js
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { RegionClimateProfile } from '../../../src/domain/climate/RegionClimateProfile.js';
+
+test('RegionClimateProfile keeps normalized regional climate baselines', () => {
+  const profile = new RegionClimateProfile({
+    regionId: ' north-coast ',
+    biome: 'coastal',
+    altitudeMeters: 12,
+    coastal: true,
+    seasonalAverages: {
+      spring: { averageTemperatureC: 12, averagePrecipitationLevel: 68 },
+      summer: { averageTemperatureC: 21, averagePrecipitationLevel: 44 },
+      autumn: { averageTemperatureC: 14, averagePrecipitationLevel: 71 },
+      winter: { averageTemperatureC: 5, averagePrecipitationLevel: 80 },
+    },
+    catastropheRisks: {
+      stormSurge: 'high',
+      drought: 'moderate',
+    },
+    tags: ['maritime', ' fog ', 'maritime'],
+  });
+
+  assert.deepEqual(profile.toJSON(), {
+    regionId: 'north-coast',
+    biome: 'coastal',
+    altitudeMeters: 12,
+    coastal: true,
+    seasonalAverages: {
+      spring: { averageTemperatureC: 12, averagePrecipitationLevel: 68 },
+      summer: { averageTemperatureC: 21, averagePrecipitationLevel: 44 },
+      autumn: { averageTemperatureC: 14, averagePrecipitationLevel: 71 },
+      winter: { averageTemperatureC: 5, averagePrecipitationLevel: 80 },
+    },
+    catastropheRisks: {
+      stormSurge: 'high',
+      drought: 'moderate',
+    },
+    tags: ['fog', 'maritime'],
+  });
+
+  assert.deepEqual(profile.averageForSeason('summer'), {
+    averageTemperatureC: 21,
+    averagePrecipitationLevel: 44,
+  });
+  assert.equal(profile.riskLevelFor('stormSurge'), 'high');
+  assert.equal(profile.riskLevelFor('wildfire'), 'low');
+});
+
+test('RegionClimateProfile supports immutable risk and tag updates', () => {
+  const profile = new RegionClimateProfile({
+    regionId: 'highlands',
+    biome: 'highland',
+    altitudeMeters: 1400,
+    seasonalAverages: {
+      winter: { averageTemperatureC: -6, averagePrecipitationLevel: 76 },
+    },
+  });
+
+  const updated = profile.withRisk('avalanche', 'extreme').addTag('snowbound');
+
+  assert.notEqual(updated, profile);
+  assert.equal(profile.riskLevelFor('avalanche'), 'low');
+  assert.equal(updated.riskLevelFor('avalanche'), 'extreme');
+  assert.deepEqual(updated.tags, ['snowbound']);
+});
+
+test('RegionClimateProfile rejects invalid configuration', () => {
+  assert.throws(
+    () => new RegionClimateProfile({ regionId: '', biome: 'coastal', seasonalAverages: { spring: { averageTemperatureC: 10, averagePrecipitationLevel: 50 } } }),
+    /regionId is required/,
+  );
+
+  assert.throws(
+    () => new RegionClimateProfile({ regionId: 'north', biome: 'unknown', seasonalAverages: { spring: { averageTemperatureC: 10, averagePrecipitationLevel: 50 } } }),
+    /biome must be one of/,
+  );
+
+  assert.throws(
+    () => new RegionClimateProfile({ regionId: 'north', biome: 'coastal', seasonalAverages: {} }),
+    /seasonalAverages cannot be empty/,
+  );
+
+  assert.throws(
+    () => new RegionClimateProfile({ regionId: 'north', biome: 'coastal', seasonalAverages: { monsoon: { averageTemperatureC: 10, averagePrecipitationLevel: 50 } } }),
+    /seasonalAverages season must be one of/,
+  );
+
+  assert.throws(
+    () => new RegionClimateProfile({ regionId: 'north', biome: 'coastal', seasonalAverages: { spring: { averageTemperatureC: 10, averagePrecipitationLevel: 150 } } }),
+    /averagePrecipitationLevel must be a finite number between 0 and 100/,
+  );
+});


### PR DESCRIPTION
Epsilon: implements #85.\n\n## Summary\n- add a RegionClimateProfile model for biome, seasonal baselines, catastrophe risks, and regional climate tags\n- add immutable helpers to read seasonal averages and evolve catastrophe risk/tag metadata\n- add node:test coverage for normalization, default risk lookup, immutable updates, and invalid configuration\n\n## Testing\n- npm test\n\n## Notes for Zeta\nEpsilon: please validate this PR before merge.