### PR TITLE
Gamma: [G14] Integrate Clock in Gamma systems

### DIFF
--- a/src/application/culture/ClockPort.js
+++ b/src/application/culture/ClockPort.js
@@ -1,0 +1,25 @@
+function requireIsoTimestamp(value, label) {
+  const normalizedValue = value instanceof Date ? value.toISOString() : String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  const parsedDate = new Date(normalizedValue);
+  if (Number.isNaN(parsedDate.getTime())) {
+    throw new RangeError(`${label} must be a valid ISO timestamp.`);
+  }
+
+  return parsedDate.toISOString();
+}
+
+export class ClockPort {
+  async now() {
+    throw new Error('ClockPort.now must be implemented by an adapter.');
+  }
+
+  async requireNow() {
+    const value = await this.now();
+    return requireIsoTimestamp(value, 'ClockPort now');
+  }
+}

--- a/src/application/culture/triggerHistoricalEvent.js
+++ b/src/application/culture/triggerHistoricalEvent.js
@@ -131,6 +131,18 @@ function normalizeExecution(execution) {
   };
 }
 
+export async function triggerHistoricalEventAtCurrentTime(historicalEvent, execution = {}, clock) {
+  if (!clock || typeof clock.requireNow !== 'function') {
+    throw new TypeError('triggerHistoricalEventAtCurrentTime clock must expose requireNow().');
+  }
+
+  const triggeredAt = await clock.requireNow();
+  return triggerHistoricalEvent(historicalEvent, {
+    ...execution,
+    triggeredAt,
+  });
+}
+
 export function triggerHistoricalEvent(historicalEvent, execution = {}) {
   const normalizedHistoricalEvent = normalizeHistoricalEvent(historicalEvent);
   const normalizedExecution = normalizeExecution(execution);

--- a/test/application/culture/ClockPort.test.js
+++ b/test/application/culture/ClockPort.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ClockPort } from '../../../src/application/culture/ClockPort.js';
+
+class FixedClock extends ClockPort {
+  constructor(value) {
+    super();
+    this.value = value;
+  }
+
+  async now() {
+    return this.value;
+  }
+}
+
+test('ClockPort validates timestamps returned by adapters', async () => {
+  const clock = new FixedClock('2026-04-18T14:05:00.000Z');
+  const now = await clock.requireNow();
+
+  assert.equal(now, '2026-04-18T14:05:00.000Z');
+
+  await assert.rejects(
+    () => new FixedClock('not-a-date').requireNow(),
+    /ClockPort now must be a valid ISO timestamp/,
+  );
+});
+
+test('ClockPort base adapter method fails fast until implemented', async () => {
+  const clock = new ClockPort();
+
+  await assert.rejects(() => clock.now(), /must be implemented by an adapter/);
+});

--- a/test/application/culture/triggerHistoricalEvent.test.js
+++ b/test/application/culture/triggerHistoricalEvent.test.js
@@ -1,7 +1,66 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { triggerHistoricalEvent } from '../../../src/application/culture/triggerHistoricalEvent.js';
+import {
+  triggerHistoricalEvent,
+  triggerHistoricalEventAtCurrentTime,
+} from '../../../src/application/culture/triggerHistoricalEvent.js';
+
+class FixedClock {
+  constructor(value) {
+    this.value = value;
+  }
+
+  async requireNow() {
+    return this.value;
+  }
+}
+
+test('triggerHistoricalEventAtCurrentTime uses Clock integration for trigger timestamps', async () => {
+  const triggeredEvent = await triggerHistoricalEventAtCurrentTime(
+    {
+      id: 'event-court-reckoning',
+      title: 'Court Reckoning',
+      era: 'early-modern',
+      summary: 'The court reorders its chronicles after a public scandal.',
+      affectedCultureIds: ['culture-east'],
+      consequenceIds: ['archive-census'],
+      unlockedResearchIds: ['statecraft'],
+      repeatable: true,
+      triggerCount: 0,
+      lastTriggeredAt: null,
+      divergenceId: null,
+    },
+    {
+      triggeredBy: 'gamma-council',
+      consequenceIds: ['public-ledger'],
+    },
+    new FixedClock('2026-04-18T14:08:00.000Z'),
+  );
+
+  assert.equal(triggeredEvent.lastTriggeredAt, '2026-04-18T14:08:00.000Z');
+  assert.equal(triggeredEvent.lastTriggeredBy, 'gamma-council');
+  assert.deepEqual(triggeredEvent.consequenceIds, ['archive-census', 'public-ledger']);
+});
+
+test('triggerHistoricalEventAtCurrentTime rejects invalid clocks', async () => {
+  await assert.rejects(
+    () => triggerHistoricalEventAtCurrentTime({
+      id: 'event-court-reckoning',
+      title: 'Court Reckoning',
+      era: 'early-modern',
+      summary: 'The court reorders its chronicles after a public scandal.',
+      affectedCultureIds: ['culture-east'],
+      consequenceIds: [],
+      unlockedResearchIds: [],
+      repeatable: true,
+      triggerCount: 0,
+      lastTriggeredAt: null,
+      divergenceId: null,
+    }, {}, null),
+    /triggerHistoricalEventAtCurrentTime clock must expose requireNow\(\)/,
+  );
+});
 
 test('triggerHistoricalEvent merges consequences and unlocked research immutably', () => {
   const historicalEvent = {


### PR DESCRIPTION
Gamma: ## Summary
Gamma: Integrate a `ClockPort` into the Gamma historical event flow by adding a small port and using it to timestamp triggers consistently.
Gamma:
Gamma: ## Related issue
Gamma: - Closes #54
Gamma:
Gamma: ## Changes
Gamma: - add `src/application/culture/ClockPort.js`
Gamma: - add `triggerHistoricalEventAtCurrentTime(historicalEvent, execution, clock)` in the historical event use case module
Gamma: - validate clock output and fail fast for invalid adapter implementations
Gamma: - cover clock-driven triggering and invalid input cases with node tests
Gamma:
Gamma: ## Testing
Gamma: - [x] Local checks run
Gamma: - [x] Relevant tests added or updated
Gamma: - [ ] Manual check if relevant
Gamma: - [x] `npm test -- --test-reporter tap`
Gamma:
Gamma: ## Rules check
Gamma: - [x] This work comes through a pull request
Gamma: - [x] This PR is mandatory to avoid bugs and validation problems with Zeta
Gamma: - [x] GitHub text starts with the agent name followed by `:`
Gamma: - [x] The work stays inside the author's domain
Gamma: - [ ] Zeta has been asked for validation before merge
Gamma:
Gamma: ## Notes
Gamma: This PR is intentionally stacked on top of `Gamma: [G08] Implement TriggerHistoricalEvent use case` because the clock integration hooks into that historical event flow.
