### PR TITLE
Delta: [D07] Implement ResoudreSabotage use case

### DIFF
--- a/src/application/intrigue/ResoudreSabotage.js
+++ b/src/application/intrigue/ResoudreSabotage.js
@@ -1,0 +1,124 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireScore(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new RangeError(`${label} must be an integer between 0 and 100.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function deriveOutcomeSeverity({ readiness, targetStability, targetSecurity, randomFactor }) {
+  return Math.max(0, readiness + randomFactor - Math.round((targetStability + targetSecurity) / 2));
+}
+
+export function resoudreSabotage({
+  operation,
+  target,
+  randomFactor = 0,
+  infrastructureIds = target?.infrastructureIds ?? [],
+}) {
+  const normalizedOperation = requireObject(operation, 'ResoudreSabotage operation');
+  const normalizedTarget = requireObject(target, 'ResoudreSabotage target');
+  const normalizedRandomFactor = requireScore(randomFactor, 'ResoudreSabotage randomFactor');
+  const normalizedInfrastructureIds = normalizeUniqueTexts(
+    infrastructureIds,
+    'ResoudreSabotage infrastructureIds',
+  );
+  const operationId = requireText(normalizedOperation.id, 'ResoudreSabotage operation id');
+  const targetId = requireText(normalizedTarget.id, 'ResoudreSabotage target id');
+  const readiness = requireScore(normalizedOperation.readiness ?? 0, 'ResoudreSabotage operation readiness');
+  const heat = requireScore(normalizedOperation.heat ?? 0, 'ResoudreSabotage operation heat');
+  const targetStability = requireScore(normalizedTarget.stability ?? 0, 'ResoudreSabotage target stability');
+  const targetSecurity = requireScore(normalizedTarget.security ?? 0, 'ResoudreSabotage target security');
+  const targetIndustry = requireScore(normalizedTarget.industry ?? 0, 'ResoudreSabotage target industry');
+
+  if (normalizedInfrastructureIds.length === 0) {
+    return {
+      resolved: false,
+      outcome: 'no-target-infrastructure',
+      target: { ...normalizedTarget },
+      operation: { ...normalizedOperation },
+      summary: 'No sabotage target was available.',
+      damage: {
+        industryLoss: 0,
+        stabilityLoss: 0,
+        heatIncrease: 0,
+        disruptedInfrastructureIds: [],
+      },
+    };
+  }
+
+  const severity = deriveOutcomeSeverity({
+    readiness,
+    targetStability,
+    targetSecurity,
+    randomFactor: normalizedRandomFactor,
+  });
+  const success = severity > 0;
+  const disruptedInfrastructureIds = success
+    ? normalizedInfrastructureIds.slice(0, Math.max(1, Math.floor(severity / 25) + 1))
+    : [];
+  const industryLoss = success ? Math.min(targetIndustry, Math.max(5, Math.round(severity / 3))) : 0;
+  const stabilityLoss = success ? Math.min(targetStability, Math.max(3, Math.round(severity / 4))) : 0;
+  const heatIncrease = Math.min(100 - heat, success ? Math.max(8, 18 - Math.round(readiness / 10)) : 14);
+  const nextHeat = heat + heatIncrease;
+
+  return {
+    resolved: true,
+    outcome: success ? 'sabotage-succeeded' : 'sabotage-failed',
+    operation: {
+      ...normalizedOperation,
+      id: operationId,
+      heat: nextHeat,
+      phase: 'resolved',
+      progress: 100,
+    },
+    target: {
+      ...normalizedTarget,
+      id: targetId,
+      industry: targetIndustry - industryLoss,
+      stability: targetStability - stabilityLoss,
+      disruptedInfrastructureIds,
+    },
+    summary: success
+      ? `Sabotage disrupted ${disruptedInfrastructureIds.length} infrastructure target(s).`
+      : 'Sabotage failed to create lasting damage.',
+    damage: {
+      industryLoss,
+      stabilityLoss,
+      heatIncrease,
+      disruptedInfrastructureIds,
+    },
+  };
+}

--- a/test/application/intrigue/ResoudreSabotage.test.js
+++ b/test/application/intrigue/ResoudreSabotage.test.js
@@ -1,0 +1,156 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resoudreSabotage } from '../../../src/application/intrigue/ResoudreSabotage.js';
+
+test('ResoudreSabotage produces explicit damage on success', () => {
+  const result = resoudreSabotage({
+    operation: {
+      id: 'op-cendre',
+      readiness: 78,
+      heat: 12,
+      phase: 'infiltration',
+      progress: 60,
+    },
+    target: {
+      id: 'city-aster-port',
+      industry: 70,
+      stability: 62,
+      security: 34,
+    },
+    infrastructureIds: ['rail-hub', 'arsenal', 'signal-yard'],
+    randomFactor: 19,
+  });
+
+  assert.deepEqual(result, {
+    resolved: true,
+    outcome: 'sabotage-succeeded',
+    operation: {
+      id: 'op-cendre',
+      readiness: 78,
+      heat: 22,
+      phase: 'resolved',
+      progress: 100,
+    },
+    target: {
+      id: 'city-aster-port',
+      industry: 54,
+      stability: 50,
+      security: 34,
+      disruptedInfrastructureIds: ['arsenal', 'rail-hub'],
+    },
+    summary: 'Sabotage disrupted 2 infrastructure target(s).',
+    damage: {
+      industryLoss: 16,
+      stabilityLoss: 12,
+      heatIncrease: 10,
+      disruptedInfrastructureIds: ['arsenal', 'rail-hub'],
+    },
+  });
+});
+
+test('ResoudreSabotage keeps failure outcomes explicit', () => {
+  const result = resoudreSabotage({
+    operation: {
+      id: 'op-cendre',
+      readiness: 24,
+      heat: 33,
+      phase: 'infiltration',
+      progress: 60,
+    },
+    target: {
+      id: 'city-aster-port',
+      industry: 70,
+      stability: 62,
+      security: 58,
+    },
+    infrastructureIds: ['rail-hub', 'arsenal'],
+    randomFactor: 6,
+  });
+
+  assert.deepEqual(result, {
+    resolved: true,
+    outcome: 'sabotage-failed',
+    operation: {
+      id: 'op-cendre',
+      readiness: 24,
+      heat: 47,
+      phase: 'resolved',
+      progress: 100,
+    },
+    target: {
+      id: 'city-aster-port',
+      industry: 70,
+      stability: 62,
+      security: 58,
+      disruptedInfrastructureIds: [],
+    },
+    summary: 'Sabotage failed to create lasting damage.',
+    damage: {
+      industryLoss: 0,
+      stabilityLoss: 0,
+      heatIncrease: 14,
+      disruptedInfrastructureIds: [],
+    },
+  });
+});
+
+test('ResoudreSabotage validates inputs and handles missing infrastructure', () => {
+  assert.throws(
+    () => resoudreSabotage({ operation: null, target: {} }),
+    /ResoudreSabotage operation must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      resoudreSabotage({
+        operation: { id: 'op-cendre', readiness: 20, heat: 0 },
+        target: { id: 'city-aster-port', industry: 50, stability: 50, security: 50 },
+        randomFactor: 120,
+      }),
+    /ResoudreSabotage randomFactor must be an integer between 0 and 100/,
+  );
+
+  const result = resoudreSabotage({
+    operation: {
+      id: 'op-cendre',
+      readiness: 65,
+      heat: 10,
+      phase: 'infiltration',
+      progress: 50,
+    },
+    target: {
+      id: 'city-aster-port',
+      industry: 52,
+      stability: 48,
+      security: 45,
+    },
+    infrastructureIds: [],
+    randomFactor: 10,
+  });
+
+  assert.deepEqual(result, {
+    resolved: false,
+    outcome: 'no-target-infrastructure',
+    operation: {
+      id: 'op-cendre',
+      readiness: 65,
+      heat: 10,
+      phase: 'infiltration',
+      progress: 50,
+    },
+    target: {
+      id: 'city-aster-port',
+      industry: 52,
+      stability: 48,
+      security: 45,
+    },
+    summary: 'No sabotage target was available.',
+    damage: {
+      industryLoss: 0,
+      stabilityLoss: 0,
+      heatIncrease: 0,
+      disruptedInfrastructureIds: [],
+    },
+  });
+});


### PR DESCRIPTION
Delta: Cette PR traite l'issue #67 en ajoutant le use case `ResoudreSabotage`.

## Contenu
- ajout d'un use case pur pour résoudre une tentative de sabotage
- explicitation des issues succès, échec et absence de cible exploitable
- calcul des dégâts, de la chaleur et des infrastructures perturbées
- ajout de tests pour un sabotage réussi, raté et invalide

## Vérification
- `npm test`

## Notes
- cette PR est empilée sur `delta/d06-implement-lanceroperation`
- je demanderai la validation de Zeta avant tout merge
