### PR TITLE
Alpha: [A10] Create MapRepository port

### DIFF
--- a/src/application/war/MapRepository.js
+++ b/src/application/war/MapRepository.js
@@ -1,0 +1,58 @@
+import { Province } from '../../domain/war/Province.js';
+
+function requireProvinceId(provinceId) {
+  const normalizedProvinceId = String(provinceId ?? '').trim();
+
+  if (!normalizedProvinceId) {
+    throw new RangeError('MapRepository provinceId is required.');
+  }
+
+  return normalizedProvinceId;
+}
+
+function requireProvince(province) {
+  if (!(province instanceof Province)) {
+    throw new TypeError('MapRepository province must be a Province instance.');
+  }
+
+  return province;
+}
+
+export class MapRepository {
+  async getProvinceById(_provinceId) {
+    throw new Error('MapRepository.getProvinceById must be implemented by an adapter.');
+  }
+
+  async listProvinces() {
+    throw new Error('MapRepository.listProvinces must be implemented by an adapter.');
+  }
+
+  async saveProvince(_province) {
+    throw new Error('MapRepository.saveProvince must be implemented by an adapter.');
+  }
+
+  async requireProvinceById(provinceId) {
+    const normalizedProvinceId = requireProvinceId(provinceId);
+    const province = await this.getProvinceById(normalizedProvinceId);
+
+    if (!(province instanceof Province)) {
+      throw new RangeError(`MapRepository could not find province ${normalizedProvinceId}.`);
+    }
+
+    return province;
+  }
+
+  async saveAll(provinces) {
+    if (!Array.isArray(provinces)) {
+      throw new TypeError('MapRepository provinces must be an array.');
+    }
+
+    const savedProvinces = [];
+
+    for (const province of provinces) {
+      savedProvinces.push(await this.saveProvince(requireProvince(province)));
+    }
+
+    return savedProvinces;
+  }
+}

--- a/test/application/war/MapRepository.test.js
+++ b/test/application/war/MapRepository.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { MapRepository } from '../../../src/application/war/MapRepository.js';
+import { Province } from '../../../src/domain/war/Province.js';
+
+function createProvince(overrides) {
+  return new Province({
+    id: 'prov-1',
+    name: 'Province',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    neighborIds: [],
+    ...overrides,
+  });
+}
+
+class InMemoryMapRepository extends MapRepository {
+  constructor(provinces = []) {
+    super();
+    this.provinces = new Map(provinces.map((province) => [province.id, province]));
+  }
+
+  async getProvinceById(provinceId) {
+    return this.provinces.get(provinceId) ?? null;
+  }
+
+  async listProvinces() {
+    return [...this.provinces.values()];
+  }
+
+  async saveProvince(province) {
+    this.provinces.set(province.id, province);
+    return province;
+  }
+}
+
+test('MapRepository provides shared helpers for province lookup and batch saving', async () => {
+  const provinceA = createProvince({ id: 'prov-a' });
+  const provinceB = createProvince({ id: 'prov-b' });
+  const repository = new InMemoryMapRepository([provinceA]);
+
+  const foundProvince = await repository.requireProvinceById(' prov-a ');
+  const savedProvinces = await repository.saveAll([provinceA, provinceB]);
+
+  assert.equal(foundProvince, provinceA);
+  assert.deepEqual(savedProvinces, [provinceA, provinceB]);
+  assert.deepEqual(await repository.listProvinces(), [provinceA, provinceB]);
+});
+
+test('MapRepository base methods fail fast until an adapter implements them', async () => {
+  const repository = new MapRepository();
+  const province = createProvince();
+
+  await assert.rejects(() => repository.getProvinceById('prov-1'), /must be implemented by an adapter/);
+  await assert.rejects(() => repository.listProvinces(), /must be implemented by an adapter/);
+  await assert.rejects(() => repository.saveProvince(province), /must be implemented by an adapter/);
+});
+
+test('MapRepository rejects missing provinces and invalid saveAll payloads', async () => {
+  const repository = new InMemoryMapRepository();
+
+  await assert.rejects(() => repository.requireProvinceById(''), /provinceId is required/);
+  await assert.rejects(() => repository.requireProvinceById('prov-missing'), /could not find province prov-missing/);
+  await assert.rejects(() => repository.saveAll(null), /provinces must be an array/);
+  await assert.rejects(() => repository.saveAll([{}]), /province must be a Province instance/);
+});


### PR DESCRIPTION
## Summary

- Alpha: add a `MapRepository` port for province and map persistence needs
- Alpha: define shared lookup and batch-save helpers on top of adapter-specific methods
- Alpha: add node:test coverage for adapter contracts, helper behavior, and invalid inputs

## Related issue

- Alpha: closes #10

## Changes

- Alpha: add `src/application/war/MapRepository.js` with adapter hooks for province reads and writes
- Alpha: add `test/application/war/MapRepository.test.js` with an in-memory test adapter to verify the contract
- Alpha: keep the port aligned with the existing Province entity already present on `main`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?