### PR TITLE
Gamma: [G13] Integrate RandomProvider in Gamma systems

### DIFF
--- a/src/application/culture/RandomProviderPort.js
+++ b/src/application/culture/RandomProviderPort.js
@@ -1,0 +1,18 @@
+function requireUnitInterval(value, label) {
+  if (typeof value !== 'number' || Number.isNaN(value) || value < 0 || value >= 1) {
+    throw new RangeError(`${label} must be a number greater than or equal to 0 and lower than 1.`);
+  }
+
+  return value;
+}
+
+export class RandomProviderPort {
+  async nextFloat() {
+    throw new Error('RandomProviderPort.nextFloat must be implemented by an adapter.');
+  }
+
+  async requireNextFloat() {
+    const value = await this.nextFloat();
+    return requireUnitInterval(value, 'RandomProviderPort nextFloat');
+  }
+}

--- a/src/application/culture/triggerHistoricalEvent.js
+++ b/src/application/culture/triggerHistoricalEvent.js
@@ -131,6 +131,33 @@ function normalizeExecution(execution) {
   };
 }
 
+export async function selectHistoricalEvent(historicalEvents, randomProvider) {
+  if (!Array.isArray(historicalEvents) || historicalEvents.length === 0) {
+    throw new RangeError('selectHistoricalEvent historicalEvents must be a non-empty array.');
+  }
+
+  if (!randomProvider || typeof randomProvider.requireNextFloat !== 'function') {
+    throw new TypeError('selectHistoricalEvent randomProvider must expose requireNextFloat().');
+  }
+
+  const normalizedEvents = historicalEvents.map((historicalEvent) => normalizeHistoricalEvent(historicalEvent));
+  const randomValue = await randomProvider.requireNextFloat();
+  const selectedIndex = Math.min(
+    normalizedEvents.length - 1,
+    Math.floor(randomValue * normalizedEvents.length),
+  );
+
+  return {
+    selectedEvent: {
+      ...normalizedEvents[selectedIndex],
+      selectionRoll: randomValue,
+      selectionIndex: selectedIndex,
+    },
+    selectionRoll: randomValue,
+    selectionIndex: selectedIndex,
+  };
+}
+
 export function triggerHistoricalEvent(historicalEvent, execution = {}) {
   const normalizedHistoricalEvent = normalizeHistoricalEvent(historicalEvent);
   const normalizedExecution = normalizeExecution(execution);

--- a/test/application/culture/RandomProviderPort.test.js
+++ b/test/application/culture/RandomProviderPort.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { RandomProviderPort } from '../../../src/application/culture/RandomProviderPort.js';
+
+class FixedRandomProvider extends RandomProviderPort {
+  constructor(value) {
+    super();
+    this.value = value;
+  }
+
+  async nextFloat() {
+    return this.value;
+  }
+}
+
+test('RandomProviderPort validates the float returned by adapters', async () => {
+  const validProvider = new FixedRandomProvider(0.42);
+  const value = await validProvider.requireNextFloat();
+
+  assert.equal(value, 0.42);
+
+  await assert.rejects(
+    () => new FixedRandomProvider(1).requireNextFloat(),
+    /RandomProviderPort nextFloat must be a number greater than or equal to 0 and lower than 1/,
+  );
+  await assert.rejects(
+    () => new FixedRandomProvider(-0.1).requireNextFloat(),
+    /RandomProviderPort nextFloat must be a number greater than or equal to 0 and lower than 1/,
+  );
+});
+
+test('RandomProviderPort base adapter method fails fast until implemented', async () => {
+  const provider = new RandomProviderPort();
+
+  await assert.rejects(() => provider.nextFloat(), /must be implemented by an adapter/);
+});

--- a/test/application/culture/triggerHistoricalEvent.test.js
+++ b/test/application/culture/triggerHistoricalEvent.test.js
@@ -1,7 +1,68 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { triggerHistoricalEvent } from '../../../src/application/culture/triggerHistoricalEvent.js';
+import { selectHistoricalEvent, triggerHistoricalEvent } from '../../../src/application/culture/triggerHistoricalEvent.js';
+
+class FixedRandomProvider {
+  constructor(value) {
+    this.value = value;
+  }
+
+  async requireNextFloat() {
+    return this.value;
+  }
+}
+
+test('selectHistoricalEvent chooses an event through RandomProvider integration', async () => {
+  const { selectedEvent, selectionIndex, selectionRoll } = await selectHistoricalEvent(
+    [
+      {
+        id: 'event-first',
+        title: 'First Turning',
+        era: 'classical',
+        summary: 'The first branch remains dormant.',
+        affectedCultureIds: ['culture-north'],
+        consequenceIds: [],
+        unlockedResearchIds: [],
+        repeatable: true,
+        triggerCount: 0,
+        lastTriggeredAt: null,
+        divergenceId: null,
+      },
+      {
+        id: 'event-second',
+        title: 'Second Turning',
+        era: 'classical',
+        summary: 'The second branch becomes active.',
+        affectedCultureIds: ['culture-south'],
+        consequenceIds: ['canon-shift'],
+        unlockedResearchIds: ['astronomy'],
+        repeatable: true,
+        triggerCount: 0,
+        lastTriggeredAt: null,
+        divergenceId: null,
+      },
+    ],
+    new FixedRandomProvider(0.75),
+  );
+
+  assert.equal(selectionIndex, 1);
+  assert.equal(selectionRoll, 0.75);
+  assert.equal(selectedEvent.id, 'event-second');
+  assert.equal(selectedEvent.selectionIndex, 1);
+  assert.equal(selectedEvent.selectionRoll, 0.75);
+});
+
+test('selectHistoricalEvent rejects invalid candidate lists and random providers', async () => {
+  await assert.rejects(
+    () => selectHistoricalEvent([], new FixedRandomProvider(0.2)),
+    /selectHistoricalEvent historicalEvents must be a non-empty array/,
+  );
+  await assert.rejects(
+    () => selectHistoricalEvent([{ id: 'event', title: 'Event', era: 'classical', summary: 'x', affectedCultureIds: [], consequenceIds: [], unlockedResearchIds: [], repeatable: true, triggerCount: 0, lastTriggeredAt: null, divergenceId: null }], null),
+    /selectHistoricalEvent randomProvider must expose requireNextFloat\(\)/,
+  );
+});
 
 test('triggerHistoricalEvent merges consequences and unlocked research immutably', () => {
   const historicalEvent = {


### PR DESCRIPTION
Gamma: ## Summary
Gamma: Integrate a `RandomProvider` into the Gamma historical event flow by adding a small port and using it to select which historical event candidate should fire.
Gamma:
Gamma: ## Related issue
Gamma: - Closes #53
Gamma:
Gamma: ## Changes
Gamma: - add `src/application/culture/RandomProviderPort.js`
Gamma: - add `selectHistoricalEvent(historicalEvents, randomProvider)` in the historical event use case module
Gamma: - validate random provider output and fail fast for invalid adapter implementations
Gamma: - cover event selection and invalid input cases with node tests
Gamma:
Gamma: ## Testing
Gamma: - [x] Local checks run
Gamma: - [x] Relevant tests added or updated
Gamma: - [ ] Manual check if relevant
Gamma: - [x] `npm test -- --test-reporter tap`
Gamma:
Gamma: ## Rules check
Gamma: - [x] This work comes through a pull request
Gamma: - [x] This PR is mandatory to avoid bugs and validation problems with Zeta
Gamma: - [x] GitHub text starts with the agent name followed by `:`
Gamma: - [x] The work stays inside the author's domain
Gamma: - [ ] Zeta has been asked for validation before merge
Gamma:
Gamma: ## Notes
Gamma: This PR is intentionally stacked on top of `Gamma: [G08] Implement TriggerHistoricalEvent use case` because the random selection hooks into that historical event flow.
