### PR TITLE
Gamma: [G10] Create ResearchRepository port

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/domain/culture/ResearchRepositoryPort.js
+++ b/src/domain/culture/ResearchRepositoryPort.js
@@ -1,0 +1,60 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function normalizeUniqueTexts(values, label) {
+  const normalizedValues = [...new Set(requireArray(values, label).map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function requireResearchState(researchState) {
+  if (!researchState || typeof researchState !== 'object' || Array.isArray(researchState)) {
+    throw new TypeError('ResearchRepositoryPort researchState must be an object.');
+  }
+
+  return {
+    ...researchState,
+    id: requireText(researchState.id, 'ResearchRepositoryPort researchState.id'),
+    cultureId: requireText(researchState.cultureId, 'ResearchRepositoryPort researchState.cultureId'),
+    focusIds: normalizeUniqueTexts(
+      researchState.focusIds ?? [],
+      'ResearchRepositoryPort researchState.focusIds',
+    ),
+  };
+}
+
+export class ResearchRepositoryPort {
+  async getById(researchStateId) {
+    requireText(researchStateId, 'ResearchRepositoryPort researchStateId');
+    throw new Error('ResearchRepositoryPort.getById must be implemented by an adapter.');
+  }
+
+  async save(researchState) {
+    requireResearchState(researchState);
+    throw new Error('ResearchRepositoryPort.save must be implemented by an adapter.');
+  }
+
+  async listByCulture(cultureId) {
+    requireText(cultureId, 'ResearchRepositoryPort cultureId');
+    throw new Error('ResearchRepositoryPort.listByCulture must be implemented by an adapter.');
+  }
+}

--- a/test/domain/culture/ResearchRepositoryPort.test.js
+++ b/test/domain/culture/ResearchRepositoryPort.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ResearchRepositoryPort } from '../../../src/domain/culture/ResearchRepositoryPort.js';
+
+test('ResearchRepositoryPort validates identifiers before delegating to adapters', async () => {
+  const port = new ResearchRepositoryPort();
+
+  await assert.rejects(() => port.getById(''), /ResearchRepositoryPort researchStateId is required/);
+  await assert.rejects(() => port.listByCulture('   '), /ResearchRepositoryPort cultureId is required/);
+});
+
+test('ResearchRepositoryPort validates research state payloads before save', async () => {
+  const port = new ResearchRepositoryPort();
+
+  await assert.rejects(() => port.save(null), /ResearchRepositoryPort researchState must be an object/);
+  await assert.rejects(
+    () => port.save({ id: 'research-state-1', cultureId: 'culture-north', focusIds: ['archives', ' '] }),
+    /ResearchRepositoryPort researchState.focusIds cannot contain empty values/,
+  );
+  await assert.rejects(
+    () => port.save({ id: ' ', cultureId: 'culture-north', focusIds: [] }),
+    /ResearchRepositoryPort researchState.id is required/,
+  );
+  await assert.rejects(
+    () => port.save({ id: 'research-state-1', cultureId: ' ', focusIds: [] }),
+    /ResearchRepositoryPort researchState.cultureId is required/,
+  );
+});
+
+test('ResearchRepositoryPort exposes explicit adapter implementation errors', async () => {
+  const port = new ResearchRepositoryPort();
+  const researchState = {
+    id: 'research-state-1',
+    cultureId: 'culture-north',
+    focusIds: ['archives', 'astronomy'],
+  };
+
+  await assert.rejects(
+    () => port.getById('research-state-1'),
+    /ResearchRepositoryPort\.getById must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.save(researchState),
+    /ResearchRepositoryPort\.save must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.listByCulture('culture-north'),
+    /ResearchRepositoryPort\.listByCulture must be implemented by an adapter/,
+  );
+});


### PR DESCRIPTION
Gamma: ## Summary
Gamma: Add a small, explicit `ResearchRepositoryPort` for the Gamma domain, with input validation and adapter-facing failure modes.
Gamma:
Gamma: ## Related issue
Gamma: - Closes #50
Gamma:
Gamma: ## Changes
Gamma: - add `src/domain/culture/ResearchRepositoryPort.js`
Gamma: - validate research state ids, culture ids, and research focus ids before delegation
Gamma: - expose explicit adapter implementation errors for `getById`, `save`, and `listByCulture`
Gamma: - add node tests for validation and base adapter behavior
Gamma:
Gamma: ## Testing
Gamma: - [x] Local checks run
Gamma: - [x] Relevant tests added or updated
Gamma: - [ ] Manual check if relevant
Gamma: - [x] `npm test -- --test-reporter tap`
Gamma:
Gamma: ## Rules check
Gamma: - [x] This work comes through a pull request
Gamma: - [x] This PR is mandatory to avoid bugs and validation problems with Zeta
Gamma: - [x] GitHub text starts with the agent name followed by `:`
Gamma: - [x] The work stays inside the author's domain
Gamma: - [ ] Zeta has been asked for validation before merge
Gamma:
Gamma: ## Notes
Gamma: This branch includes the minimal `package.json` test script so the repository can run node tests consistently.
