### PR TITLE
Delta: [D13] Create ClockPort

### DIFF
--- a/src/application/intrigue/ClockPort.js
+++ b/src/application/intrigue/ClockPort.js
@@ -1,0 +1,42 @@
+function requireClockSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+    throw new TypeError('ClockPort snapshot must be an object.');
+  }
+
+  const tick = snapshot.tick;
+
+  if (!Number.isInteger(tick) || tick < 0) {
+    throw new RangeError('ClockPort tick must be a non-negative integer.');
+  }
+
+  const year = snapshot.year;
+
+  if (!Number.isInteger(year) || year < 0) {
+    throw new RangeError('ClockPort year must be a non-negative integer.');
+  }
+
+  const season = String(snapshot.season ?? '').trim();
+
+  if (!season) {
+    throw new RangeError('ClockPort season is required.');
+  }
+
+  return {
+    ...snapshot,
+    tick,
+    year,
+    season,
+  };
+}
+
+export class ClockPort {
+  async now() {
+    throw new Error('ClockPort.now must be implemented by an adapter.');
+  }
+
+  async requireNow() {
+    const snapshot = await this.now();
+
+    return requireClockSnapshot(snapshot);
+  }
+}

--- a/test/application/intrigue/ClockPort.test.js
+++ b/test/application/intrigue/ClockPort.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ClockPort } from '../../../src/application/intrigue/ClockPort.js';
+
+class FixedClockPort extends ClockPort {
+  constructor(snapshot) {
+    super();
+    this.snapshot = snapshot;
+    this.calls = 0;
+  }
+
+  async now() {
+    this.calls += 1;
+    return this.snapshot;
+  }
+}
+
+test('ClockPort normalizes current time snapshots from adapters', async () => {
+  const clock = new FixedClockPort({
+    tick: 42,
+    year: 3,
+    season: ' autumn ',
+    label: 'Turn 42',
+  });
+
+  const snapshot = await clock.requireNow();
+
+  assert.equal(clock.calls, 1);
+  assert.deepEqual(snapshot, {
+    tick: 42,
+    year: 3,
+    season: 'autumn',
+    label: 'Turn 42',
+  });
+});
+
+test('ClockPort base adapter method fails fast until implemented', async () => {
+  const clock = new ClockPort();
+
+  await assert.rejects(() => clock.now(), /must be implemented by an adapter/);
+});
+
+test('ClockPort rejects invalid snapshots', async () => {
+  const invalidTickClock = new FixedClockPort({ tick: -1, year: 2, season: 'spring' });
+  const invalidYearClock = new FixedClockPort({ tick: 4, year: 1.5, season: 'spring' });
+  const invalidSeasonClock = new FixedClockPort({ tick: 4, year: 2, season: '   ' });
+
+  await assert.rejects(() => invalidTickClock.requireNow(), /tick must be a non-negative integer/);
+  await assert.rejects(() => invalidYearClock.requireNow(), /year must be a non-negative integer/);
+  await assert.rejects(() => invalidSeasonClock.requireNow(), /season is required/);
+
+  const malformedClock = new FixedClockPort(null);
+
+  await assert.rejects(() => malformedClock.requireNow(), /snapshot must be an object/);
+});


### PR DESCRIPTION
Delta: Cette PR traite l'issue #73 en ajoutant le port `ClockPort`.

## Contenu
- ajout d'un port `ClockPort` orienté adapter avec `now()` et `requireNow()`
- normalisation du snapshot de temps courant (`tick`, `year`, `season`)
- ajout de tests sur normalisation, erreur de base non implémentée et snapshots invalides

## Vérification
- `npm test`

## Notes
- cette PR part de `main` et cible directement `main`
- je demanderai la validation de Zeta avant tout merge
