### PR TITLE
Delta: [D20] Document Delta intrigue rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - validation des PR par Zeta
 - Main coordonne et Zeta valide
 
+## Règles Delta, intrigue et opérations clandestines
+- `LancerOperation` vérifie la disponibilité de la cellule, des agents assignés et des assets requis avant tout lancement
+- la `readiness` d'une opération baisse avec la difficulté, le risque de détection, l'alerte courante et l'exposition de la cellule
+- une cellule devient exposée dès qu'elle passe en état `compromised` ou que son exposition franchit le seuil critique métier
+- `NiveauAlerte` suit une échelle stable de `latent` à `verrouille`, avec une intensité de surveillance associée à chaque palier
+- côté UI, le niveau d'alerte peut être transformé en badge lisible avec texte, ton, couleur, emphase et tooltip
+- les tests Delta couvrent explicitement le risque de détection, l'exposition réseau et l'affichage du niveau d'alerte
+
 ## Règles du projet
 - pas de merge direct de feature sur `main`
 - chaque spécialiste travaille sur les issues de son domaine


### PR DESCRIPTION
Delta: Cette PR traite l'issue #80 en documentant les règles d'intrigue Delta dans le README.

## Contenu
- documentation du rôle de `LancerOperation` et des facteurs qui font varier la readiness
- rappel de la logique d'exposition réseau des cellules
- documentation de l'échelle `NiveauAlerte` et de son usage côté UI
- mention explicite des couvertures de tests déjà en place sur détection, exposition et affichage

## Vérification
- `npm test`

## Notes
- cette PR part de `main` et cible directement `main`
- je demanderai la validation de Zeta avant tout merge
