### PR TITLE
Epsilon: Implement AdvanceSeasons use case

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "historia",
   "version": "0.1.0",
   "private": true,
+  "description": "Historia strategy/simulation prototype",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/src/application/climate/AdvanceSeasons.js
+++ b/src/application/climate/AdvanceSeasons.js
@@ -1,0 +1,55 @@
+import { ClimateState } from '../../domain/climate/ClimateState.js';
+import { SeasonCycle } from '../../domain/climate/SeasonCycle.js';
+
+function normalizeRegionalStates(regionalStates) {
+  if (!Array.isArray(regionalStates)) {
+    throw new RangeError('AdvanceSeasons regionalStates must be an array.');
+  }
+
+  return regionalStates.map((state) => {
+    if (state instanceof ClimateState) {
+      return state;
+    }
+
+    return new ClimateState(state);
+  });
+}
+
+function computeSeasonalShift(fromSeason, toSeason) {
+  const transitions = {
+    'spring:summer': { temperatureDelta: 6, precipitationDelta: -8, droughtDelta: 10 },
+    'summer:autumn': { temperatureDelta: -7, precipitationDelta: 10, droughtDelta: -8 },
+    'autumn:winter': { temperatureDelta: -9, precipitationDelta: 6, droughtDelta: -6 },
+    'winter:spring': { temperatureDelta: 8, precipitationDelta: -2, droughtDelta: 2 },
+  };
+
+  return transitions[`${fromSeason}:${toSeason}`] ?? { temperatureDelta: 0, precipitationDelta: 0, droughtDelta: 0 };
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export class AdvanceSeasons {
+  execute({ seasonCycle, regionalStates }) {
+    const currentCycle = seasonCycle instanceof SeasonCycle ? seasonCycle : new SeasonCycle(seasonCycle);
+    const states = normalizeRegionalStates(regionalStates);
+    const nextCycle = currentCycle.advanceSeason();
+    const shift = computeSeasonalShift(currentCycle.currentSeason, nextCycle.currentSeason);
+
+    const updatedRegionalStates = states.map((state) =>
+      state.withSeason(nextCycle.currentSeason).withReadings({
+        temperatureC: state.temperatureC + shift.temperatureDelta,
+        precipitationLevel: clamp(state.precipitationLevel + shift.precipitationDelta, 0, 100),
+        droughtIndex: clamp(state.droughtIndex + shift.droughtDelta, 0, 100),
+        anomaly: state.anomaly,
+      }),
+    );
+
+    return {
+      previousCycle: currentCycle,
+      nextCycle,
+      updatedRegionalStates,
+    };
+  }
+}

--- a/src/domain/climate/ClimateState.js
+++ b/src/domain/climate/ClimateState.js
@@ -1,0 +1,106 @@
+export class ClimateState {
+  constructor({
+    regionId,
+    season,
+    temperatureC,
+    precipitationLevel,
+    droughtIndex = 0,
+    anomaly = null,
+    activeCatastropheIds = [],
+    updatedAt = new Date().toISOString(),
+  }) {
+    if (!regionId || typeof regionId !== 'string') {
+      throw new Error('ClimateState requires a non-empty regionId');
+    }
+
+    if (!season || typeof season !== 'string') {
+      throw new Error('ClimateState requires a season');
+    }
+
+    if (!Number.isFinite(temperatureC)) {
+      throw new Error('ClimateState temperatureC must be a finite number');
+    }
+
+    if (!Number.isFinite(precipitationLevel) || precipitationLevel < 0 || precipitationLevel > 100) {
+      throw new Error('ClimateState precipitationLevel must be between 0 and 100');
+    }
+
+    if (!Number.isFinite(droughtIndex) || droughtIndex < 0 || droughtIndex > 100) {
+      throw new Error('ClimateState droughtIndex must be between 0 and 100');
+    }
+
+    this.regionId = regionId;
+    this.season = season;
+    this.temperatureC = temperatureC;
+    this.precipitationLevel = precipitationLevel;
+    this.droughtIndex = droughtIndex;
+    this.anomaly = anomaly;
+    this.activeCatastropheIds = Array.from(new Set(activeCatastropheIds));
+    this.updatedAt = updatedAt;
+  }
+
+  withSeason(season, updatedAt = new Date().toISOString()) {
+    return new ClimateState({
+      ...this.toJSON(),
+      season,
+      updatedAt,
+    });
+  }
+
+  withReadings({
+    temperatureC = this.temperatureC,
+    precipitationLevel = this.precipitationLevel,
+    droughtIndex = this.droughtIndex,
+    anomaly = this.anomaly,
+  }, updatedAt = new Date().toISOString()) {
+    return new ClimateState({
+      ...this.toJSON(),
+      temperatureC,
+      precipitationLevel,
+      droughtIndex,
+      anomaly,
+      updatedAt,
+    });
+  }
+
+  activateCatastrophe(catastropheId, updatedAt = new Date().toISOString()) {
+    if (!catastropheId || typeof catastropheId !== 'string') {
+      throw new Error('ClimateState catastropheId must be a non-empty string');
+    }
+
+    return new ClimateState({
+      ...this.toJSON(),
+      activeCatastropheIds: [...this.activeCatastropheIds, catastropheId],
+      updatedAt,
+    });
+  }
+
+  resolveCatastrophe(catastropheId, updatedAt = new Date().toISOString()) {
+    return new ClimateState({
+      ...this.toJSON(),
+      activeCatastropheIds: this.activeCatastropheIds.filter((id) => id !== catastropheId),
+      updatedAt,
+    });
+  }
+
+  hasAnomaly() {
+    return this.anomaly !== null;
+  }
+
+  isStable() {
+    return this.droughtIndex < 60 && this.precipitationLevel >= 20 && !this.hasAnomaly();
+  }
+
+  toJSON() {
+    return {
+      regionId: this.regionId,
+      season: this.season,
+      temperatureC: this.temperatureC,
+      precipitationLevel: this.precipitationLevel,
+      droughtIndex: this.droughtIndex,
+      anomaly: this.anomaly,
+      activeCatastropheIds: [...this.activeCatastropheIds],
+      updatedAt: this.updatedAt,
+    };
+  }
+}

--- a/src/domain/climate/index.js
+++ b/src/domain/climate/index.js
@@ -1,1 +1,2 @@
+export { ClimateState } from './ClimateState.js';
 export { SeasonCycle } from './SeasonCycle.js';

--- a/test/application/climate/AdvanceSeasons.test.js
+++ b/test/application/climate/AdvanceSeasons.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AdvanceSeasons } from '../../../src/application/climate/AdvanceSeasons.js';
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+import { SeasonCycle } from '../../../src/domain/climate/SeasonCycle.js';
+
+test('AdvanceSeasons rolls the global cycle forward and updates each region season', () => {
+  const useCase = new AdvanceSeasons();
+  const seasonCycle = new SeasonCycle({
+    currentSeason: 'spring',
+    year: 4,
+    dayOfSeason: 30,
+    seasonLengthDays: 30,
+  });
+  const regionalStates = [
+    new ClimateState({
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 66,
+      droughtIndex: 18,
+    }),
+    new ClimateState({
+      regionId: 'sunreach',
+      season: 'spring',
+      temperatureC: 23,
+      precipitationLevel: 28,
+      droughtIndex: 44,
+    }),
+  ];
+
+  const result = useCase.execute({ seasonCycle, regionalStates });
+
+  assert.equal(result.previousCycle, seasonCycle);
+  assert.equal(result.nextCycle.currentSeason, 'summer');
+  assert.equal(result.nextCycle.year, 4);
+  assert.deepEqual(
+    result.updatedRegionalStates.map((state) => state.toJSON()),
+    [
+      {
+        regionId: 'north-coast',
+        season: 'summer',
+        temperatureC: 18,
+        precipitationLevel: 58,
+        droughtIndex: 28,
+        anomaly: null,
+        activeCatastropheIds: [],
+        updatedAt: result.updatedRegionalStates[0].updatedAt,
+      },
+      {
+        regionId: 'sunreach',
+        season: 'summer',
+        temperatureC: 29,
+        precipitationLevel: 20,
+        droughtIndex: 54,
+        anomaly: null,
+        activeCatastropheIds: [],
+        updatedAt: result.updatedRegionalStates[1].updatedAt,
+      },
+    ],
+  );
+
+  assert.equal(regionalStates[0].season, 'spring');
+  assert.equal(regionalStates[1].temperatureC, 23);
+});
+
+test('AdvanceSeasons handles year rollover and clamps climate indicators', () => {
+  const useCase = new AdvanceSeasons();
+
+  const result = useCase.execute({
+    seasonCycle: {
+      currentSeason: 'winter',
+      year: 7,
+      dayOfSeason: 10,
+      seasonLengthDays: 10,
+    },
+    regionalStates: [
+      {
+        regionId: 'frostmarch',
+        season: 'winter',
+        temperatureC: -12,
+        precipitationLevel: 2,
+        droughtIndex: 99,
+        anomaly: 'aurora',
+      },
+    ],
+  });
+
+  assert.equal(result.nextCycle.currentSeason, 'spring');
+  assert.equal(result.nextCycle.year, 8);
+  assert.equal(result.updatedRegionalStates[0].temperatureC, -4);
+  assert.equal(result.updatedRegionalStates[0].precipitationLevel, 0);
+  assert.equal(result.updatedRegionalStates[0].droughtIndex, 100);
+  assert.equal(result.updatedRegionalStates[0].anomaly, 'aurora');
+});
+
+test('AdvanceSeasons rejects invalid regional state collections', () => {
+  const useCase = new AdvanceSeasons();
+
+  assert.throws(
+    () => useCase.execute({
+      seasonCycle: { currentSeason: 'spring', seasonLengthDays: 30 },
+      regionalStates: null,
+    }),
+    /regionalStates must be an array/,
+  );
+});

--- a/test/domain/climate/ClimateState.test.js
+++ b/test/domain/climate/ClimateState.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+
+test('creates a climate state for a region', () => {
+  const state = new ClimateState({
+    regionId: 'region-north',
+    season: 'spring',
+    temperatureC: 13,
+    precipitationLevel: 57,
+    droughtIndex: 18,
+  });
+
+  assert.deepEqual(state.toJSON(), {
+    regionId: 'region-north',
+    season: 'spring',
+    temperatureC: 13,
+    precipitationLevel: 57,
+    droughtIndex: 18,
+    anomaly: null,
+    activeCatastropheIds: [],
+    updatedAt: state.updatedAt,
+  });
+  assert.equal(state.isStable(), true);
+});
+
+test('updates seasonal readings immutably', () => {
+  const original = new ClimateState({
+    regionId: 'region-delta',
+    season: 'summer',
+    temperatureC: 28,
+    precipitationLevel: 44,
+    droughtIndex: 31,
+  });
+
+  const updated = original
+    .withSeason('autumn', '2026-04-18T12:00:00.000Z')
+    .withReadings({ precipitationLevel: 61, anomaly: 'cold-front' }, '2026-04-19T12:00:00.000Z');
+
+  assert.equal(original.season, 'summer');
+  assert.equal(updated.season, 'autumn');
+  assert.equal(updated.precipitationLevel, 61);
+  assert.equal(updated.anomaly, 'cold-front');
+  assert.equal(updated.updatedAt, '2026-04-19T12:00:00.000Z');
+  assert.equal(updated.isStable(), false);
+});
+
+test('tracks active catastrophes without duplicates', () => {
+  const base = new ClimateState({
+    regionId: 'region-ash',
+    season: 'winter',
+    temperatureC: -4,
+    precipitationLevel: 80,
+    droughtIndex: 5,
+  });
+
+  const active = base
+    .activateCatastrophe('blizzard', '2026-04-20T10:00:00.000Z')
+    .activateCatastrophe('blizzard', '2026-04-20T11:00:00.000Z')
+    .activateCatastrophe('famine', '2026-04-20T12:00:00.000Z');
+
+  assert.deepEqual(active.activeCatastropheIds, ['blizzard', 'famine']);
+
+  const resolved = active.resolveCatastrophe('blizzard', '2026-04-21T10:00:00.000Z');
+  assert.deepEqual(resolved.activeCatastropheIds, ['famine']);
+});
+
+test('rejects invalid climate values', () => {
+  assert.throws(() => new ClimateState({
+    regionId: '',
+    season: 'spring',
+    temperatureC: 10,
+    precipitationLevel: 50,
+  }), /regionId/);
+
+  assert.throws(() => new ClimateState({
+    regionId: 'region-bad',
+    season: 'spring',
+    temperatureC: Number.NaN,
+    precipitationLevel: 50,
+  }), /temperatureC/);
+
+  assert.throws(() => new ClimateState({
+    regionId: 'region-bad',
+    season: 'spring',
+    temperatureC: 10,
+    precipitationLevel: 101,
+  }), /precipitationLevel/);
+});


### PR DESCRIPTION
Epsilon: implements #86 on top of the climate model stack.

## Summary
- add the AdvanceSeasons application use case to roll the season cycle forward across regions
- update each ClimateState immutably with the next season and derived climate shifts
- add node:test coverage for normal progression, year rollover, clamping, and invalid input handling

## Testing
- npm test

## Notes for Zeta
Epsilon: this PR is stacked on the E02 branch because AdvanceSeasons depends on the climate models from E01 and E02. Please validate this PR before any merge.