### PR TITLE
Beta: implement ConsumeNeeds use case

### DIFF
--- a/src/application/economy/consumeNeeds.js
+++ b/src/application/economy/consumeNeeds.js
@@ -1,0 +1,153 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+function normalizeObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeCity(city) {
+  const normalizedCity = normalizeObject(city, 'consumeNeeds city');
+  const stockByResource = normalizeObject(normalizedCity.stockByResource ?? {}, 'consumeNeeds city.stockByResource');
+
+  return {
+    ...normalizedCity,
+    id: requireText(normalizedCity.id, 'consumeNeeds city.id'),
+    population: requireInteger(normalizedCity.population ?? 0, 'consumeNeeds city.population', 0),
+    prosperity: requireInteger(normalizedCity.prosperity ?? 50, 'consumeNeeds city.prosperity', 0, 100),
+    stability: requireInteger(normalizedCity.stability ?? 50, 'consumeNeeds city.stability', 0, 100),
+    stockByResource: Object.fromEntries(
+      Object.entries(stockByResource).map(([resourceId, quantity]) => [
+        requireText(resourceId, 'consumeNeeds city.stock resourceId'),
+        requireInteger(quantity, `consumeNeeds city stock quantity for ${String(resourceId).trim()}`, 0),
+      ]),
+    ),
+  };
+}
+
+function normalizeNeeds(needs) {
+  if (!Array.isArray(needs)) {
+    throw new TypeError('consumeNeeds needs must be an array.');
+  }
+
+  return needs.map((need, index) => {
+    const normalizedNeed = normalizeObject(need, `consumeNeeds needs[${index}]`);
+
+    return {
+      resourceId: requireText(normalizedNeed.resourceId, `consumeNeeds needs[${index}].resourceId`),
+      requiredQuantity: requireInteger(
+        normalizedNeed.requiredQuantity,
+        `consumeNeeds needs[${index}].requiredQuantity`,
+        0,
+      ),
+      shortagePenalty: requireInteger(
+        normalizedNeed.shortagePenalty ?? 0,
+        `consumeNeeds needs[${index}].shortagePenalty`,
+        0,
+        100,
+      ),
+      priority: requireInteger(
+        normalizedNeed.priority ?? 50,
+        `consumeNeeds needs[${index}].priority`,
+        0,
+        100,
+      ),
+      affects: requireText(normalizedNeed.affects ?? 'stability', `consumeNeeds needs[${index}].affects`),
+    };
+  }).sort((left, right) => right.priority - left.priority || left.resourceId.localeCompare(right.resourceId));
+}
+
+function consumeResource(stockByResource, resourceId, requiredQuantity) {
+  const availableQuantity = stockByResource[resourceId] ?? 0;
+  const consumedQuantity = Math.min(availableQuantity, requiredQuantity);
+  const shortageQuantity = requiredQuantity - consumedQuantity;
+
+  return {
+    nextStockByResource: {
+      ...stockByResource,
+      [resourceId]: availableQuantity - consumedQuantity,
+    },
+    consumedQuantity,
+    shortageQuantity,
+  };
+}
+
+function applyPenalty(city, need, shortageQuantity) {
+  if (shortageQuantity === 0 || need.shortagePenalty === 0) {
+    return city;
+  }
+
+  const nextCity = { ...city };
+  const penalty = Math.min(need.shortagePenalty, 100);
+
+  if (need.affects === 'prosperity') {
+    nextCity.prosperity = Math.max(0, nextCity.prosperity - penalty);
+    return nextCity;
+  }
+
+  if (need.affects === 'population') {
+    nextCity.population = Math.max(0, nextCity.population - penalty);
+    return nextCity;
+  }
+
+  nextCity.stability = Math.max(0, nextCity.stability - penalty);
+  return nextCity;
+}
+
+export function consumeNeeds(city, needs) {
+  let normalizedCity = normalizeCity(city);
+  const normalizedNeeds = normalizeNeeds(needs);
+  const consumption = [];
+  const shortages = [];
+  let nextStockByResource = { ...normalizedCity.stockByResource };
+
+  for (const need of normalizedNeeds) {
+    const result = consumeResource(nextStockByResource, need.resourceId, need.requiredQuantity);
+    nextStockByResource = result.nextStockByResource;
+
+    consumption.push({
+      resourceId: need.resourceId,
+      requiredQuantity: need.requiredQuantity,
+      consumedQuantity: result.consumedQuantity,
+    });
+
+    if (result.shortageQuantity > 0) {
+      shortages.push({
+        resourceId: need.resourceId,
+        shortageQuantity: result.shortageQuantity,
+        affects: need.affects,
+        penaltyApplied: need.shortagePenalty,
+      });
+      normalizedCity = applyPenalty(normalizedCity, need, result.shortageQuantity);
+    }
+  }
+
+  return {
+    city: {
+      ...normalizedCity,
+      stockByResource: nextStockByResource,
+    },
+    consumption,
+    shortages,
+    fulfilledNeedCount: consumption.length - shortages.length,
+    shortageCount: shortages.length,
+  };
+}

--- a/test/application/economy/consumeNeeds.test.js
+++ b/test/application/economy/consumeNeeds.test.js
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { consumeNeeds } from '../../../src/application/economy/consumeNeeds.js';
+
+test('consumeNeeds subtracts fulfilled needs from city stock without mutating the input city', () => {
+  const city = {
+    id: 'city-granary',
+    population: 120,
+    prosperity: 62,
+    stability: 71,
+    stockByResource: {
+      grain: 40,
+      water: 25,
+    },
+  };
+
+  const result = consumeNeeds(city, [
+    { resourceId: 'grain', requiredQuantity: 12, shortagePenalty: 8, priority: 90, affects: 'stability' },
+    { resourceId: 'water', requiredQuantity: 10, shortagePenalty: 4, priority: 80, affects: 'prosperity' },
+  ]);
+
+  assert.deepEqual(result.city.stockByResource, {
+    grain: 28,
+    water: 15,
+  });
+  assert.deepEqual(result.consumption, [
+    { resourceId: 'grain', requiredQuantity: 12, consumedQuantity: 12 },
+    { resourceId: 'water', requiredQuantity: 10, consumedQuantity: 10 },
+  ]);
+  assert.deepEqual(result.shortages, []);
+  assert.equal(result.fulfilledNeedCount, 2);
+  assert.equal(result.shortageCount, 0);
+  assert.deepEqual(city.stockByResource, { grain: 40, water: 25 });
+});
+
+test('consumeNeeds records shortages and applies penalties to the targeted city metric', () => {
+  const result = consumeNeeds(
+    {
+      id: 'city-siege',
+      population: 80,
+      prosperity: 55,
+      stability: 48,
+      stockByResource: {
+        grain: 3,
+        water: 1,
+        medicine: 0,
+      },
+    },
+    [
+      { resourceId: 'grain', requiredQuantity: 6, shortagePenalty: 10, priority: 90, affects: 'stability' },
+      { resourceId: 'water', requiredQuantity: 4, shortagePenalty: 7, priority: 80, affects: 'prosperity' },
+      { resourceId: 'medicine', requiredQuantity: 2, shortagePenalty: 5, priority: 70, affects: 'population' },
+    ],
+  );
+
+  assert.deepEqual(result.city.stockByResource, {
+    grain: 0,
+    water: 0,
+    medicine: 0,
+  });
+  assert.deepEqual(result.shortages, [
+    { resourceId: 'grain', shortageQuantity: 3, affects: 'stability', penaltyApplied: 10 },
+    { resourceId: 'water', shortageQuantity: 3, affects: 'prosperity', penaltyApplied: 7 },
+    { resourceId: 'medicine', shortageQuantity: 2, affects: 'population', penaltyApplied: 5 },
+  ]);
+  assert.equal(result.city.stability, 38);
+  assert.equal(result.city.prosperity, 48);
+  assert.equal(result.city.population, 75);
+  assert.equal(result.fulfilledNeedCount, 0);
+  assert.equal(result.shortageCount, 3);
+});
+
+test('consumeNeeds applies needs in priority order before lower-priority consumption', () => {
+  const result = consumeNeeds(
+    {
+      id: 'city-market',
+      population: 60,
+      prosperity: 50,
+      stability: 50,
+      stockByResource: {
+        grain: 5,
+      },
+    },
+    [
+      { resourceId: 'grain', requiredQuantity: 4, shortagePenalty: 4, priority: 10, affects: 'prosperity' },
+      { resourceId: 'grain', requiredQuantity: 4, shortagePenalty: 6, priority: 90, affects: 'stability' },
+    ],
+  );
+
+  assert.deepEqual(result.consumption, [
+    { resourceId: 'grain', requiredQuantity: 4, consumedQuantity: 4 },
+    { resourceId: 'grain', requiredQuantity: 4, consumedQuantity: 1 },
+  ]);
+  assert.deepEqual(result.shortages, [
+    { resourceId: 'grain', shortageQuantity: 3, affects: 'prosperity', penaltyApplied: 4 },
+  ]);
+  assert.equal(result.city.stability, 50);
+  assert.equal(result.city.prosperity, 46);
+});
+
+test('consumeNeeds rejects invalid city and need payloads', () => {
+  assert.throws(() => consumeNeeds(null, []), /consumeNeeds city must be an object/);
+  assert.throws(
+    () => consumeNeeds({ id: 'city-a', population: 10, prosperity: 50, stability: 50, stockByResource: {} }, {}),
+    /consumeNeeds needs must be an array/,
+  );
+  assert.throws(
+    () => consumeNeeds(
+      { id: 'city-a', population: 10, prosperity: 50, stability: 50, stockByResource: {} },
+      [{ resourceId: '', requiredQuantity: 1 }],
+    ),
+    /consumeNeeds needs\[0\]\.resourceId is required/,
+  );
+  assert.throws(
+    () => consumeNeeds(
+      { id: 'city-a', population: 10, prosperity: 50, stability: 50, stockByResource: {} },
+      [{ resourceId: 'grain', requiredQuantity: -1 }],
+    ),
+    /consumeNeeds needs\[0\]\.requiredQuantity must be an integer between 0 and/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: implement the `consumeNeeds` use case for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `consumeNeeds` in the application layer with validation for city state and prioritized need definitions
Beta: - consume stock per resource, record shortages, and apply shortage penalties to stability, prosperity, or population
Beta: - return an immutable updated city snapshot plus consumption and shortage summaries
Beta: - add node tests for fulfilled needs, shortage penalties, priority ordering, and invalid payloads
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #26
