### PR TITLE
Delta: [D10] Create WorldReadPort

### DIFF
--- a/src/application/ports/WorldReadPort.js
+++ b/src/application/ports/WorldReadPort.js
@@ -1,0 +1,48 @@
+function requireFunction(value, label) {
+  if (typeof value !== 'function') {
+    throw new TypeError(`${label} must be a function.`);
+  }
+
+  return value;
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function ensureSnapshot(snapshot) {
+  const normalizedSnapshot = requireObject(snapshot, 'WorldReadPort snapshot');
+
+  if (!('worldId' in normalizedSnapshot)) {
+    throw new RangeError('WorldReadPort snapshot.worldId is required.');
+  }
+
+  return { ...normalizedSnapshot };
+}
+
+export function createWorldReadPort({ readWorld }) {
+  const normalizedReadWorld = requireFunction(readWorld, 'WorldReadPort readWorld');
+
+  return {
+    readWorld(query = {}) {
+      requireObject(query, 'WorldReadPort query');
+      return ensureSnapshot(normalizedReadWorld({ ...query }));
+    },
+  };
+}
+
+export function assertWorldReadPort(port) {
+  const normalizedPort = requireObject(port, 'WorldReadPort');
+  const readWorld = requireFunction(normalizedPort.readWorld, 'WorldReadPort readWorld');
+
+  return {
+    readWorld(query = {}) {
+      requireObject(query, 'WorldReadPort query');
+      return ensureSnapshot(readWorld.call(normalizedPort, { ...query }));
+    },
+  };
+}

--- a/test/application/ports/WorldReadPort.test.js
+++ b/test/application/ports/WorldReadPort.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { assertWorldReadPort, createWorldReadPort } from '../../../src/application/ports/WorldReadPort.js';
+
+test('createWorldReadPort wraps a reader and returns immutable snapshots', () => {
+  const receivedQueries = [];
+  const port = createWorldReadPort({
+    readWorld(query) {
+      receivedQueries.push(query);
+      return {
+        worldId: 'world-historia',
+        tick: 42,
+        regionIds: ['north', 'delta'],
+      };
+    },
+  });
+
+  const snapshot = port.readWorld({ tick: 42, regionId: 'delta' });
+  snapshot.tick = 99;
+
+  assert.deepEqual(receivedQueries, [{ tick: 42, regionId: 'delta' }]);
+  assert.deepEqual(port.readWorld({ tick: 43 }), {
+    worldId: 'world-historia',
+    tick: 42,
+    regionIds: ['north', 'delta'],
+  });
+});
+
+test('assertWorldReadPort validates the contract and preserves context', () => {
+  const port = {
+    prefix: 'world',
+    readWorld(query) {
+      return {
+        worldId: `${this.prefix}-${query.tick}`,
+        tick: query.tick,
+      };
+    },
+  };
+
+  const validatedPort = assertWorldReadPort(port);
+
+  assert.deepEqual(validatedPort.readWorld({ tick: 7 }), {
+    worldId: 'world-7',
+    tick: 7,
+  });
+
+  assert.throws(() => assertWorldReadPort({}), /WorldReadPort readWorld must be a function/);
+  assert.throws(
+    () => validatedPort.readWorld(null),
+    /WorldReadPort query must be an object/,
+  );
+});
+
+test('WorldReadPort rejects invalid snapshots', () => {
+  const port = createWorldReadPort({
+    readWorld() {
+      return { tick: 42 };
+    },
+  });
+
+  assert.throws(() => port.readWorld({}), /WorldReadPort snapshot.worldId is required/);
+  assert.throws(
+    () =>
+      createWorldReadPort({
+        readWorld: 'nope',
+      }),
+    /WorldReadPort readWorld must be a function/,
+  );
+});


### PR DESCRIPTION
Delta: Cette PR traite l'issue #70 en ajoutant le port `WorldReadPort`.

## Contenu
- ajout d'une factory `createWorldReadPort`
- ajout d'un validateur `assertWorldReadPort`
- validation des queries et snapshots retournés
- ajout de tests sur contrat, contexte et snapshots invalides

## Vérification
- `npm test`

## Notes
- cette PR est empilée sur `delta/d09-implement-collecterrenseignement`
- je demanderai la validation de Zeta avant tout merge
