### PR TITLE
Gamma: [G17] Add tests for research unlocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "historia",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/application/culture/evaluateResearchUnlocks.js
+++ b/src/application/culture/evaluateResearchUnlocks.js
@@ -1,0 +1,102 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireFiniteNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new RangeError(`${label} must be a finite number.`);
+  }
+
+  return value;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return [...new Set(values.map((value) => requireText(value, label)))].sort();
+}
+
+function normalizeResearchState(researchState) {
+  if (!researchState || typeof researchState !== 'object' || Array.isArray(researchState)) {
+    throw new TypeError('evaluateResearchUnlocks researchState must be an object.');
+  }
+
+  return {
+    ...researchState,
+    id: requireText(researchState.id, 'evaluateResearchUnlocks researchState.id'),
+    cultureId: requireText(researchState.cultureId, 'evaluateResearchUnlocks researchState.cultureId'),
+    focusIds: normalizeUniqueTexts(
+      researchState.focusIds ?? [],
+      'evaluateResearchUnlocks researchState.focusIds',
+    ),
+    unlockedResearchIds: normalizeUniqueTexts(
+      researchState.unlockedResearchIds ?? [],
+      'evaluateResearchUnlocks researchState.unlockedResearchIds',
+    ),
+    activeProjectId:
+      researchState.activeProjectId === null || researchState.activeProjectId === undefined
+        ? null
+        : requireText(
+            researchState.activeProjectId,
+            'evaluateResearchUnlocks researchState.activeProjectId',
+          ),
+    knowledgePoints: requireFiniteNumber(
+      researchState.knowledgePoints ?? 0,
+      'evaluateResearchUnlocks researchState.knowledgePoints',
+    ),
+  };
+}
+
+function normalizeResearchProject(researchProject, index) {
+  if (!researchProject || typeof researchProject !== 'object' || Array.isArray(researchProject)) {
+    throw new TypeError(`evaluateResearchUnlocks researchProjects[${index}] must be an object.`);
+  }
+
+  return {
+    ...researchProject,
+    id: requireText(researchProject.id, `evaluateResearchUnlocks researchProjects[${index}].id`),
+    requiredKnowledgePoints: requireFiniteNumber(
+      researchProject.requiredKnowledgePoints,
+      `evaluateResearchUnlocks researchProjects[${index}].requiredKnowledgePoints`,
+    ),
+  };
+}
+
+export function evaluateResearchUnlocks(researchState, researchProjects) {
+  const normalizedResearchState = normalizeResearchState(researchState);
+
+  if (!Array.isArray(researchProjects)) {
+    throw new TypeError('evaluateResearchUnlocks researchProjects must be an array.');
+  }
+
+  const normalizedResearchProjects = researchProjects.map((researchProject, index) =>
+    normalizeResearchProject(researchProject, index),
+  );
+
+  const unlockedResearchIds = new Set(normalizedResearchState.unlockedResearchIds);
+  const newlyUnlockedResearchIds = [];
+
+  for (const researchProject of normalizedResearchProjects) {
+    if (
+      normalizedResearchState.knowledgePoints >= researchProject.requiredKnowledgePoints &&
+      !unlockedResearchIds.has(researchProject.id)
+    ) {
+      unlockedResearchIds.add(researchProject.id);
+      newlyUnlockedResearchIds.push(researchProject.id);
+    }
+  }
+
+  return {
+    ...normalizedResearchState,
+    unlockedResearchIds: [...unlockedResearchIds].sort(),
+    newlyUnlockedResearchIds: newlyUnlockedResearchIds.sort(),
+  };
+}

--- a/test/application/culture/evaluateResearchUnlocks.test.js
+++ b/test/application/culture/evaluateResearchUnlocks.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evaluateResearchUnlocks } from '../../../src/application/culture/evaluateResearchUnlocks.js';
+
+test('evaluateResearchUnlocks unlocks projects that match current knowledge points', () => {
+  const result = evaluateResearchUnlocks(
+    {
+      id: 'research-state-north',
+      cultureId: 'culture-north',
+      focusIds: ['astronomy'],
+      unlockedResearchIds: ['paper-ledgers'],
+      activeProjectId: 'project-observatory',
+      knowledgePoints: 18,
+    },
+    [
+      { id: 'paper-ledgers', requiredKnowledgePoints: 4 },
+      { id: 'observatory-maps', requiredKnowledgePoints: 10 },
+      { id: 'stellar-census', requiredKnowledgePoints: 18 },
+      { id: 'deep-vaults', requiredKnowledgePoints: 25 },
+    ],
+  );
+
+  assert.deepEqual(result.unlockedResearchIds, [
+    'observatory-maps',
+    'paper-ledgers',
+    'stellar-census',
+  ]);
+  assert.deepEqual(result.newlyUnlockedResearchIds, ['observatory-maps', 'stellar-census']);
+});
+
+test('evaluateResearchUnlocks returns no new unlocks when thresholds are unmet', () => {
+  const result = evaluateResearchUnlocks(
+    {
+      id: 'research-state-south',
+      cultureId: 'culture-south',
+      focusIds: [],
+      unlockedResearchIds: [],
+      activeProjectId: null,
+      knowledgePoints: 3,
+    },
+    [
+      { id: 'paper-ledgers', requiredKnowledgePoints: 4 },
+      { id: 'observatory-maps', requiredKnowledgePoints: 10 },
+    ],
+  );
+
+  assert.deepEqual(result.unlockedResearchIds, []);
+  assert.deepEqual(result.newlyUnlockedResearchIds, []);
+});
+
+test('evaluateResearchUnlocks rejects invalid research state and project shapes', () => {
+  assert.throws(
+    () => evaluateResearchUnlocks(null, []),
+    /evaluateResearchUnlocks researchState must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      evaluateResearchUnlocks(
+        {
+          id: 'research-state-east',
+          cultureId: 'culture-east',
+          focusIds: [],
+          unlockedResearchIds: [],
+          activeProjectId: null,
+          knowledgePoints: 'not-a-number',
+        },
+        [],
+      ),
+    /evaluateResearchUnlocks researchState.knowledgePoints must be a finite number/,
+  );
+
+  assert.throws(
+    () =>
+      evaluateResearchUnlocks(
+        {
+          id: 'research-state-east',
+          cultureId: 'culture-east',
+          focusIds: [],
+          unlockedResearchIds: [],
+          activeProjectId: null,
+          knowledgePoints: 8,
+        },
+        [{ id: 'observatory-maps', requiredKnowledgePoints: '10' }],
+      ),
+    /evaluateResearchUnlocks researchProjects\[0\]\.requiredKnowledgePoints must be a finite number/,
+  );
+});


### PR DESCRIPTION
Gamma: ## Summary
Gamma: Add focused tests for Gamma research unlock thresholds, with a small helper that evaluates which research projects become available from current knowledge points.
Gamma:
Gamma: ## Related issue
Gamma: - Closes #57
Gamma:
Gamma: ## Changes
Gamma: - add `src/application/culture/evaluateResearchUnlocks.js`
Gamma: - evaluate unlock thresholds against current research state knowledge points
Gamma: - report both the full unlocked set and the newly unlocked ids
Gamma: - add node tests for successful unlocks, no-op cases, and invalid payloads
Gamma:
Gamma: ## Testing
Gamma: - [x] Local checks run
Gamma: - [x] Relevant tests added or updated
Gamma: - [ ] Manual check if relevant
Gamma: - [x] `npm test -- --test-reporter tap`
Gamma:
Gamma: ## Rules check
Gamma: - [x] This work comes through a pull request
Gamma: - [x] This PR is mandatory to avoid bugs and validation problems with Zeta
Gamma: - [x] GitHub text starts with the agent name followed by `:`
Gamma: - [x] The work stays inside the author's domain
Gamma: - [x] This PR starts from `main` and targets `main`
Gamma: - [ ] Zeta has been asked for validation before merge
Gamma:
Gamma: ## Notes
Gamma: I kept the helper self-contained so later Gamma use cases can reuse the same unlock evaluation logic without coupling tests to a larger orchestration flow.
