### PR TITLE
Alpha: [A14] Add in-memory faction state adapter

### DIFF
--- a/src/adapters/war/InMemoryFactionStateRepository.js
+++ b/src/adapters/war/InMemoryFactionStateRepository.js
@@ -1,0 +1,68 @@
+import { FactionStateRepository } from '../../application/war/FactionStateRepository.js';
+
+function normalizeFactionState(state) {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    throw new TypeError('InMemoryFactionStateRepository state must be a plain object.');
+  }
+
+  const factionId = String(state.factionId ?? '').trim();
+
+  if (!factionId) {
+    throw new RangeError('InMemoryFactionStateRepository factionId is required.');
+  }
+
+  const occupiedProvinceIds = Array.isArray(state.occupiedProvinceIds)
+    ? [...new Set(state.occupiedProvinceIds.map((provinceId) => String(provinceId ?? '').trim()))]
+    : [];
+
+  if (occupiedProvinceIds.some((provinceId) => provinceId.length === 0)) {
+    throw new RangeError('InMemoryFactionStateRepository occupiedProvinceIds cannot contain empty values.');
+  }
+
+  return {
+    ...state,
+    factionId,
+    occupiedProvinceIds: occupiedProvinceIds.sort(),
+  };
+}
+
+export class InMemoryFactionStateRepository extends FactionStateRepository {
+  constructor(states = []) {
+    super();
+    this.states = new Map();
+    this.seed(states);
+  }
+
+  seed(states) {
+    if (!Array.isArray(states)) {
+      throw new TypeError('InMemoryFactionStateRepository states must be an array.');
+    }
+
+    for (const state of states) {
+      const normalizedState = normalizeFactionState(state);
+      this.states.set(normalizedState.factionId, normalizedState);
+    }
+
+    return this;
+  }
+
+  async getFactionStateById(factionId) {
+    return this.states.get(String(factionId).trim()) ?? null;
+  }
+
+  async listFactionStates() {
+    return [...this.states.values()].sort((left, right) => left.factionId.localeCompare(right.factionId));
+  }
+
+  async saveFactionState(state) {
+    const normalizedState = normalizeFactionState(state);
+    this.states.set(normalizedState.factionId, normalizedState);
+    return normalizedState;
+  }
+
+  snapshot() {
+    return [...this.states.values()]
+      .sort((left, right) => left.factionId.localeCompare(right.factionId))
+      .map((state) => ({ ...state, occupiedProvinceIds: [...state.occupiedProvinceIds] }));
+  }
+}

--- a/test/adapters/war/InMemoryFactionStateRepository.test.js
+++ b/test/adapters/war/InMemoryFactionStateRepository.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryFactionStateRepository } from '../../../src/adapters/war/InMemoryFactionStateRepository.js';
+import { FactionStateRepository } from '../../../src/application/war/FactionStateRepository.js';
+
+test('InMemoryFactionStateRepository extends the port and normalizes seeded states', async () => {
+  const repository = new InMemoryFactionStateRepository([
+    {
+      factionId: ' faction-b ',
+      occupiedProvinceIds: ['prov-2', ' prov-1 ', 'prov-2'],
+      frontPressure: 12,
+    },
+  ]);
+
+  const state = await repository.requireFactionStateById('faction-b');
+
+  assert.equal(repository instanceof FactionStateRepository, true);
+  assert.deepEqual(state, {
+    factionId: 'faction-b',
+    occupiedProvinceIds: ['prov-1', 'prov-2'],
+    frontPressure: 12,
+  });
+});
+
+test('InMemoryFactionStateRepository lists states in stable order and persists updates', async () => {
+  const repository = new InMemoryFactionStateRepository([
+    { factionId: 'faction-c', occupiedProvinceIds: ['prov-4'] },
+  ]);
+
+  await repository.saveFactionState({
+    factionId: 'faction-a',
+    occupiedProvinceIds: ['prov-3', 'prov-1'],
+    supplyLevel: 'stable',
+  });
+
+  const stateIds = (await repository.listFactionStates()).map((state) => state.factionId);
+  assert.deepEqual(stateIds, ['faction-a', 'faction-c']);
+  assert.deepEqual(repository.snapshot(), [
+    {
+      factionId: 'faction-a',
+      occupiedProvinceIds: ['prov-1', 'prov-3'],
+      supplyLevel: 'stable',
+    },
+    {
+      factionId: 'faction-c',
+      occupiedProvinceIds: ['prov-4'],
+    },
+  ]);
+});
+
+test('InMemoryFactionStateRepository rejects invalid payloads', async () => {
+  assert.throws(() => new InMemoryFactionStateRepository(null), /states must be an array/);
+  assert.throws(() => new InMemoryFactionStateRepository([null]), /state must be a plain object/);
+
+  const repository = new InMemoryFactionStateRepository();
+
+  await assert.rejects(
+    () => repository.saveFactionState({ factionId: 'faction-a', occupiedProvinceIds: ['prov-1', '   '] }),
+    /occupiedProvinceIds cannot contain empty values/,
+  );
+});


### PR DESCRIPTION
Alpha: ## Summary
Alpha: Rebuild the in-memory faction state adapter PR directly from `main` so Alpha war work complies with the new non-stacked PR rule.
Alpha:
Alpha: ## Changes
Alpha: Add `InMemoryFactionStateRepository` as an adapter for the existing war repository port.
Alpha: Add tests for normalization, stable ordering, persistence, and invalid payload rejection.
Alpha:
Alpha: ## Testing
Alpha: - [x] `npm test`
Alpha:
Alpha: ## Notes
Alpha: This replaces the stacked Alpha A14 branch with a clean branch based on `main`.
