### PR TITLE
Gamma: [G07] Implement RegisterDivergence use case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/application/culture/registerDivergence.js
+++ b/src/application/culture/registerDivergence.js
@@ -1,0 +1,145 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min, max) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function normalizeDate(value, label) {
+  const normalizedValue = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(normalizedValue.getTime())) {
+    throw new RangeError(`${label} must be a valid date.`);
+  }
+
+  return normalizedValue.toISOString();
+}
+
+function normalizeDivergencePoint(divergencePoint) {
+  if (!divergencePoint || typeof divergencePoint !== 'object') {
+    throw new TypeError('registerDivergence divergencePoint must be an object.');
+  }
+
+  return {
+    ...divergencePoint,
+    id: requireText(divergencePoint.id, 'registerDivergence divergencePoint.id'),
+    title: requireText(divergencePoint.title, 'registerDivergence divergencePoint.title'),
+    era: requireText(divergencePoint.era, 'registerDivergence divergencePoint.era'),
+    baselineSummary: requireText(
+      divergencePoint.baselineSummary,
+      'registerDivergence divergencePoint.baselineSummary',
+    ),
+    divergenceSummary: requireText(
+      divergencePoint.divergenceSummary,
+      'registerDivergence divergencePoint.divergenceSummary',
+    ),
+    affectedCultureIds: normalizeUniqueTexts(
+      divergencePoint.affectedCultureIds ?? [],
+      'registerDivergence divergencePoint.affectedCultureIds',
+    ),
+    consequenceIds: normalizeUniqueTexts(
+      divergencePoint.consequenceIds ?? [],
+      'registerDivergence divergencePoint.consequenceIds',
+    ),
+    severity: requireInteger(
+      divergencePoint.severity,
+      'registerDivergence divergencePoint.severity',
+      1,
+      5,
+    ),
+    discovered: Boolean(divergencePoint.discovered),
+    registeredAt: normalizeDate(
+      divergencePoint.registeredAt,
+      'registerDivergence divergencePoint.registeredAt',
+    ),
+    triggeredEventId:
+      divergencePoint.triggeredEventId === null || divergencePoint.triggeredEventId === undefined
+        ? null
+        : requireText(
+            divergencePoint.triggeredEventId,
+            'registerDivergence divergencePoint.triggeredEventId',
+          ),
+  };
+}
+
+function normalizeRegistration(registration) {
+  if (!registration || typeof registration !== 'object') {
+    throw new TypeError('registerDivergence registration must be an object.');
+  }
+
+  return {
+    consequenceIds: normalizeUniqueTexts(
+      registration.consequenceIds ?? [],
+      'registerDivergence registration.consequenceIds',
+    ),
+    discovered:
+      registration.discovered === undefined ? undefined : Boolean(registration.discovered),
+    triggeredEventId:
+      registration.triggeredEventId === null || registration.triggeredEventId === undefined
+        ? null
+        : requireText(
+            registration.triggeredEventId,
+            'registerDivergence registration.triggeredEventId',
+          ),
+    registeredAt: normalizeDate(
+      registration.registeredAt ?? new Date(),
+      'registerDivergence registration.registeredAt',
+    ),
+  };
+}
+
+export function registerDivergence(divergencePoint, registration = {}) {
+  const normalizedDivergencePoint = normalizeDivergencePoint(divergencePoint);
+  const normalizedRegistration = normalizeRegistration(registration);
+  const mergedConsequences = normalizeUniqueTexts(
+    [...normalizedDivergencePoint.consequenceIds, ...normalizedRegistration.consequenceIds],
+    'registerDivergence merged consequence ids',
+  );
+  const discovered = normalizedRegistration.discovered ?? normalizedDivergencePoint.discovered;
+  const triggeredEventId = normalizedRegistration.triggeredEventId ?? normalizedDivergencePoint.triggeredEventId;
+
+  if (discovered && triggeredEventId === null) {
+    throw new RangeError(
+      'registerDivergence requires a triggeredEventId when a divergence is marked as discovered.',
+    );
+  }
+
+  if (!discovered && triggeredEventId !== null) {
+    throw new RangeError(
+      'registerDivergence cannot attach a triggeredEventId while the divergence is undiscovered.',
+    );
+  }
+
+  return {
+    ...normalizedDivergencePoint,
+    consequenceIds: mergedConsequences,
+    discovered,
+    triggeredEventId,
+    registeredAt: normalizedRegistration.registeredAt,
+  };
+}

--- a/test/application/culture/registerDivergence.test.js
+++ b/test/application/culture/registerDivergence.test.js
@@ -1,0 +1,174 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { registerDivergence } from '../../../src/application/culture/registerDivergence.js';
+
+test('registerDivergence merges consequence ids and refreshes registration time immutably', () => {
+  const divergencePoint = {
+    id: 'divergence-fork-01',
+    title: 'The Silent Armada',
+    era: 'late-antiquity',
+    baselineSummary: 'Maritime trade routes remain stable across the inner sea.',
+    divergenceSummary: 'A volcanic winter strands the western fleets for a generation.',
+    affectedCultureIds: ['culture-west'],
+    consequenceIds: ['grain-shortage'],
+    severity: 4,
+    discovered: false,
+    registeredAt: '2026-04-18T12:10:00.000Z',
+    triggeredEventId: null,
+  };
+
+  const registeredDivergence = registerDivergence(divergencePoint, {
+    consequenceIds: [' harbor-rationing ', 'grain-shortage'],
+    registeredAt: '2026-04-18T12:50:00.000Z',
+  });
+
+  assert.notEqual(registeredDivergence, divergencePoint);
+  assert.deepEqual(registeredDivergence.consequenceIds, ['grain-shortage', 'harbor-rationing']);
+  assert.equal(registeredDivergence.registeredAt, '2026-04-18T12:50:00.000Z');
+  assert.equal(registeredDivergence.discovered, false);
+  assert.equal(registeredDivergence.triggeredEventId, null);
+  assert.deepEqual(divergencePoint.consequenceIds, ['grain-shortage']);
+});
+
+test('registerDivergence can mark a divergence as discovered with a triggering event', () => {
+  const registeredDivergence = registerDivergence(
+    {
+      id: 'divergence-fork-01',
+      title: 'The Silent Armada',
+      era: 'late-antiquity',
+      baselineSummary: 'Maritime trade routes remain stable across the inner sea.',
+      divergenceSummary: 'A volcanic winter strands the western fleets for a generation.',
+      affectedCultureIds: ['culture-west'],
+      consequenceIds: [],
+      severity: 4,
+      discovered: false,
+      registeredAt: '2026-04-18T12:10:00.000Z',
+      triggeredEventId: null,
+    },
+    {
+      discovered: true,
+      triggeredEventId: 'event-ashen-harbors',
+      registeredAt: '2026-04-18T12:51:00.000Z',
+    },
+  );
+
+  assert.equal(registeredDivergence.discovered, true);
+  assert.equal(registeredDivergence.triggeredEventId, 'event-ashen-harbors');
+  assert.equal(registeredDivergence.registeredAt, '2026-04-18T12:51:00.000Z');
+});
+
+test('registerDivergence preserves prior discovery linkage when adding later consequences', () => {
+  const registeredDivergence = registerDivergence(
+    {
+      id: 'divergence-fork-01',
+      title: 'The Silent Armada',
+      era: 'late-antiquity',
+      baselineSummary: 'Maritime trade routes remain stable across the inner sea.',
+      divergenceSummary: 'A volcanic winter strands the western fleets for a generation.',
+      affectedCultureIds: ['culture-west'],
+      consequenceIds: ['grain-shortage'],
+      severity: 4,
+      discovered: true,
+      registeredAt: '2026-04-18T12:10:00.000Z',
+      triggeredEventId: 'event-ashen-harbors',
+    },
+    {
+      consequenceIds: ['port-migrations'],
+      registeredAt: '2026-04-18T12:52:00.000Z',
+    },
+  );
+
+  assert.equal(registeredDivergence.discovered, true);
+  assert.equal(registeredDivergence.triggeredEventId, 'event-ashen-harbors');
+  assert.deepEqual(registeredDivergence.consequenceIds, ['grain-shortage', 'port-migrations']);
+});
+
+test('registerDivergence rejects inconsistent discovery and invalid payloads', () => {
+  assert.throws(
+    () =>
+      registerDivergence(
+        {
+          id: 'divergence-fork-01',
+          title: 'The Silent Armada',
+          era: 'late-antiquity',
+          baselineSummary: 'Maritime trade routes remain stable across the inner sea.',
+          divergenceSummary: 'A volcanic winter strands the western fleets for a generation.',
+          affectedCultureIds: ['culture-west'],
+          consequenceIds: [],
+          severity: 4,
+          discovered: false,
+          registeredAt: '2026-04-18T12:10:00.000Z',
+          triggeredEventId: null,
+        },
+        {
+          discovered: true,
+          registeredAt: '2026-04-18T12:51:00.000Z',
+        },
+      ),
+    /registerDivergence requires a triggeredEventId when a divergence is marked as discovered/,
+  );
+
+  assert.throws(
+    () =>
+      registerDivergence(
+        {
+          id: 'divergence-fork-01',
+          title: 'The Silent Armada',
+          era: 'late-antiquity',
+          baselineSummary: 'Maritime trade routes remain stable across the inner sea.',
+          divergenceSummary: 'A volcanic winter strands the western fleets for a generation.',
+          affectedCultureIds: ['culture-west'],
+          consequenceIds: [],
+          severity: 4,
+          discovered: false,
+          registeredAt: '2026-04-18T12:10:00.000Z',
+          triggeredEventId: null,
+        },
+        {
+          triggeredEventId: 'event-ashen-harbors',
+        },
+      ),
+    /registerDivergence cannot attach a triggeredEventId while the divergence is undiscovered/,
+  );
+
+  assert.throws(
+    () =>
+      registerDivergence(
+        {
+          id: 'divergence-fork-01',
+          title: 'The Silent Armada',
+          era: 'late-antiquity',
+          baselineSummary: 'Maritime trade routes remain stable across the inner sea.',
+          divergenceSummary: 'A volcanic winter strands the western fleets for a generation.',
+          affectedCultureIds: ['culture-west'],
+          consequenceIds: [],
+          severity: 9,
+          discovered: false,
+          registeredAt: '2026-04-18T12:10:00.000Z',
+          triggeredEventId: null,
+        },
+      ),
+    /registerDivergence divergencePoint.severity must be an integer between 1 and 5/,
+  );
+
+  assert.throws(
+    () =>
+      registerDivergence(
+        {
+          id: 'divergence-fork-01',
+          title: 'The Silent Armada',
+          era: 'late-antiquity',
+          baselineSummary: 'Maritime trade routes remain stable across the inner sea.',
+          divergenceSummary: 'A volcanic winter strands the western fleets for a generation.',
+          affectedCultureIds: ['culture-west'],
+          consequenceIds: [],
+          severity: 4,
+          discovered: false,
+          registeredAt: 'not-a-date',
+          triggeredEventId: null,
+        },
+      ),
+    /registerDivergence divergencePoint.registeredAt must be a valid date/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add a `registerDivergence` application use case for alternate history forks
- Gamma: validate divergence registration payloads, merge consequences, and enforce discovery or triggering-event consistency
- Gamma: cover standard registration, discovery linking, later consequence updates, and invalid payloads with node tests

## Related issue

- Gamma: closes #47

## Changes

- Gamma: bootstrap the repository with a minimal Node test setup
- Gamma: add `src/application/culture/registerDivergence.js` with immutable registration logic and validation
- Gamma: add `test/application/culture/registerDivergence.test.js` for use case behavior

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: @Zeta, could you validate this PR before merge?
