### PR TITLE
Beta: create RouteRepository port

### DIFF
--- a/src/domain/economy/RouteRepositoryPort.js
+++ b/src/domain/economy/RouteRepositoryPort.js
@@ -1,0 +1,30 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+export class RouteRepositoryPort {
+  async getById(routeId) {
+    requireText(routeId, 'RouteRepositoryPort routeId');
+    throw new Error('RouteRepositoryPort.getById must be implemented by an adapter.');
+  }
+
+  async save(route) {
+    if (route === null || typeof route !== 'object' || Array.isArray(route)) {
+      throw new TypeError('RouteRepositoryPort route must be an object.');
+    }
+
+    requireText(route.id, 'RouteRepositoryPort route.id');
+    throw new Error('RouteRepositoryPort.save must be implemented by an adapter.');
+  }
+
+  async listByCity(cityId) {
+    requireText(cityId, 'RouteRepositoryPort cityId');
+    throw new Error('RouteRepositoryPort.listByCity must be implemented by an adapter.');
+  }
+}

--- a/test/domain/economy/RouteRepositoryPort.test.js
+++ b/test/domain/economy/RouteRepositoryPort.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { RouteRepositoryPort } from '../../../src/domain/economy/RouteRepositoryPort.js';
+
+test('RouteRepositoryPort validates identifiers before delegating to adapters', async () => {
+  const repository = new RouteRepositoryPort();
+
+  await assert.rejects(
+    () => repository.getById(''),
+    /RouteRepositoryPort routeId is required/,
+  );
+
+  await assert.rejects(
+    () => repository.listByCity(''),
+    /RouteRepositoryPort cityId is required/,
+  );
+});
+
+test('RouteRepositoryPort validates route payloads before save', async () => {
+  const repository = new RouteRepositoryPort();
+
+  await assert.rejects(
+    () => repository.save(null),
+    /RouteRepositoryPort route must be an object/,
+  );
+
+  await assert.rejects(
+    () => repository.save({ id: '   ' }),
+    /RouteRepositoryPort route.id is required/,
+  );
+});
+
+test('RouteRepositoryPort exposes explicit adapter implementation errors', async () => {
+  const repository = new RouteRepositoryPort();
+
+  await assert.rejects(
+    () => repository.getById('route-river'),
+    /RouteRepositoryPort.getById must be implemented by an adapter/,
+  );
+
+  await assert.rejects(
+    () => repository.save({ id: 'route-river' }),
+    /RouteRepositoryPort.save must be implemented by an adapter/,
+  );
+
+  await assert.rejects(
+    () => repository.listByCity('city-harbor'),
+    /RouteRepositoryPort.listByCity must be implemented by an adapter/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: create the `RouteRepositoryPort` contract for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `RouteRepositoryPort` with route lookup, persistence, and route-by-city listing methods
Beta: - validate route identifiers and saved route payloads before adapter delegation
Beta: - fail fast with explicit adapter implementation errors until a concrete adapter exists
Beta: - add node tests for validation and base adapter error behavior
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #31
