### PR TITLE
Delta: [D11] Create FactionReadPort

### DIFF
--- a/src/application/ports/FactionReadPort.js
+++ b/src/application/ports/FactionReadPort.js
@@ -1,0 +1,57 @@
+function requireFunction(value, label) {
+  if (typeof value !== 'function') {
+    throw new TypeError(`${label} must be a function.`);
+  }
+
+  return value;
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function ensureFactionSnapshot(snapshot) {
+  const normalizedSnapshot = requireObject(snapshot, 'FactionReadPort snapshot');
+
+  return {
+    ...normalizedSnapshot,
+    factionId: requireText(normalizedSnapshot.factionId, 'FactionReadPort snapshot.factionId'),
+  };
+}
+
+export function createFactionReadPort({ readFaction }) {
+  const normalizedReadFaction = requireFunction(readFaction, 'FactionReadPort readFaction');
+
+  return {
+    readFaction(query = {}) {
+      const normalizedQuery = requireObject(query, 'FactionReadPort query');
+      return ensureFactionSnapshot(normalizedReadFaction({ ...normalizedQuery }));
+    },
+  };
+}
+
+export function assertFactionReadPort(port) {
+  const normalizedPort = requireObject(port, 'FactionReadPort');
+  const readFaction = requireFunction(normalizedPort.readFaction, 'FactionReadPort readFaction');
+
+  return {
+    readFaction(query = {}) {
+      const normalizedQuery = requireObject(query, 'FactionReadPort query');
+      return ensureFactionSnapshot(readFaction.call(normalizedPort, { ...normalizedQuery }));
+    },
+  };
+}

--- a/test/application/ports/FactionReadPort.test.js
+++ b/test/application/ports/FactionReadPort.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { assertFactionReadPort, createFactionReadPort } from '../../../src/application/ports/FactionReadPort.js';
+
+test('createFactionReadPort wraps a reader and returns normalized faction snapshots', () => {
+  const receivedQueries = [];
+  const port = createFactionReadPort({
+    readFaction(query) {
+      receivedQueries.push(query);
+      return {
+        factionId: 'delta-league',
+        stability: 61,
+        influence: 47,
+      };
+    },
+  });
+
+  const snapshot = port.readFaction({ factionId: 'delta-league' });
+  snapshot.stability = 0;
+
+  assert.deepEqual(receivedQueries, [{ factionId: 'delta-league' }]);
+  assert.deepEqual(port.readFaction({ factionId: 'delta-league' }), {
+    factionId: 'delta-league',
+    stability: 61,
+    influence: 47,
+  });
+});
+
+test('assertFactionReadPort validates the contract and preserves context', () => {
+  const port = {
+    suffix: 'league',
+    readFaction(query) {
+      return {
+        factionId: `${query.prefix}-${this.suffix}`,
+        legitimacy: 72,
+      };
+    },
+  };
+
+  const validatedPort = assertFactionReadPort(port);
+
+  assert.deepEqual(validatedPort.readFaction({ prefix: 'delta' }), {
+    factionId: 'delta-league',
+    legitimacy: 72,
+  });
+
+  assert.throws(() => assertFactionReadPort({}), /FactionReadPort readFaction must be a function/);
+  assert.throws(() => validatedPort.readFaction(null), /FactionReadPort query must be an object/);
+});
+
+test('FactionReadPort rejects invalid snapshots', () => {
+  const port = createFactionReadPort({
+    readFaction() {
+      return { stability: 42 };
+    },
+  });
+
+  assert.throws(() => port.readFaction({}), /FactionReadPort snapshot.factionId is required/);
+  assert.throws(
+    () => createFactionReadPort({ readFaction: 42 }),
+    /FactionReadPort readFaction must be a function/,
+  );
+});


### PR DESCRIPTION
Delta: Cette PR traite l'issue #71 en ajoutant le port `FactionReadPort`.

## Contenu
- ajout d'une factory `createFactionReadPort`
- ajout d'un validateur `assertFactionReadPort`
- validation des queries et snapshots de faction retournés
- ajout de tests sur contrat, contexte et snapshots invalides

## Vérification
- `npm test`

## Notes
- cette PR est empilée sur `delta/d10-create-worldreadport`
- je demanderai la validation de Zeta avant tout merge
