### PR TITLE
Alpha: [A11] Create FactionStateRepository port

### DIFF
--- a/src/application/war/FactionStateRepository.js
+++ b/src/application/war/FactionStateRepository.js
@@ -1,0 +1,59 @@
+function requireFactionId(factionId) {
+  const normalizedFactionId = String(factionId ?? '').trim();
+
+  if (!normalizedFactionId) {
+    throw new RangeError('FactionStateRepository factionId is required.');
+  }
+
+  return normalizedFactionId;
+}
+
+function requireFactionState(state) {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    throw new TypeError('FactionStateRepository state must be an object.');
+  }
+
+  return {
+    ...state,
+    factionId: requireFactionId(state.factionId),
+  };
+}
+
+export class FactionStateRepository {
+  async getFactionStateById(_factionId) {
+    throw new Error('FactionStateRepository.getFactionStateById must be implemented by an adapter.');
+  }
+
+  async listFactionStates() {
+    throw new Error('FactionStateRepository.listFactionStates must be implemented by an adapter.');
+  }
+
+  async saveFactionState(_state) {
+    throw new Error('FactionStateRepository.saveFactionState must be implemented by an adapter.');
+  }
+
+  async requireFactionStateById(factionId) {
+    const normalizedFactionId = requireFactionId(factionId);
+    const state = await this.getFactionStateById(normalizedFactionId);
+
+    if (!state || state.factionId !== normalizedFactionId) {
+      throw new RangeError(`FactionStateRepository could not find faction state ${normalizedFactionId}.`);
+    }
+
+    return state;
+  }
+
+  async saveAll(states) {
+    if (!Array.isArray(states)) {
+      throw new TypeError('FactionStateRepository states must be an array.');
+    }
+
+    const savedStates = [];
+
+    for (const state of states) {
+      savedStates.push(await this.saveFactionState(requireFactionState(state)));
+    }
+
+    return savedStates;
+  }
+}

--- a/test/application/war/FactionStateRepository.test.js
+++ b/test/application/war/FactionStateRepository.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { FactionStateRepository } from '../../../src/application/war/FactionStateRepository.js';
+
+class InMemoryFactionStateRepository extends FactionStateRepository {
+  constructor(states = []) {
+    super();
+    this.states = new Map(states.map((state) => [state.factionId, state]));
+  }
+
+  async getFactionStateById(factionId) {
+    return this.states.get(factionId) ?? null;
+  }
+
+  async listFactionStates() {
+    return [...this.states.values()];
+  }
+
+  async saveFactionState(state) {
+    this.states.set(state.factionId, state);
+    return state;
+  }
+}
+
+test('FactionStateRepository provides shared helpers for faction state lookup and batch saving', async () => {
+  const stateA = { factionId: 'faction-a', occupiedProvinceIds: ['prov-1'] };
+  const stateB = { factionId: 'faction-b', occupiedProvinceIds: [] };
+  const repository = new InMemoryFactionStateRepository([stateA]);
+
+  const foundState = await repository.requireFactionStateById(' faction-a ');
+  const savedStates = await repository.saveAll([stateA, stateB]);
+
+  assert.equal(foundState, stateA);
+  assert.deepEqual(savedStates, [stateA, stateB]);
+  assert.deepEqual(await repository.listFactionStates(), [stateA, stateB]);
+});
+
+test('FactionStateRepository base methods fail fast until an adapter implements them', async () => {
+  const repository = new FactionStateRepository();
+  const state = { factionId: 'faction-a' };
+
+  await assert.rejects(
+    () => repository.getFactionStateById('faction-a'),
+    /must be implemented by an adapter/,
+  );
+  await assert.rejects(() => repository.listFactionStates(), /must be implemented by an adapter/);
+  await assert.rejects(
+    () => repository.saveFactionState(state),
+    /must be implemented by an adapter/,
+  );
+});
+
+test('FactionStateRepository rejects missing states and invalid saveAll payloads', async () => {
+  const repository = new InMemoryFactionStateRepository();
+
+  await assert.rejects(() => repository.requireFactionStateById(''), /factionId is required/);
+  await assert.rejects(
+    () => repository.requireFactionStateById('faction-missing'),
+    /could not find faction state faction-missing/,
+  );
+  await assert.rejects(() => repository.saveAll(null), /states must be an array/);
+  await assert.rejects(() => repository.saveAll([null]), /state must be an object/);
+  await assert.rejects(() => repository.saveAll([{ factionId: '   ' }]), /factionId is required/);
+});


### PR DESCRIPTION
## Summary

- Alpha: add a `FactionStateRepository` port for faction war-state persistence
- Alpha: define shared lookup and batch-save helpers on top of adapter-specific methods
- Alpha: add node:test coverage for adapter contracts, helper behavior, and invalid inputs

## Related issue

- Alpha: closes #11

## Changes

- Alpha: add `src/application/war/FactionStateRepository.js` with adapter hooks for faction state reads and writes
- Alpha: add `test/application/war/FactionStateRepository.test.js` with an in-memory test adapter to verify the contract
- Alpha: keep the port flexible so later Alpha read models and adapters can plug into it cleanly

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?