### PR TITLE
Alpha: [A12] Create BattleResolverPort

### DIFF
--- a/src/application/war/BattleResolverPort.js
+++ b/src/application/war/BattleResolverPort.js
@@ -1,0 +1,64 @@
+function requireBattleContext(context) {
+  if (!context || typeof context !== 'object' || Array.isArray(context)) {
+    throw new TypeError('BattleResolverPort context must be an object.');
+  }
+
+  const attackerFactionId = String(context.attackerFactionId ?? '').trim();
+  const defenderFactionId = String(context.defenderFactionId ?? '').trim();
+  const frontId = String(context.frontId ?? '').trim();
+
+  if (!attackerFactionId) {
+    throw new RangeError('BattleResolverPort attackerFactionId is required.');
+  }
+
+  if (!defenderFactionId) {
+    throw new RangeError('BattleResolverPort defenderFactionId is required.');
+  }
+
+  if (!frontId) {
+    throw new RangeError('BattleResolverPort frontId is required.');
+  }
+
+  return {
+    ...context,
+    attackerFactionId,
+    defenderFactionId,
+    frontId,
+  };
+}
+
+function requireBattleOutcome(outcome) {
+  if (!outcome || typeof outcome !== 'object' || Array.isArray(outcome)) {
+    throw new TypeError('BattleResolverPort outcome must be an object.');
+  }
+
+  const winnerFactionId = String(outcome.winnerFactionId ?? '').trim();
+  const pressureDelta = outcome.pressureDelta;
+
+  if (!winnerFactionId) {
+    throw new RangeError('BattleResolverPort winnerFactionId is required.');
+  }
+
+  if (!Number.isInteger(pressureDelta)) {
+    throw new RangeError('BattleResolverPort pressureDelta must be an integer.');
+  }
+
+  return {
+    ...outcome,
+    winnerFactionId,
+    pressureDelta,
+  };
+}
+
+export class BattleResolverPort {
+  async resolveBattle(_context) {
+    throw new Error('BattleResolverPort.resolveBattle must be implemented by an adapter.');
+  }
+
+  async requireResolvedBattle(context) {
+    const normalizedContext = requireBattleContext(context);
+    const outcome = await this.resolveBattle(normalizedContext);
+
+    return requireBattleOutcome(outcome);
+  }
+}

--- a/test/application/war/BattleResolverPort.test.js
+++ b/test/application/war/BattleResolverPort.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BattleResolverPort } from '../../../src/application/war/BattleResolverPort.js';
+
+class FixedBattleResolverPort extends BattleResolverPort {
+  constructor(outcome) {
+    super();
+    this.outcome = outcome;
+    this.calls = [];
+  }
+
+  async resolveBattle(context) {
+    this.calls.push(context);
+    return this.outcome;
+  }
+}
+
+test('BattleResolverPort normalizes battle context before delegating to an adapter', async () => {
+  const resolver = new FixedBattleResolverPort({
+    winnerFactionId: 'faction-a',
+    pressureDelta: 18,
+    casualties: { attacker: 12, defender: 20 },
+  });
+
+  const outcome = await resolver.requireResolvedBattle({
+    attackerFactionId: ' faction-a ',
+    defenderFactionId: ' faction-b ',
+    frontId: ' front-north ',
+    terrainType: 'forest',
+  });
+
+  assert.deepEqual(resolver.calls, [
+    {
+      attackerFactionId: 'faction-a',
+      defenderFactionId: 'faction-b',
+      frontId: 'front-north',
+      terrainType: 'forest',
+    },
+  ]);
+
+  assert.deepEqual(outcome, {
+    winnerFactionId: 'faction-a',
+    pressureDelta: 18,
+    casualties: { attacker: 12, defender: 20 },
+  });
+});
+
+test('BattleResolverPort base adapter method fails fast until implemented', async () => {
+  const resolver = new BattleResolverPort();
+
+  await assert.rejects(
+    () =>
+      resolver.resolveBattle({
+        attackerFactionId: 'faction-a',
+        defenderFactionId: 'faction-b',
+        frontId: 'front-north',
+      }),
+    /must be implemented by an adapter/,
+  );
+});
+
+test('BattleResolverPort rejects invalid battle contexts and invalid outcomes', async () => {
+  const invalidOutcomeResolver = new FixedBattleResolverPort({ pressureDelta: 1 });
+
+  await assert.rejects(() => invalidOutcomeResolver.requireResolvedBattle(null), /context must be an object/);
+  await assert.rejects(
+    () => invalidOutcomeResolver.requireResolvedBattle({ attackerFactionId: '', defenderFactionId: 'faction-b', frontId: 'front' }),
+    /attackerFactionId is required/,
+  );
+  await assert.rejects(
+    () => invalidOutcomeResolver.requireResolvedBattle({ attackerFactionId: 'faction-a', defenderFactionId: 'faction-b', frontId: 'front' }),
+    /winnerFactionId is required/,
+  );
+
+  const invalidPressureResolver = new FixedBattleResolverPort({ winnerFactionId: 'faction-a', pressureDelta: 1.5 });
+
+  await assert.rejects(
+    () => invalidPressureResolver.requireResolvedBattle({ attackerFactionId: 'faction-a', defenderFactionId: 'faction-b', frontId: 'front' }),
+    /pressureDelta must be an integer/,
+  );
+});


### PR DESCRIPTION
## Summary

- Alpha: add a `BattleResolverPort` for battle outcome resolution in the war slice
- Alpha: define normalized battle context validation and required outcome validation for adapters
- Alpha: add node:test coverage for adapter contracts, context normalization, and invalid outcomes

## Related issue

- Alpha: closes #12

## Changes

- Alpha: add `src/application/war/BattleResolverPort.js` with adapter hooks and normalized resolution helpers
- Alpha: add `test/application/war/BattleResolverPort.test.js` with a fixed test adapter to verify the contract
- Alpha: keep the port ready for future battle simulation adapters without coupling to one implementation

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] Zeta has been asked for validation before merge

## Notes

- Alpha: @Zeta, could you validate this PR before merge?