### PR TITLE
Gamma: [G15] Build JSON content loader for events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/application/culture/loadHistoricalEventsFromJson.js
+++ b/src/application/culture/loadHistoricalEventsFromJson.js
@@ -1,0 +1,85 @@
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeTextArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(value.map((item) => requireText(item, label)))];
+  return normalizedValues.sort();
+}
+
+function normalizeHistoricalEvent(event, index) {
+  const normalizedEvent = requireObject(event, `loadHistoricalEventsFromJson event[${index}]`);
+
+  return {
+    id: requireText(normalizedEvent.id, `loadHistoricalEventsFromJson event[${index}].id`),
+    title: requireText(normalizedEvent.title, `loadHistoricalEventsFromJson event[${index}].title`),
+    era: requireText(normalizedEvent.era, `loadHistoricalEventsFromJson event[${index}].era`),
+    summary: requireText(normalizedEvent.summary, `loadHistoricalEventsFromJson event[${index}].summary`),
+    affectedCultureIds: normalizeTextArray(
+      normalizedEvent.affectedCultureIds ?? [],
+      `loadHistoricalEventsFromJson event[${index}].affectedCultureIds`,
+    ),
+    consequenceIds: normalizeTextArray(
+      normalizedEvent.consequenceIds ?? [],
+      `loadHistoricalEventsFromJson event[${index}].consequenceIds`,
+    ),
+    unlockedResearchIds: normalizeTextArray(
+      normalizedEvent.unlockedResearchIds ?? [],
+      `loadHistoricalEventsFromJson event[${index}].unlockedResearchIds`,
+    ),
+    repeatable: Boolean(normalizedEvent.repeatable),
+    triggerCount: Number.isInteger(normalizedEvent.triggerCount) ? normalizedEvent.triggerCount : 0,
+    lastTriggeredAt:
+      normalizedEvent.lastTriggeredAt === null || normalizedEvent.lastTriggeredAt === undefined
+        ? null
+        : requireText(
+            normalizedEvent.lastTriggeredAt,
+            `loadHistoricalEventsFromJson event[${index}].lastTriggeredAt`,
+          ),
+    divergenceId:
+      normalizedEvent.divergenceId === null || normalizedEvent.divergenceId === undefined
+        ? null
+        : requireText(
+            normalizedEvent.divergenceId,
+            `loadHistoricalEventsFromJson event[${index}].divergenceId`,
+          ),
+  };
+}
+
+export function loadHistoricalEventsFromJson(jsonText) {
+  const normalizedJsonText = requireText(jsonText, 'loadHistoricalEventsFromJson jsonText');
+
+  let parsed;
+  try {
+    parsed = JSON.parse(normalizedJsonText);
+  } catch (error) {
+    throw new SyntaxError(`loadHistoricalEventsFromJson could not parse JSON: ${error.message}`);
+  }
+
+  const root = requireObject(parsed, 'loadHistoricalEventsFromJson root');
+  const rawEvents = root.events;
+
+  if (!Array.isArray(rawEvents)) {
+    throw new TypeError('loadHistoricalEventsFromJson root.events must be an array.');
+  }
+
+  return rawEvents.map((event, index) => normalizeHistoricalEvent(event, index));
+}

--- a/test/application/culture/loadHistoricalEventsFromJson.test.js
+++ b/test/application/culture/loadHistoricalEventsFromJson.test.js
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { loadHistoricalEventsFromJson } from '../../../src/application/culture/loadHistoricalEventsFromJson.js';
+
+test('loadHistoricalEventsFromJson parses and normalizes historical events', () => {
+  const events = loadHistoricalEventsFromJson(`{
+    "events": [
+      {
+        "id": "event-open-archives",
+        "title": "Open Archives",
+        "era": "late-medieval",
+        "summary": "Guild scholars gain access to royal archives.",
+        "affectedCultureIds": ["culture-north", "culture-north", "culture-south"],
+        "consequenceIds": ["archive-reform", "public-catalogue"],
+        "unlockedResearchIds": ["astronomy", "paper-ledgers"],
+        "repeatable": true,
+        "triggerCount": 2,
+        "lastTriggeredAt": "2026-04-18T14:15:00.000Z",
+        "divergenceId": "divergence-open-archives"
+      }
+    ]
+  }`);
+
+  assert.equal(events.length, 1);
+  assert.deepEqual(events[0], {
+    id: 'event-open-archives',
+    title: 'Open Archives',
+    era: 'late-medieval',
+    summary: 'Guild scholars gain access to royal archives.',
+    affectedCultureIds: ['culture-north', 'culture-south'],
+    consequenceIds: ['archive-reform', 'public-catalogue'],
+    unlockedResearchIds: ['astronomy', 'paper-ledgers'],
+    repeatable: true,
+    triggerCount: 2,
+    lastTriggeredAt: '2026-04-18T14:15:00.000Z',
+    divergenceId: 'divergence-open-archives',
+  });
+});
+
+test('loadHistoricalEventsFromJson applies defaults for optional fields', () => {
+  const events = loadHistoricalEventsFromJson(`{
+    "events": [
+      {
+        "id": "event-silent-monastery",
+        "title": "Silent Monastery",
+        "era": "classical",
+        "summary": "A monastery hides dissenting chronicles."
+      }
+    ]
+  }`);
+
+  assert.deepEqual(events[0], {
+    id: 'event-silent-monastery',
+    title: 'Silent Monastery',
+    era: 'classical',
+    summary: 'A monastery hides dissenting chronicles.',
+    affectedCultureIds: [],
+    consequenceIds: [],
+    unlockedResearchIds: [],
+    repeatable: false,
+    triggerCount: 0,
+    lastTriggeredAt: null,
+    divergenceId: null,
+  });
+});
+
+test('loadHistoricalEventsFromJson rejects invalid JSON and invalid event shapes', () => {
+  assert.throws(
+    () => loadHistoricalEventsFromJson('{broken'),
+    /loadHistoricalEventsFromJson could not parse JSON/,
+  );
+
+  assert.throws(
+    () => loadHistoricalEventsFromJson('{"events":{}}'),
+    /loadHistoricalEventsFromJson root.events must be an array/,
+  );
+
+  assert.throws(
+    () =>
+      loadHistoricalEventsFromJson(`{
+        "events": [
+          {
+            "id": " ",
+            "title": "Open Archives",
+            "era": "late-medieval",
+            "summary": "Guild scholars gain access to royal archives."
+          }
+        ]
+      }`),
+    /loadHistoricalEventsFromJson event\[0\]\.id is required/,
+  );
+
+  assert.throws(
+    () =>
+      loadHistoricalEventsFromJson(`{
+        "events": [
+          {
+            "id": "event-open-archives",
+            "title": "Open Archives",
+            "era": "late-medieval",
+            "summary": "Guild scholars gain access to royal archives.",
+            "affectedCultureIds": [""]
+          }
+        ]
+      }`),
+    /loadHistoricalEventsFromJson event\[0\]\.affectedCultureIds is required/,
+  );
+});


### PR DESCRIPTION
Gamma: ## Summary
Gamma: Add a JSON content loader for Gamma historical events with normalization, defaults, and validation.
Gamma:
Gamma: ## Related issue
Gamma: - Closes #55
Gamma:
Gamma: ## Changes
Gamma: - add `src/application/culture/loadHistoricalEventsFromJson.js`
Gamma: - parse a JSON document with an `events` array and normalize each historical event entry
Gamma: - validate required event fields and reject malformed arrays or malformed JSON
Gamma: - add node tests for normalization, defaults, and failure cases
Gamma:
Gamma: ## Testing
Gamma: - [x] Local checks run
Gamma: - [x] Relevant tests added or updated
Gamma: - [ ] Manual check if relevant
Gamma: - [x] `npm test -- --test-reporter tap`
Gamma:
Gamma: ## Rules check
Gamma: - [x] This work comes through a pull request
Gamma: - [x] This PR is mandatory to avoid bugs and validation problems with Zeta
Gamma: - [x] GitHub text starts with the agent name followed by `:`
Gamma: - [x] The work stays inside the author's domain
Gamma: - [ ] Zeta has been asked for validation before merge
Gamma:
Gamma: ## Notes
Gamma: This PR keeps the loader independent so later Gamma systems can consume normalized event content without binding to file I/O yet.
