### PR TITLE
Beta: define TradeRoute model

### DIFF
--- a/src/domain/economy/TradeRoute.js
+++ b/src/domain/economy/TradeRoute.js
@@ -1,0 +1,164 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTextList(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function requireInteger(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+export class TradeRoute {
+  constructor({
+    id,
+    sourceCityId,
+    destinationCityId,
+    transportType,
+    distance,
+    capacity,
+    travelTime,
+    maintenanceCost = 0,
+    riskLevel = 0,
+    active = true,
+    blocked = false,
+    tags = [],
+  }) {
+    this.sourceCityId = requireText(sourceCityId, 'TradeRoute sourceCityId');
+    this.destinationCityId = requireText(destinationCityId, 'TradeRoute destinationCityId');
+
+    if (this.sourceCityId === this.destinationCityId) {
+      throw new RangeError('TradeRoute cities must be different.');
+    }
+
+    this.id = requireText(id, 'TradeRoute id');
+    this.transportType = requireText(transportType, 'TradeRoute transportType');
+    this.distance = requireInteger(
+      distance,
+      'TradeRoute distance',
+      1,
+      Number.MAX_SAFE_INTEGER,
+    );
+    this.capacity = requireInteger(
+      capacity,
+      'TradeRoute capacity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+    this.travelTime = requireInteger(
+      travelTime,
+      'TradeRoute travelTime',
+      1,
+      Number.MAX_SAFE_INTEGER,
+    );
+    this.maintenanceCost = requireInteger(
+      maintenanceCost,
+      'TradeRoute maintenanceCost',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+    this.riskLevel = requireInteger(
+      riskLevel,
+      'TradeRoute riskLevel',
+      0,
+      100,
+    );
+    this.active = Boolean(active);
+    this.blocked = Boolean(blocked);
+    this.tags = normalizeUniqueTextList(tags, 'TradeRoute tags');
+  }
+
+  get isOperational() {
+    return this.active && !this.blocked && this.capacity > 0;
+  }
+
+  get throughputPerDay() {
+    if (this.travelTime === 0) {
+      return Infinity;
+    }
+
+    return this.capacity / this.travelTime;
+  }
+
+  get pressureLevel() {
+    if (this.blocked || this.capacity === 0) {
+      return 'blocked';
+    }
+
+    if (this.riskLevel >= 70) {
+      return 'critical';
+    }
+
+    if (this.riskLevel >= 40) {
+      return 'strained';
+    }
+
+    return 'stable';
+  }
+
+  withCapacity(capacity) {
+    return new TradeRoute({
+      ...this.toJSON(),
+      capacity,
+    });
+  }
+
+  withRiskLevel(riskLevel) {
+    return new TradeRoute({
+      ...this.toJSON(),
+      riskLevel,
+    });
+  }
+
+  withBlocked(blocked) {
+    return new TradeRoute({
+      ...this.toJSON(),
+      blocked,
+    });
+  }
+
+  withActive(active) {
+    return new TradeRoute({
+      ...this.toJSON(),
+      active,
+    });
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      sourceCityId: this.sourceCityId,
+      destinationCityId: this.destinationCityId,
+      transportType: this.transportType,
+      distance: this.distance,
+      capacity: this.capacity,
+      travelTime: this.travelTime,
+      maintenanceCost: this.maintenanceCost,
+      riskLevel: this.riskLevel,
+      active: this.active,
+      blocked: this.blocked,
+      tags: [...this.tags],
+    };
+  }
+}

--- a/test/domain/economy/TradeRoute.test.js
+++ b/test/domain/economy/TradeRoute.test.js
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TradeRoute } from '../../../src/domain/economy/TradeRoute.js';
+
+test('TradeRoute keeps a normalized logistics definition', () => {
+  const route = new TradeRoute({
+    id: ' route-river-01 ',
+    sourceCityId: ' city-a ',
+    destinationCityId: ' city-b ',
+    transportType: ' river barge ',
+    distance: 180,
+    capacity: 90,
+    travelTime: 6,
+    maintenanceCost: 14,
+    riskLevel: 35,
+    active: 1,
+    blocked: 0,
+    tags: [' river ', 'bulk', 'river'],
+  });
+
+  assert.deepEqual(route.toJSON(), {
+    id: 'route-river-01',
+    sourceCityId: 'city-a',
+    destinationCityId: 'city-b',
+    transportType: 'river barge',
+    distance: 180,
+    capacity: 90,
+    travelTime: 6,
+    maintenanceCost: 14,
+    riskLevel: 35,
+    active: true,
+    blocked: false,
+    tags: ['bulk', 'river'],
+  });
+
+  assert.equal(route.isOperational, true);
+  assert.equal(route.throughputPerDay, 15);
+  assert.equal(route.pressureLevel, 'stable');
+});
+
+test('TradeRoute supports immutable capacity, risk, activity, and blockage updates', () => {
+  const route = new TradeRoute({
+    id: 'route-pass',
+    sourceCityId: 'city-a',
+    destinationCityId: 'city-b',
+    transportType: 'mountain road',
+    distance: 80,
+    capacity: 40,
+    travelTime: 4,
+  });
+
+  const expandedRoute = route.withCapacity(60);
+  const strainedRoute = expandedRoute.withRiskLevel(75);
+  const blockedRoute = strainedRoute.withBlocked(true);
+  const inactiveRoute = blockedRoute.withActive(false);
+
+  assert.notEqual(expandedRoute, route);
+  assert.notEqual(strainedRoute, expandedRoute);
+  assert.notEqual(blockedRoute, strainedRoute);
+  assert.notEqual(inactiveRoute, blockedRoute);
+  assert.equal(expandedRoute.capacity, 60);
+  assert.equal(strainedRoute.pressureLevel, 'critical');
+  assert.equal(blockedRoute.isOperational, false);
+  assert.equal(blockedRoute.pressureLevel, 'blocked');
+  assert.equal(inactiveRoute.active, false);
+  assert.equal(route.capacity, 40);
+  assert.equal(route.riskLevel, 0);
+  assert.equal(route.blocked, false);
+});
+
+test('TradeRoute surfaces strained routes and zero-capacity disruptions', () => {
+  const strainedRoute = new TradeRoute({
+    id: 'route-desert',
+    sourceCityId: 'city-oasis',
+    destinationCityId: 'city-port',
+    transportType: 'caravan',
+    distance: 220,
+    capacity: 0,
+    travelTime: 11,
+    riskLevel: 55,
+  });
+
+  assert.equal(strainedRoute.isOperational, false);
+  assert.equal(strainedRoute.pressureLevel, 'blocked');
+  assert.equal(strainedRoute.throughputPerDay, 0);
+});
+
+test('TradeRoute rejects invalid city pairs and logistics invariants', () => {
+  assert.throws(
+    () => new TradeRoute({ id: '', sourceCityId: 'city-a', destinationCityId: 'city-b', transportType: 'road', distance: 10, capacity: 5, travelTime: 1 }),
+    /TradeRoute id is required/,
+  );
+
+  assert.throws(
+    () => new TradeRoute({ id: 'route', sourceCityId: 'city-a', destinationCityId: 'city-a', transportType: 'road', distance: 10, capacity: 5, travelTime: 1 }),
+    /TradeRoute cities must be different/,
+  );
+
+  assert.throws(
+    () => new TradeRoute({ id: 'route', sourceCityId: 'city-a', destinationCityId: 'city-b', transportType: 'road', distance: 0, capacity: 5, travelTime: 1 }),
+    /TradeRoute distance must be an integer between 1 and/,
+  );
+
+  assert.throws(
+    () => new TradeRoute({ id: 'route', sourceCityId: 'city-a', destinationCityId: 'city-b', transportType: 'road', distance: 10, capacity: 5, travelTime: 1, riskLevel: 101 }),
+    /TradeRoute riskLevel must be an integer between 0 and 100/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: define the `TradeRoute` model for Beta logistics work.
Beta:
Beta: ## Changes
Beta: - add `TradeRoute` with normalized endpoints, transport type, distance, capacity, travel time, maintenance cost, risk, and route tags
Beta: - expose derived helpers for operational state, throughput, and route pressure
Beta: - add immutable update helpers and node tests for normalization, disruption states, and invalid route invariants
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #24
