### PR TITLE
Delta: [D06] Implement LancerOperation use case

### DIFF
--- a/src/application/intrigue/LancerOperation.js
+++ b/src/application/intrigue/LancerOperation.js
@@ -1,0 +1,146 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function requireScore(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new RangeError(`${label} must be an integer between 0 and 100.`);
+  }
+
+  return value;
+}
+
+function getMissingEntries(requiredIds, availableIds, key) {
+  const availableSet = new Set(availableIds);
+
+  return requiredIds
+    .filter((id) => !availableSet.has(id))
+    .map((id) => ({ [key]: id }));
+}
+
+export function lancerOperation({
+  cellule,
+  operation,
+  availableAgentIds = operation?.assignedAgentIds ?? [],
+  availableAssetIds = cellule?.assetIds ?? [],
+  alertLevel = 0,
+}) {
+  const normalizedCellule = requireObject(cellule, 'LancerOperation cellule');
+  const normalizedOperation = requireObject(operation, 'LancerOperation operation');
+  const normalizedAvailableAgentIds = normalizeUniqueTexts(
+    availableAgentIds,
+    'LancerOperation availableAgentIds',
+  );
+  const normalizedAvailableAssetIds = normalizeUniqueTexts(
+    availableAssetIds,
+    'LancerOperation availableAssetIds',
+  );
+  const normalizedAssignedAgentIds = normalizeUniqueTexts(
+    normalizedOperation.assignedAgentIds ?? [],
+    'LancerOperation operation assignedAgentIds',
+  );
+  const normalizedRequiredAssetIds = normalizeUniqueTexts(
+    normalizedOperation.requiredAssetIds ?? [],
+    'LancerOperation operation requiredAssetIds',
+  );
+  const normalizedAlertLevel = requireScore(alertLevel, 'LancerOperation alertLevel');
+  const celluleStatus = String(normalizedCellule.status ?? '').trim();
+  const celluleExposure = requireScore(normalizedCellule.exposure ?? 0, 'LancerOperation cellule exposure');
+  const operationDifficulty = requireScore(
+    normalizedOperation.difficulty ?? 0,
+    'LancerOperation operation difficulty',
+  );
+  const operationDetectionRisk = requireScore(
+    normalizedOperation.detectionRisk ?? 0,
+    'LancerOperation operation detectionRisk',
+  );
+
+  if (!celluleStatus) {
+    throw new RangeError('LancerOperation cellule status is required.');
+  }
+
+  if (normalizedAssignedAgentIds.length === 0) {
+    return {
+      launched: false,
+      reason: 'no-assigned-agents',
+      nextOperation: { ...normalizedOperation },
+      readiness: 0,
+      blockers: [],
+    };
+  }
+
+  if (celluleStatus === 'compromised' || celluleStatus === 'dismantled') {
+    return {
+      launched: false,
+      reason: 'cellule-unavailable',
+      nextOperation: { ...normalizedOperation },
+      readiness: 0,
+      blockers: [{ status: celluleStatus }],
+    };
+  }
+
+  const missingAgents = getMissingEntries(normalizedAssignedAgentIds, normalizedAvailableAgentIds, 'agentId');
+
+  if (missingAgents.length > 0) {
+    return {
+      launched: false,
+      reason: 'missing-agents',
+      nextOperation: { ...normalizedOperation },
+      readiness: 0,
+      blockers: missingAgents,
+    };
+  }
+
+  const missingAssets = getMissingEntries(normalizedRequiredAssetIds, normalizedAvailableAssetIds, 'assetId');
+
+  if (missingAssets.length > 0) {
+    return {
+      launched: false,
+      reason: 'missing-assets',
+      nextOperation: { ...normalizedOperation },
+      readiness: 0,
+      blockers: missingAssets,
+    };
+  }
+
+  const readiness = Math.max(
+    0,
+    Math.min(
+      100,
+      100 - operationDifficulty - operationDetectionRisk - normalizedAlertLevel - celluleExposure,
+    ),
+  );
+  const nextPhase = normalizedOperation.phase === 'planning' ? 'infiltration' : normalizedOperation.phase;
+  const nextProgress = nextPhase === 'infiltration' ? Math.max(normalizedOperation.progress ?? 0, 10) : normalizedOperation.progress ?? 0;
+
+  return {
+    launched: true,
+    reason: 'operation-launched',
+    readiness,
+    blockers: [],
+    nextOperation: {
+      ...normalizedOperation,
+      phase: nextPhase,
+      progress: nextProgress,
+      heat: Math.min(100, (normalizedOperation.heat ?? 0) + Math.round(normalizedAlertLevel / 10)),
+    },
+  };
+}

--- a/test/application/intrigue/LancerOperation.test.js
+++ b/test/application/intrigue/LancerOperation.test.js
@@ -1,0 +1,168 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { lancerOperation } from '../../../src/application/intrigue/LancerOperation.js';
+
+test('LancerOperation moves a prepared operation into infiltration', () => {
+  const result = lancerOperation({
+    cellule: {
+      id: 'cellule-ombre',
+      status: 'active',
+      exposure: 12,
+      assetIds: ['safehouse-port', 'forged-seals'],
+    },
+    operation: {
+      id: 'op-cendre',
+      assignedAgentIds: ['agent-corbeau', 'agent-brume'],
+      requiredAssetIds: ['forged-seals'],
+      difficulty: 28,
+      detectionRisk: 17,
+      progress: 0,
+      phase: 'planning',
+      heat: 4,
+    },
+    availableAgentIds: ['agent-corbeau', 'agent-brume', 'agent-echo'],
+    alertLevel: 15,
+  });
+
+  assert.deepEqual(result, {
+    launched: true,
+    reason: 'operation-launched',
+    readiness: 28,
+    blockers: [],
+    nextOperation: {
+      id: 'op-cendre',
+      assignedAgentIds: ['agent-corbeau', 'agent-brume'],
+      requiredAssetIds: ['forged-seals'],
+      difficulty: 28,
+      detectionRisk: 17,
+      progress: 10,
+      phase: 'infiltration',
+      heat: 6,
+    },
+  });
+});
+
+test('LancerOperation reports blockers for unavailable cellule resources', () => {
+  const missingAgentsResult = lancerOperation({
+    cellule: {
+      status: 'active',
+      exposure: 22,
+      assetIds: ['forged-seals'],
+    },
+    operation: {
+      assignedAgentIds: ['agent-corbeau', 'agent-brume'],
+      requiredAssetIds: ['forged-seals'],
+      difficulty: 20,
+      detectionRisk: 10,
+      progress: 0,
+      phase: 'planning',
+      heat: 0,
+    },
+    availableAgentIds: ['agent-corbeau'],
+    alertLevel: 10,
+  });
+
+  assert.deepEqual(missingAgentsResult, {
+    launched: false,
+    reason: 'missing-agents',
+    readiness: 0,
+    blockers: [{ agentId: 'agent-brume' }],
+    nextOperation: {
+      assignedAgentIds: ['agent-corbeau', 'agent-brume'],
+      requiredAssetIds: ['forged-seals'],
+      difficulty: 20,
+      detectionRisk: 10,
+      progress: 0,
+      phase: 'planning',
+      heat: 0,
+    },
+  });
+
+  const missingAssetsResult = lancerOperation({
+    cellule: {
+      status: 'active',
+      exposure: 22,
+      assetIds: ['safehouse-port'],
+    },
+    operation: {
+      assignedAgentIds: ['agent-corbeau'],
+      requiredAssetIds: ['forged-seals'],
+      difficulty: 20,
+      detectionRisk: 10,
+      progress: 0,
+      phase: 'planning',
+      heat: 0,
+    },
+    availableAgentIds: ['agent-corbeau'],
+    alertLevel: 10,
+  });
+
+  assert.deepEqual(missingAssetsResult, {
+    launched: false,
+    reason: 'missing-assets',
+    readiness: 0,
+    blockers: [{ assetId: 'forged-seals' }],
+    nextOperation: {
+      assignedAgentIds: ['agent-corbeau'],
+      requiredAssetIds: ['forged-seals'],
+      difficulty: 20,
+      detectionRisk: 10,
+      progress: 0,
+      phase: 'planning',
+      heat: 0,
+    },
+  });
+});
+
+test('LancerOperation rejects invalid inputs and blocks unavailable cellules', () => {
+  assert.throws(
+    () => lancerOperation({ cellule: null, operation: {} }),
+    /LancerOperation cellule must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      lancerOperation({
+        cellule: { status: 'active', exposure: 0 },
+        operation: { assignedAgentIds: ['agent-corbeau'], difficulty: 10, detectionRisk: 5 },
+        alertLevel: 101,
+      }),
+    /LancerOperation alertLevel must be an integer between 0 and 100/,
+  );
+
+  const unavailableCellule = lancerOperation({
+    cellule: {
+      status: 'compromised',
+      exposure: 71,
+      assetIds: ['forged-seals'],
+    },
+    operation: {
+      assignedAgentIds: ['agent-corbeau'],
+      requiredAssetIds: [],
+      difficulty: 10,
+      detectionRisk: 5,
+      progress: 0,
+      phase: 'planning',
+      heat: 0,
+    },
+    availableAgentIds: ['agent-corbeau'],
+    alertLevel: 20,
+  });
+
+  assert.deepEqual(unavailableCellule, {
+    launched: false,
+    reason: 'cellule-unavailable',
+    readiness: 0,
+    blockers: [{ status: 'compromised' }],
+    nextOperation: {
+      assignedAgentIds: ['agent-corbeau'],
+      requiredAssetIds: [],
+      difficulty: 10,
+      detectionRisk: 5,
+      progress: 0,
+      phase: 'planning',
+      heat: 0,
+    },
+  });
+});


### PR DESCRIPTION
## Summary

- Delta: implement the intrigue launch use case, `LancerOperation`
- Delta: validate cellule status, assigned agents, required assets, alert level, and operation risk inputs before launch
- Delta: cover successful launch, blockers, and input validation with node tests

## Related issue

- Delta: closes #66

## Changes

- Delta: add `src/application/intrigue/LancerOperation.js`
- Delta: add `test/application/intrigue/LancerOperation.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Delta: `readiness` and the returned blockers are ready to feed later intrigue orchestration and UI work.
- Delta: Please review for validation before merge, Zeta.
