### PR TITLE
Alpha: [A16] Add tests for front detection

### DIFF
--- a/src/domain/war/detectFrontSegments.js
+++ b/src/domain/war/detectFrontSegments.js
@@ -1,0 +1,76 @@
+import { BorderSegment } from './BorderSegment.js';
+import { Province } from './Province.js';
+
+function requireProvince(province) {
+  if (!(province instanceof Province)) {
+    throw new TypeError('detectFrontSegments provinces must be Province instances.');
+  }
+
+  return province;
+}
+
+function buildProvinceMap(provinces) {
+  const provinceMap = new Map();
+
+  for (const province of provinces) {
+    const normalizedProvince = requireProvince(province);
+    provinceMap.set(normalizedProvince.id, normalizedProvince);
+  }
+
+  return provinceMap;
+}
+
+function buildSegmentId(provinceAId, provinceBId) {
+  return [provinceAId, provinceBId].sort().join('::');
+}
+
+export function detectFrontSegments(provinces, segmentOptionsByPair = {}) {
+  if (!Array.isArray(provinces)) {
+    throw new TypeError('detectFrontSegments provinces must be an array.');
+  }
+
+  if (!segmentOptionsByPair || typeof segmentOptionsByPair !== 'object' || Array.isArray(segmentOptionsByPair)) {
+    throw new TypeError('detectFrontSegments segmentOptionsByPair must be an object.');
+  }
+
+  const provinceMap = buildProvinceMap(provinces);
+  const segments = [];
+  const seenSegmentIds = new Set();
+
+  for (const province of provinceMap.values()) {
+    for (const neighborId of province.neighborIds) {
+      const neighbor = provinceMap.get(neighborId);
+
+      if (!(neighbor instanceof Province)) {
+        continue;
+      }
+
+      if (province.controllingFactionId === neighbor.controllingFactionId) {
+        continue;
+      }
+
+      const segmentId = buildSegmentId(province.id, neighbor.id);
+
+      if (seenSegmentIds.has(segmentId)) {
+        continue;
+      }
+
+      const options = segmentOptionsByPair[segmentId] ?? {};
+      segments.push(
+        new BorderSegment({
+          provinceAId: province.id,
+          provinceBId: neighbor.id,
+          terrainType: options.terrainType ?? 'plain',
+          pressure: options.pressure ?? 0,
+          contested: options.contested ?? true,
+          chokepoint: options.chokepoint ?? false,
+          length: options.length ?? 1,
+          position: options.position ?? 0,
+        }),
+      );
+      seenSegmentIds.add(segmentId);
+    }
+  }
+
+  return segments.sort((left, right) => left.id.localeCompare(right.id));
+}

--- a/test/domain/war/detectFrontSegments.test.js
+++ b/test/domain/war/detectFrontSegments.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Province } from '../../../src/domain/war/Province.js';
+import { detectFrontSegments } from '../../../src/domain/war/detectFrontSegments.js';
+
+function createProvince(overrides = {}) {
+  return new Province({
+    id: 'prov-a',
+    name: 'Province A',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    neighborIds: [],
+    ...overrides,
+  });
+}
+
+test('detectFrontSegments creates one border segment per hostile adjacency', () => {
+  const provinces = [
+    createProvince({ id: 'prov-a', neighborIds: ['prov-b', 'prov-c'] }),
+    createProvince({ id: 'prov-b', controllingFactionId: 'faction-b', ownerFactionId: 'faction-b', neighborIds: ['prov-a'] }),
+    createProvince({ id: 'prov-c', neighborIds: ['prov-a'] }),
+  ];
+
+  const segments = detectFrontSegments(provinces);
+
+  assert.deepEqual(segments.map((segment) => segment.toJSON()), [
+    {
+      id: 'prov-a::prov-b',
+      provinceAId: 'prov-a',
+      provinceBId: 'prov-b',
+      terrainType: 'plain',
+      pressure: 0,
+      contested: true,
+      chokepoint: false,
+      length: 1,
+      position: 0,
+    },
+  ]);
+});
+
+test('detectFrontSegments supports per-pair options and ignores duplicate neighbor declarations', () => {
+  const provinces = [
+    createProvince({ id: 'prov-a', neighborIds: ['prov-b'] }),
+    createProvince({
+      id: 'prov-b',
+      controllingFactionId: 'faction-b',
+      ownerFactionId: 'faction-b',
+      neighborIds: ['prov-a'],
+    }),
+  ];
+
+  const segments = detectFrontSegments(provinces, {
+    'prov-a::prov-b': {
+      terrainType: 'river',
+      pressure: 18,
+      chokepoint: true,
+      length: 2,
+      position: 1,
+    },
+  });
+
+  assert.equal(segments.length, 1);
+  assert.deepEqual(segments[0].toJSON(), {
+    id: 'prov-a::prov-b',
+    provinceAId: 'prov-a',
+    provinceBId: 'prov-b',
+    terrainType: 'river',
+    pressure: 18,
+    contested: true,
+    chokepoint: true,
+    length: 2,
+    position: 1,
+  });
+});
+
+test('detectFrontSegments returns no segments for friendly or missing neighbors', () => {
+  const provinces = [
+    createProvince({ id: 'prov-a', neighborIds: ['prov-b', 'prov-missing'] }),
+    createProvince({ id: 'prov-b', neighborIds: ['prov-a'] }),
+  ];
+
+  assert.deepEqual(detectFrontSegments(provinces), []);
+});
+
+test('detectFrontSegments rejects invalid inputs', () => {
+  assert.throws(() => detectFrontSegments(null), /provinces must be an array/);
+  assert.throws(() => detectFrontSegments([{}]), /provinces must be Province instances/);
+  assert.throws(() => detectFrontSegments([], []), /segmentOptionsByPair must be an object/);
+});


### PR DESCRIPTION
Alpha: ## Summary
Alpha: Add concrete front detection coverage with a small pure war-domain helper.
Alpha:
Alpha: ## Changes
Alpha: Add `detectFrontSegments` to derive hostile border segments from province adjacencies.
Alpha: Cover hostile adjacency detection, duplicate neighbor filtering, pair-specific segment options, and invalid input handling.
Alpha: Keep the implementation domain-level and easy to reuse in later Alpha use cases.
Alpha:
Alpha: ## Testing
Alpha: - [x] `npm test`
Alpha:
Alpha: ## Notes
Alpha: This PR is stacked on top of `alpha/a15-emit-war-events-for-front-changes` to keep the slice small.
