### PR TITLE
Beta: define ResourceStock value object

### DIFF
--- a/src/domain/economy/ResourceStock.js
+++ b/src/domain/economy/ResourceStock.js
@@ -1,0 +1,112 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+export class ResourceStock {
+  constructor({
+    resourceId,
+    quantity,
+    capacity,
+    reserved = 0,
+    reorderPoint = 0,
+    spoilageRisk = 0,
+  }) {
+    this.resourceId = requireText(resourceId, 'ResourceStock resourceId');
+    this.capacity = requireInteger(
+      capacity,
+      'ResourceStock capacity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+    this.quantity = requireInteger(
+      quantity,
+      'ResourceStock quantity',
+      0,
+      this.capacity,
+    );
+    this.reserved = requireInteger(
+      reserved,
+      'ResourceStock reserved',
+      0,
+      this.quantity,
+    );
+    this.reorderPoint = requireInteger(
+      reorderPoint,
+      'ResourceStock reorderPoint',
+      0,
+      this.capacity,
+    );
+    this.spoilageRisk = requireInteger(
+      spoilageRisk,
+      'ResourceStock spoilageRisk',
+      0,
+      100,
+    );
+  }
+
+  get availableQuantity() {
+    return this.quantity - this.reserved;
+  }
+
+  get isScarce() {
+    return this.quantity <= this.reorderPoint;
+  }
+
+  get fillRatio() {
+    if (this.capacity === 0) {
+      return this.quantity === 0 ? 0 : Infinity;
+    }
+
+    return this.quantity / this.capacity;
+  }
+
+  withQuantity(quantity) {
+    return new ResourceStock({
+      ...this.toJSON(),
+      quantity,
+      reserved: Math.min(this.reserved, quantity),
+    });
+  }
+
+  withReservation(reserved) {
+    return new ResourceStock({
+      ...this.toJSON(),
+      reserved,
+    });
+  }
+
+  withCapacity(capacity) {
+    return new ResourceStock({
+      ...this.toJSON(),
+      capacity,
+      quantity: Math.min(this.quantity, capacity),
+      reserved: Math.min(this.reserved, Math.min(this.quantity, capacity)),
+      reorderPoint: Math.min(this.reorderPoint, capacity),
+    });
+  }
+
+  toJSON() {
+    return {
+      resourceId: this.resourceId,
+      quantity: this.quantity,
+      capacity: this.capacity,
+      reserved: this.reserved,
+      reorderPoint: this.reorderPoint,
+      spoilageRisk: this.spoilageRisk,
+    };
+  }
+}

--- a/test/domain/economy/ResourceStock.test.js
+++ b/test/domain/economy/ResourceStock.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ResourceStock } from '../../../src/domain/economy/ResourceStock.js';
+
+test('ResourceStock keeps normalized stock fields and exposes derived values', () => {
+  const stock = new ResourceStock({
+    resourceId: ' grain ',
+    quantity: 120,
+    capacity: 300,
+    reserved: 25,
+    reorderPoint: 40,
+    spoilageRisk: 12,
+  });
+
+  assert.deepEqual(stock.toJSON(), {
+    resourceId: 'grain',
+    quantity: 120,
+    capacity: 300,
+    reserved: 25,
+    reorderPoint: 40,
+    spoilageRisk: 12,
+  });
+  assert.equal(stock.availableQuantity, 95);
+  assert.equal(stock.isScarce, false);
+  assert.equal(stock.fillRatio, 120 / 300);
+});
+
+test('ResourceStock supports immutable quantity, reservation, and capacity updates', () => {
+  const stock = new ResourceStock({
+    resourceId: 'wood',
+    quantity: 80,
+    capacity: 100,
+    reserved: 20,
+    reorderPoint: 30,
+  });
+
+  const reducedStock = stock.withQuantity(10);
+  const reservedStock = reducedStock.withReservation(5);
+  const resizedStock = reservedStock.withCapacity(8);
+
+  assert.notEqual(reducedStock, stock);
+  assert.notEqual(reservedStock, reducedStock);
+  assert.notEqual(resizedStock, reservedStock);
+  assert.equal(reducedStock.quantity, 10);
+  assert.equal(reducedStock.reserved, 10);
+  assert.equal(reservedStock.availableQuantity, 5);
+  assert.equal(resizedStock.capacity, 8);
+  assert.equal(resizedStock.quantity, 8);
+  assert.equal(resizedStock.reserved, 5);
+  assert.equal(resizedStock.reorderPoint, 8);
+  assert.equal(stock.quantity, 80);
+  assert.equal(stock.reserved, 20);
+  assert.equal(stock.capacity, 100);
+});
+
+test('ResourceStock reports scarcity and handles zero-capacity ratios safely', () => {
+  const scarceStock = new ResourceStock({
+    resourceId: 'salt',
+    quantity: 0,
+    capacity: 0,
+    reorderPoint: 0,
+  });
+
+  assert.equal(scarceStock.isScarce, true);
+  assert.equal(scarceStock.fillRatio, 0);
+  assert.equal(scarceStock.availableQuantity, 0);
+});
+
+test('ResourceStock rejects invalid identifiers and stock invariants', () => {
+  assert.throws(
+    () => new ResourceStock({ resourceId: '', quantity: 1, capacity: 10 }),
+    /ResourceStock resourceId is required/,
+  );
+
+  assert.throws(
+    () => new ResourceStock({ resourceId: 'grain', quantity: 11, capacity: 10 }),
+    /ResourceStock quantity must be an integer between 0 and 10/,
+  );
+
+  assert.throws(
+    () => new ResourceStock({ resourceId: 'grain', quantity: 10, capacity: 10, reserved: 11 }),
+    /ResourceStock reserved must be an integer between 0 and 10/,
+  );
+
+  assert.throws(
+    () => new ResourceStock({ resourceId: 'grain', quantity: 10, capacity: 10, spoilageRisk: 101 }),
+    /ResourceStock spoilageRisk must be an integer between 0 and 100/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: define the `ResourceStock` value object for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `ResourceStock` with normalized resource ids and bounded quantity, capacity, reservation, reorder-point, and spoilage invariants
Beta: - expose derived economy helpers for available quantity, scarcity, and fill ratio
Beta: - add immutable update helpers and node tests for normalization, derived values, and invalid stock states
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #22
