### PR TITLE
Epsilon: add in-memory climate adapter

### DIFF
--- a/src/adapters/climate/InMemoryClimateRepository.js
+++ b/src/adapters/climate/InMemoryClimateRepository.js
@@ -1,0 +1,49 @@
+import { ClimateRepositoryPort } from '../../application/ports/ClimateRepositoryPort.js';
+import { ClimateState } from '../../domain/climate/ClimateState.js';
+
+function normalizeClimateState(state) {
+  if (state instanceof ClimateState) {
+    return state;
+  }
+
+  return new ClimateState(state);
+}
+
+export class InMemoryClimateRepository extends ClimateRepositoryPort {
+  constructor(seed = []) {
+    super();
+    this.states = new Map();
+
+    this.saveMany(seed);
+  }
+
+  loadByRegionId(regionId) {
+    const normalizedRegionId = String(regionId ?? '').trim();
+
+    if (!normalizedRegionId) {
+      throw new RangeError('InMemoryClimateRepository.loadByRegionId regionId is required.');
+    }
+
+    return this.states.get(normalizedRegionId) ?? null;
+  }
+
+  save(climateState) {
+    const normalizedState = normalizeClimateState(climateState);
+    this.states.set(normalizedState.regionId, normalizedState);
+    return normalizedState;
+  }
+
+  deleteByRegionId(regionId) {
+    const normalizedRegionId = String(regionId ?? '').trim();
+
+    if (!normalizedRegionId) {
+      throw new RangeError('InMemoryClimateRepository.deleteByRegionId regionId is required.');
+    }
+
+    return this.states.delete(normalizedRegionId);
+  }
+
+  snapshot() {
+    return [...this.states.values()].map((state) => state.toJSON());
+  }
+}

--- a/test/adapters/climate/InMemoryClimateRepository.test.js
+++ b/test/adapters/climate/InMemoryClimateRepository.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryClimateRepository } from '../../../src/adapters/climate/InMemoryClimateRepository.js';
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+
+test('InMemoryClimateRepository loads and saves climate states by region', () => {
+  const repository = new InMemoryClimateRepository([
+    new ClimateState({
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 66,
+      droughtIndex: 18,
+    }),
+  ]);
+
+  assert.equal(repository.loadByRegionId('north-coast')?.season, 'spring');
+  assert.equal(repository.loadByRegionId('sunreach'), null);
+
+  const saved = repository.save({
+    regionId: 'sunreach',
+    season: 'summer',
+    temperatureC: 33,
+    precipitationLevel: 24,
+    droughtIndex: 58,
+    anomaly: 'heatwave',
+  });
+
+  assert.equal(saved.regionId, 'sunreach');
+  assert.equal(repository.loadByRegionId('sunreach')?.anomaly, 'heatwave');
+  assert.deepEqual(repository.loadMany(['north-coast', 'sunreach']).map((state) => state?.regionId), ['north-coast', 'sunreach']);
+});
+
+test('InMemoryClimateRepository can delete and snapshot stored climate states', () => {
+  const repository = new InMemoryClimateRepository([
+    {
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 66,
+      droughtIndex: 18,
+    },
+    {
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 31,
+      precipitationLevel: 18,
+      droughtIndex: 62,
+    },
+  ]);
+
+  assert.equal(repository.deleteByRegionId('sunreach'), true);
+  assert.equal(repository.deleteByRegionId('sunreach'), false);
+  assert.deepEqual(repository.snapshot().map((state) => state.regionId), ['north-coast']);
+});
+
+test('InMemoryClimateRepository rejects blank region identifiers', () => {
+  const repository = new InMemoryClimateRepository();
+
+  assert.throws(
+    () => repository.loadByRegionId('  '),
+    /regionId is required/,
+  );
+
+  assert.throws(
+    () => repository.deleteByRegionId(''),
+    /regionId is required/,
+  );
+});


### PR DESCRIPTION
Epsilon: ## Summary
- ajoute `InMemoryClimateRepository` comme adapter mémoire du port climat
- fournit lecture, sauvegarde, suppression et snapshot par région
- couvre le comportement avec des tests dédiés

## Testing
- [x] `npm test -- --test-reporter=spec`

## Notes
- PR empilée sur #165 pour garder un diff propre côté climat
- prépare le terrain pour connecter les use cases au stockage applicatif
- closes #92