### PR TITLE
Alpha: [A17] Add tests for expansion and consolidation

### DIFF
--- a/src/domain/war/consolidateProvinceControl.js
+++ b/src/domain/war/consolidateProvinceControl.js
@@ -1,0 +1,42 @@
+import { Province } from './Province.js';
+
+function clampLoyalty(value) {
+  return Math.max(0, Math.min(100, value));
+}
+
+export function consolidateProvinceControl({ province, loyaltyGain = 10, supplyLevel = null }) {
+  if (!(province instanceof Province)) {
+    throw new TypeError('consolidateProvinceControl province must be a Province instance.');
+  }
+
+  if (!province.isOccupied) {
+    return {
+      consolidated: false,
+      reason: 'not-occupied',
+      province,
+    };
+  }
+
+  if (!Number.isInteger(loyaltyGain) || loyaltyGain < 0) {
+    throw new RangeError('consolidateProvinceControl loyaltyGain must be a non-negative integer.');
+  }
+
+  const nextSupplyLevel = supplyLevel === null ? province.supplyLevel : String(supplyLevel ?? '').trim();
+
+  if (!nextSupplyLevel) {
+    throw new RangeError('consolidateProvinceControl supplyLevel cannot be empty.');
+  }
+
+  const consolidatedProvince = new Province({
+    ...province.toJSON(),
+    loyalty: clampLoyalty(province.loyalty + loyaltyGain),
+    contested: false,
+    supplyLevel: nextSupplyLevel,
+  });
+
+  return {
+    consolidated: true,
+    reason: 'consolidated',
+    province: consolidatedProvince,
+  };
+}

--- a/src/domain/war/expandFrontLine.js
+++ b/src/domain/war/expandFrontLine.js
@@ -1,0 +1,78 @@
+import { Province } from './Province.js';
+
+function requireProvince(province) {
+  if (!(province instanceof Province)) {
+    throw new TypeError('expandFrontLine province must be a Province instance.');
+  }
+
+  return province;
+}
+
+function requireSegment(segment) {
+  if (!segment || typeof segment !== 'object' || Array.isArray(segment)) {
+    throw new TypeError('expandFrontLine segment must be an object.');
+  }
+
+  const provinceAId = String(segment.provinceAId ?? '').trim();
+  const provinceBId = String(segment.provinceBId ?? '').trim();
+
+  if (!provinceAId || !provinceBId) {
+    throw new RangeError('expandFrontLine segment must define provinceAId and provinceBId.');
+  }
+
+  return {
+    ...segment,
+    provinceAId,
+    provinceBId,
+  };
+}
+
+export function expandFrontLine({ attackerFactionId, targetProvince, segment, pressureDelta = 0 }) {
+  const normalizedAttackerFactionId = String(attackerFactionId ?? '').trim();
+
+  if (!normalizedAttackerFactionId) {
+    throw new RangeError('expandFrontLine attackerFactionId is required.');
+  }
+
+  const province = requireProvince(targetProvince);
+  const normalizedSegment = requireSegment(segment);
+
+  if (!Number.isInteger(pressureDelta)) {
+    throw new RangeError('expandFrontLine pressureDelta must be an integer.');
+  }
+
+  if (
+    normalizedSegment.provinceAId !== province.id &&
+    normalizedSegment.provinceBId !== province.id
+  ) {
+    return {
+      expanded: false,
+      reason: 'segment-mismatch',
+      province,
+    };
+  }
+
+  if (province.controllingFactionId === normalizedAttackerFactionId) {
+    return {
+      expanded: false,
+      reason: 'already-controlled',
+      province,
+    };
+  }
+
+  if (pressureDelta <= 0) {
+    return {
+      expanded: false,
+      reason: 'insufficient-pressure',
+      province,
+    };
+  }
+
+  const expandedProvince = province.withControllingFaction(normalizedAttackerFactionId);
+
+  return {
+    expanded: true,
+    reason: 'expanded',
+    province: expandedProvince,
+  };
+}

--- a/test/domain/war/consolidateProvinceControl.test.js
+++ b/test/domain/war/consolidateProvinceControl.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Province } from '../../../src/domain/war/Province.js';
+import { consolidateProvinceControl } from '../../../src/domain/war/consolidateProvinceControl.js';
+
+function createOccupiedProvince(overrides = {}) {
+  return new Province({
+    id: 'prov-held',
+    name: 'Held Province',
+    ownerFactionId: 'faction-b',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'disrupted',
+    loyalty: 35,
+    contested: true,
+    capturedAt: '2026-04-18T13:00:00.000Z',
+    neighborIds: ['prov-origin'],
+    ...overrides,
+  });
+}
+
+test('consolidateProvinceControl clears contestation and increases loyalty for occupied provinces', () => {
+  const province = createOccupiedProvince();
+
+  const result = consolidateProvinceControl({
+    province,
+    loyaltyGain: 15,
+    supplyLevel: 'stable',
+  });
+
+  assert.equal(result.consolidated, true);
+  assert.equal(result.reason, 'consolidated');
+  assert.equal(result.province.contested, false);
+  assert.equal(result.province.loyalty, 50);
+  assert.equal(result.province.supplyLevel, 'stable');
+  assert.equal(province.contested, true);
+  assert.equal(province.loyalty, 35);
+});
+
+test('consolidateProvinceControl leaves non-occupied provinces unchanged', () => {
+  const province = new Province({
+    id: 'prov-home',
+    name: 'Home Province',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    loyalty: 80,
+    neighborIds: [],
+  });
+
+  const result = consolidateProvinceControl({ province, loyaltyGain: 12 });
+
+  assert.equal(result.consolidated, false);
+  assert.equal(result.reason, 'not-occupied');
+  assert.equal(result.province, province);
+});
+
+test('consolidateProvinceControl rejects invalid inputs', () => {
+  const province = createOccupiedProvince();
+
+  assert.throws(() => consolidateProvinceControl({ province: {} }), /province must be a Province instance/);
+  assert.throws(
+    () => consolidateProvinceControl({ province, loyaltyGain: -1 }),
+    /loyaltyGain must be a non-negative integer/,
+  );
+  assert.throws(
+    () => consolidateProvinceControl({ province, supplyLevel: '   ' }),
+    /supplyLevel cannot be empty/,
+  );
+});

--- a/test/domain/war/expandFrontLine.test.js
+++ b/test/domain/war/expandFrontLine.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Province } from '../../../src/domain/war/Province.js';
+import { expandFrontLine } from '../../../src/domain/war/expandFrontLine.js';
+
+function createProvince(overrides = {}) {
+  return new Province({
+    id: 'prov-target',
+    name: 'Target Province',
+    ownerFactionId: 'faction-b',
+    controllingFactionId: 'faction-b',
+    supplyLevel: 'strained',
+    contested: false,
+    neighborIds: ['prov-origin'],
+    ...overrides,
+  });
+}
+
+test('expandFrontLine captures a hostile province when pressure is positive', () => {
+  const province = createProvince();
+
+  const result = expandFrontLine({
+    attackerFactionId: 'faction-a',
+    targetProvince: province,
+    segment: { provinceAId: 'prov-origin', provinceBId: 'prov-target' },
+    pressureDelta: 12,
+  });
+
+  assert.equal(result.expanded, true);
+  assert.equal(result.reason, 'expanded');
+  assert.equal(result.province.controllingFactionId, 'faction-a');
+  assert.equal(result.province.contested, true);
+  assert.equal(province.controllingFactionId, 'faction-b');
+});
+
+test('expandFrontLine refuses expansion when pressure is missing or control is already secured', () => {
+  const occupiedProvince = createProvince({ controllingFactionId: 'faction-a', contested: true });
+  const hostileProvince = createProvince();
+
+  const noPressureResult = expandFrontLine({
+    attackerFactionId: 'faction-a',
+    targetProvince: hostileProvince,
+    segment: { provinceAId: 'prov-origin', provinceBId: 'prov-target' },
+    pressureDelta: 0,
+  });
+  const alreadyControlledResult = expandFrontLine({
+    attackerFactionId: 'faction-a',
+    targetProvince: occupiedProvince,
+    segment: { provinceAId: 'prov-origin', provinceBId: 'prov-target' },
+    pressureDelta: 8,
+  });
+
+  assert.equal(noPressureResult.expanded, false);
+  assert.equal(noPressureResult.reason, 'insufficient-pressure');
+  assert.equal(alreadyControlledResult.expanded, false);
+  assert.equal(alreadyControlledResult.reason, 'already-controlled');
+});
+
+test('expandFrontLine rejects invalid inputs', () => {
+  const province = createProvince();
+
+  assert.throws(
+    () => expandFrontLine({ attackerFactionId: '', targetProvince: province, segment: { provinceAId: 'a', provinceBId: 'b' }, pressureDelta: 1 }),
+    /attackerFactionId is required/,
+  );
+  assert.throws(
+    () => expandFrontLine({ attackerFactionId: 'faction-a', targetProvince: {}, segment: { provinceAId: 'a', provinceBId: 'b' }, pressureDelta: 1 }),
+    /province must be a Province instance/,
+  );
+  assert.throws(
+    () => expandFrontLine({ attackerFactionId: 'faction-a', targetProvince: province, segment: null, pressureDelta: 1 }),
+    /segment must be an object/,
+  );
+  assert.throws(
+    () => expandFrontLine({ attackerFactionId: 'faction-a', targetProvince: province, segment: { provinceAId: 'a', provinceBId: 'b' }, pressureDelta: 1.5 }),
+    /pressureDelta must be an integer/,
+  );
+});


### PR DESCRIPTION
Alpha: ## Summary
Alpha: Add concrete expansion and consolidation coverage with two small pure war-domain helpers.
Alpha:
Alpha: ## Changes
Alpha: Add `expandFrontLine` to model a simple pressure-gated territorial push.
Alpha: Add `consolidateProvinceControl` to model post-capture stabilization and loyalty recovery.
Alpha: Add focused domain tests for success, refusal, immutability, and invalid input handling.
Alpha:
Alpha: ## Testing
Alpha: - [x] `npm test`
Alpha:
Alpha: ## Notes
Alpha: This PR is stacked on top of `alpha/a16-add-front-detection-tests` to keep the slice small.
