### PR TITLE
Beta: create MarketRepository port

### DIFF
--- a/src/application/economy/MarketRepository.js
+++ b/src/application/economy/MarketRepository.js
@@ -1,0 +1,47 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+export class MarketRepository {
+  getPrice({ cityId, resourceId }) {
+    requireObject({ cityId, resourceId }, 'MarketRepository getPrice input');
+    requireText(cityId, 'MarketRepository getPrice cityId');
+    requireText(resourceId, 'MarketRepository getPrice resourceId');
+    throw new Error('MarketRepository.getPrice must be implemented by an adapter.');
+  }
+
+  setPrice({ cityId, resourceId, price }) {
+    requireObject({ cityId, resourceId, price }, 'MarketRepository setPrice input');
+    requireText(cityId, 'MarketRepository setPrice cityId');
+    requireText(resourceId, 'MarketRepository setPrice resourceId');
+    requireInteger(price, 'MarketRepository setPrice price', 0);
+    throw new Error('MarketRepository.setPrice must be implemented by an adapter.');
+  }
+
+  listPricesByCity(cityId) {
+    requireText(cityId, 'MarketRepository listPricesByCity cityId');
+    throw new Error('MarketRepository.listPricesByCity must be implemented by an adapter.');
+  }
+}

--- a/test/application/economy/MarketRepository.test.js
+++ b/test/application/economy/MarketRepository.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { MarketRepository } from '../../../src/application/economy/MarketRepository.js';
+
+test('MarketRepository validates city, resource, and price inputs before adapter delegation', () => {
+  const repository = new MarketRepository();
+
+  assert.throws(
+    () => repository.getPrice({ cityId: '', resourceId: 'grain' }),
+    /MarketRepository getPrice cityId is required/,
+  );
+
+  assert.throws(
+    () => repository.getPrice({ cityId: 'city-a', resourceId: '' }),
+    /MarketRepository getPrice resourceId is required/,
+  );
+
+  assert.throws(
+    () => repository.setPrice({ cityId: 'city-a', resourceId: 'grain', price: -1 }),
+    /MarketRepository setPrice price must be an integer between 0 and/,
+  );
+
+  assert.throws(
+    () => repository.listPricesByCity(''),
+    /MarketRepository listPricesByCity cityId is required/,
+  );
+});
+
+test('MarketRepository exposes explicit adapter implementation errors', () => {
+  const repository = new MarketRepository();
+
+  assert.throws(
+    () => repository.getPrice({ cityId: 'city-a', resourceId: 'grain' }),
+    /MarketRepository.getPrice must be implemented by an adapter/,
+  );
+
+  assert.throws(
+    () => repository.setPrice({ cityId: 'city-a', resourceId: 'grain', price: 12 }),
+    /MarketRepository.setPrice must be implemented by an adapter/,
+  );
+
+  assert.throws(
+    () => repository.listPricesByCity('city-a'),
+    /MarketRepository.listPricesByCity must be implemented by an adapter/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: create the `MarketRepository` port for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `MarketRepository` with price lookup, price update, and city-market listing contract methods
Beta: - validate city ids, resource ids, and price payloads before any adapter delegation
Beta: - fail fast with explicit adapter implementation errors until a concrete adapter is added
Beta: - add node tests for validation and base adapter error behavior
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #30
