### PR TITLE
Epsilon: [E10] Create ClimateRepositoryPort

### DIFF
--- a/src/application/ports/ClimateRepositoryPort.js
+++ b/src/application/ports/ClimateRepositoryPort.js
@@ -1,0 +1,35 @@
+import { ClimateState } from '../../domain/climate/ClimateState.js';
+
+function normalizeClimateState(state) {
+  if (state instanceof ClimateState) {
+    return state;
+  }
+
+  return new ClimateState(state);
+}
+
+export class ClimateRepositoryPort {
+  loadByRegionId(regionId) {
+    throw new Error(`ClimateRepositoryPort.loadByRegionId must be implemented for region ${regionId ?? 'unknown'}.`);
+  }
+
+  save(climateState) {
+    throw new Error(`ClimateRepositoryPort.save must be implemented for region ${climateState?.regionId ?? 'unknown'}.`);
+  }
+
+  loadMany(regionIds) {
+    if (!Array.isArray(regionIds)) {
+      throw new RangeError('ClimateRepositoryPort.loadMany regionIds must be an array.');
+    }
+
+    return regionIds.map((regionId) => this.loadByRegionId(regionId));
+  }
+
+  saveMany(climateStates) {
+    if (!Array.isArray(climateStates)) {
+      throw new RangeError('ClimateRepositoryPort.saveMany climateStates must be an array.');
+    }
+
+    return climateStates.map((state) => this.save(normalizeClimateState(state)));
+  }
+}

--- a/test/application/ports/ClimateRepositoryPort.test.js
+++ b/test/application/ports/ClimateRepositoryPort.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ClimateRepositoryPort } from '../../../src/application/ports/ClimateRepositoryPort.js';
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+
+class InMemoryClimateRepository extends ClimateRepositoryPort {
+  constructor(seed = []) {
+    super();
+    this.states = new Map(seed.map((state) => [state.regionId, state]));
+  }
+
+  loadByRegionId(regionId) {
+    return this.states.get(regionId) ?? null;
+  }
+
+  save(climateState) {
+    this.states.set(climateState.regionId, climateState);
+    return climateState;
+  }
+}
+
+test('ClimateRepositoryPort provides batch helpers around region-based operations', () => {
+  const repository = new InMemoryClimateRepository([
+    new ClimateState({
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 66,
+      droughtIndex: 18,
+    }),
+  ]);
+
+  const loaded = repository.loadMany(['north-coast', 'sunreach']);
+
+  assert.equal(loaded[0].regionId, 'north-coast');
+  assert.equal(loaded[1], null);
+
+  const saved = repository.saveMany([
+    {
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 33,
+      precipitationLevel: 24,
+      droughtIndex: 58,
+      anomaly: 'heatwave',
+    },
+  ]);
+
+  assert.equal(saved[0].regionId, 'sunreach');
+  assert.equal(repository.loadByRegionId('sunreach').anomaly, 'heatwave');
+});
+
+test('ClimateRepositoryPort exposes clear errors for missing implementations and invalid batches', () => {
+  const repository = new ClimateRepositoryPort();
+
+  assert.throws(
+    () => repository.loadByRegionId('north-coast'),
+    /loadByRegionId must be implemented/,
+  );
+
+  assert.throws(
+    () => repository.save(new ClimateState({
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 66,
+      droughtIndex: 18,
+    })),
+    /save must be implemented/,
+  );
+
+  assert.throws(
+    () => repository.loadMany(null),
+    /regionIds must be an array/,
+  );
+
+  assert.throws(
+    () => repository.saveMany(null),
+    /climateStates must be an array/,
+  );
+});


### PR DESCRIPTION
## Summary
- recreate the lost ClimateRepositoryPort work from closed PR #185 on a clean branch from `main`
- add the ClimateRepositoryPort definition
- add focused tests for the port contract

## Testing
- npm test

## Notes
- Epsilon: clean replacement for closed PR #185 because the earlier branch was closed without the code reaching `main`.
