### PR TITLE
Delta: [D05] Define NiveauAlerte scale

### DIFF
--- a/src/domain/intrigue/NiveauAlerte.js
+++ b/src/domain/intrigue/NiveauAlerte.js
@@ -1,0 +1,102 @@
+const LEVELS = Object.freeze([
+  { value: 0, code: 'latent', label: 'Latent', surveillanceIntensity: 10 },
+  { value: 1, code: 'surveille', label: 'Surveillé', surveillanceIntensity: 30 },
+  { value: 2, code: 'renforce', label: 'Renforcé', surveillanceIntensity: 55 },
+  { value: 3, code: 'critique', label: 'Critique', surveillanceIntensity: 80 },
+  { value: 4, code: 'verrouille', label: 'Verrouillé', surveillanceIntensity: 100 },
+]);
+
+const LEVEL_BY_VALUE = new Map(LEVELS.map((level) => [level.value, level]));
+const LEVEL_BY_CODE = new Map(LEVELS.map((level) => [level.code, level]));
+
+export class NiveauAlerte {
+  constructor(value = 0) {
+    this.value = NiveauAlerte.#normalizeValue(value);
+  }
+
+  get code() {
+    return LEVEL_BY_VALUE.get(this.value).code;
+  }
+
+  get label() {
+    return LEVEL_BY_VALUE.get(this.value).label;
+  }
+
+  get surveillanceIntensity() {
+    return LEVEL_BY_VALUE.get(this.value).surveillanceIntensity;
+  }
+
+  get isCritical() {
+    return this.value >= 3;
+  }
+
+  increase(step = 1) {
+    const normalizedStep = NiveauAlerte.#normalizeStep(step);
+    return new NiveauAlerte(Math.min(this.value + normalizedStep, NiveauAlerte.maximum().value));
+  }
+
+  decrease(step = 1) {
+    const normalizedStep = NiveauAlerte.#normalizeStep(step);
+    return new NiveauAlerte(Math.max(this.value - normalizedStep, NiveauAlerte.minimum().value));
+  }
+
+  equals(other) {
+    return other instanceof NiveauAlerte && other.value === this.value;
+  }
+
+  toJSON() {
+    return {
+      value: this.value,
+      code: this.code,
+      label: this.label,
+      surveillanceIntensity: this.surveillanceIntensity,
+    };
+  }
+
+  static from(value) {
+    if (value instanceof NiveauAlerte) {
+      return new NiveauAlerte(value.value);
+    }
+
+    if (typeof value === 'string') {
+      const normalizedCode = value.trim().toLowerCase();
+      const level = LEVEL_BY_CODE.get(normalizedCode);
+
+      if (!level) {
+        throw new RangeError(`NiveauAlerte code must be one of: ${[...LEVEL_BY_CODE.keys()].join(', ')}.`);
+      }
+
+      return new NiveauAlerte(level.value);
+    }
+
+    return new NiveauAlerte(value);
+  }
+
+  static minimum() {
+    return new NiveauAlerte(LEVELS[0].value);
+  }
+
+  static maximum() {
+    return new NiveauAlerte(LEVELS.at(-1).value);
+  }
+
+  static all() {
+    return LEVELS.map((level) => new NiveauAlerte(level.value));
+  }
+
+  static #normalizeValue(value) {
+    if (!Number.isInteger(value) || !LEVEL_BY_VALUE.has(value)) {
+      throw new RangeError(`NiveauAlerte value must be an integer between 0 and ${LEVELS.at(-1).value}.`);
+    }
+
+    return value;
+  }
+
+  static #normalizeStep(step) {
+    if (!Number.isInteger(step) || step < 0) {
+      throw new RangeError('NiveauAlerte step must be a non-negative integer.');
+    }
+
+    return step;
+  }
+}

--- a/test/domain/intrigue/NiveauAlerte.test.js
+++ b/test/domain/intrigue/NiveauAlerte.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { NiveauAlerte } from '../../../src/domain/intrigue/NiveauAlerte.js';
+
+test('NiveauAlerte exposes a stable alert scale', () => {
+  const level = new NiveauAlerte(2);
+
+  assert.deepEqual(level.toJSON(), {
+    value: 2,
+    code: 'renforce',
+    label: 'Renforcé',
+    surveillanceIntensity: 55,
+  });
+
+  assert.equal(level.isCritical, false);
+  assert.deepEqual(
+    NiveauAlerte.all().map((entry) => entry.code),
+    ['latent', 'surveille', 'renforce', 'critique', 'verrouille'],
+  );
+});
+
+test('NiveauAlerte supports clamped escalation and de-escalation', () => {
+  const latent = NiveauAlerte.minimum();
+  const escalated = latent.increase(3);
+  const maximum = escalated.increase(5);
+  const reduced = maximum.decrease(2);
+
+  assert.notEqual(escalated, latent);
+  assert.equal(escalated.value, 3);
+  assert.equal(escalated.code, 'critique');
+  assert.equal(escalated.isCritical, true);
+  assert.equal(maximum.value, 4);
+  assert.equal(reduced.value, 2);
+  assert.equal(reduced.code, 'renforce');
+});
+
+test('NiveauAlerte can be created from code or another instance', () => {
+  const fromCode = NiveauAlerte.from(' verrouille ');
+  const cloned = NiveauAlerte.from(fromCode);
+
+  assert.equal(fromCode.value, 4);
+  assert.equal(fromCode.label, 'Verrouillé');
+  assert.notEqual(cloned, fromCode);
+  assert.equal(cloned.equals(fromCode), true);
+});
+
+test('NiveauAlerte rejects invalid values, codes, and steps', () => {
+  assert.throws(() => new NiveauAlerte(9), /NiveauAlerte value must be an integer between 0 and 4/);
+
+  assert.throws(
+    () => NiveauAlerte.from('panic'),
+    /NiveauAlerte code must be one of: latent, surveille, renforce, critique, verrouille/,
+  );
+
+  assert.throws(
+    () => new NiveauAlerte(1).increase(-1),
+    /NiveauAlerte step must be a non-negative integer/,
+  );
+});


### PR DESCRIPTION
## Summary

- Delta: add the intrigue alert-level value object, `NiveauAlerte`
- Delta: define a stable five-step scale with codes, labels, and surveillance intensity
- Delta: cover creation, escalation, de-escalation, cloning, and validation with node tests

## Related issue

- Delta: closes #65

## Changes

- Delta: add `src/domain/intrigue/NiveauAlerte.js`
- Delta: add `test/domain/intrigue/NiveauAlerte.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Delta: `surveillanceIntensity` and `isCritical` are ready to support future detection and exposure use cases.
- Delta: Please review for validation before merge, Zeta.
