### PR TITLE
Beta: [B11] Create RouteRepository port

### DIFF
--- a/src/domain/economy/RouteRepositoryPort.js
+++ b/src/domain/economy/RouteRepositoryPort.js
@@ -1,0 +1,30 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+export class RouteRepositoryPort {
+  async getById(routeId) {
+    requireText(routeId, 'RouteRepositoryPort routeId');
+    throw new Error('RouteRepositoryPort.getById must be implemented by an adapter.');
+  }
+
+  async save(route) {
+    if (route === null || typeof route !== 'object' || Array.isArray(route)) {
+      throw new TypeError('RouteRepositoryPort route must be an object.');
+    }
+
+    requireText(route.id, 'RouteRepositoryPort route.id');
+    throw new Error('RouteRepositoryPort.save must be implemented by an adapter.');
+  }
+
+  async listByCity(cityId) {
+    requireText(cityId, 'RouteRepositoryPort cityId');
+    throw new Error('RouteRepositoryPort.listByCity must be implemented by an adapter.');
+  }
+}

--- a/test/domain/economy/RouteRepositoryPort.test.js
+++ b/test/domain/economy/RouteRepositoryPort.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { RouteRepositoryPort } from '../../../src/domain/economy/RouteRepositoryPort.js';
+
+test('RouteRepositoryPort validates identifiers before delegating to adapters', async () => {
+  const repository = new RouteRepositoryPort();
+
+  await assert.rejects(
+    () => repository.getById(''),
+    /RouteRepositoryPort routeId is required/,
+  );
+
+  await assert.rejects(
+    () => repository.listByCity(''),
+    /RouteRepositoryPort cityId is required/,
+  );
+});
+
+test('RouteRepositoryPort validates route payloads before save', async () => {
+  const repository = new RouteRepositoryPort();
+
+  await assert.rejects(
+    () => repository.save(null),
+    /RouteRepositoryPort route must be an object/,
+  );
+
+  await assert.rejects(
+    () => repository.save({ id: '   ' }),
+    /RouteRepositoryPort route.id is required/,
+  );
+});
+
+test('RouteRepositoryPort exposes explicit adapter implementation errors', async () => {
+  const repository = new RouteRepositoryPort();
+
+  await assert.rejects(
+    () => repository.getById('route-river'),
+    /RouteRepositoryPort.getById must be implemented by an adapter/,
+  );
+
+  await assert.rejects(
+    () => repository.save({ id: 'route-river' }),
+    /RouteRepositoryPort.save must be implemented by an adapter/,
+  );
+
+  await assert.rejects(
+    () => repository.listByCity('city-harbor'),
+    /RouteRepositoryPort.listByCity must be implemented by an adapter/,
+  );
+});


### PR DESCRIPTION
## Summary
- recreate the lost RouteRepository port work from closed PR #179 on a clean branch from `main`
- add the RouteRepository port definition
- add focused tests for the port contract

## Testing
- npm test

## Notes
- Beta: clean replacement for closed PR #179 because the earlier branch was closed without the code reaching `main`.
