### PR TITLE
Epsilon: implement RegisterMythFromEvent use case

### DIFF
--- a/src/application/climate/RegisterMythFromEvent.js
+++ b/src/application/climate/RegisterMythFromEvent.js
@@ -1,0 +1,75 @@
+import { Catastrophe } from '../../domain/climate/Catastrophe.js';
+import { Myth } from '../../domain/climate/Myth.js';
+
+function normalizeEvent(event) {
+  if (event instanceof Catastrophe) {
+    return event;
+  }
+
+  if (event === null || typeof event !== 'object' || Array.isArray(event)) {
+    throw new RangeError('RegisterMythFromEvent event must be an object or Catastrophe.');
+  }
+
+  return new Catastrophe(event);
+}
+
+function normalizeCreatedAt(createdAt) {
+  return createdAt ?? new Date();
+}
+
+function pickCategory(event) {
+  if (event.type === 'drought' || event.type === 'flood') {
+    return 'catastrophe';
+  }
+
+  return 'omen';
+}
+
+function pickTitle(event) {
+  const titles = {
+    drought: 'The Withering Season',
+    flood: 'The River Without Mercy',
+    heatwave: 'The Burning Sky',
+  };
+
+  return titles[event.type] ?? `The Sign of ${event.type}`;
+}
+
+function buildSummary(event) {
+  const regionList = event.regionIds.join(', ');
+  return `${event.type} struck ${regionList} with ${event.severity} force.`;
+}
+
+function deriveCredibility(event) {
+  const base = {
+    minor: 35,
+    major: 58,
+    critical: 76,
+  }[event.severity] ?? 40;
+
+  return Math.max(0, Math.min(100, base + (event.isResolved ? -6 : 8)));
+}
+
+export class RegisterMythFromEvent {
+  execute({ event, createdAt = new Date() } = {}) {
+    const normalizedEvent = normalizeEvent(event);
+    const mythCreatedAt = normalizeCreatedAt(createdAt);
+
+    const myth = new Myth({
+      id: `myth-${normalizedEvent.id}`,
+      title: pickTitle(normalizedEvent),
+      category: pickCategory(normalizedEvent),
+      originEventIds: [normalizedEvent.id],
+      summary: buildSummary(normalizedEvent),
+      credibility: deriveCredibility(normalizedEvent),
+      regions: normalizedEvent.regionIds,
+      tags: [normalizedEvent.type, normalizedEvent.severity, normalizedEvent.status],
+      createdAt: mythCreatedAt,
+    });
+
+    return {
+      myth,
+      sourceEvent: normalizedEvent,
+    };
+  }
+}

--- a/src/domain/climate/Myth.js
+++ b/src/domain/climate/Myth.js
@@ -1,0 +1,162 @@
+const VALID_CATEGORIES = ['origin', 'omen', 'catastrophe', 'seasonal', 'heroic'];
+const VALID_STATUSES = ['emerging', 'canonized', 'forgotten'];
+
+function normalizeTags(tags) {
+  if (!Array.isArray(tags)) {
+    throw new RangeError('Myth tags must be an array.');
+  }
+
+  return [...new Set(tags.map((tag) => Myth.requireText(tag, 'Myth tag')))];
+}
+
+function normalizeOrigins(origins) {
+  if (!Array.isArray(origins) || origins.length === 0) {
+    throw new RangeError('Myth origins must be a non-empty array.');
+  }
+
+  return [...new Set(origins.map((origin) => Myth.requireText(origin, 'Myth origin')))];
+}
+
+export class Myth {
+  constructor({
+    id,
+    title,
+    category,
+    status = 'emerging',
+    originEventIds,
+    summary,
+    credibility = 50,
+    regions = [],
+    tags = [],
+    createdAt = new Date(),
+    canonizedAt = null,
+  }) {
+    this.id = Myth.requireText(id, 'Myth id');
+    this.title = Myth.requireText(title, 'Myth title');
+    this.category = Myth.requireChoice(category, 'Myth category', VALID_CATEGORIES);
+    this.status = Myth.requireChoice(status, 'Myth status', VALID_STATUSES);
+    this.originEventIds = normalizeOrigins(originEventIds);
+    this.summary = Myth.requireText(summary, 'Myth summary');
+    this.credibility = Myth.requireIntegerInRange(credibility, 'Myth credibility', 0, 100);
+    this.regions = normalizeTags(regions).sort();
+    this.tags = normalizeTags(tags).sort();
+    this.createdAt = Myth.normalizeDate(createdAt, 'Myth createdAt');
+    this.canonizedAt = Myth.normalizeOptionalDate(canonizedAt, 'Myth canonizedAt');
+
+    if (this.status === 'canonized' && this.canonizedAt === null) {
+      throw new RangeError('Myth canonized status requires canonizedAt.');
+    }
+
+    if (this.canonizedAt !== null && this.canonizedAt < this.createdAt) {
+      throw new RangeError('Myth canonizedAt cannot be earlier than createdAt.');
+    }
+  }
+
+  get isCanonized() {
+    return this.status === 'canonized';
+  }
+
+  rememberInRegion(regionId) {
+    return new Myth({
+      ...this.toJSON(),
+      regions: [...this.regions, regionId],
+    });
+  }
+
+  withCredibility(credibility) {
+    return new Myth({
+      ...this.toJSON(),
+      credibility,
+    });
+  }
+
+  addTag(tag) {
+    return new Myth({
+      ...this.toJSON(),
+      tags: [...this.tags, tag],
+    });
+  }
+
+  canonize(canonizedAt = new Date()) {
+    return new Myth({
+      ...this.toJSON(),
+      status: 'canonized',
+      canonizedAt,
+    });
+  }
+
+  forget() {
+    return new Myth({
+      ...this.toJSON(),
+      status: 'forgotten',
+      canonizedAt: null,
+    });
+  }
+
+  referencesEvent(eventId) {
+    const normalizedEventId = String(eventId ?? '').trim();
+    return this.originEventIds.includes(normalizedEventId);
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      title: this.title,
+      category: this.category,
+      status: this.status,
+      originEventIds: [...this.originEventIds],
+      summary: this.summary,
+      credibility: this.credibility,
+      regions: [...this.regions],
+      tags: [...this.tags],
+      createdAt: this.createdAt.toISOString(),
+      canonizedAt: this.canonizedAt?.toISOString() ?? null,
+    };
+  }
+
+  static requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static requireChoice(value, label, validValues) {
+    const normalizedValue = Myth.requireText(value, label);
+
+    if (!validValues.includes(normalizedValue)) {
+      throw new RangeError(`${label} must be one of: ${validValues.join(', ')}.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+
+  static normalizeDate(value, label) {
+    const date = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      throw new RangeError(`${label} must be a valid date.`);
+    }
+
+    return date;
+  }
+
+  static normalizeOptionalDate(value, label) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    return Myth.normalizeDate(value, label);
+  }
+}

--- a/src/domain/climate/index.js
+++ b/src/domain/climate/index.js
@@ -1,3 +1,4 @@
 export { ClimateState } from './ClimateState.js';
 export { SeasonCycle } from './SeasonCycle.js';
 export { Catastrophe } from './Catastrophe.js';
+export { Myth } from './Myth.js';

--- a/test/application/climate/RegisterMythFromEvent.test.js
+++ b/test/application/climate/RegisterMythFromEvent.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { RegisterMythFromEvent } from '../../../src/application/climate/RegisterMythFromEvent.js';
+import { Catastrophe } from '../../../src/domain/climate/Catastrophe.js';
+
+test('RegisterMythFromEvent turns a catastrophe into a structured myth', () => {
+  const useCase = new RegisterMythFromEvent();
+  const event = new Catastrophe({
+    id: 'sunreach-drought-summer',
+    type: 'drought',
+    severity: 'critical',
+    status: 'active',
+    regionIds: ['sunreach'],
+    startedAt: '2026-04-18T13:30:00.000Z',
+    impact: { harvest: -50, unrest: -12 },
+  });
+
+  const result = useCase.execute({
+    event,
+    createdAt: '2026-04-18T14:00:00.000Z',
+  });
+
+  assert.equal(result.sourceEvent, event);
+  assert.equal(result.myth.id, 'myth-sunreach-drought-summer');
+  assert.equal(result.myth.title, 'The Withering Season');
+  assert.equal(result.myth.category, 'catastrophe');
+  assert.equal(result.myth.credibility, 84);
+  assert.deepEqual(result.myth.originEventIds, ['sunreach-drought-summer']);
+  assert.deepEqual(result.myth.regions, ['sunreach']);
+  assert.deepEqual(result.myth.tags, ['active', 'critical', 'drought']);
+  assert.match(result.myth.summary, /sunreach/);
+});
+
+test('RegisterMythFromEvent accepts plain event payloads and adapts credibility', () => {
+  const useCase = new RegisterMythFromEvent();
+
+  const result = useCase.execute({
+    event: {
+      id: 'riverlands-flood-winter',
+      type: 'flood',
+      severity: 'major',
+      status: 'resolved',
+      regionIds: ['riverlands'],
+      startedAt: '2026-04-18T10:00:00.000Z',
+      resolvedAt: '2026-04-18T12:00:00.000Z',
+      impact: { infrastructure: -22 },
+    },
+    createdAt: '2026-04-18T12:10:00.000Z',
+  });
+
+  assert.equal(result.myth.category, 'catastrophe');
+  assert.equal(result.myth.credibility, 52);
+  assert.equal(result.myth.title, 'The River Without Mercy');
+});
+
+test('RegisterMythFromEvent rejects invalid events', () => {
+  const useCase = new RegisterMythFromEvent();
+
+  assert.throws(
+    () => useCase.execute({ event: null }),
+    /event must be an object or Catastrophe/,
+  );
+});

--- a/test/domain/climate/Myth.test.js
+++ b/test/domain/climate/Myth.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Myth } from '../../../src/domain/climate/Myth.js';
+
+test('Myth keeps normalized folklore metadata', () => {
+  const myth = new Myth({
+    id: ' myth-aurora ',
+    title: ' The Skyfire Returns ',
+    category: 'omen',
+    originEventIds: ['storm-001', ' storm-001 ', 'eclipse-002'],
+    summary: ' A radiant omen seen before the floods ',
+    credibility: 64,
+    regions: ['north-coast', 'riverlands', 'north-coast'],
+    tags: ['skyfire', ' flood ', 'skyfire'],
+    createdAt: '2026-04-18T12:00:00.000Z',
+  });
+
+  assert.deepEqual(myth.toJSON(), {
+    id: 'myth-aurora',
+    title: 'The Skyfire Returns',
+    category: 'omen',
+    status: 'emerging',
+    originEventIds: ['storm-001', 'eclipse-002'],
+    summary: 'A radiant omen seen before the floods',
+    credibility: 64,
+    regions: ['north-coast', 'riverlands'],
+    tags: ['flood', 'skyfire'],
+    createdAt: '2026-04-18T12:00:00.000Z',
+    canonizedAt: null,
+  });
+
+  assert.equal(myth.referencesEvent('eclipse-002'), true);
+  assert.equal(myth.isCanonized, false);
+});
+
+test('Myth transitions through memory lifecycle immutably', () => {
+  const myth = new Myth({
+    id: 'myth-blizzard-king',
+    title: 'The Blizzard King',
+    category: 'catastrophe',
+    originEventIds: ['blizzard-7'],
+    summary: 'A tale born from the great white winter.',
+    credibility: 40,
+    createdAt: '2026-04-18T10:00:00.000Z',
+  });
+
+  const spread = myth.rememberInRegion('highlands').addTag('winter').withCredibility(71);
+  const canonized = spread.canonize('2026-04-21T10:00:00.000Z');
+  const forgotten = canonized.forget();
+
+  assert.equal(myth.regions.length, 0);
+  assert.deepEqual(spread.regions, ['highlands']);
+  assert.deepEqual(spread.tags, ['winter']);
+  assert.equal(spread.credibility, 71);
+  assert.equal(canonized.status, 'canonized');
+  assert.equal(canonized.isCanonized, true);
+  assert.equal(canonized.canonizedAt?.toISOString(), '2026-04-21T10:00:00.000Z');
+  assert.equal(forgotten.status, 'forgotten');
+  assert.equal(forgotten.canonizedAt, null);
+});
+
+test('Myth rejects invalid values and impossible chronology', () => {
+  assert.throws(
+    () => new Myth({ id: '', title: 'Bad', category: 'omen', originEventIds: ['e1'], summary: 'Nope' }),
+    /Myth id is required/,
+  );
+
+  assert.throws(
+    () => new Myth({ id: 'm1', title: 'Bad', category: 'legend', originEventIds: ['e1'], summary: 'Nope' }),
+    /Myth category must be one of/,
+  );
+
+  assert.throws(
+    () => new Myth({ id: 'm1', title: 'Bad', category: 'omen', originEventIds: [], summary: 'Nope' }),
+    /Myth origins must be a non-empty array/,
+  );
+
+  assert.throws(
+    () => new Myth({ id: 'm1', title: 'Bad', category: 'omen', originEventIds: ['e1'], summary: 'Nope', status: 'canonized' }),
+    /canonized status requires canonizedAt/,
+  );
+
+  assert.throws(
+    () => new Myth({ id: 'm1', title: 'Bad', category: 'omen', originEventIds: ['e1'], summary: 'Nope', createdAt: '2026-04-18T12:00:00.000Z', canonizedAt: '2026-04-17T12:00:00.000Z' }),
+    /canonizedAt cannot be earlier than createdAt/,
+  );
+});


### PR DESCRIPTION
Epsilon: ## Summary
- ajoute le use case `RegisterMythFromEvent`
- transforme une catastrophe climatique en mythe structuré et testable
- couvre le flux avec des tests dédiés et la validation des entrées

## Testing
- [x] `npm test -- --test-reporter=spec`

## Notes
- PR empilée sur #149 pour garder un diff propre côté climat
- s’appuie sur le modèle `Myth` ajouté dans la branche empilée
- closes #89