### PR TITLE
Gamma: [G16] Build JSON content loader for research

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/application/culture/loadResearchStatesFromJson.js
+++ b/src/application/culture/loadResearchStatesFromJson.js
@@ -1,0 +1,84 @@
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeTextArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return [...new Set(value.map((item) => requireText(item, label)))].sort();
+}
+
+function normalizeResearchState(researchState, index) {
+  const normalizedResearchState = requireObject(
+    researchState,
+    `loadResearchStatesFromJson researchState[${index}]`,
+  );
+
+  return {
+    id: requireText(
+      normalizedResearchState.id,
+      `loadResearchStatesFromJson researchState[${index}].id`,
+    ),
+    cultureId: requireText(
+      normalizedResearchState.cultureId,
+      `loadResearchStatesFromJson researchState[${index}].cultureId`,
+    ),
+    focusIds: normalizeTextArray(
+      normalizedResearchState.focusIds ?? [],
+      `loadResearchStatesFromJson researchState[${index}].focusIds`,
+    ),
+    unlockedResearchIds: normalizeTextArray(
+      normalizedResearchState.unlockedResearchIds ?? [],
+      `loadResearchStatesFromJson researchState[${index}].unlockedResearchIds`,
+    ),
+    activeProjectId:
+      normalizedResearchState.activeProjectId === null ||
+      normalizedResearchState.activeProjectId === undefined
+        ? null
+        : requireText(
+            normalizedResearchState.activeProjectId,
+            `loadResearchStatesFromJson researchState[${index}].activeProjectId`,
+          ),
+    knowledgePoints: Number.isFinite(normalizedResearchState.knowledgePoints)
+      ? normalizedResearchState.knowledgePoints
+      : 0,
+  };
+}
+
+export function loadResearchStatesFromJson(jsonText) {
+  const normalizedJsonText = requireText(jsonText, 'loadResearchStatesFromJson jsonText');
+
+  let parsed;
+  try {
+    parsed = JSON.parse(normalizedJsonText);
+  } catch (error) {
+    throw new SyntaxError(`loadResearchStatesFromJson could not parse JSON: ${error.message}`);
+  }
+
+  const root = requireObject(parsed, 'loadResearchStatesFromJson root');
+  const rawResearchStates = root.researchStates;
+
+  if (!Array.isArray(rawResearchStates)) {
+    throw new TypeError('loadResearchStatesFromJson root.researchStates must be an array.');
+  }
+
+  return rawResearchStates.map((researchState, index) =>
+    normalizeResearchState(researchState, index),
+  );
+}

--- a/test/application/culture/loadResearchStatesFromJson.test.js
+++ b/test/application/culture/loadResearchStatesFromJson.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { loadResearchStatesFromJson } from '../../../src/application/culture/loadResearchStatesFromJson.js';
+
+test('loadResearchStatesFromJson parses and normalizes research states', () => {
+  const researchStates = loadResearchStatesFromJson(`{
+    "researchStates": [
+      {
+        "id": "research-state-north",
+        "cultureId": "culture-north",
+        "focusIds": ["astronomy", "archives", "astronomy"],
+        "unlockedResearchIds": ["paper-ledgers", "navigation"],
+        "activeProjectId": "project-star-census",
+        "knowledgePoints": 14
+      }
+    ]
+  }`);
+
+  assert.equal(researchStates.length, 1);
+  assert.deepEqual(researchStates[0], {
+    id: 'research-state-north',
+    cultureId: 'culture-north',
+    focusIds: ['archives', 'astronomy'],
+    unlockedResearchIds: ['navigation', 'paper-ledgers'],
+    activeProjectId: 'project-star-census',
+    knowledgePoints: 14,
+  });
+});
+
+test('loadResearchStatesFromJson applies defaults for optional fields', () => {
+  const researchStates = loadResearchStatesFromJson(`{
+    "researchStates": [
+      {
+        "id": "research-state-south",
+        "cultureId": "culture-south"
+      }
+    ]
+  }`);
+
+  assert.deepEqual(researchStates[0], {
+    id: 'research-state-south',
+    cultureId: 'culture-south',
+    focusIds: [],
+    unlockedResearchIds: [],
+    activeProjectId: null,
+    knowledgePoints: 0,
+  });
+});
+
+test('loadResearchStatesFromJson rejects invalid JSON and invalid research state shapes', () => {
+  assert.throws(
+    () => loadResearchStatesFromJson('{broken'),
+    /loadResearchStatesFromJson could not parse JSON/,
+  );
+
+  assert.throws(
+    () => loadResearchStatesFromJson('{"researchStates":{}}'),
+    /loadResearchStatesFromJson root.researchStates must be an array/,
+  );
+
+  assert.throws(
+    () =>
+      loadResearchStatesFromJson(`{
+        "researchStates": [
+          {
+            "id": " ",
+            "cultureId": "culture-north"
+          }
+        ]
+      }`),
+    /loadResearchStatesFromJson researchState\[0\]\.id is required/,
+  );
+
+  assert.throws(
+    () =>
+      loadResearchStatesFromJson(`{
+        "researchStates": [
+          {
+            "id": "research-state-north",
+            "cultureId": "culture-north",
+            "focusIds": [""]
+          }
+        ]
+      }`),
+    /loadResearchStatesFromJson researchState\[0\]\.focusIds is required/,
+  );
+});


### PR DESCRIPTION
Gamma: ## Summary
Gamma: Add a JSON content loader for Gamma research states with normalization, defaults, and validation.
Gamma:
Gamma: ## Related issue
Gamma: - Closes #56
Gamma:
Gamma: ## Changes
Gamma: - add `src/application/culture/loadResearchStatesFromJson.js`
Gamma: - parse a JSON document with a `researchStates` array and normalize each research state entry
Gamma: - validate required research fields and reject malformed arrays or malformed JSON
Gamma: - add node tests for normalization, defaults, and failure cases
Gamma:
Gamma: ## Testing
Gamma: - [x] Local checks run
Gamma: - [x] Relevant tests added or updated
Gamma: - [ ] Manual check if relevant
Gamma: - [x] `npm test -- --test-reporter tap`
Gamma:
Gamma: ## Rules check
Gamma: - [x] This work comes through a pull request
Gamma: - [x] This PR is mandatory to avoid bugs and validation problems with Zeta
Gamma: - [x] GitHub text starts with the agent name followed by `:`
Gamma: - [x] The work stays inside the author's domain
Gamma: - [ ] Zeta has been asked for validation before merge
Gamma:
Gamma: ## Notes
Gamma: This PR starts from `main` and targets `main` directly, in line with the current feature PR rule.
