### PR TITLE
Beta: define ProductionRule model

### DIFF
--- a/src/domain/economy/ProductionRule.js
+++ b/src/domain/economy/ProductionRule.js
@@ -1,0 +1,200 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTextList(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function requireInteger(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+export class ProductionRule {
+  constructor({
+    id,
+    cityId,
+    resourceId,
+    buildingType,
+    laborRequired,
+    baseYield,
+    inputByResource = {},
+    seasonModifiers = {},
+    tags = [],
+    active = true,
+    priority = 50,
+  }) {
+    this.id = requireText(id, 'ProductionRule id');
+    this.cityId = requireText(cityId, 'ProductionRule cityId');
+    this.resourceId = requireText(resourceId, 'ProductionRule resourceId');
+    this.buildingType = requireText(buildingType, 'ProductionRule buildingType');
+    this.laborRequired = requireInteger(
+      laborRequired,
+      'ProductionRule laborRequired',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+    this.baseYield = requireInteger(
+      baseYield,
+      'ProductionRule baseYield',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+    this.inputByResource = ProductionRule.#normalizeInputByResource(inputByResource);
+    this.seasonModifiers = ProductionRule.#normalizeSeasonModifiers(seasonModifiers);
+    this.tags = normalizeUniqueTextList(tags, 'ProductionRule tags');
+    this.active = Boolean(active);
+    this.priority = requireInteger(priority, 'ProductionRule priority', 0, 100);
+  }
+
+  get totalInputRequired() {
+    return Object.values(this.inputByResource).reduce((sum, quantity) => sum + quantity, 0);
+  }
+
+  get netBaseYield() {
+    return this.baseYield - this.totalInputRequired;
+  }
+
+  get hasInputs() {
+    return Object.keys(this.inputByResource).length > 0;
+  }
+
+  get bestSeason() {
+    const entries = Object.entries(this.seasonModifiers);
+
+    if (entries.length === 0) {
+      return null;
+    }
+
+    return entries.reduce((bestSeason, currentSeason) => {
+      if (bestSeason === null || currentSeason[1] > bestSeason[1]) {
+        return currentSeason;
+      }
+
+      return bestSeason;
+    }, null)?.[0] ?? null;
+  }
+
+  withPriority(priority) {
+    return new ProductionRule({
+      ...this.toJSON(),
+      priority,
+    });
+  }
+
+  withActive(active) {
+    return new ProductionRule({
+      ...this.toJSON(),
+      active,
+    });
+  }
+
+  withSeasonModifier(season, modifier) {
+    const normalizedSeason = requireText(season, 'ProductionRule season');
+
+    return new ProductionRule({
+      ...this.toJSON(),
+      seasonModifiers: {
+        ...this.seasonModifiers,
+        [normalizedSeason]: requireInteger(
+          modifier,
+          'ProductionRule season modifier',
+          -100,
+          100,
+        ),
+      },
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      cityId: this.cityId,
+      resourceId: this.resourceId,
+      buildingType: this.buildingType,
+      laborRequired: this.laborRequired,
+      baseYield: this.baseYield,
+      inputByResource: { ...this.inputByResource },
+      seasonModifiers: { ...this.seasonModifiers },
+      tags: [...this.tags],
+      active: this.active,
+      priority: this.priority,
+    };
+  }
+
+  static #normalizeInputByResource(inputByResource) {
+    if (
+      inputByResource === null
+      || typeof inputByResource !== 'object'
+      || Array.isArray(inputByResource)
+    ) {
+      throw new TypeError('ProductionRule inputByResource must be an object.');
+    }
+
+    return Object.fromEntries(
+      Object.entries(inputByResource)
+        .map(([resourceId, quantity]) => {
+          const normalizedResourceId = requireText(resourceId, 'ProductionRule input resourceId');
+
+          return [
+            normalizedResourceId,
+            requireInteger(
+              quantity,
+              `ProductionRule input quantity for ${normalizedResourceId}`,
+              0,
+              Number.MAX_SAFE_INTEGER,
+            ),
+          ];
+        })
+        .sort(([leftId], [rightId]) => leftId.localeCompare(rightId)),
+    );
+  }
+
+  static #normalizeSeasonModifiers(seasonModifiers) {
+    if (
+      seasonModifiers === null
+      || typeof seasonModifiers !== 'object'
+      || Array.isArray(seasonModifiers)
+    ) {
+      throw new TypeError('ProductionRule seasonModifiers must be an object.');
+    }
+
+    return Object.fromEntries(
+      Object.entries(seasonModifiers)
+        .map(([season, modifier]) => {
+          const normalizedSeason = requireText(season, 'ProductionRule season');
+
+          return [
+            normalizedSeason,
+            requireInteger(
+              modifier,
+              `ProductionRule season modifier for ${normalizedSeason}`,
+              -100,
+              100,
+            ),
+          ];
+        })
+        .sort(([leftSeason], [rightSeason]) => leftSeason.localeCompare(rightSeason)),
+    );
+  }
+}

--- a/test/domain/economy/ProductionRule.test.js
+++ b/test/domain/economy/ProductionRule.test.js
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ProductionRule } from '../../../src/domain/economy/ProductionRule.js';
+
+test('ProductionRule keeps a normalized production definition', () => {
+  const rule = new ProductionRule({
+    id: ' rule-granary ',
+    cityId: ' city-001 ',
+    resourceId: ' grain ',
+    buildingType: ' granary ',
+    laborRequired: 30,
+    baseYield: 90,
+    inputByResource: {
+      water: 5,
+      ' seed ': 10,
+    },
+    seasonModifiers: {
+      winter: -20,
+      ' autumn ': 15,
+    },
+    tags: [' staple ', 'food', 'staple'],
+    active: 1,
+    priority: 70,
+  });
+
+  assert.deepEqual(rule.toJSON(), {
+    id: 'rule-granary',
+    cityId: 'city-001',
+    resourceId: 'grain',
+    buildingType: 'granary',
+    laborRequired: 30,
+    baseYield: 90,
+    inputByResource: {
+      seed: 10,
+      water: 5,
+    },
+    seasonModifiers: {
+      autumn: 15,
+      winter: -20,
+    },
+    tags: ['food', 'staple'],
+    active: true,
+    priority: 70,
+  });
+
+  assert.equal(rule.totalInputRequired, 15);
+  assert.equal(rule.netBaseYield, 75);
+  assert.equal(rule.hasInputs, true);
+  assert.equal(rule.bestSeason, 'autumn');
+});
+
+test('ProductionRule supports immutable priority, activation, and season updates', () => {
+  const rule = new ProductionRule({
+    id: 'rule-lumberyard',
+    cityId: 'city-forest',
+    resourceId: 'wood',
+    buildingType: 'lumberyard',
+    laborRequired: 18,
+    baseYield: 40,
+  });
+
+  const prioritizedRule = rule.withPriority(85);
+  const pausedRule = prioritizedRule.withActive(false);
+  const seasonalRule = pausedRule.withSeasonModifier('spring', 12);
+
+  assert.notEqual(prioritizedRule, rule);
+  assert.notEqual(pausedRule, prioritizedRule);
+  assert.notEqual(seasonalRule, pausedRule);
+  assert.equal(prioritizedRule.priority, 85);
+  assert.equal(pausedRule.active, false);
+  assert.deepEqual(seasonalRule.seasonModifiers, { spring: 12 });
+  assert.equal(rule.priority, 50);
+  assert.equal(rule.active, true);
+  assert.deepEqual(rule.seasonModifiers, {});
+});
+
+test('ProductionRule handles rules without inputs or seasonal modifiers', () => {
+  const rule = new ProductionRule({
+    id: 'rule-well',
+    cityId: 'city-001',
+    resourceId: 'water',
+    buildingType: 'well',
+    laborRequired: 8,
+    baseYield: 12,
+  });
+
+  assert.equal(rule.totalInputRequired, 0);
+  assert.equal(rule.netBaseYield, 12);
+  assert.equal(rule.hasInputs, false);
+  assert.equal(rule.bestSeason, null);
+});
+
+test('ProductionRule rejects invalid identifiers and economic invariants', () => {
+  assert.throws(
+    () => new ProductionRule({ id: '', cityId: 'city-001', resourceId: 'grain', buildingType: 'granary', laborRequired: 10, baseYield: 20 }),
+    /ProductionRule id is required/,
+  );
+
+  assert.throws(
+    () => new ProductionRule({ id: 'rule', cityId: 'city-001', resourceId: 'grain', buildingType: 'granary', laborRequired: -1, baseYield: 20 }),
+    /ProductionRule laborRequired must be an integer between 0 and/,
+  );
+
+  assert.throws(
+    () => new ProductionRule({ id: 'rule', cityId: 'city-001', resourceId: 'grain', buildingType: 'granary', laborRequired: 10, baseYield: 20, inputByResource: [] }),
+    /ProductionRule inputByResource must be an object/,
+  );
+
+  assert.throws(
+    () => new ProductionRule({ id: 'rule', cityId: 'city-001', resourceId: 'grain', buildingType: 'granary', laborRequired: 10, baseYield: 20, seasonModifiers: { winter: 101 } }),
+    /ProductionRule season modifier for winter must be an integer between -100 and 100/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: define the `ProductionRule` model for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `ProductionRule` with normalized ids, labor, base yield, input resources, seasonal modifiers, tags, activity state, and priority
Beta: - expose derived helpers for total input cost, net base yield, input presence, and best season
Beta: - add immutable update helpers and node tests for normalization, derived values, season updates, and invalid invariants
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #23
