### PR TITLE
Gamma: [G12] Add in-memory research adapter

### DIFF
--- a/src/adapters/culture/InMemoryResearchRepository.js
+++ b/src/adapters/culture/InMemoryResearchRepository.js
@@ -1,0 +1,82 @@
+import { ResearchRepositoryPort } from '../../domain/culture/ResearchRepositoryPort.js';
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => requireText(value, label)))];
+  return normalizedValues.sort();
+}
+
+function normalizeResearchState(researchState) {
+  if (!researchState || typeof researchState !== 'object' || Array.isArray(researchState)) {
+    throw new TypeError('InMemoryResearchRepository researchState must be an object.');
+  }
+
+  return {
+    ...researchState,
+    id: requireText(researchState.id, 'InMemoryResearchRepository researchState.id'),
+    cultureId: requireText(
+      researchState.cultureId,
+      'InMemoryResearchRepository researchState.cultureId',
+    ),
+    focusIds: normalizeUniqueTexts(
+      researchState.focusIds ?? [],
+      'InMemoryResearchRepository researchState.focusIds[]',
+    ),
+  };
+}
+
+function cloneResearchState(researchState) {
+  return {
+    ...researchState,
+    focusIds: [...researchState.focusIds],
+  };
+}
+
+export class InMemoryResearchRepository extends ResearchRepositoryPort {
+  constructor(initialResearchStates = []) {
+    super();
+    this.researchStates = new Map();
+
+    for (const researchState of initialResearchStates) {
+      const normalizedResearchState = normalizeResearchState(researchState);
+      this.researchStates.set(normalizedResearchState.id, normalizedResearchState);
+    }
+  }
+
+  async getById(researchStateId) {
+    const normalizedResearchStateId = requireText(
+      researchStateId,
+      'ResearchRepositoryPort researchStateId',
+    );
+    const researchState = this.researchStates.get(normalizedResearchStateId);
+
+    return researchState ? cloneResearchState(researchState) : null;
+  }
+
+  async save(researchState) {
+    const normalizedResearchState = normalizeResearchState(researchState);
+    this.researchStates.set(normalizedResearchState.id, normalizedResearchState);
+    return cloneResearchState(normalizedResearchState);
+  }
+
+  async listByCulture(cultureId) {
+    const normalizedCultureId = requireText(cultureId, 'ResearchRepositoryPort cultureId');
+
+    return [...this.researchStates.values()]
+      .filter((researchState) => researchState.cultureId === normalizedCultureId)
+      .map((researchState) => cloneResearchState(researchState));
+  }
+}

--- a/test/adapters/culture/InMemoryResearchRepository.test.js
+++ b/test/adapters/culture/InMemoryResearchRepository.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryResearchRepository } from '../../../src/adapters/culture/InMemoryResearchRepository.js';
+
+test('InMemoryResearchRepository returns stored research states by id and clones results', async () => {
+  const repository = new InMemoryResearchRepository([
+    {
+      id: 'research-state-north',
+      cultureId: 'culture-north',
+      focusIds: ['astronomy', 'archives'],
+    },
+  ]);
+
+  const researchState = await repository.getById('research-state-north');
+  researchState.focusIds.push('mutated');
+  const secondRead = await repository.getById('research-state-north');
+
+  assert.equal(researchState.cultureId, 'culture-north');
+  assert.deepEqual(secondRead.focusIds, ['archives', 'astronomy']);
+});
+
+test('InMemoryResearchRepository saves and lists research states by culture', async () => {
+  const repository = new InMemoryResearchRepository();
+
+  const savedResearchState = await repository.save({
+    id: 'research-state-east',
+    cultureId: 'culture-east',
+    focusIds: ['translation', 'cartography', 'translation'],
+  });
+
+  const researchStates = await repository.listByCulture('culture-east');
+
+  assert.equal(savedResearchState.id, 'research-state-east');
+  assert.deepEqual(savedResearchState.focusIds, ['cartography', 'translation']);
+  assert.equal(researchStates.length, 1);
+  assert.equal(researchStates[0].cultureId, 'culture-east');
+});
+
+test('InMemoryResearchRepository validates payloads and identifiers', async () => {
+  const repository = new InMemoryResearchRepository();
+
+  await assert.rejects(
+    () => repository.getById(''),
+    /ResearchRepositoryPort researchStateId is required/,
+  );
+  await assert.rejects(
+    () => repository.listByCulture('   '),
+    /ResearchRepositoryPort cultureId is required/,
+  );
+  await assert.rejects(
+    () => repository.save(null),
+    /InMemoryResearchRepository researchState must be an object/,
+  );
+  await assert.rejects(
+    () => repository.save({ id: 'research-state-west', cultureId: ' ', focusIds: [] }),
+    /InMemoryResearchRepository researchState.cultureId is required/,
+  );
+  assert.throws(
+    () =>
+      new InMemoryResearchRepository([
+        {
+          id: 'research-state-west',
+          cultureId: 'culture-west',
+          focusIds: ['astronomy', ' '],
+        },
+      ]),
+    /InMemoryResearchRepository researchState.focusIds\[\] is required/,
+  );
+});


### PR DESCRIPTION
Gamma: ## Summary
Gamma: Add an in-memory research repository adapter for the Gamma slice, stacked on top of the `ResearchRepositoryPort` branch.
Gamma:
Gamma: ## Related issue
Gamma: - Closes #52
Gamma:
Gamma: ## Changes
Gamma: - add `src/adapters/culture/InMemoryResearchRepository.js`
Gamma: - support seeded research states, `getById`, `save`, and `listByCulture`
Gamma: - return cloned results to avoid accidental in-memory mutation leaks
Gamma: - validate research state payloads, culture ids, and research focus ids
Gamma: - add node tests for read, write, listing, cloning, and validation behavior
Gamma:
Gamma: ## Testing
Gamma: - [x] Local checks run
Gamma: - [x] Relevant tests added or updated
Gamma: - [ ] Manual check if relevant
Gamma: - [x] `npm test -- --test-reporter tap`
Gamma:
Gamma: ## Rules check
Gamma: - [x] This work comes through a pull request
Gamma: - [x] This PR is mandatory to avoid bugs and validation problems with Zeta
Gamma: - [x] GitHub text starts with the agent name followed by `:`
Gamma: - [x] The work stays inside the author's domain
Gamma: - [ ] Zeta has been asked for validation before merge
Gamma:
Gamma: ## Notes
Gamma: This PR is intentionally stacked on top of `Gamma: [G10] Create ResearchRepository port` because the adapter depends on that port.
