### PR TITLE
Epsilon: implement TriggerCatastrophe use case

### DIFF
--- a/src/application/climate/TriggerCatastrophe.js
+++ b/src/application/climate/TriggerCatastrophe.js
@@ -1,0 +1,108 @@
+import { Catastrophe } from '../../domain/climate/Catastrophe.js';
+import { ClimateState } from '../../domain/climate/ClimateState.js';
+
+function normalizeRegionalStates(regionalStates) {
+  if (!Array.isArray(regionalStates)) {
+    throw new RangeError('TriggerCatastrophe regionalStates must be an array.');
+  }
+
+  return regionalStates.map((state) => {
+    if (state instanceof ClimateState) {
+      return state;
+    }
+
+    return new ClimateState(state);
+  });
+}
+
+function normalizeThresholds(thresholds = {}) {
+  return {
+    droughtIndex: Number.isFinite(thresholds.droughtIndex) ? thresholds.droughtIndex : 70,
+    precipitationLevel: Number.isFinite(thresholds.precipitationLevel) ? thresholds.precipitationLevel : 18,
+    temperatureC: Number.isFinite(thresholds.temperatureC) ? thresholds.temperatureC : 34,
+    floodPrecipitationLevel: Number.isFinite(thresholds.floodPrecipitationLevel) ? thresholds.floodPrecipitationLevel : 82,
+  };
+}
+
+function buildDefaultImpact(state, type) {
+  if (type === 'drought') {
+    return {
+      harvest: -Math.min(60, Math.round(state.droughtIndex * 0.6)),
+      unrest: Math.round(Math.max(5, state.droughtIndex * 0.18)),
+    };
+  }
+
+  if (type === 'flood') {
+    return {
+      infrastructure: -Math.round(Math.max(10, state.precipitationLevel * 0.35)),
+      harvest: -Math.round(Math.max(8, state.precipitationLevel * 0.2)),
+    };
+  }
+
+  return {
+    unrest: -10,
+  };
+}
+
+function decideCatastropheType(state, thresholds) {
+  if (state.droughtIndex >= thresholds.droughtIndex && state.precipitationLevel <= thresholds.precipitationLevel) {
+    return {
+      type: 'drought',
+      severity: state.droughtIndex >= thresholds.droughtIndex + 15 ? 'critical' : 'major',
+    };
+  }
+
+  if (state.precipitationLevel >= thresholds.floodPrecipitationLevel && state.temperatureC <= thresholds.temperatureC - 10) {
+    return {
+      type: 'flood',
+      severity: state.precipitationLevel >= thresholds.floodPrecipitationLevel + 10 ? 'critical' : 'major',
+    };
+  }
+
+  if (state.anomaly === 'heatwave' && state.temperatureC >= thresholds.temperatureC) {
+    return {
+      type: 'heatwave',
+      severity: state.temperatureC >= thresholds.temperatureC + 4 ? 'critical' : 'major',
+    };
+  }
+
+  return null;
+}
+
+export class TriggerCatastrophe {
+  execute({ regionalStates, triggeredAt = new Date(), thresholds } = {}) {
+    const states = normalizeRegionalStates(regionalStates);
+    const normalizedThresholds = normalizeThresholds(thresholds);
+    const catastrophes = [];
+    const updatedRegionalStates = [];
+
+    for (const state of states) {
+      const catastropheDecision = decideCatastropheType(state, normalizedThresholds);
+
+      if (catastropheDecision === null || state.activeCatastropheIds.length > 0) {
+        updatedRegionalStates.push(state);
+        continue;
+      }
+
+      const catastrophe = new Catastrophe({
+        id: `${state.regionId}-${catastropheDecision.type}-${state.season}`,
+        type: catastropheDecision.type,
+        severity: catastropheDecision.severity,
+        status: 'active',
+        regionIds: [state.regionId],
+        startedAt: triggeredAt,
+        impact: buildDefaultImpact(state, catastropheDecision.type),
+        description: `${catastropheDecision.type} in ${state.regionId} during ${state.season}`,
+      });
+
+      catastrophes.push(catastrophe);
+      updatedRegionalStates.push(state.activateCatastrophe(catastrophe.id));
+    }
+
+    return {
+      catastrophes,
+      updatedRegionalStates,
+      triggeredCount: catastrophes.length,
+    };
+  }
+}

--- a/src/domain/climate/Catastrophe.js
+++ b/src/domain/climate/Catastrophe.js
@@ -1,0 +1,158 @@
+const VALID_SEVERITIES = ['minor', 'major', 'critical'];
+const VALID_STATUSES = ['warning', 'active', 'resolved'];
+
+function normalizeRegionIds(regionIds) {
+  if (!Array.isArray(regionIds) || regionIds.length === 0) {
+    throw new RangeError('Catastrophe regionIds must be a non-empty array.');
+  }
+
+  const normalized = [...new Set(regionIds.map((regionId) => Catastrophe.requireText(regionId, 'Catastrophe regionId')))];
+
+  return normalized.sort();
+}
+
+export class Catastrophe {
+  constructor({
+    id,
+    type,
+    severity,
+    status = 'warning',
+    regionIds,
+    startedAt,
+    expectedEndAt = null,
+    resolvedAt = null,
+    impact = {},
+    description = null,
+  }) {
+    this.id = Catastrophe.requireText(id, 'Catastrophe id');
+    this.type = Catastrophe.requireText(type, 'Catastrophe type');
+    this.severity = Catastrophe.requireChoice(severity, 'Catastrophe severity', VALID_SEVERITIES);
+    this.status = Catastrophe.requireChoice(status, 'Catastrophe status', VALID_STATUSES);
+    this.regionIds = normalizeRegionIds(regionIds);
+    this.startedAt = Catastrophe.normalizeDate(startedAt, 'Catastrophe startedAt');
+    this.expectedEndAt = Catastrophe.normalizeOptionalDate(expectedEndAt, 'Catastrophe expectedEndAt');
+    this.resolvedAt = Catastrophe.normalizeOptionalDate(resolvedAt, 'Catastrophe resolvedAt');
+    this.impact = Catastrophe.normalizeImpact(impact);
+    this.description = description === null ? null : Catastrophe.requireText(description, 'Catastrophe description');
+
+    if (this.status === 'resolved' && this.resolvedAt === null) {
+      throw new RangeError('Catastrophe resolved status requires resolvedAt.');
+    }
+
+    if (this.resolvedAt !== null && this.resolvedAt < this.startedAt) {
+      throw new RangeError('Catastrophe resolvedAt cannot be earlier than startedAt.');
+    }
+  }
+
+  get isActive() {
+    return this.status === 'active';
+  }
+
+  get isResolved() {
+    return this.status === 'resolved';
+  }
+
+  activate() {
+    return new Catastrophe({
+      ...this.toJSON(),
+      status: 'active',
+      resolvedAt: null,
+    });
+  }
+
+  resolve(resolvedAt = new Date()) {
+    return new Catastrophe({
+      ...this.toJSON(),
+      status: 'resolved',
+      resolvedAt,
+    });
+  }
+
+  withImpact(impact) {
+    return new Catastrophe({
+      ...this.toJSON(),
+      impact: {
+        ...this.impact,
+        ...impact,
+      },
+    });
+  }
+
+  affectsRegion(regionId) {
+    const normalizedRegionId = String(regionId ?? '').trim();
+    return this.regionIds.includes(normalizedRegionId);
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      type: this.type,
+      severity: this.severity,
+      status: this.status,
+      regionIds: [...this.regionIds],
+      startedAt: this.startedAt.toISOString(),
+      expectedEndAt: this.expectedEndAt?.toISOString() ?? null,
+      resolvedAt: this.resolvedAt?.toISOString() ?? null,
+      impact: { ...this.impact },
+      description: this.description,
+    };
+  }
+
+  static requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static requireChoice(value, label, validValues) {
+    const normalizedValue = Catastrophe.requireText(value, label);
+
+    if (!validValues.includes(normalizedValue)) {
+      throw new RangeError(`${label} must be one of: ${validValues.join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static normalizeDate(value, label) {
+    const date = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      throw new RangeError(`${label} must be a valid date.`);
+    }
+
+    return date;
+  }
+
+  static normalizeOptionalDate(value, label) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    return Catastrophe.normalizeDate(value, label);
+  }
+
+  static normalizeImpact(impact) {
+    if (impact === null || typeof impact !== 'object' || Array.isArray(impact)) {
+      throw new RangeError('Catastrophe impact must be an object.');
+    }
+
+    const normalized = {};
+
+    for (const [key, value] of Object.entries(impact)) {
+      const normalizedKey = Catastrophe.requireText(key, 'Catastrophe impact key');
+
+      if (!Number.isFinite(value)) {
+        throw new RangeError(`Catastrophe impact ${normalizedKey} must be a finite number.`);
+      }
+
+      normalized[normalizedKey] = value;
+    }
+
+    return normalized;
+  }
+}

--- a/src/domain/climate/index.js
+++ b/src/domain/climate/index.js
@@ -1,2 +1,3 @@
 export { ClimateState } from './ClimateState.js';
 export { SeasonCycle } from './SeasonCycle.js';
+export { Catastrophe } from './Catastrophe.js';

--- a/test/application/climate/TriggerCatastrophe.test.js
+++ b/test/application/climate/TriggerCatastrophe.test.js
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TriggerCatastrophe } from '../../../src/application/climate/TriggerCatastrophe.js';
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+
+test('TriggerCatastrophe creates drought catastrophes for endangered regions', () => {
+  const useCase = new TriggerCatastrophe();
+  const regionalStates = [
+    new ClimateState({
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 37,
+      precipitationLevel: 10,
+      droughtIndex: 88,
+      anomaly: 'heatwave',
+    }),
+    new ClimateState({
+      regionId: 'north-coast',
+      season: 'summer',
+      temperatureC: 22,
+      precipitationLevel: 44,
+      droughtIndex: 24,
+    }),
+  ];
+
+  const result = useCase.execute({
+    regionalStates,
+    triggeredAt: '2026-04-18T13:30:00.000Z',
+  });
+
+  assert.equal(result.triggeredCount, 1);
+  assert.equal(result.catastrophes[0].type, 'drought');
+  assert.equal(result.catastrophes[0].status, 'active');
+  assert.deepEqual(result.catastrophes[0].regionIds, ['sunreach']);
+  assert.match(result.catastrophes[0].id, /^sunreach-drought-summer$/);
+  assert.deepEqual(result.updatedRegionalStates[0].activeCatastropheIds, ['sunreach-drought-summer']);
+  assert.deepEqual(result.updatedRegionalStates[1].activeCatastropheIds, []);
+  assert.equal(regionalStates[0].activeCatastropheIds.length, 0);
+});
+
+test('TriggerCatastrophe can create flood catastrophes and skips already active regions', () => {
+  const useCase = new TriggerCatastrophe();
+
+  const result = useCase.execute({
+    regionalStates: [
+      {
+        regionId: 'riverlands',
+        season: 'winter',
+        temperatureC: 18,
+        precipitationLevel: 96,
+        droughtIndex: 10,
+      },
+      {
+        regionId: 'ash-plains',
+        season: 'summer',
+        temperatureC: 39,
+        precipitationLevel: 8,
+        droughtIndex: 91,
+        activeCatastropheIds: ['ash-plains-drought-summer'],
+      },
+    ],
+    triggeredAt: '2026-04-18T14:00:00.000Z',
+  });
+
+  assert.equal(result.triggeredCount, 1);
+  assert.equal(result.catastrophes[0].type, 'flood');
+  assert.equal(result.updatedRegionalStates[1].activeCatastropheIds[0], 'ash-plains-drought-summer');
+});
+
+test('TriggerCatastrophe rejects invalid collections', () => {
+  const useCase = new TriggerCatastrophe();
+
+  assert.throws(
+    () => useCase.execute({ regionalStates: null }),
+    /regionalStates must be an array/,
+  );
+});

--- a/test/domain/climate/Catastrophe.test.js
+++ b/test/domain/climate/Catastrophe.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Catastrophe } from '../../../src/domain/climate/Catastrophe.js';
+
+test('Catastrophe keeps normalized disaster metadata', () => {
+  const catastrophe = new Catastrophe({
+    id: ' storm-001 ',
+    type: 'great-storm',
+    severity: 'major',
+    regionIds: ['north-coast', ' north-coast ', 'riverlands'],
+    startedAt: '2026-04-18T12:00:00.000Z',
+    expectedEndAt: '2026-04-20T12:00:00.000Z',
+    impact: { harvest: -25, morale: -10 },
+    description: ' Gale-force rain and floods ',
+  });
+
+  assert.deepEqual(catastrophe.toJSON(), {
+    id: 'storm-001',
+    type: 'great-storm',
+    severity: 'major',
+    status: 'warning',
+    regionIds: ['north-coast', 'riverlands'],
+    startedAt: '2026-04-18T12:00:00.000Z',
+    expectedEndAt: '2026-04-20T12:00:00.000Z',
+    resolvedAt: null,
+    impact: { harvest: -25, morale: -10 },
+    description: 'Gale-force rain and floods',
+  });
+
+  assert.equal(catastrophe.affectsRegion('riverlands'), true);
+  assert.equal(catastrophe.isActive, false);
+});
+
+test('Catastrophe transitions from warning to active to resolved immutably', () => {
+  const warning = new Catastrophe({
+    id: 'quake-002',
+    type: 'earthquake',
+    severity: 'critical',
+    regionIds: ['highlands'],
+    startedAt: '2026-04-18T09:00:00.000Z',
+    impact: { infrastructure: -55 },
+  });
+
+  const active = warning.activate().withImpact({ population: -12 });
+  const resolved = active.resolve('2026-04-19T09:00:00.000Z');
+
+  assert.equal(warning.status, 'warning');
+  assert.equal(active.status, 'active');
+  assert.equal(active.isActive, true);
+  assert.deepEqual(active.impact, { infrastructure: -55, population: -12 });
+  assert.equal(resolved.status, 'resolved');
+  assert.equal(resolved.isResolved, true);
+  assert.equal(resolved.resolvedAt?.toISOString(), '2026-04-19T09:00:00.000Z');
+});
+
+test('Catastrophe rejects invalid values and timelines', () => {
+  assert.throws(
+    () => new Catastrophe({ id: '', type: 'storm', severity: 'major', regionIds: ['north'], startedAt: new Date(), impact: {} }),
+    /Catastrophe id is required/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'extreme', regionIds: ['north'], startedAt: new Date(), impact: {} }),
+    /Catastrophe severity must be one of/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'major', regionIds: [], startedAt: new Date(), impact: {} }),
+    /regionIds must be a non-empty array/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'major', status: 'resolved', regionIds: ['north'], startedAt: '2026-04-18T12:00:00.000Z', impact: {} }),
+    /resolved status requires resolvedAt/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'major', regionIds: ['north'], startedAt: '2026-04-18T12:00:00.000Z', resolvedAt: '2026-04-17T12:00:00.000Z', impact: {} }),
+    /resolvedAt cannot be earlier than startedAt/,
+  );
+});


### PR DESCRIPTION
Epsilon: ## Summary
- ajoute le use case `TriggerCatastrophe`
- déclenche des catastrophes simples à partir d’états climatiques régionaux
- active les catastrophes dans les régions touchées et couvre le flux par des tests

## Testing
- [x] `npm test -- --test-reporter=spec`

## Notes
- PR empilée sur #142 pour garder un diff lisible côté climat
- s’appuie sur le modèle `Catastrophe` déjà présent dans la branche empilée
- closes #88