### PR TITLE
Beta: implement ProduceResources use case

### DIFF
--- a/src/application/economy/produceResources.js
+++ b/src/application/economy/produceResources.js
@@ -1,0 +1,217 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+function normalizeCity(city) {
+  if (!city || typeof city !== 'object' || Array.isArray(city)) {
+    throw new TypeError('produceResources city must be an object.');
+  }
+
+  const stockByResource = city.stockByResource ?? {};
+
+  if (!stockByResource || typeof stockByResource !== 'object' || Array.isArray(stockByResource)) {
+    throw new TypeError('produceResources city.stockByResource must be an object.');
+  }
+
+  return {
+    ...city,
+    id: requireText(city.id, 'produceResources city.id'),
+    workforce: requireInteger(city.workforce ?? 0, 'produceResources city.workforce', 0),
+    stockByResource: Object.fromEntries(
+      Object.entries(stockByResource).map(([resourceId, quantity]) => [
+        requireText(resourceId, 'produceResources city.stock resourceId'),
+        requireInteger(quantity, `produceResources city stock quantity for ${String(resourceId).trim()}`, 0),
+      ]),
+    ),
+  };
+}
+
+function normalizeRules(rules, cityId) {
+  if (!Array.isArray(rules)) {
+    throw new TypeError('produceResources productionRules must be an array.');
+  }
+
+  return rules.map((rule, index) => normalizeRule(rule, cityId, index));
+}
+
+function normalizeRule(rule, cityId, index) {
+  if (!rule || typeof rule !== 'object' || Array.isArray(rule)) {
+    throw new TypeError(`produceResources productionRules[${index}] must be an object.`);
+  }
+
+  const normalizedCityId = requireText(rule.cityId, `produceResources productionRules[${index}].cityId`);
+
+  if (normalizedCityId !== cityId) {
+    throw new RangeError(
+      `produceResources productionRules[${index}].cityId must match city ${cityId}.`,
+    );
+  }
+
+  const inputByResource = rule.inputByResource ?? {};
+  const seasonModifiers = rule.seasonModifiers ?? {};
+
+  if (!inputByResource || typeof inputByResource !== 'object' || Array.isArray(inputByResource)) {
+    throw new TypeError(`produceResources productionRules[${index}].inputByResource must be an object.`);
+  }
+
+  if (!seasonModifiers || typeof seasonModifiers !== 'object' || Array.isArray(seasonModifiers)) {
+    throw new TypeError(`produceResources productionRules[${index}].seasonModifiers must be an object.`);
+  }
+
+  return {
+    ...rule,
+    id: requireText(rule.id, `produceResources productionRules[${index}].id`),
+    cityId: normalizedCityId,
+    resourceId: requireText(rule.resourceId, `produceResources productionRules[${index}].resourceId`),
+    laborRequired: requireInteger(
+      rule.laborRequired ?? 0,
+      `produceResources productionRules[${index}].laborRequired`,
+      0,
+    ),
+    baseYield: requireInteger(
+      rule.baseYield ?? 0,
+      `produceResources productionRules[${index}].baseYield`,
+      0,
+    ),
+    active: Boolean(rule.active ?? true),
+    priority: requireInteger(
+      rule.priority ?? 50,
+      `produceResources productionRules[${index}].priority`,
+      0,
+      100,
+    ),
+    inputByResource: Object.fromEntries(
+      Object.entries(inputByResource).map(([resourceId, quantity]) => [
+        requireText(resourceId, `produceResources productionRules[${index}].input resourceId`),
+        requireInteger(
+          quantity,
+          `produceResources productionRules[${index}] input quantity for ${String(resourceId).trim()}`,
+          0,
+        ),
+      ]),
+    ),
+    seasonModifiers: Object.fromEntries(
+      Object.entries(seasonModifiers).map(([season, modifier]) => [
+        requireText(season, `produceResources productionRules[${index}].season`),
+        requireInteger(
+          modifier,
+          `produceResources productionRules[${index}] season modifier for ${String(season).trim()}`,
+          -100,
+          100,
+        ),
+      ]),
+    ),
+  };
+}
+
+function normalizeContext(context) {
+  if (context === undefined) {
+    return { season: null };
+  }
+
+  if (!context || typeof context !== 'object' || Array.isArray(context)) {
+    throw new TypeError('produceResources context must be an object.');
+  }
+
+  return {
+    season: context.season == null ? null : requireText(context.season, 'produceResources context.season'),
+  };
+}
+
+function canAffordInputs(stockByResource, inputByResource) {
+  return Object.entries(inputByResource).every(
+    ([resourceId, quantity]) => (stockByResource[resourceId] ?? 0) >= quantity,
+  );
+}
+
+function applyInputs(stockByResource, inputByResource) {
+  const nextStock = { ...stockByResource };
+
+  for (const [resourceId, quantity] of Object.entries(inputByResource)) {
+    nextStock[resourceId] = (nextStock[resourceId] ?? 0) - quantity;
+  }
+
+  return nextStock;
+}
+
+function applyOutput(stockByResource, resourceId, quantity) {
+  return {
+    ...stockByResource,
+    [resourceId]: (stockByResource[resourceId] ?? 0) + quantity,
+  };
+}
+
+function computeProducedQuantity(rule, season) {
+  const seasonalModifier = season === null ? 0 : (rule.seasonModifiers[season] ?? 0);
+  return Math.max(0, Math.floor(rule.baseYield * (100 + seasonalModifier) / 100));
+}
+
+export function produceResources(city, productionRules, context = undefined) {
+  const normalizedCity = normalizeCity(city);
+  const normalizedRules = normalizeRules(productionRules, normalizedCity.id)
+    .sort((left, right) => right.priority - left.priority || left.id.localeCompare(right.id));
+  const normalizedContext = normalizeContext(context);
+
+  let remainingWorkforce = normalizedCity.workforce;
+  let nextStock = { ...normalizedCity.stockByResource };
+  const executedRules = [];
+  const skippedRules = [];
+
+  for (const rule of normalizedRules) {
+    if (!rule.active) {
+      skippedRules.push({ ruleId: rule.id, reason: 'inactive' });
+      continue;
+    }
+
+    if (rule.laborRequired > remainingWorkforce) {
+      skippedRules.push({ ruleId: rule.id, reason: 'insufficient-workforce' });
+      continue;
+    }
+
+    if (!canAffordInputs(nextStock, rule.inputByResource)) {
+      skippedRules.push({ ruleId: rule.id, reason: 'missing-inputs' });
+      continue;
+    }
+
+    const producedQuantity = computeProducedQuantity(rule, normalizedContext.season);
+    nextStock = applyInputs(nextStock, rule.inputByResource);
+    nextStock = applyOutput(nextStock, rule.resourceId, producedQuantity);
+    remainingWorkforce -= rule.laborRequired;
+    executedRules.push({
+      ruleId: rule.id,
+      resourceId: rule.resourceId,
+      producedQuantity,
+      consumedInputs: { ...rule.inputByResource },
+      laborUsed: rule.laborRequired,
+    });
+  }
+
+  return {
+    city: {
+      ...normalizedCity,
+      stockByResource: nextStock,
+    },
+    producedByResource: executedRules.reduce((summary, execution) => ({
+      ...summary,
+      [execution.resourceId]: (summary[execution.resourceId] ?? 0) + execution.producedQuantity,
+    }), {}),
+    executedRules,
+    skippedRules,
+    workforceUsed: normalizedCity.workforce - remainingWorkforce,
+    workforceRemaining: remainingWorkforce,
+  };
+}

--- a/test/application/economy/produceResources.test.js
+++ b/test/application/economy/produceResources.test.js
@@ -1,0 +1,161 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { produceResources } from '../../../src/application/economy/produceResources.js';
+
+test('produceResources executes active rules in priority order and updates city stock', () => {
+  const city = {
+    id: 'city-harbor',
+    workforce: 20,
+    stockByResource: {
+      grain: 10,
+      wood: 4,
+    },
+  };
+
+  const result = produceResources(
+    city,
+    [
+      {
+        id: 'rule-mill',
+        cityId: 'city-harbor',
+        resourceId: 'flour',
+        laborRequired: 8,
+        baseYield: 12,
+        priority: 60,
+        inputByResource: { grain: 5 },
+        seasonModifiers: { autumn: 25 },
+        active: true,
+      },
+      {
+        id: 'rule-sawmill',
+        cityId: 'city-harbor',
+        resourceId: 'planks',
+        laborRequired: 6,
+        baseYield: 6,
+        priority: 80,
+        inputByResource: { wood: 2 },
+        active: true,
+      },
+    ],
+    { season: 'autumn' },
+  );
+
+  assert.deepEqual(result.city.stockByResource, {
+    grain: 5,
+    wood: 2,
+    planks: 6,
+    flour: 15,
+  });
+  assert.deepEqual(result.producedByResource, {
+    planks: 6,
+    flour: 15,
+  });
+  assert.deepEqual(result.executedRules.map((entry) => entry.ruleId), ['rule-sawmill', 'rule-mill']);
+  assert.equal(result.workforceUsed, 14);
+  assert.equal(result.workforceRemaining, 6);
+  assert.deepEqual(city.stockByResource, { grain: 10, wood: 4 });
+});
+
+test('produceResources skips rules when workforce or inputs are missing', () => {
+  const result = produceResources(
+    {
+      id: 'city-steppe',
+      workforce: 5,
+      stockByResource: {
+        grain: 1,
+      },
+    },
+    [
+      {
+        id: 'rule-bakery',
+        cityId: 'city-steppe',
+        resourceId: 'bread',
+        laborRequired: 4,
+        baseYield: 4,
+        inputByResource: { grain: 2 },
+        priority: 70,
+      },
+      {
+        id: 'rule-stonemason',
+        cityId: 'city-steppe',
+        resourceId: 'brick',
+        laborRequired: 8,
+        baseYield: 3,
+        priority: 60,
+      },
+      {
+        id: 'rule-idle',
+        cityId: 'city-steppe',
+        resourceId: 'cloth',
+        laborRequired: 1,
+        baseYield: 2,
+        active: false,
+        priority: 50,
+      },
+    ],
+  );
+
+  assert.deepEqual(result.executedRules, []);
+  assert.deepEqual(result.skippedRules, [
+    { ruleId: 'rule-bakery', reason: 'missing-inputs' },
+    { ruleId: 'rule-stonemason', reason: 'insufficient-workforce' },
+    { ruleId: 'rule-idle', reason: 'inactive' },
+  ]);
+  assert.equal(result.workforceUsed, 0);
+  assert.equal(result.workforceRemaining, 5);
+  assert.deepEqual(result.city.stockByResource, { grain: 1 });
+});
+
+test('produceResources applies negative seasonal modifiers without dropping below zero', () => {
+  const result = produceResources(
+    {
+      id: 'city-north',
+      workforce: 10,
+      stockByResource: {},
+    },
+    [
+      {
+        id: 'rule-herbs',
+        cityId: 'city-north',
+        resourceId: 'herbs',
+        laborRequired: 2,
+        baseYield: 3,
+        seasonModifiers: { winter: -80 },
+      },
+    ],
+    { season: 'winter' },
+  );
+
+  assert.equal(result.city.stockByResource.herbs, 0);
+  assert.deepEqual(result.producedByResource, { herbs: 0 });
+});
+
+test('produceResources rejects invalid city, rule, and context data', () => {
+  assert.throws(
+    () => produceResources(null, []),
+    /produceResources city must be an object/,
+  );
+
+  assert.throws(
+    () => produceResources({ id: 'city-a', workforce: 3, stockByResource: {} }, {}),
+    /produceResources productionRules must be an array/,
+  );
+
+  assert.throws(
+    () => produceResources(
+      { id: 'city-a', workforce: 3, stockByResource: {} },
+      [{ id: 'rule-a', cityId: 'city-b', resourceId: 'grain', laborRequired: 1, baseYield: 2 }],
+    ),
+    /produceResources productionRules\[0\]\.cityId must match city city-a/,
+  );
+
+  assert.throws(
+    () => produceResources(
+      { id: 'city-a', workforce: 3, stockByResource: {} },
+      [{ id: 'rule-a', cityId: 'city-a', resourceId: 'grain', laborRequired: 1, baseYield: 2 }],
+      { season: '' },
+    ),
+    /produceResources context.season is required/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: implement the `produceResources` use case for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `produceResources` in the application layer with validation for city state, production rules, and seasonal context
Beta: - execute active rules by priority while consuming workforce and input stock before applying produced output
Beta: - return an immutable updated city snapshot plus production, skipped-rule, and workforce summaries
Beta: - add node tests for priority ordering, missing inputs, seasonal modifiers, and invalid payloads
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #25
