### PR TITLE
Delta: [D12] Create RandomPort

### DIFF
--- a/src/application/ports/RandomPort.js
+++ b/src/application/ports/RandomPort.js
@@ -1,0 +1,56 @@
+function requireFunction(value, label) {
+  if (typeof value !== 'function') {
+    throw new TypeError(`${label} must be a function.`);
+  }
+
+  return value;
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireFiniteNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TypeError(`${label} must be a finite number.`);
+  }
+
+  return value;
+}
+
+function ensureRoll(value, label) {
+  const normalizedValue = requireFiniteNumber(value, label);
+
+  if (normalizedValue < 0 || normalizedValue > 1) {
+    throw new RangeError(`${label} must be between 0 and 1.`);
+  }
+
+  return normalizedValue;
+}
+
+export function createRandomPort({ nextFloat }) {
+  const normalizedNextFloat = requireFunction(nextFloat, 'RandomPort nextFloat');
+
+  return {
+    nextFloat(options = {}) {
+      requireObject(options, 'RandomPort options');
+      return ensureRoll(normalizedNextFloat({ ...options }), 'RandomPort roll');
+    },
+  };
+}
+
+export function assertRandomPort(port) {
+  const normalizedPort = requireObject(port, 'RandomPort');
+  const nextFloat = requireFunction(normalizedPort.nextFloat, 'RandomPort nextFloat');
+
+  return {
+    nextFloat(options = {}) {
+      requireObject(options, 'RandomPort options');
+      return ensureRoll(nextFloat.call(normalizedPort, { ...options }), 'RandomPort roll');
+    },
+  };
+}

--- a/test/application/ports/RandomPort.test.js
+++ b/test/application/ports/RandomPort.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { assertRandomPort, createRandomPort } from '../../../src/application/ports/RandomPort.js';
+
+test('createRandomPort wraps a random reader and normalizes rolls', () => {
+  const receivedOptions = [];
+  const port = createRandomPort({
+    nextFloat(options) {
+      receivedOptions.push(options);
+      return 0.42;
+    },
+  });
+
+  assert.equal(port.nextFloat({ stream: 'intrigue' }), 0.42);
+  assert.deepEqual(receivedOptions, [{ stream: 'intrigue' }]);
+});
+
+test('assertRandomPort validates the contract and preserves context', () => {
+  const port = {
+    offset: 0.1,
+    nextFloat(options) {
+      return Math.min(1, options.base + this.offset);
+    },
+  };
+
+  const validatedPort = assertRandomPort(port);
+
+  assert.equal(validatedPort.nextFloat({ base: 0.25 }), 0.35);
+  assert.throws(() => assertRandomPort({}), /RandomPort nextFloat must be a function/);
+  assert.throws(() => validatedPort.nextFloat(null), /RandomPort options must be an object/);
+});
+
+test('RandomPort rejects invalid rolls', () => {
+  const highPort = createRandomPort({
+    nextFloat() {
+      return 1.2;
+    },
+  });
+
+  const invalidPort = createRandomPort({
+    nextFloat() {
+      return 'oops';
+    },
+  });
+
+  assert.throws(() => highPort.nextFloat({}), /RandomPort roll must be between 0 and 1/);
+  assert.throws(() => invalidPort.nextFloat({}), /RandomPort roll must be a finite number/);
+  assert.throws(() => createRandomPort({ nextFloat: 5 }), /RandomPort nextFloat must be a function/);
+});


### PR DESCRIPTION
Delta: Cette PR traite l'issue #72 en ajoutant le port `RandomPort`.

## Contenu
- ajout d'une factory `createRandomPort`
- ajout d'un validateur `assertRandomPort`
- validation des options et des rolls produits
- ajout de tests sur contrat, contexte et valeurs invalides

## Vérification
- `npm test`

## Notes
- cette PR est empilée sur `delta/d11-create-factionreadport`
- je demanderai la validation de Zeta avant tout merge
