### PR TITLE
Delta: [D19] Show alert level in UI

### DIFF
--- a/src/ui/intrigue/AlertLevelBadge.js
+++ b/src/ui/intrigue/AlertLevelBadge.js
@@ -1,0 +1,41 @@
+import { NiveauAlerte } from '../../domain/intrigue/NiveauAlerte.js';
+
+const TONE_BY_CODE = Object.freeze({
+  latent: 'muted',
+  surveille: 'watch',
+  renforce: 'warning',
+  critique: 'danger',
+  verrouille: 'critical',
+});
+
+const COLOR_BY_CODE = Object.freeze({
+  latent: '#6B7280',
+  surveille: '#2563EB',
+  renforce: '#D97706',
+  critique: '#DC2626',
+  verrouille: '#7F1D1D',
+});
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+export function buildAlertLevelBadge(level, options = {}) {
+  const normalizedOptions = requireObject(options, 'AlertLevelBadge options');
+  const alertLevel = NiveauAlerte.from(level);
+  const prefix = String(normalizedOptions.prefix ?? 'Alerte').trim() || 'Alerte';
+
+  return {
+    text: `${prefix} ${alertLevel.label}`,
+    shortText: `${prefix} ${alertLevel.value}`,
+    tone: TONE_BY_CODE[alertLevel.code],
+    color: COLOR_BY_CODE[alertLevel.code],
+    emphasis: alertLevel.isCritical ? 'high' : 'normal',
+    tooltip: `Niveau ${alertLevel.value} sur ${NiveauAlerte.maximum().value}, surveillance ${alertLevel.surveillanceIntensity}%`,
+    level: alertLevel.toJSON(),
+  };
+}

--- a/test/ui/intrigue/AlertLevelBadge.test.js
+++ b/test/ui/intrigue/AlertLevelBadge.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildAlertLevelBadge } from '../../../src/ui/intrigue/AlertLevelBadge.js';
+
+test('AlertLevelBadge builds UI metadata from a numeric alert level', () => {
+  const badge = buildAlertLevelBadge(2);
+
+  assert.deepEqual(badge, {
+    text: 'Alerte Renforcé',
+    shortText: 'Alerte 2',
+    tone: 'warning',
+    color: '#D97706',
+    emphasis: 'normal',
+    tooltip: 'Niveau 2 sur 4, surveillance 55%',
+    level: {
+      value: 2,
+      code: 'renforce',
+      label: 'Renforcé',
+      surveillanceIntensity: 55,
+    },
+  });
+});
+
+test('AlertLevelBadge supports custom prefixes and critical levels', () => {
+  const badge = buildAlertLevelBadge('verrouille', { prefix: 'Sécurité' });
+
+  assert.deepEqual(badge, {
+    text: 'Sécurité Verrouillé',
+    shortText: 'Sécurité 4',
+    tone: 'critical',
+    color: '#7F1D1D',
+    emphasis: 'high',
+    tooltip: 'Niveau 4 sur 4, surveillance 100%',
+    level: {
+      value: 4,
+      code: 'verrouille',
+      label: 'Verrouillé',
+      surveillanceIntensity: 100,
+    },
+  });
+});
+
+test('AlertLevelBadge rejects invalid options and invalid levels', () => {
+  assert.throws(() => buildAlertLevelBadge(1, null), /AlertLevelBadge options must be an object/);
+  assert.throws(() => buildAlertLevelBadge('panic'), /NiveauAlerte code must be one of/);
+});


### PR DESCRIPTION
Delta: Cette PR traite l'issue #79 en ajoutant un helper UI pour afficher le niveau d'alerte.

## Contenu
- ajout de `buildAlertLevelBadge` pour transformer `NiveauAlerte` en métadonnées UI prêtes à afficher
- mapping explicite du niveau vers texte, couleur, tone, emphasis et tooltip
- ajout de tests sur niveau numérique, code textuel, niveau critique et validations

## Vérification
- `npm test`

## Notes
- cette PR part de `main` et cible directement `main`
- je demanderai la validation de Zeta avant tout merge
