### PR TITLE
Beta: implement PlanLogisticsFlows use case

### DIFF
--- a/src/application/economy/PlanLogisticsFlows.js
+++ b/src/application/economy/PlanLogisticsFlows.js
@@ -1,0 +1,209 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+function normalizeCities(cities) {
+  if (!Array.isArray(cities)) {
+    throw new TypeError('PlanLogisticsFlows cities must be an array.');
+  }
+
+  return cities.map((city, index) => {
+    const normalizedCity = requireObject(city, `PlanLogisticsFlows cities[${index}]`);
+    const stockByResource = requireObject(
+      normalizedCity.stockByResource ?? {},
+      `PlanLogisticsFlows cities[${index}].stockByResource`,
+    );
+
+    return {
+      ...normalizedCity,
+      id: requireText(normalizedCity.id, `PlanLogisticsFlows cities[${index}].id`),
+      stockByResource: Object.fromEntries(
+        Object.entries(stockByResource).map(([resourceId, quantity]) => [
+          requireText(resourceId, `PlanLogisticsFlows cities[${index}] stock resourceId`),
+          requireInteger(
+            quantity,
+            `PlanLogisticsFlows cities[${index}] stock quantity for ${String(resourceId).trim()}`,
+            0,
+          ),
+        ]),
+      ),
+    };
+  });
+}
+
+function normalizeRoutes(routes) {
+  if (!Array.isArray(routes)) {
+    throw new TypeError('PlanLogisticsFlows routes must be an array.');
+  }
+
+  return routes.map((route, index) => {
+    const normalizedRoute = requireObject(route, `PlanLogisticsFlows routes[${index}]`);
+    const stopCityIds = normalizedRoute.stopCityIds;
+    const capacityByResource = requireObject(
+      normalizedRoute.capacityByResource ?? {},
+      `PlanLogisticsFlows routes[${index}].capacityByResource`,
+    );
+
+    if (!Array.isArray(stopCityIds) || stopCityIds.length < 2) {
+      throw new RangeError(`PlanLogisticsFlows routes[${index}].stopCityIds must contain at least two cities.`);
+    }
+
+    return {
+      ...normalizedRoute,
+      id: requireText(normalizedRoute.id, `PlanLogisticsFlows routes[${index}].id`),
+      stopCityIds: stopCityIds.map((cityId, stopIndex) => requireText(cityId, `PlanLogisticsFlows routes[${index}].stopCityIds[${stopIndex}]`)),
+      capacityByResource: Object.fromEntries(
+        Object.entries(capacityByResource).map(([resourceId, quantity]) => [
+          requireText(resourceId, `PlanLogisticsFlows routes[${index}] capacity resourceId`),
+          requireInteger(
+            quantity,
+            `PlanLogisticsFlows routes[${index}] capacity for ${String(resourceId).trim()}`,
+            0,
+          ),
+        ]),
+      ),
+      active: normalizedRoute.active !== false,
+    };
+  });
+}
+
+function normalizeShortageRequests(shortageRequests) {
+  if (!Array.isArray(shortageRequests)) {
+    throw new TypeError('PlanLogisticsFlows shortageRequests must be an array.');
+  }
+
+  return shortageRequests.map((request, index) => {
+    const normalizedRequest = requireObject(request, `PlanLogisticsFlows shortageRequests[${index}]`);
+
+    return {
+      cityId: requireText(normalizedRequest.cityId, `PlanLogisticsFlows shortageRequests[${index}].cityId`),
+      resourceId: requireText(normalizedRequest.resourceId, `PlanLogisticsFlows shortageRequests[${index}].resourceId`),
+      requestedQuantity: requireInteger(
+        normalizedRequest.requestedQuantity,
+        `PlanLogisticsFlows shortageRequests[${index}].requestedQuantity`,
+        1,
+      ),
+      priority: requireInteger(
+        normalizedRequest.priority ?? 50,
+        `PlanLogisticsFlows shortageRequests[${index}].priority`,
+        0,
+        100,
+      ),
+    };
+  }).sort((left, right) => right.priority - left.priority || left.cityId.localeCompare(right.cityId));
+}
+
+function getAvailableExports(city, resourceId, reserveByResource) {
+  const currentQuantity = city.stockByResource[resourceId] ?? 0;
+  const reserveQuantity = reserveByResource[resourceId] ?? 0;
+  return Math.max(0, currentQuantity - reserveQuantity);
+}
+
+export function planLogisticsFlows({ cities, routes, shortageRequests, reserveByResource = {} }) {
+  const normalizedCities = normalizeCities(cities);
+  const normalizedRoutes = normalizeRoutes(routes);
+  const normalizedRequests = normalizeShortageRequests(shortageRequests);
+  const normalizedReserveByResource = requireObject(reserveByResource, 'PlanLogisticsFlows reserveByResource');
+
+  const citiesById = new Map(
+    normalizedCities.map((city) => [city.id, { ...city, stockByResource: { ...city.stockByResource } }]),
+  );
+  const transfers = [];
+  const unresolvedRequests = [];
+
+  for (const request of normalizedRequests) {
+    const destinationCity = citiesById.get(request.cityId);
+
+    if (!destinationCity) {
+      unresolvedRequests.push({ ...request, reason: 'unknown-city' });
+      continue;
+    }
+
+    let remainingQuantity = request.requestedQuantity;
+    const candidateRoutes = normalizedRoutes.filter((route) => route.active && route.stopCityIds.includes(request.cityId));
+
+    for (const route of candidateRoutes) {
+      if (remainingQuantity === 0) {
+        break;
+      }
+
+      const routeCapacity = route.capacityByResource[request.resourceId] ?? 0;
+
+      if (routeCapacity === 0) {
+        continue;
+      }
+
+      for (const sourceCityId of route.stopCityIds) {
+        if (sourceCityId === request.cityId || remainingQuantity === 0) {
+          continue;
+        }
+
+        const sourceCity = citiesById.get(sourceCityId);
+
+        if (!sourceCity) {
+          continue;
+        }
+
+        const availableExports = getAvailableExports(
+          sourceCity,
+          request.resourceId,
+          normalizedReserveByResource,
+        );
+        const transferableQuantity = Math.min(availableExports, remainingQuantity, routeCapacity);
+
+        if (transferableQuantity === 0) {
+          continue;
+        }
+
+        sourceCity.stockByResource[request.resourceId] = (sourceCity.stockByResource[request.resourceId] ?? 0) - transferableQuantity;
+        destinationCity.stockByResource[request.resourceId] = (destinationCity.stockByResource[request.resourceId] ?? 0) + transferableQuantity;
+        remainingQuantity -= transferableQuantity;
+
+        transfers.push({
+          routeId: route.id,
+          sourceCityId,
+          destinationCityId: request.cityId,
+          resourceId: request.resourceId,
+          quantity: transferableQuantity,
+        });
+      }
+    }
+
+    if (remainingQuantity > 0) {
+      unresolvedRequests.push({
+        ...request,
+        unresolvedQuantity: remainingQuantity,
+        reason: 'insufficient-capacity-or-stock',
+      });
+    }
+  }
+
+  return {
+    cities: Array.from(citiesById.values()),
+    transfers,
+    unresolvedRequests,
+    fulfilledRequestCount: normalizedRequests.length - unresolvedRequests.length,
+  };
+}

--- a/test/application/economy/PlanLogisticsFlows.test.js
+++ b/test/application/economy/PlanLogisticsFlows.test.js
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { planLogisticsFlows } from '../../../src/application/economy/PlanLogisticsFlows.js';
+
+test('PlanLogisticsFlows moves stock from connected surplus cities to shortage cities', () => {
+  const result = planLogisticsFlows({
+    cities: [
+      { id: 'city-granary', stockByResource: { grain: 20, wood: 2 } },
+      { id: 'city-ford', stockByResource: { grain: 8 } },
+      { id: 'city-harbor', stockByResource: { grain: 1 } },
+    ],
+    routes: [
+      {
+        id: 'route-river',
+        stopCityIds: ['city-granary', 'city-ford', 'city-harbor'],
+        capacityByResource: { grain: 6 },
+        active: true,
+      },
+    ],
+    shortageRequests: [
+      { cityId: 'city-harbor', resourceId: 'grain', requestedQuantity: 5, priority: 90 },
+    ],
+    reserveByResource: { grain: 4 },
+  });
+
+  assert.deepEqual(result.transfers, [
+    {
+      routeId: 'route-river',
+      sourceCityId: 'city-granary',
+      destinationCityId: 'city-harbor',
+      resourceId: 'grain',
+      quantity: 5,
+    },
+  ]);
+  assert.equal(result.fulfilledRequestCount, 1);
+  assert.deepEqual(result.unresolvedRequests, []);
+  assert.deepEqual(
+    result.cities.find((city) => city.id === 'city-granary').stockByResource,
+    { grain: 15, wood: 2 },
+  );
+  assert.deepEqual(
+    result.cities.find((city) => city.id === 'city-harbor').stockByResource,
+    { grain: 6 },
+  );
+});
+
+test('PlanLogisticsFlows leaves unresolved quantities when routes are inactive or capacity is insufficient', () => {
+  const result = planLogisticsFlows({
+    cities: [
+      { id: 'city-granary', stockByResource: { grain: 10 } },
+      { id: 'city-harbor', stockByResource: { grain: 0 } },
+    ],
+    routes: [
+      {
+        id: 'route-closed',
+        stopCityIds: ['city-granary', 'city-harbor'],
+        capacityByResource: { grain: 3 },
+        active: false,
+      },
+      {
+        id: 'route-open',
+        stopCityIds: ['city-granary', 'city-harbor'],
+        capacityByResource: { grain: 2 },
+        active: true,
+      },
+    ],
+    shortageRequests: [
+      { cityId: 'city-harbor', resourceId: 'grain', requestedQuantity: 5, priority: 90 },
+    ],
+    reserveByResource: { grain: 9 },
+  });
+
+  assert.deepEqual(result.transfers, [
+    {
+      routeId: 'route-open',
+      sourceCityId: 'city-granary',
+      destinationCityId: 'city-harbor',
+      resourceId: 'grain',
+      quantity: 1,
+    },
+  ]);
+  assert.deepEqual(result.unresolvedRequests, [
+    {
+      cityId: 'city-harbor',
+      resourceId: 'grain',
+      requestedQuantity: 5,
+      priority: 90,
+      unresolvedQuantity: 4,
+      reason: 'insufficient-capacity-or-stock',
+    },
+  ]);
+  assert.equal(result.fulfilledRequestCount, 0);
+});
+
+test('PlanLogisticsFlows splits flows across multiple sources on the same route', () => {
+  const result = planLogisticsFlows({
+    cities: [
+      { id: 'city-mill', stockByResource: { flour: 4 } },
+      { id: 'city-granary', stockByResource: { flour: 7 } },
+      { id: 'city-capital', stockByResource: { flour: 0 } },
+    ],
+    routes: [
+      {
+        id: 'route-road',
+        stopCityIds: ['city-mill', 'city-granary', 'city-capital'],
+        capacityByResource: { flour: 4 },
+        active: true,
+      },
+    ],
+    shortageRequests: [
+      { cityId: 'city-capital', resourceId: 'flour', requestedQuantity: 6, priority: 80 },
+    ],
+    reserveByResource: { flour: 2 },
+  });
+
+  assert.deepEqual(result.transfers, [
+    {
+      routeId: 'route-road',
+      sourceCityId: 'city-mill',
+      destinationCityId: 'city-capital',
+      resourceId: 'flour',
+      quantity: 2,
+    },
+    {
+      routeId: 'route-road',
+      sourceCityId: 'city-granary',
+      destinationCityId: 'city-capital',
+      resourceId: 'flour',
+      quantity: 4,
+    },
+  ]);
+  assert.deepEqual(result.unresolvedRequests, []);
+});
+
+test('PlanLogisticsFlows rejects invalid city, route, and request payloads', () => {
+  assert.throws(
+    () => planLogisticsFlows({ cities: {}, routes: [], shortageRequests: [] }),
+    /PlanLogisticsFlows cities must be an array/,
+  );
+
+  assert.throws(
+    () => planLogisticsFlows({ cities: [], routes: {}, shortageRequests: [] }),
+    /PlanLogisticsFlows routes must be an array/,
+  );
+
+  assert.throws(
+    () => planLogisticsFlows({ cities: [], routes: [], shortageRequests: {} }),
+    /PlanLogisticsFlows shortageRequests must be an array/,
+  );
+
+  assert.throws(
+    () => planLogisticsFlows({
+      cities: [{ id: 'city-a', stockByResource: {} }],
+      routes: [{ id: 'route-a', stopCityIds: ['city-a'], capacityByResource: {} }],
+      shortageRequests: [],
+    }),
+    /PlanLogisticsFlows routes\[0\]\.stopCityIds must contain at least two cities/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: implement the `PlanLogisticsFlows` use case for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `PlanLogisticsFlows` to route shortage requests across active trade networks using per-resource capacity and reserve thresholds
Beta: - update city stock immutably while tracking transfers, unresolved quantities, and fulfilled request counts
Beta: - support multi-source routing along one route and explicit handling for inactive routes or constrained capacity
Beta: - add node tests for successful transfers, partial fulfillment, multi-source flows, and invalid payloads
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #28
