### PR TITLE
Delta: [D09] Implement CollecterRenseignement use case

### DIFF
--- a/src/application/intrigue/CollecterRenseignement.js
+++ b/src/application/intrigue/CollecterRenseignement.js
@@ -1,0 +1,124 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireScore(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new RangeError(`${label} must be an integer between 0 and 100.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function computeIntelYield({ readiness, targetSecurity, targetSecrecy, randomFactor }) {
+  return Math.max(0, readiness + randomFactor - Math.round((targetSecurity + targetSecrecy) / 2));
+}
+
+export function collecterRenseignement({
+  operation,
+  target,
+  randomFactor = 0,
+  intelChannelIds = target?.intelChannelIds ?? [],
+}) {
+  const normalizedOperation = requireObject(operation, 'CollecterRenseignement operation');
+  const normalizedTarget = requireObject(target, 'CollecterRenseignement target');
+  const normalizedRandomFactor = requireScore(randomFactor, 'CollecterRenseignement randomFactor');
+  const normalizedIntelChannelIds = normalizeUniqueTexts(
+    intelChannelIds,
+    'CollecterRenseignement intelChannelIds',
+  );
+
+  const operationId = requireText(normalizedOperation.id, 'CollecterRenseignement operation id');
+  const targetId = requireText(normalizedTarget.id, 'CollecterRenseignement target id');
+  const readiness = requireScore(normalizedOperation.readiness ?? 0, 'CollecterRenseignement operation readiness');
+  const heat = requireScore(normalizedOperation.heat ?? 0, 'CollecterRenseignement operation heat');
+  const targetSecurity = requireScore(normalizedTarget.security ?? 0, 'CollecterRenseignement target security');
+  const targetSecrecy = requireScore(normalizedTarget.secrecy ?? 0, 'CollecterRenseignement target secrecy');
+  const targetAwareness = requireScore(normalizedTarget.awareness ?? 0, 'CollecterRenseignement target awareness');
+
+  if (normalizedIntelChannelIds.length === 0) {
+    return {
+      collected: false,
+      outcome: 'no-intel-channels',
+      operation: { ...normalizedOperation, id: operationId },
+      target: { ...normalizedTarget, id: targetId },
+      summary: 'No intelligence channel was available.',
+      intel: {
+        intelPoints: 0,
+        insightLevel: 0,
+        heatIncrease: 0,
+        compromisedChannelIds: [],
+      },
+    };
+  }
+
+  const yieldScore = computeIntelYield({
+    readiness,
+    targetSecurity,
+    targetSecrecy,
+    randomFactor: normalizedRandomFactor,
+  });
+  const success = yieldScore > 0;
+  const compromisedChannelIds = success
+    ? normalizedIntelChannelIds.slice(0, Math.max(1, Math.floor(yieldScore / 25) + 1))
+    : [];
+  const intelPoints = success ? Math.max(6, Math.round(yieldScore / 2)) : 0;
+  const insightLevel = success ? Math.min(100, Math.max(8, Math.round(yieldScore / 1.5))) : 0;
+  const awarenessGain = success ? Math.max(4, Math.round(yieldScore / 6)) : Math.max(2, Math.round(normalizedRandomFactor / 10));
+  const heatIncrease = Math.min(100 - heat, success ? Math.max(4, 10 - Math.round(readiness / 20)) : 9);
+
+  return {
+    collected: true,
+    outcome: success ? 'intel-collected' : 'intel-denied',
+    operation: {
+      ...normalizedOperation,
+      id: operationId,
+      heat: heat + heatIncrease,
+      phase: 'resolved',
+      progress: 100,
+    },
+    target: {
+      ...normalizedTarget,
+      id: targetId,
+      awareness: Math.min(100, targetAwareness + awarenessGain),
+      compromisedChannelIds,
+    },
+    summary: success
+      ? `Collected intelligence through ${compromisedChannelIds.length} channel(s).`
+      : 'Target security denied meaningful intelligence collection.',
+    intel: {
+      intelPoints,
+      insightLevel,
+      heatIncrease,
+      compromisedChannelIds,
+    },
+  };
+}

--- a/test/application/intrigue/CollecterRenseignement.test.js
+++ b/test/application/intrigue/CollecterRenseignement.test.js
@@ -1,0 +1,155 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { collecterRenseignement } from '../../../src/application/intrigue/CollecterRenseignement.js';
+
+test('CollecterRenseignement returns explicit intel gains on success', () => {
+  const result = collecterRenseignement({
+    operation: {
+      id: 'op-verre',
+      readiness: 72,
+      heat: 14,
+      phase: 'infiltration',
+      progress: 40,
+    },
+    target: {
+      id: 'faction-aurora',
+      security: 39,
+      secrecy: 44,
+      awareness: 16,
+    },
+    intelChannelIds: ['court-ledger', 'dock-clerks', 'messenger-chain'],
+    randomFactor: 18,
+  });
+
+  assert.deepEqual(result, {
+    collected: true,
+    outcome: 'intel-collected',
+    operation: {
+      id: 'op-verre',
+      readiness: 72,
+      heat: 20,
+      phase: 'resolved',
+      progress: 100,
+    },
+    target: {
+      id: 'faction-aurora',
+      security: 39,
+      secrecy: 44,
+      awareness: 24,
+      compromisedChannelIds: ['court-ledger', 'dock-clerks'],
+    },
+    summary: 'Collected intelligence through 2 channel(s).',
+    intel: {
+      intelPoints: 24,
+      insightLevel: 32,
+      heatIncrease: 6,
+      compromisedChannelIds: ['court-ledger', 'dock-clerks'],
+    },
+  });
+});
+
+test('CollecterRenseignement reports denied collection explicitly', () => {
+  const result = collecterRenseignement({
+    operation: {
+      id: 'op-verre',
+      readiness: 24,
+      heat: 21,
+      phase: 'infiltration',
+      progress: 40,
+    },
+    target: {
+      id: 'faction-aurora',
+      security: 63,
+      secrecy: 59,
+      awareness: 16,
+    },
+    intelChannelIds: ['court-ledger', 'dock-clerks'],
+    randomFactor: 7,
+  });
+
+  assert.deepEqual(result, {
+    collected: true,
+    outcome: 'intel-denied',
+    operation: {
+      id: 'op-verre',
+      readiness: 24,
+      heat: 30,
+      phase: 'resolved',
+      progress: 100,
+    },
+    target: {
+      id: 'faction-aurora',
+      security: 63,
+      secrecy: 59,
+      awareness: 18,
+      compromisedChannelIds: [],
+    },
+    summary: 'Target security denied meaningful intelligence collection.',
+    intel: {
+      intelPoints: 0,
+      insightLevel: 0,
+      heatIncrease: 9,
+      compromisedChannelIds: [],
+    },
+  });
+});
+
+test('CollecterRenseignement validates inputs and handles missing channels', () => {
+  assert.throws(
+    () => collecterRenseignement({ operation: null, target: {} }),
+    /CollecterRenseignement operation must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      collecterRenseignement({
+        operation: { id: 'op-verre', readiness: 55, heat: 10 },
+        target: { id: 'faction-aurora', security: 39, secrecy: 44, awareness: 16 },
+        randomFactor: 120,
+      }),
+    /CollecterRenseignement randomFactor must be an integer between 0 and 100/,
+  );
+
+  const result = collecterRenseignement({
+    operation: {
+      id: 'op-verre',
+      readiness: 60,
+      heat: 9,
+      phase: 'infiltration',
+      progress: 40,
+    },
+    target: {
+      id: 'faction-aurora',
+      security: 39,
+      secrecy: 44,
+      awareness: 16,
+    },
+    intelChannelIds: [],
+  });
+
+  assert.deepEqual(result, {
+    collected: false,
+    outcome: 'no-intel-channels',
+    operation: {
+      id: 'op-verre',
+      readiness: 60,
+      heat: 9,
+      phase: 'infiltration',
+      progress: 40,
+    },
+    target: {
+      id: 'faction-aurora',
+      security: 39,
+      secrecy: 44,
+      awareness: 16,
+    },
+    summary: 'No intelligence channel was available.',
+    intel: {
+      intelPoints: 0,
+      insightLevel: 0,
+      heatIncrease: 0,
+      compromisedChannelIds: [],
+    },
+  });
+});


### PR DESCRIPTION
Delta: Cette PR traite l'issue #69 en ajoutant le use case `CollecterRenseignement`.

## Contenu
- ajout d'un use case pur pour collecter du renseignement
- explicitation des issues collecte, refus et absence de canaux exploitables
- calcul des points de renseignement, du niveau d'insight, de la chaleur et de l'éveil de la cible
- ajout de tests sur succès, échec et validations

## Vérification
- `npm test`

## Notes
- cette PR est empilée sur `delta/d08-implement-diffuserrumeur`
- je demanderai la validation de Zeta avant tout merge
