### PR TITLE
Delta: [D08] Implement DiffuserRumeur use case

### DIFF
--- a/src/application/intrigue/DiffuserRumeur.js
+++ b/src/application/intrigue/DiffuserRumeur.js
@@ -1,0 +1,134 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireScore(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new RangeError(`${label} must be an integer between 0 and 100.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function computeRumorPressure({ readiness, credibility, spread, targetStability, alertLevel }) {
+  return Math.max(0, readiness + credibility + spread - targetStability - alertLevel);
+}
+
+export function diffuserRumeur({
+  operation,
+  rumor,
+  target,
+  alertLevel = 0,
+  channelIds = rumor?.channelIds ?? [],
+}) {
+  const normalizedOperation = requireObject(operation, 'DiffuserRumeur operation');
+  const normalizedRumor = requireObject(rumor, 'DiffuserRumeur rumor');
+  const normalizedTarget = requireObject(target, 'DiffuserRumeur target');
+  const normalizedAlertLevel = requireScore(alertLevel, 'DiffuserRumeur alertLevel');
+  const normalizedChannelIds = normalizeUniqueTexts(channelIds, 'DiffuserRumeur channelIds');
+
+  const operationId = requireText(normalizedOperation.id, 'DiffuserRumeur operation id');
+  const rumorId = requireText(normalizedRumor.id, 'DiffuserRumeur rumor id');
+  const targetId = requireText(normalizedTarget.id, 'DiffuserRumeur target id');
+  const readiness = requireScore(normalizedOperation.readiness ?? 0, 'DiffuserRumeur operation readiness');
+  const heat = requireScore(normalizedOperation.heat ?? 0, 'DiffuserRumeur operation heat');
+  const credibility = requireScore(normalizedRumor.credibility ?? 0, 'DiffuserRumeur rumor credibility');
+  const spread = requireScore(normalizedRumor.spread ?? 0, 'DiffuserRumeur rumor spread');
+  const targetStability = requireScore(normalizedTarget.stability ?? 0, 'DiffuserRumeur target stability');
+  const targetLegitimacy = requireScore(normalizedTarget.legitimacy ?? 0, 'DiffuserRumeur target legitimacy');
+
+  if (normalizedChannelIds.length === 0) {
+    return {
+      propagated: false,
+      outcome: 'no-rumor-channels',
+      operation: { ...normalizedOperation, id: operationId },
+      rumor: { ...normalizedRumor, id: rumorId },
+      target: { ...normalizedTarget, id: targetId },
+      summary: 'No rumor channel was available.',
+      effect: {
+        legitimacyLoss: 0,
+        stabilityLoss: 0,
+        panicGain: 0,
+        reachedChannelIds: [],
+      },
+    };
+  }
+
+  const pressure = computeRumorPressure({
+    readiness,
+    credibility,
+    spread,
+    targetStability,
+    alertLevel: normalizedAlertLevel,
+  });
+  const success = pressure > 0;
+  const reachedChannelIds = success
+    ? normalizedChannelIds.slice(0, Math.max(1, Math.floor(pressure / 25) + 1))
+    : normalizedChannelIds.slice(0, 1);
+  const legitimacyLoss = success ? Math.min(targetLegitimacy, Math.max(4, Math.round(pressure / 3))) : 0;
+  const stabilityLoss = success ? Math.min(targetStability, Math.max(2, Math.round(pressure / 5))) : 0;
+  const panicGain = success ? Math.min(100, Math.max(6, Math.round(pressure / 2))) : Math.max(2, Math.round(spread / 10));
+  const heatIncrease = Math.min(100 - heat, success ? Math.max(5, 12 - Math.round(readiness / 15)) : 10);
+
+  return {
+    propagated: true,
+    outcome: success ? 'rumor-spread' : 'rumor-contained',
+    operation: {
+      ...normalizedOperation,
+      id: operationId,
+      heat: heat + heatIncrease,
+      phase: 'resolved',
+      progress: 100,
+    },
+    rumor: {
+      ...normalizedRumor,
+      id: rumorId,
+      channelIds: reachedChannelIds,
+      lastOutcome: success ? 'spread' : 'contained',
+    },
+    target: {
+      ...normalizedTarget,
+      id: targetId,
+      legitimacy: targetLegitimacy - legitimacyLoss,
+      stability: targetStability - stabilityLoss,
+      panic: Math.min(100, (normalizedTarget.panic ?? 0) + panicGain),
+    },
+    summary: success
+      ? `Rumor spread through ${reachedChannelIds.length} channel(s).`
+      : 'Rumor was contained before it caused lasting damage.',
+    effect: {
+      legitimacyLoss,
+      stabilityLoss,
+      panicGain,
+      reachedChannelIds,
+    },
+  };
+}

--- a/test/application/intrigue/DiffuserRumeur.test.js
+++ b/test/application/intrigue/DiffuserRumeur.test.js
@@ -1,0 +1,187 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { diffuserRumeur } from '../../../src/application/intrigue/DiffuserRumeur.js';
+
+test('DiffuserRumeur applies legitimacy and panic effects on success', () => {
+  const result = diffuserRumeur({
+    operation: {
+      id: 'op-voile',
+      readiness: 74,
+      heat: 16,
+      phase: 'infiltration',
+      progress: 45,
+    },
+    rumor: {
+      id: 'rumor-succession',
+      credibility: 68,
+      spread: 61,
+    },
+    target: {
+      id: 'court-aurelia',
+      legitimacy: 72,
+      stability: 57,
+      panic: 9,
+    },
+    alertLevel: 18,
+    channelIds: ['court-whispers', 'market-gossip', 'river-barges'],
+  });
+
+  assert.deepEqual(result, {
+    propagated: true,
+    outcome: 'rumor-spread',
+    operation: {
+      id: 'op-voile',
+      readiness: 74,
+      heat: 23,
+      phase: 'resolved',
+      progress: 100,
+    },
+    rumor: {
+      id: 'rumor-succession',
+      credibility: 68,
+      spread: 61,
+      channelIds: ['court-whispers', 'market-gossip', 'river-barges'],
+      lastOutcome: 'spread',
+    },
+    target: {
+      id: 'court-aurelia',
+      legitimacy: 29,
+      stability: 31,
+      panic: 73,
+    },
+    summary: 'Rumor spread through 3 channel(s).',
+    effect: {
+      legitimacyLoss: 43,
+      stabilityLoss: 26,
+      panicGain: 64,
+      reachedChannelIds: ['court-whispers', 'market-gossip', 'river-barges'],
+    },
+  });
+});
+
+test('DiffuserRumeur reports contained rumors explicitly', () => {
+  const result = diffuserRumeur({
+    operation: {
+      id: 'op-voile',
+      readiness: 28,
+      heat: 22,
+      phase: 'infiltration',
+      progress: 45,
+    },
+    rumor: {
+      id: 'rumor-succession',
+      credibility: 34,
+      spread: 27,
+    },
+    target: {
+      id: 'court-aurelia',
+      legitimacy: 72,
+      stability: 63,
+      panic: 11,
+    },
+    alertLevel: 39,
+    channelIds: ['court-whispers', 'market-gossip'],
+  });
+
+  assert.deepEqual(result, {
+    propagated: true,
+    outcome: 'rumor-contained',
+    operation: {
+      id: 'op-voile',
+      readiness: 28,
+      heat: 32,
+      phase: 'resolved',
+      progress: 100,
+    },
+    rumor: {
+      id: 'rumor-succession',
+      credibility: 34,
+      spread: 27,
+      channelIds: ['court-whispers'],
+      lastOutcome: 'contained',
+    },
+    target: {
+      id: 'court-aurelia',
+      legitimacy: 72,
+      stability: 63,
+      panic: 14,
+    },
+    summary: 'Rumor was contained before it caused lasting damage.',
+    effect: {
+      legitimacyLoss: 0,
+      stabilityLoss: 0,
+      panicGain: 3,
+      reachedChannelIds: ['court-whispers'],
+    },
+  });
+});
+
+test('DiffuserRumeur validates inputs and handles missing channels', () => {
+  assert.throws(
+    () => diffuserRumeur({ operation: null, rumor: {}, target: {} }),
+    /DiffuserRumeur operation must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      diffuserRumeur({
+        operation: { id: 'op-voile', readiness: 25, heat: 10 },
+        rumor: { id: 'rumor-succession', credibility: 110, spread: 15 },
+        target: { id: 'court-aurelia', legitimacy: 72, stability: 63 },
+      }),
+    /DiffuserRumeur rumor credibility must be an integer between 0 and 100/,
+  );
+
+  const result = diffuserRumeur({
+    operation: {
+      id: 'op-voile',
+      readiness: 60,
+      heat: 12,
+      phase: 'infiltration',
+      progress: 45,
+    },
+    rumor: {
+      id: 'rumor-succession',
+      credibility: 55,
+      spread: 40,
+    },
+    target: {
+      id: 'court-aurelia',
+      legitimacy: 72,
+      stability: 63,
+      panic: 8,
+    },
+    channelIds: [],
+  });
+
+  assert.deepEqual(result, {
+    propagated: false,
+    outcome: 'no-rumor-channels',
+    operation: {
+      id: 'op-voile',
+      readiness: 60,
+      heat: 12,
+      phase: 'infiltration',
+      progress: 45,
+    },
+    rumor: {
+      id: 'rumor-succession',
+      credibility: 55,
+      spread: 40,
+    },
+    target: {
+      id: 'court-aurelia',
+      legitimacy: 72,
+      stability: 63,
+      panic: 8,
+    },
+    summary: 'No rumor channel was available.',
+    effect: {
+      legitimacyLoss: 0,
+      stabilityLoss: 0,
+      panicGain: 0,
+      reachedChannelIds: [],
+    },
+  });
+});


### PR DESCRIPTION
Delta: Cette PR traite l'issue #68 en ajoutant le use case `DiffuserRumeur`.

## Contenu
- ajout d'un use case pur pour diffuser une rumeur
- explicitation des issues propagation, containment et absence de canaux
- calcul des effets sur légitimité, stabilité, panique et chaleur
- ajout de tests sur succès, échec contenu et validations

## Vérification
- `npm test`

## Notes
- cette PR est empilée sur `delta/d07-implement-resoudresabotage`
- je demanderai la validation de Zeta avant tout merge
