### PR TITLE
Beta: implement UpdateCityEconomy use case

### DIFF
--- a/src/application/economy/ConsumeNeeds.js
+++ b/src/application/economy/ConsumeNeeds.js
@@ -1,0 +1,153 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+function normalizeObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeCity(city) {
+  const normalizedCity = normalizeObject(city, 'ConsumeNeeds city');
+  const stockByResource = normalizeObject(normalizedCity.stockByResource ?? {}, 'ConsumeNeeds city.stockByResource');
+
+  return {
+    ...normalizedCity,
+    id: requireText(normalizedCity.id, 'ConsumeNeeds city.id'),
+    population: requireInteger(normalizedCity.population ?? 0, 'ConsumeNeeds city.population', 0),
+    prosperity: requireInteger(normalizedCity.prosperity ?? 50, 'ConsumeNeeds city.prosperity', 0, 100),
+    stability: requireInteger(normalizedCity.stability ?? 50, 'ConsumeNeeds city.stability', 0, 100),
+    stockByResource: Object.fromEntries(
+      Object.entries(stockByResource).map(([resourceId, quantity]) => [
+        requireText(resourceId, 'ConsumeNeeds city.stock resourceId'),
+        requireInteger(quantity, `ConsumeNeeds city stock quantity for ${String(resourceId).trim()}`, 0),
+      ]),
+    ),
+  };
+}
+
+function normalizeNeeds(needs) {
+  if (!Array.isArray(needs)) {
+    throw new TypeError('ConsumeNeeds needs must be an array.');
+  }
+
+  return needs.map((need, index) => {
+    const normalizedNeed = normalizeObject(need, `ConsumeNeeds needs[${index}]`);
+
+    return {
+      resourceId: requireText(normalizedNeed.resourceId, `ConsumeNeeds needs[${index}].resourceId`),
+      requiredQuantity: requireInteger(
+        normalizedNeed.requiredQuantity,
+        `ConsumeNeeds needs[${index}].requiredQuantity`,
+        0,
+      ),
+      shortagePenalty: requireInteger(
+        normalizedNeed.shortagePenalty ?? 0,
+        `ConsumeNeeds needs[${index}].shortagePenalty`,
+        0,
+        100,
+      ),
+      priority: requireInteger(
+        normalizedNeed.priority ?? 50,
+        `ConsumeNeeds needs[${index}].priority`,
+        0,
+        100,
+      ),
+      affects: requireText(normalizedNeed.affects ?? 'stability', `ConsumeNeeds needs[${index}].affects`),
+    };
+  }).sort((left, right) => right.priority - left.priority || left.resourceId.localeCompare(right.resourceId));
+}
+
+function consumeResource(stockByResource, resourceId, requiredQuantity) {
+  const availableQuantity = stockByResource[resourceId] ?? 0;
+  const consumedQuantity = Math.min(availableQuantity, requiredQuantity);
+  const shortageQuantity = requiredQuantity - consumedQuantity;
+
+  return {
+    nextStockByResource: {
+      ...stockByResource,
+      [resourceId]: availableQuantity - consumedQuantity,
+    },
+    consumedQuantity,
+    shortageQuantity,
+  };
+}
+
+function applyPenalty(city, need, shortageQuantity) {
+  if (shortageQuantity === 0 || need.shortagePenalty === 0) {
+    return city;
+  }
+
+  const nextCity = { ...city };
+  const penalty = Math.min(need.shortagePenalty, 100);
+
+  if (need.affects === 'prosperity') {
+    nextCity.prosperity = Math.max(0, nextCity.prosperity - penalty);
+    return nextCity;
+  }
+
+  if (need.affects === 'population') {
+    nextCity.population = Math.max(0, nextCity.population - penalty);
+    return nextCity;
+  }
+
+  nextCity.stability = Math.max(0, nextCity.stability - penalty);
+  return nextCity;
+}
+
+export function consumeNeeds(city, needs) {
+  let normalizedCity = normalizeCity(city);
+  const normalizedNeeds = normalizeNeeds(needs);
+  const consumption = [];
+  const shortages = [];
+  let nextStockByResource = { ...normalizedCity.stockByResource };
+
+  for (const need of normalizedNeeds) {
+    const result = consumeResource(nextStockByResource, need.resourceId, need.requiredQuantity);
+    nextStockByResource = result.nextStockByResource;
+
+    consumption.push({
+      resourceId: need.resourceId,
+      requiredQuantity: need.requiredQuantity,
+      consumedQuantity: result.consumedQuantity,
+    });
+
+    if (result.shortageQuantity > 0) {
+      shortages.push({
+        resourceId: need.resourceId,
+        shortageQuantity: result.shortageQuantity,
+        affects: need.affects,
+        penaltyApplied: need.shortagePenalty,
+      });
+      normalizedCity = applyPenalty(normalizedCity, need, result.shortageQuantity);
+    }
+  }
+
+  return {
+    city: {
+      ...normalizedCity,
+      stockByResource: nextStockByResource,
+    },
+    consumption,
+    shortages,
+    fulfilledNeedCount: consumption.length - shortages.length,
+    shortageCount: shortages.length,
+  };
+}

--- a/src/application/economy/UpdateCityEconomy.js
+++ b/src/application/economy/UpdateCityEconomy.js
@@ -1,0 +1,103 @@
+import { produceResources } from './ProduceResources.js';
+import { consumeNeeds } from './ConsumeNeeds.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeCity(city) {
+  const normalizedCity = requireObject(city, 'UpdateCityEconomy city');
+
+  if (typeof normalizedCity.id !== 'string' || normalizedCity.id.trim().length === 0) {
+    throw new RangeError('UpdateCityEconomy city.id is required.');
+  }
+
+  return {
+    ...normalizedCity,
+    id: normalizedCity.id.trim(),
+    stockByResource: requireObject(
+      normalizedCity.stockByResource ?? {},
+      'UpdateCityEconomy city.stockByResource',
+    ),
+  };
+}
+
+function normalizeProductionRules(rules) {
+  if (!Array.isArray(rules)) {
+    throw new TypeError('UpdateCityEconomy productionRules must be an array.');
+  }
+
+  return rules.map((rule, index) => ({
+    ...requireObject(rule, `UpdateCityEconomy productionRules[${index}]`),
+  }));
+}
+
+function normalizeNeeds(needs) {
+  if (!Array.isArray(needs)) {
+    throw new TypeError('UpdateCityEconomy needs must be an array.');
+  }
+
+  return needs.map((need, index) => ({
+    ...requireObject(need, `UpdateCityEconomy needs[${index}]`),
+  }));
+}
+
+export function updateCityEconomy({ city, productionRules = [], needs = [] }) {
+  const normalizedCity = normalizeCity(city);
+  const normalizedProductionRules = normalizeProductionRules(productionRules);
+  const normalizedNeeds = normalizeNeeds(needs);
+
+  let currentCity = {
+    ...normalizedCity,
+    stockByResource: { ...normalizedCity.stockByResource },
+  };
+  let totalWorkforceUsed = 0;
+  const productionResults = [];
+
+  for (const rule of normalizedProductionRules) {
+    const productionResult = produceResources({
+      city: currentCity,
+      rule,
+      stockByResource: currentCity.stockByResource,
+    });
+
+    productionResults.push({
+      ruleId: rule.id ?? null,
+      ...productionResult,
+    });
+
+    currentCity = {
+      ...currentCity,
+      workforce: Math.max(0, (currentCity.workforce ?? 0) - productionResult.workforceUsed),
+      stockByResource: { ...productionResult.nextStockByResource },
+    };
+    totalWorkforceUsed += productionResult.workforceUsed;
+  }
+
+  const consumptionResult = consumeNeeds(currentCity, normalizedNeeds);
+
+  return {
+    city: consumptionResult.city,
+    productionResults,
+    consumption: consumptionResult.consumption,
+    shortages: consumptionResult.shortages,
+    producedByResource: productionResults.reduce((summary, result) => {
+      for (const [resourceId, quantity] of Object.entries(result.producedByResource ?? {})) {
+        summary[resourceId] = (summary[resourceId] ?? 0) + quantity;
+      }
+      return summary;
+    }, {}),
+    consumedByResource: consumptionResult.consumption.reduce((summary, entry) => {
+      summary[entry.resourceId] = (summary[entry.resourceId] ?? 0) + entry.consumedQuantity;
+      return summary;
+    }, {}),
+    workforceUsed: totalWorkforceUsed,
+    workforceRemaining: currentCity.workforce ?? 0,
+    executedProductionRuleCount: productionResults.filter((result) => result.executed).length,
+    shortageCount: consumptionResult.shortageCount,
+  };
+}

--- a/test/application/economy/UpdateCityEconomy.test.js
+++ b/test/application/economy/UpdateCityEconomy.test.js
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { updateCityEconomy } from '../../../src/application/economy/UpdateCityEconomy.js';
+
+test('UpdateCityEconomy orchestrates production before consumption for one city tick', () => {
+  const result = updateCityEconomy({
+    city: {
+      id: 'city-harbor',
+      population: 90,
+      workforce: 20,
+      prosperity: 60,
+      stability: 65,
+      stockByResource: {
+        grain: 10,
+        wood: 3,
+      },
+    },
+    productionRules: [
+      {
+        id: 'rule-mill',
+        workforceRequired: 8,
+        inputByResource: { grain: 6 },
+        outputByResource: { flour: 9 },
+      },
+      {
+        id: 'rule-lumber',
+        workforceRequired: 4,
+        inputByResource: { wood: 1 },
+        outputByResource: { planks: 2 },
+      },
+    ],
+    needs: [
+      { resourceId: 'flour', requiredQuantity: 5, shortagePenalty: 8, priority: 90, affects: 'stability' },
+      { resourceId: 'grain', requiredQuantity: 2, shortagePenalty: 5, priority: 80, affects: 'prosperity' },
+    ],
+  });
+
+  assert.deepEqual(result.city.stockByResource, {
+    grain: 2,
+    wood: 2,
+    flour: 4,
+    planks: 2,
+  });
+  assert.deepEqual(result.producedByResource, { flour: 9, planks: 2 });
+  assert.deepEqual(result.consumedByResource, { flour: 5, grain: 2 });
+  assert.equal(result.workforceUsed, 12);
+  assert.equal(result.workforceRemaining, 8);
+  assert.equal(result.executedProductionRuleCount, 2);
+  assert.equal(result.shortageCount, 0);
+});
+
+test('UpdateCityEconomy carries forward blocked production and resulting shortages', () => {
+  const result = updateCityEconomy({
+    city: {
+      id: 'city-siege',
+      population: 70,
+      workforce: 5,
+      prosperity: 55,
+      stability: 52,
+      stockByResource: {
+        grain: 1,
+      },
+    },
+    productionRules: [
+      {
+        id: 'rule-bakery',
+        workforceRequired: 6,
+        inputByResource: { grain: 2 },
+        outputByResource: { bread: 4 },
+      },
+    ],
+    needs: [
+      { resourceId: 'bread', requiredQuantity: 3, shortagePenalty: 9, priority: 90, affects: 'stability' },
+    ],
+  });
+
+  assert.equal(result.productionResults[0].executed, false);
+  assert.equal(result.productionResults[0].reason, 'insufficient-workforce');
+  assert.deepEqual(result.shortages, [
+    { resourceId: 'bread', shortageQuantity: 3, affects: 'stability', penaltyApplied: 9 },
+  ]);
+  assert.equal(result.city.stability, 43);
+  assert.equal(result.workforceUsed, 0);
+  assert.equal(result.workforceRemaining, 5);
+});
+
+test('UpdateCityEconomy validates its top-level inputs', () => {
+  assert.throws(
+    () => updateCityEconomy({ city: null }),
+    /UpdateCityEconomy city must be an object/,
+  );
+
+  assert.throws(
+    () => updateCityEconomy({ city: { id: 'city-a', stockByResource: {} }, productionRules: {} }),
+    /UpdateCityEconomy productionRules must be an array/,
+  );
+
+  assert.throws(
+    () => updateCityEconomy({ city: { id: 'city-a', stockByResource: {} }, needs: {} }),
+    /UpdateCityEconomy needs must be an array/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: implement the `UpdateCityEconomy` use case for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `UpdateCityEconomy` to orchestrate per-city production and need consumption in one application flow
Beta: - include a local `ConsumeNeeds` implementation in the branch so the orchestration remains self-contained and testable before stacked merges land on `main`
Beta: - return aggregated production, consumption, shortage, and workforce summaries for a full city economy tick
Beta: - add node tests for normal orchestration, blocked production with resulting shortages, and invalid top-level payloads
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #27
