### PR TITLE
Beta: add in-memory city adapter

### DIFF
--- a/src/adapters/economy/InMemoryCityRepository.js
+++ b/src/adapters/economy/InMemoryCityRepository.js
@@ -1,0 +1,68 @@
+import { CityRepositoryPort } from '../../domain/economy/CityRepositoryPort.js';
+import { City } from '../../domain/economy/City.js';
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeCity(city) {
+  if (city instanceof City) {
+    return new City(city.toJSON());
+  }
+
+  if (city === null || typeof city !== 'object' || Array.isArray(city)) {
+    throw new TypeError('InMemoryCityRepository city must be an object.');
+  }
+
+  return new City(city);
+}
+
+export class InMemoryCityRepository extends CityRepositoryPort {
+  constructor({ cities = [] } = {}) {
+    super();
+
+    if (!Array.isArray(cities)) {
+      throw new TypeError('InMemoryCityRepository cities must be an array.');
+    }
+
+    this.citiesById = new Map();
+
+    for (const city of cities) {
+      const normalizedCity = normalizeCity(city);
+      this.citiesById.set(normalizedCity.id, normalizedCity);
+    }
+  }
+
+  async getById(cityId) {
+    const normalizedCityId = requireText(cityId, 'CityRepositoryPort cityId');
+    const city = this.citiesById.get(normalizedCityId);
+    return city ? new City(city.toJSON()) : null;
+  }
+
+  async save(city) {
+    if (city === null || typeof city !== 'object' || Array.isArray(city)) {
+      throw new TypeError('CityRepositoryPort city must be an object.');
+    }
+
+    requireText(city.id, 'CityRepositoryPort city.id');
+
+    const normalizedCity = normalizeCity(city);
+    this.citiesById.set(normalizedCity.id, normalizedCity);
+    return new City(normalizedCity.toJSON());
+  }
+
+  async listByRegion(regionId) {
+    const normalizedRegionId = requireText(regionId, 'CityRepositoryPort regionId');
+
+    return [...this.citiesById.values()]
+      .filter((city) => city.regionId === normalizedRegionId)
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((city) => new City(city.toJSON()));
+  }
+}

--- a/test/adapters/economy/InMemoryCityRepository.test.js
+++ b/test/adapters/economy/InMemoryCityRepository.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryCityRepository } from '../../../src/adapters/economy/InMemoryCityRepository.js';
+import { City } from '../../../src/domain/economy/City.js';
+
+test('InMemoryCityRepository loads cities and returns defensive copies', async () => {
+  const repository = new InMemoryCityRepository({
+    cities: [
+      {
+        id: 'city-harbor',
+        name: 'Harbor',
+        regionId: 'coast-west',
+        population: 100,
+        stockByResource: { grain: 12 },
+      },
+    ],
+  });
+
+  const city = await repository.getById('city-harbor');
+
+  assert.ok(city instanceof City);
+  assert.equal(city.id, 'city-harbor');
+  assert.deepEqual(city.stockByResource, { grain: 12 });
+
+  city.stockByResource.grain = 0;
+
+  const reloadedCity = await repository.getById('city-harbor');
+  assert.deepEqual(reloadedCity.stockByResource, { grain: 12 });
+  assert.equal(await repository.getById('unknown-city'), null);
+});
+
+test('InMemoryCityRepository saves cities and filters them by region', async () => {
+  const repository = new InMemoryCityRepository();
+
+  await repository.save({
+    id: 'city-harbor',
+    name: 'Harbor',
+    regionId: 'coast-west',
+    population: 100,
+    stockByResource: { grain: 12 },
+  });
+
+  await repository.save(
+    new City({
+      id: 'city-granary',
+      name: 'Granary',
+      regionId: 'coast-west',
+      population: 80,
+      stockByResource: { grain: 40 },
+    }),
+  );
+
+  await repository.save({
+    id: 'city-hillfort',
+    name: 'Hillfort',
+    regionId: 'highlands',
+    population: 60,
+    stockByResource: { stone: 15 },
+  });
+
+  const coastCities = await repository.listByRegion('coast-west');
+
+  assert.deepEqual(
+    coastCities.map((city) => city.id),
+    ['city-granary', 'city-harbor'],
+  );
+  assert.ok(coastCities.every((city) => city instanceof City));
+});
+
+test('InMemoryCityRepository rejects malformed constructor and save payloads', async () => {
+  assert.throws(
+    () => new InMemoryCityRepository({ cities: {} }),
+    /InMemoryCityRepository cities must be an array/,
+  );
+
+  const repository = new InMemoryCityRepository();
+
+  await assert.rejects(
+    () => repository.save(null),
+    /CityRepositoryPort city must be an object/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: add the in-memory city adapter for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `InMemoryCityRepository` as a concrete adapter for the `CityRepositoryPort`
Beta: - support initial city snapshots, defensive copies on reads, and region-based listing
Beta: - normalize saved payloads through the `City` model and preserve in-memory storage by id
Beta: - add node tests for loading, saving, filtering, defensive copies, and invalid payload handling
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #32
