### PR TITLE
Alpha: [A14] Add in-memory faction state adapter

### DIFF
--- a/src/adapters/war/InMemoryFactionStateRepository.js
+++ b/src/adapters/war/InMemoryFactionStateRepository.js
@@ -1,0 +1,68 @@
+import { FactionStateRepository } from '../../application/war/FactionStateRepository.js';
+
+function normalizeFactionState(state) {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    throw new TypeError('InMemoryFactionStateRepository state must be a plain object.');
+  }
+
+  const factionId = String(state.factionId ?? '').trim();
+
+  if (!factionId) {
+    throw new RangeError('InMemoryFactionStateRepository factionId is required.');
+  }
+
+  const occupiedProvinceIds = Array.isArray(state.occupiedProvinceIds)
+    ? [...new Set(state.occupiedProvinceIds.map((provinceId) => String(provinceId ?? '').trim()))]
+    : [];
+
+  if (occupiedProvinceIds.some((provinceId) => provinceId.length === 0)) {
+    throw new RangeError('InMemoryFactionStateRepository occupiedProvinceIds cannot contain empty values.');
+  }
+
+  return {
+    ...state,
+    factionId,
+    occupiedProvinceIds: occupiedProvinceIds.sort(),
+  };
+}
+
+export class InMemoryFactionStateRepository extends FactionStateRepository {
+  constructor(states = []) {
+    super();
+    this.states = new Map();
+    this.seed(states);
+  }
+
+  seed(states) {
+    if (!Array.isArray(states)) {
+      throw new TypeError('InMemoryFactionStateRepository states must be an array.');
+    }
+
+    for (const state of states) {
+      const normalizedState = normalizeFactionState(state);
+      this.states.set(normalizedState.factionId, normalizedState);
+    }
+
+    return this;
+  }
+
+  async getFactionStateById(factionId) {
+    return this.states.get(String(factionId).trim()) ?? null;
+  }
+
+  async listFactionStates() {
+    return [...this.states.values()].sort((left, right) => left.factionId.localeCompare(right.factionId));
+  }
+
+  async saveFactionState(state) {
+    const normalizedState = normalizeFactionState(state);
+    this.states.set(normalizedState.factionId, normalizedState);
+    return normalizedState;
+  }
+
+  snapshot() {
+    return [...this.states.values()]
+      .sort((left, right) => left.factionId.localeCompare(right.factionId))
+      .map((state) => ({ ...state, occupiedProvinceIds: [...state.occupiedProvinceIds] }));
+  }
+}

--- a/src/application/war/FactionStateRepository.js
+++ b/src/application/war/FactionStateRepository.js
@@ -1,0 +1,59 @@
+function requireFactionId(factionId) {
+  const normalizedFactionId = String(factionId ?? '').trim();
+
+  if (!normalizedFactionId) {
+    throw new RangeError('FactionStateRepository factionId is required.');
+  }
+
+  return normalizedFactionId;
+}
+
+function requireFactionState(state) {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    throw new TypeError('FactionStateRepository state must be an object.');
+  }
+
+  return {
+    ...state,
+    factionId: requireFactionId(state.factionId),
+  };
+}
+
+export class FactionStateRepository {
+  async getFactionStateById(_factionId) {
+    throw new Error('FactionStateRepository.getFactionStateById must be implemented by an adapter.');
+  }
+
+  async listFactionStates() {
+    throw new Error('FactionStateRepository.listFactionStates must be implemented by an adapter.');
+  }
+
+  async saveFactionState(_state) {
+    throw new Error('FactionStateRepository.saveFactionState must be implemented by an adapter.');
+  }
+
+  async requireFactionStateById(factionId) {
+    const normalizedFactionId = requireFactionId(factionId);
+    const state = await this.getFactionStateById(normalizedFactionId);
+
+    if (!state || state.factionId !== normalizedFactionId) {
+      throw new RangeError(`FactionStateRepository could not find faction state ${normalizedFactionId}.`);
+    }
+
+    return state;
+  }
+
+  async saveAll(states) {
+    if (!Array.isArray(states)) {
+      throw new TypeError('FactionStateRepository states must be an array.');
+    }
+
+    const savedStates = [];
+
+    for (const state of states) {
+      savedStates.push(await this.saveFactionState(requireFactionState(state)));
+    }
+
+    return savedStates;
+  }
+}

--- a/test/adapters/war/InMemoryFactionStateRepository.test.js
+++ b/test/adapters/war/InMemoryFactionStateRepository.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryFactionStateRepository } from '../../../src/adapters/war/InMemoryFactionStateRepository.js';
+import { FactionStateRepository } from '../../../src/application/war/FactionStateRepository.js';
+
+test('InMemoryFactionStateRepository extends the port and normalizes seeded states', async () => {
+  const repository = new InMemoryFactionStateRepository([
+    {
+      factionId: ' faction-b ',
+      occupiedProvinceIds: ['prov-2', ' prov-1 ', 'prov-2'],
+      frontPressure: 12,
+    },
+  ]);
+
+  const state = await repository.requireFactionStateById('faction-b');
+
+  assert.equal(repository instanceof FactionStateRepository, true);
+  assert.deepEqual(state, {
+    factionId: 'faction-b',
+    occupiedProvinceIds: ['prov-1', 'prov-2'],
+    frontPressure: 12,
+  });
+});
+
+test('InMemoryFactionStateRepository lists states in stable order and persists updates', async () => {
+  const repository = new InMemoryFactionStateRepository([
+    { factionId: 'faction-c', occupiedProvinceIds: ['prov-4'] },
+  ]);
+
+  await repository.saveFactionState({
+    factionId: 'faction-a',
+    occupiedProvinceIds: ['prov-3', 'prov-1'],
+    supplyLevel: 'stable',
+  });
+
+  const stateIds = (await repository.listFactionStates()).map((state) => state.factionId);
+  assert.deepEqual(stateIds, ['faction-a', 'faction-c']);
+  assert.deepEqual(repository.snapshot(), [
+    {
+      factionId: 'faction-a',
+      occupiedProvinceIds: ['prov-1', 'prov-3'],
+      supplyLevel: 'stable',
+    },
+    {
+      factionId: 'faction-c',
+      occupiedProvinceIds: ['prov-4'],
+    },
+  ]);
+});
+
+test('InMemoryFactionStateRepository rejects invalid payloads', async () => {
+  assert.throws(() => new InMemoryFactionStateRepository(null), /states must be an array/);
+  assert.throws(() => new InMemoryFactionStateRepository([null]), /state must be a plain object/);
+
+  const repository = new InMemoryFactionStateRepository();
+
+  await assert.rejects(
+    () => repository.saveFactionState({ factionId: 'faction-a', occupiedProvinceIds: ['prov-1', '   '] }),
+    /occupiedProvinceIds cannot contain empty values/,
+  );
+});

--- a/test/application/war/FactionStateRepository.test.js
+++ b/test/application/war/FactionStateRepository.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { FactionStateRepository } from '../../../src/application/war/FactionStateRepository.js';
+
+class InMemoryFactionStateRepository extends FactionStateRepository {
+  constructor(states = []) {
+    super();
+    this.states = new Map(states.map((state) => [state.factionId, state]));
+  }
+
+  async getFactionStateById(factionId) {
+    return this.states.get(factionId) ?? null;
+  }
+
+  async listFactionStates() {
+    return [...this.states.values()];
+  }
+
+  async saveFactionState(state) {
+    this.states.set(state.factionId, state);
+    return state;
+  }
+}
+
+test('FactionStateRepository provides shared helpers for faction state lookup and batch saving', async () => {
+  const stateA = { factionId: 'faction-a', occupiedProvinceIds: ['prov-1'] };
+  const stateB = { factionId: 'faction-b', occupiedProvinceIds: [] };
+  const repository = new InMemoryFactionStateRepository([stateA]);
+
+  const foundState = await repository.requireFactionStateById(' faction-a ');
+  const savedStates = await repository.saveAll([stateA, stateB]);
+
+  assert.equal(foundState, stateA);
+  assert.deepEqual(savedStates, [stateA, stateB]);
+  assert.deepEqual(await repository.listFactionStates(), [stateA, stateB]);
+});
+
+test('FactionStateRepository base methods fail fast until an adapter implements them', async () => {
+  const repository = new FactionStateRepository();
+  const state = { factionId: 'faction-a' };
+
+  await assert.rejects(
+    () => repository.getFactionStateById('faction-a'),
+    /must be implemented by an adapter/,
+  );
+  await assert.rejects(() => repository.listFactionStates(), /must be implemented by an adapter/);
+  await assert.rejects(
+    () => repository.saveFactionState(state),
+    /must be implemented by an adapter/,
+  );
+});
+
+test('FactionStateRepository rejects missing states and invalid saveAll payloads', async () => {
+  const repository = new InMemoryFactionStateRepository();
+
+  await assert.rejects(() => repository.requireFactionStateById(''), /factionId is required/);
+  await assert.rejects(
+    () => repository.requireFactionStateById('faction-missing'),
+    /could not find faction state faction-missing/,
+  );
+  await assert.rejects(() => repository.saveAll(null), /states must be an array/);
+  await assert.rejects(() => repository.saveAll([null]), /state must be an object/);
+  await assert.rejects(() => repository.saveAll([{ factionId: '   ' }]), /factionId is required/);
+});


### PR DESCRIPTION
Alpha: ## Summary
Alpha: Add an in-memory adapter for Alpha's faction state repository slice.
Alpha:
Alpha: ## Changes
Alpha: Add `InMemoryFactionStateRepository` under `src/adapters/war/`.
Alpha: Normalize seeded faction states and occupied province ids.
Alpha: Keep list and snapshot ordering deterministic for tests and future orchestration.
Alpha: Add adapter tests covering hydration, persistence, ordering, and invalid payload rejection.
Alpha:
Alpha: ## Testing
Alpha: - [x] `npm test`
Alpha:
Alpha: ## Notes
Alpha: This PR is stacked on top of `alpha/a13-add-in-memory-map-adapter` to keep the change focused.
