### PR TITLE
Alpha: [A13] Add in-memory map adapter

### DIFF
--- a/src/adapters/war/InMemoryMapRepository.js
+++ b/src/adapters/war/InMemoryMapRepository.js
@@ -1,0 +1,55 @@
+import { MapRepository } from '../../application/war/MapRepository.js';
+import { Province } from '../../domain/war/Province.js';
+
+function requireProvinceRecord(record) {
+  if (record instanceof Province) {
+    return record;
+  }
+
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    throw new TypeError('InMemoryMapRepository province record must be a Province or plain object.');
+  }
+
+  return new Province(record);
+}
+
+export class InMemoryMapRepository extends MapRepository {
+  constructor(provinces = []) {
+    super();
+    this.provinces = new Map();
+    this.seed(provinces);
+  }
+
+  seed(provinces) {
+    if (!Array.isArray(provinces)) {
+      throw new TypeError('InMemoryMapRepository provinces must be an array.');
+    }
+
+    for (const provinceRecord of provinces) {
+      const province = requireProvinceRecord(provinceRecord);
+      this.provinces.set(province.id, province);
+    }
+
+    return this;
+  }
+
+  async getProvinceById(provinceId) {
+    return this.provinces.get(String(provinceId).trim()) ?? null;
+  }
+
+  async listProvinces() {
+    return [...this.provinces.values()].sort((left, right) => left.id.localeCompare(right.id));
+  }
+
+  async saveProvince(province) {
+    const normalizedProvince = requireProvinceRecord(province);
+    this.provinces.set(normalizedProvince.id, normalizedProvince);
+    return normalizedProvince;
+  }
+
+  snapshot() {
+    return [...this.provinces.values()]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((province) => province.toJSON());
+  }
+}

--- a/src/application/war/MapRepository.js
+++ b/src/application/war/MapRepository.js
@@ -1,0 +1,58 @@
+import { Province } from '../../domain/war/Province.js';
+
+function requireProvinceId(provinceId) {
+  const normalizedProvinceId = String(provinceId ?? '').trim();
+
+  if (!normalizedProvinceId) {
+    throw new RangeError('MapRepository provinceId is required.');
+  }
+
+  return normalizedProvinceId;
+}
+
+function requireProvince(province) {
+  if (!(province instanceof Province)) {
+    throw new TypeError('MapRepository province must be a Province instance.');
+  }
+
+  return province;
+}
+
+export class MapRepository {
+  async getProvinceById(_provinceId) {
+    throw new Error('MapRepository.getProvinceById must be implemented by an adapter.');
+  }
+
+  async listProvinces() {
+    throw new Error('MapRepository.listProvinces must be implemented by an adapter.');
+  }
+
+  async saveProvince(_province) {
+    throw new Error('MapRepository.saveProvince must be implemented by an adapter.');
+  }
+
+  async requireProvinceById(provinceId) {
+    const normalizedProvinceId = requireProvinceId(provinceId);
+    const province = await this.getProvinceById(normalizedProvinceId);
+
+    if (!(province instanceof Province)) {
+      throw new RangeError(`MapRepository could not find province ${normalizedProvinceId}.`);
+    }
+
+    return province;
+  }
+
+  async saveAll(provinces) {
+    if (!Array.isArray(provinces)) {
+      throw new TypeError('MapRepository provinces must be an array.');
+    }
+
+    const savedProvinces = [];
+
+    for (const province of provinces) {
+      savedProvinces.push(await this.saveProvince(requireProvince(province)));
+    }
+
+    return savedProvinces;
+  }
+}

--- a/test/adapters/war/InMemoryMapRepository.test.js
+++ b/test/adapters/war/InMemoryMapRepository.test.js
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryMapRepository } from '../../../src/adapters/war/InMemoryMapRepository.js';
+import { MapRepository } from '../../../src/application/war/MapRepository.js';
+import { Province } from '../../../src/domain/war/Province.js';
+
+function createProvince(overrides = {}) {
+  return new Province({
+    id: 'prov-1',
+    name: 'Province',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    loyalty: 60,
+    strategicValue: 3,
+    neighborIds: ['prov-2'],
+    ...overrides,
+  });
+}
+
+test('InMemoryMapRepository extends MapRepository and hydrates plain objects into Province instances', async () => {
+  const repository = new InMemoryMapRepository([
+    {
+      id: ' prov-2 ',
+      name: ' River March ',
+      ownerFactionId: ' faction-b ',
+      supplyLevel: 'strained',
+      loyalty: 45,
+      strategicValue: 6,
+      neighborIds: ['prov-1'],
+    },
+  ]);
+
+  const province = await repository.requireProvinceById('prov-2');
+
+  assert.equal(repository instanceof MapRepository, true);
+  assert.equal(province instanceof Province, true);
+  assert.deepEqual(province.toJSON(), {
+    id: 'prov-2',
+    name: 'River March',
+    ownerFactionId: 'faction-b',
+    controllingFactionId: 'faction-b',
+    supplyLevel: 'strained',
+    loyalty: 45,
+    strategicValue: 6,
+    neighborIds: ['prov-1'],
+    contested: false,
+    capturedAt: null,
+  });
+});
+
+test('InMemoryMapRepository lists provinces in stable order and persists saved updates', async () => {
+  const provinceA = createProvince({ id: 'prov-a', name: 'A Province' });
+  const provinceB = createProvince({ id: 'prov-b', name: 'B Province' });
+  const repository = new InMemoryMapRepository([provinceB]);
+
+  await repository.saveProvince(provinceA.withSupplyLevel('secure'));
+
+  const provinceIds = (await repository.listProvinces()).map((province) => province.id);
+  assert.deepEqual(provinceIds, ['prov-a', 'prov-b']);
+  assert.deepEqual(repository.snapshot(), [
+    {
+      id: 'prov-a',
+      name: 'A Province',
+      ownerFactionId: 'faction-a',
+      controllingFactionId: 'faction-a',
+      supplyLevel: 'secure',
+      loyalty: 60,
+      strategicValue: 3,
+      neighborIds: ['prov-2'],
+      contested: false,
+      capturedAt: null,
+    },
+    {
+      id: 'prov-b',
+      name: 'B Province',
+      ownerFactionId: 'faction-a',
+      controllingFactionId: 'faction-a',
+      supplyLevel: 'stable',
+      loyalty: 60,
+      strategicValue: 3,
+      neighborIds: ['prov-2'],
+      contested: false,
+      capturedAt: null,
+    },
+  ]);
+});
+
+test('InMemoryMapRepository rejects invalid seed payloads', () => {
+  assert.throws(() => new InMemoryMapRepository(null), /provinces must be an array/);
+  assert.throws(() => new InMemoryMapRepository([null]), /province record must be a Province or plain object/);
+});

--- a/test/application/war/MapRepository.test.js
+++ b/test/application/war/MapRepository.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { MapRepository } from '../../../src/application/war/MapRepository.js';
+import { Province } from '../../../src/domain/war/Province.js';
+
+function createProvince(overrides) {
+  return new Province({
+    id: 'prov-1',
+    name: 'Province',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    neighborIds: [],
+    ...overrides,
+  });
+}
+
+class InMemoryMapRepository extends MapRepository {
+  constructor(provinces = []) {
+    super();
+    this.provinces = new Map(provinces.map((province) => [province.id, province]));
+  }
+
+  async getProvinceById(provinceId) {
+    return this.provinces.get(provinceId) ?? null;
+  }
+
+  async listProvinces() {
+    return [...this.provinces.values()];
+  }
+
+  async saveProvince(province) {
+    this.provinces.set(province.id, province);
+    return province;
+  }
+}
+
+test('MapRepository provides shared helpers for province lookup and batch saving', async () => {
+  const provinceA = createProvince({ id: 'prov-a' });
+  const provinceB = createProvince({ id: 'prov-b' });
+  const repository = new InMemoryMapRepository([provinceA]);
+
+  const foundProvince = await repository.requireProvinceById(' prov-a ');
+  const savedProvinces = await repository.saveAll([provinceA, provinceB]);
+
+  assert.equal(foundProvince, provinceA);
+  assert.deepEqual(savedProvinces, [provinceA, provinceB]);
+  assert.deepEqual(await repository.listProvinces(), [provinceA, provinceB]);
+});
+
+test('MapRepository base methods fail fast until an adapter implements them', async () => {
+  const repository = new MapRepository();
+  const province = createProvince();
+
+  await assert.rejects(() => repository.getProvinceById('prov-1'), /must be implemented by an adapter/);
+  await assert.rejects(() => repository.listProvinces(), /must be implemented by an adapter/);
+  await assert.rejects(() => repository.saveProvince(province), /must be implemented by an adapter/);
+});
+
+test('MapRepository rejects missing provinces and invalid saveAll payloads', async () => {
+  const repository = new InMemoryMapRepository();
+
+  await assert.rejects(() => repository.requireProvinceById(''), /provinceId is required/);
+  await assert.rejects(() => repository.requireProvinceById('prov-missing'), /could not find province prov-missing/);
+  await assert.rejects(() => repository.saveAll(null), /provinces must be an array/);
+  await assert.rejects(() => repository.saveAll([{}]), /province must be a Province instance/);
+});


### PR DESCRIPTION
Alpha: ## Summary
Alpha: Add an in-memory adapter for Alpha's map repository slice.
Alpha:
Alpha: ## Changes
Alpha: Add `InMemoryMapRepository` under `src/adapters/war/`.
Alpha: Support seeding from plain objects or `Province` instances.
Alpha: Keep province listing and snapshots stable and deterministic.
Alpha: Add adapter tests covering hydration, persistence, ordering, and invalid seed payloads.
Alpha:
Alpha: ## Testing
Alpha: - [x] `npm test`
Alpha:
Alpha: ## Notes
Alpha: This PR is stacked on top of `alpha/a12-create-battle-resolver-port` to keep the change focused.
