### PR TITLE
Gamma: [G11] Add in-memory culture adapter

### DIFF
--- a/src/adapters/culture/InMemoryCultureRepository.js
+++ b/src/adapters/culture/InMemoryCultureRepository.js
@@ -1,0 +1,67 @@
+import { CultureRepositoryPort } from '../../domain/culture/CultureRepositoryPort.js';
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeCulture(culture) {
+  if (!culture || typeof culture !== 'object' || Array.isArray(culture)) {
+    throw new TypeError('InMemoryCultureRepository culture must be an object.');
+  }
+
+  return {
+    ...culture,
+    id: requireText(culture.id, 'InMemoryCultureRepository culture.id'),
+    name: requireText(culture.name, 'InMemoryCultureRepository culture.name'),
+    eraId: requireText(culture.eraId, 'InMemoryCultureRepository culture.eraId'),
+    tags: Array.isArray(culture.tags)
+      ? [...new Set(culture.tags.map((tag) => requireText(tag, 'InMemoryCultureRepository culture.tags[]')))].sort()
+      : [],
+  };
+}
+
+function cloneCulture(culture) {
+  return {
+    ...culture,
+    tags: [...culture.tags],
+  };
+}
+
+export class InMemoryCultureRepository extends CultureRepositoryPort {
+  constructor(initialCultures = []) {
+    super();
+    this.cultures = new Map();
+
+    for (const culture of initialCultures) {
+      const normalizedCulture = normalizeCulture(culture);
+      this.cultures.set(normalizedCulture.id, normalizedCulture);
+    }
+  }
+
+  async getById(cultureId) {
+    const normalizedCultureId = requireText(cultureId, 'CultureRepositoryPort cultureId');
+    const culture = this.cultures.get(normalizedCultureId);
+
+    return culture ? cloneCulture(culture) : null;
+  }
+
+  async save(culture) {
+    const normalizedCulture = normalizeCulture(culture);
+    this.cultures.set(normalizedCulture.id, normalizedCulture);
+    return cloneCulture(normalizedCulture);
+  }
+
+  async listByEra(eraId) {
+    const normalizedEraId = requireText(eraId, 'CultureRepositoryPort eraId');
+
+    return [...this.cultures.values()]
+      .filter((culture) => culture.eraId === normalizedEraId)
+      .map((culture) => cloneCulture(culture));
+  }
+}

--- a/test/adapters/culture/InMemoryCultureRepository.test.js
+++ b/test/adapters/culture/InMemoryCultureRepository.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryCultureRepository } from '../../../src/adapters/culture/InMemoryCultureRepository.js';
+
+test('InMemoryCultureRepository returns stored cultures by id and clones results', async () => {
+  const repository = new InMemoryCultureRepository([
+    {
+      id: 'culture-north',
+      name: 'Northern Scriptorium',
+      eraId: 'late-medieval',
+      tags: ['archives', 'maritime'],
+    },
+  ]);
+
+  const culture = await repository.getById('culture-north');
+  culture.tags.push('mutated');
+  const secondRead = await repository.getById('culture-north');
+
+  assert.equal(culture.name, 'Northern Scriptorium');
+  assert.deepEqual(secondRead.tags, ['archives', 'maritime']);
+});
+
+test('InMemoryCultureRepository saves and lists cultures by era', async () => {
+  const repository = new InMemoryCultureRepository();
+
+  const savedCulture = await repository.save({
+    id: 'culture-east',
+    name: 'Eastern Annalists',
+    eraId: 'early-modern',
+    tags: ['diplomacy', 'translation', 'diplomacy'],
+  });
+
+  const cultures = await repository.listByEra('early-modern');
+
+  assert.equal(savedCulture.id, 'culture-east');
+  assert.deepEqual(savedCulture.tags, ['diplomacy', 'translation']);
+  assert.equal(cultures.length, 1);
+  assert.equal(cultures[0].name, 'Eastern Annalists');
+});
+
+test('InMemoryCultureRepository validates payloads and identifiers', async () => {
+  const repository = new InMemoryCultureRepository();
+
+  await assert.rejects(() => repository.getById(''), /CultureRepositoryPort cultureId is required/);
+  await assert.rejects(() => repository.listByEra('   '), /CultureRepositoryPort eraId is required/);
+  await assert.rejects(() => repository.save(null), /InMemoryCultureRepository culture must be an object/);
+  await assert.rejects(
+    () => repository.save({ id: 'culture-west', name: 'Western Chroniclers', eraId: ' ', tags: [] }),
+    /InMemoryCultureRepository culture.eraId is required/,
+  );
+  assert.throws(
+    () => new InMemoryCultureRepository([{ id: 'culture-west', name: 'Western Chroniclers', eraId: 'classical', tags: ['valid', ' '] }]),
+    /InMemoryCultureRepository culture.tags\[\] is required/,
+  );
+});


### PR DESCRIPTION
Gamma: ## Summary
Gamma: Add an in-memory culture repository adapter for the Gamma slice, stacked on top of the `CultureRepositoryPort` branch.
Gamma:
Gamma: ## Related issue
Gamma: - Closes #51
Gamma:
Gamma: ## Changes
Gamma: - add `src/adapters/culture/InMemoryCultureRepository.js`
Gamma: - support seeded cultures, `getById`, `save`, and `listByEra`
Gamma: - return cloned results to avoid accidental in-memory mutation leaks
Gamma: - validate culture payloads, era ids, and culture tags
Gamma: - add node tests for read, write, listing, cloning, and validation behavior
Gamma:
Gamma: ## Testing
Gamma: - [x] Local checks run
Gamma: - [x] Relevant tests added or updated
Gamma: - [ ] Manual check if relevant
Gamma: - [x] `npm test -- --test-reporter tap`
Gamma:
Gamma: ## Rules check
Gamma: - [x] This work comes through a pull request
Gamma: - [x] This PR is mandatory to avoid bugs and validation problems with Zeta
Gamma: - [x] GitHub text starts with the agent name followed by `:`
Gamma: - [x] The work stays inside the author's domain
Gamma: - [ ] Zeta has been asked for validation before merge
Gamma:
Gamma: ## Notes
Gamma: This PR is intentionally stacked on top of `Gamma: [G09] Create CultureRepository port` because the adapter depends on that port.
