### PR TITLE
Beta: create CityRepository port

### DIFF
--- a/src/domain/economy/CityRepositoryPort.js
+++ b/src/domain/economy/CityRepositoryPort.js
@@ -1,0 +1,30 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+export class CityRepositoryPort {
+  async getById(cityId) {
+    requireText(cityId, 'CityRepositoryPort cityId');
+    throw new Error('CityRepositoryPort.getById must be implemented by an adapter.');
+  }
+
+  async save(city) {
+    if (city === null || typeof city !== 'object' || Array.isArray(city)) {
+      throw new TypeError('CityRepositoryPort city must be an object.');
+    }
+
+    requireText(city.id, 'CityRepositoryPort city.id');
+    throw new Error('CityRepositoryPort.save must be implemented by an adapter.');
+  }
+
+  async listByRegion(regionId) {
+    requireText(regionId, 'CityRepositoryPort regionId');
+    throw new Error('CityRepositoryPort.listByRegion must be implemented by an adapter.');
+  }
+}

--- a/test/domain/economy/CityRepositoryPort.test.js
+++ b/test/domain/economy/CityRepositoryPort.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CityRepositoryPort } from '../../../src/domain/economy/CityRepositoryPort.js';
+
+test('CityRepositoryPort validates identifiers before delegating to adapters', async () => {
+  const port = new CityRepositoryPort();
+
+  await assert.rejects(() => port.getById(''), /CityRepositoryPort cityId is required/);
+  await assert.rejects(() => port.listByRegion('   '), /CityRepositoryPort regionId is required/);
+});
+
+test('CityRepositoryPort validates city payloads before save', async () => {
+  const port = new CityRepositoryPort();
+
+  await assert.rejects(() => port.save(null), /CityRepositoryPort city must be an object/);
+  await assert.rejects(() => port.save({ id: ' ' }), /CityRepositoryPort city.id is required/);
+});
+
+test('CityRepositoryPort exposes explicit adapter implementation errors', async () => {
+  const port = new CityRepositoryPort();
+  const city = { id: 'city-harbor', regionId: 'coast-west' };
+
+  await assert.rejects(
+    () => port.getById('city-harbor'),
+    /CityRepositoryPort\.getById must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.save(city),
+    /CityRepositoryPort\.save must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.listByRegion('coast-west'),
+    /CityRepositoryPort\.listByRegion must be implemented by an adapter/,
+  );
+});


### PR DESCRIPTION
## Summary
- add the Beta `CityRepositoryPort` contract for city persistence adapters
- validate identifiers and city payloads before adapter delegation
- cover validation and explicit implementation errors with node tests

## Testing
- npm test

Closes #29