### PR TITLE
Epsilon: add in-memory myth ledger adapter

### DIFF
--- a/src/adapters/climate/InMemoryMythLedger.js
+++ b/src/adapters/climate/InMemoryMythLedger.js
@@ -1,0 +1,57 @@
+import { MythLedgerPort } from '../../application/ports/MythLedgerPort.js';
+import { Myth } from '../../domain/climate/Myth.js';
+
+function normalizeMyth(myth) {
+  if (myth instanceof Myth) {
+    return myth;
+  }
+
+  return new Myth(myth);
+}
+
+export class InMemoryMythLedger extends MythLedgerPort {
+  constructor(seed = []) {
+    super();
+    this.mythsById = new Map();
+    this.mythIdsByOriginEventId = new Map();
+
+    this.recordMany(seed);
+  }
+
+  record(myth) {
+    const normalizedMyth = normalizeMyth(myth);
+    this.mythsById.set(normalizedMyth.id, normalizedMyth);
+
+    for (const originEventId of normalizedMyth.originEventIds) {
+      const mythIds = this.mythIdsByOriginEventId.get(originEventId) ?? [];
+      this.mythIdsByOriginEventId.set(originEventId, [...new Set([...mythIds, normalizedMyth.id])]);
+    }
+
+    return normalizedMyth;
+  }
+
+  findByOriginEventId(originEventId) {
+    const normalizedOriginEventId = String(originEventId ?? '').trim();
+
+    if (!normalizedOriginEventId) {
+      throw new RangeError('InMemoryMythLedger.findByOriginEventId originEventId is required.');
+    }
+
+    const mythIds = this.mythIdsByOriginEventId.get(normalizedOriginEventId) ?? [];
+    return mythIds.map((mythId) => this.mythsById.get(mythId));
+  }
+
+  findByMythId(mythId) {
+    const normalizedMythId = String(mythId ?? '').trim();
+
+    if (!normalizedMythId) {
+      throw new RangeError('InMemoryMythLedger.findByMythId mythId is required.');
+    }
+
+    return this.mythsById.get(normalizedMythId) ?? null;
+  }
+
+  snapshot() {
+    return [...this.mythsById.values()].map((myth) => myth.toJSON());
+  }
+}

--- a/test/adapters/climate/InMemoryMythLedger.test.js
+++ b/test/adapters/climate/InMemoryMythLedger.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryMythLedger } from '../../../src/adapters/climate/InMemoryMythLedger.js';
+import { Myth } from '../../../src/domain/climate/Myth.js';
+
+test('InMemoryMythLedger records myths and finds them from origin events', () => {
+  const ledger = new InMemoryMythLedger([
+    new Myth({
+      id: 'myth-storm-001',
+      title: 'The Skyfire Returns',
+      category: 'omen',
+      originEventIds: ['storm-001'],
+      summary: 'A radiant omen seen before the floods.',
+    }),
+  ]);
+
+  const recorded = ledger.record({
+    id: 'myth-flood-002',
+    title: 'The River Without Mercy',
+    category: 'catastrophe',
+    originEventIds: ['flood-002', 'storm-001'],
+    summary: 'A tale born from the great flood.',
+    tags: ['flood'],
+  });
+
+  assert.equal(recorded.id, 'myth-flood-002');
+  assert.deepEqual(ledger.findByOriginEventId('flood-002').map((myth) => myth.id), ['myth-flood-002']);
+  assert.deepEqual(ledger.findByOriginEventId('storm-001').map((myth) => myth.id), ['myth-storm-001', 'myth-flood-002']);
+  assert.equal(ledger.findByMythId('myth-flood-002')?.title, 'The River Without Mercy');
+});
+
+test('InMemoryMythLedger snapshots canonical myth data and validates identifiers', () => {
+  const ledger = new InMemoryMythLedger([
+    {
+      id: 'myth-blizzard-king',
+      title: 'The Blizzard King',
+      category: 'catastrophe',
+      originEventIds: ['blizzard-7'],
+      summary: 'A tale born from the great white winter.',
+      credibility: 40,
+    },
+  ]);
+
+  assert.deepEqual(ledger.snapshot().map((myth) => myth.id), ['myth-blizzard-king']);
+
+  assert.throws(
+    () => ledger.findByOriginEventId(''),
+    /originEventId is required/,
+  );
+
+  assert.throws(
+    () => ledger.findByMythId('  '),
+    /mythId is required/,
+  );
+});


### PR DESCRIPTION
Epsilon: ## Summary
- ajoute `InMemoryMythLedger` comme adapter mémoire du port des mythes
- fournit enregistrement, recherche par événement d’origine, lookup par identifiant et snapshot
- couvre le comportement avec des tests dédiés

## Testing
- [x] `npm test -- --test-reporter=spec`

## Notes
- PR empilée sur #170 pour garder un diff propre côté climat
- prépare le terrain pour brancher les mythes aux use cases applicatifs
- closes #93