### PR TITLE
Gamma: [G09] Create CultureRepository port

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/domain/culture/CultureRepositoryPort.js
+++ b/src/domain/culture/CultureRepositoryPort.js
@@ -1,0 +1,38 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireCulture(culture) {
+  if (!culture || typeof culture !== 'object' || Array.isArray(culture)) {
+    throw new TypeError('CultureRepositoryPort culture must be an object.');
+  }
+
+  return {
+    ...culture,
+    id: requireText(culture.id, 'CultureRepositoryPort culture.id'),
+    name: requireText(culture.name, 'CultureRepositoryPort culture.name'),
+  };
+}
+
+export class CultureRepositoryPort {
+  async getById(cultureId) {
+    requireText(cultureId, 'CultureRepositoryPort cultureId');
+    throw new Error('CultureRepositoryPort.getById must be implemented by an adapter.');
+  }
+
+  async save(culture) {
+    requireCulture(culture);
+    throw new Error('CultureRepositoryPort.save must be implemented by an adapter.');
+  }
+
+  async listByEra(eraId) {
+    requireText(eraId, 'CultureRepositoryPort eraId');
+    throw new Error('CultureRepositoryPort.listByEra must be implemented by an adapter.');
+  }
+}

--- a/test/domain/culture/CultureRepositoryPort.test.js
+++ b/test/domain/culture/CultureRepositoryPort.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CultureRepositoryPort } from '../../../src/domain/culture/CultureRepositoryPort.js';
+
+test('CultureRepositoryPort validates identifiers before delegating to adapters', async () => {
+  const port = new CultureRepositoryPort();
+
+  await assert.rejects(() => port.getById(''), /CultureRepositoryPort cultureId is required/);
+  await assert.rejects(() => port.listByEra('   '), /CultureRepositoryPort eraId is required/);
+});
+
+test('CultureRepositoryPort validates culture payloads before save', async () => {
+  const port = new CultureRepositoryPort();
+
+  await assert.rejects(() => port.save(null), /CultureRepositoryPort culture must be an object/);
+  await assert.rejects(() => port.save({ id: 'culture-north', name: ' ' }), /CultureRepositoryPort culture.name is required/);
+  await assert.rejects(() => port.save({ id: ' ', name: 'Northern Scriptorium' }), /CultureRepositoryPort culture.id is required/);
+});
+
+test('CultureRepositoryPort exposes explicit adapter implementation errors', async () => {
+  const port = new CultureRepositoryPort();
+  const culture = { id: 'culture-north', name: 'Northern Scriptorium', eraId: 'late-medieval' };
+
+  await assert.rejects(
+    () => port.getById('culture-north'),
+    /CultureRepositoryPort\.getById must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.save(culture),
+    /CultureRepositoryPort\.save must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.listByEra('late-medieval'),
+    /CultureRepositoryPort\.listByEra must be implemented by an adapter/,
+  );
+});


### PR DESCRIPTION
Gamma: ## Summary
Gamma: Add a small, explicit `CultureRepositoryPort` for the Gamma domain, with input validation and adapter-facing failure modes.
Gamma:
Gamma: ## Related issue
Gamma: - Closes #49
Gamma:
Gamma: ## Changes
Gamma: - add `src/domain/culture/CultureRepositoryPort.js`
Gamma: - validate culture ids, era ids, and minimum culture payload shape before delegation
Gamma: - expose explicit adapter implementation errors for `getById`, `save`, and `listByEra`
Gamma: - add node tests for validation and base adapter behavior
Gamma:
Gamma: ## Testing
Gamma: - [x] Local checks run
Gamma: - [x] Relevant tests added or updated
Gamma: - [ ] Manual check if relevant
Gamma: - [x] `npm test -- --test-reporter tap`
Gamma:
Gamma: ## Rules check
Gamma: - [x] This work comes through a pull request
Gamma: - [x] This PR is mandatory to avoid bugs and validation problems with Zeta
Gamma: - [x] GitHub text starts with the agent name followed by `:`
Gamma: - [x] The work stays inside the author's domain
Gamma: - [ ] Zeta has been asked for validation before merge
Gamma:
Gamma: ## Notes
Gamma: This branch includes the minimal `package.json` test script so the repository can run node tests consistently.
