### PR TITLE
Gamma: [G18] Add tests for cultural drift

### DIFF
--- a/src/application/culture/evaluateCulturalDrift.js
+++ b/src/application/culture/evaluateCulturalDrift.js
@@ -1,0 +1,110 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireFiniteNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new RangeError(`${label} must be a finite number.`);
+  }
+
+  return value;
+}
+
+function normalizeNumericMap(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, amount]) => [
+      requireText(key, `${label} key`),
+      requireFiniteNumber(amount, `${label}.${key}`),
+    ]),
+  );
+}
+
+function normalizeCultureState(cultureState) {
+  if (!cultureState || typeof cultureState !== 'object' || Array.isArray(cultureState)) {
+    throw new TypeError('evaluateCulturalDrift cultureState must be an object.');
+  }
+
+  return {
+    ...cultureState,
+    id: requireText(cultureState.id, 'evaluateCulturalDrift cultureState.id'),
+    cultureId: requireText(cultureState.cultureId, 'evaluateCulturalDrift cultureState.cultureId'),
+    stability: requireFiniteNumber(
+      cultureState.stability ?? 0,
+      'evaluateCulturalDrift cultureState.stability',
+    ),
+    values: normalizeNumericMap(
+      cultureState.values ?? {},
+      'evaluateCulturalDrift cultureState.values',
+    ),
+  };
+}
+
+function normalizeDriftInputs(driftInputs) {
+  if (!driftInputs || typeof driftInputs !== 'object' || Array.isArray(driftInputs)) {
+    throw new TypeError('evaluateCulturalDrift driftInputs must be an object.');
+  }
+
+  return {
+    pressure: normalizeNumericMap(
+      driftInputs.pressure ?? {},
+      'evaluateCulturalDrift driftInputs.pressure',
+    ),
+    contact: normalizeNumericMap(
+      driftInputs.contact ?? {},
+      'evaluateCulturalDrift driftInputs.contact',
+    ),
+    resilience: requireFiniteNumber(
+      driftInputs.resilience ?? 0,
+      'evaluateCulturalDrift driftInputs.resilience',
+    ),
+  };
+}
+
+function roundToThreeDecimals(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+export function evaluateCulturalDrift(cultureState, driftInputs) {
+  const normalizedCultureState = normalizeCultureState(cultureState);
+  const normalizedDriftInputs = normalizeDriftInputs(driftInputs);
+
+  const nextValues = { ...normalizedCultureState.values };
+  const appliedDrift = {};
+  const allAxes = new Set([
+    ...Object.keys(normalizedCultureState.values),
+    ...Object.keys(normalizedDriftInputs.pressure),
+    ...Object.keys(normalizedDriftInputs.contact),
+  ]);
+
+  for (const axis of allAxes) {
+    const currentValue = normalizedCultureState.values[axis] ?? 0;
+    const pressureDelta = normalizedDriftInputs.pressure[axis] ?? 0;
+    const contactDelta = normalizedDriftInputs.contact[axis] ?? 0;
+    const driftDelta = roundToThreeDecimals(
+      pressureDelta + contactDelta - normalizedDriftInputs.resilience,
+    );
+
+    nextValues[axis] = roundToThreeDecimals(currentValue + driftDelta);
+    appliedDrift[axis] = driftDelta;
+  }
+
+  const totalDrift = Object.values(appliedDrift).reduce((sum, value) => sum + Math.abs(value), 0);
+  const nextStability = roundToThreeDecimals(normalizedCultureState.stability - totalDrift * 0.1);
+
+  return {
+    ...normalizedCultureState,
+    values: nextValues,
+    appliedDrift,
+    stability: nextStability,
+  };
+}

--- a/test/application/culture/evaluateCulturalDrift.test.js
+++ b/test/application/culture/evaluateCulturalDrift.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evaluateCulturalDrift } from '../../../src/application/culture/evaluateCulturalDrift.js';
+
+test('evaluateCulturalDrift combines pressure and contact into cultural drift', () => {
+  const result = evaluateCulturalDrift(
+    {
+      id: 'culture-state-north',
+      cultureId: 'culture-north',
+      stability: 12,
+      values: {
+        tradition: 5,
+        openness: 2,
+      },
+    },
+    {
+      pressure: {
+        tradition: -0.4,
+        openness: 0.3,
+      },
+      contact: {
+        openness: 0.5,
+        scholarship: 0.2,
+      },
+      resilience: 0.1,
+    },
+  );
+
+  assert.deepEqual(result.values, {
+    tradition: 4.5,
+    openness: 2.7,
+    scholarship: 0.1,
+  });
+  assert.deepEqual(result.appliedDrift, {
+    tradition: -0.5,
+    openness: 0.7,
+    scholarship: 0.1,
+  });
+  assert.equal(result.stability, 11.87);
+});
+
+test('evaluateCulturalDrift handles resilient cultures with no net change', () => {
+  const result = evaluateCulturalDrift(
+    {
+      id: 'culture-state-east',
+      cultureId: 'culture-east',
+      stability: 9,
+      values: {
+        ritual: 3,
+      },
+    },
+    {
+      pressure: {
+        ritual: 0.2,
+      },
+      contact: {
+        ritual: 0.1,
+      },
+      resilience: 0.3,
+    },
+  );
+
+  assert.deepEqual(result.values, { ritual: 3 });
+  assert.deepEqual(result.appliedDrift, { ritual: 0 });
+  assert.equal(result.stability, 9);
+});
+
+test('evaluateCulturalDrift rejects invalid culture states and drift inputs', () => {
+  assert.throws(
+    () => evaluateCulturalDrift(null, {}),
+    /evaluateCulturalDrift cultureState must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      evaluateCulturalDrift(
+        {
+          id: 'culture-state-south',
+          cultureId: 'culture-south',
+          stability: 'high',
+          values: {},
+        },
+        { pressure: {}, contact: {}, resilience: 0 },
+      ),
+    /evaluateCulturalDrift cultureState.stability must be a finite number/,
+  );
+
+  assert.throws(
+    () =>
+      evaluateCulturalDrift(
+        {
+          id: 'culture-state-south',
+          cultureId: 'culture-south',
+          stability: 8,
+          values: { ritual: 2 },
+        },
+        { pressure: { ritual: '0.2' }, contact: {}, resilience: 0 },
+      ),
+    /evaluateCulturalDrift driftInputs.pressure.ritual must be a finite number/,
+  );
+});


### PR DESCRIPTION
## Summary
- recreate the lost cultural drift test work from closed PR #187 on a clean branch from `main`
- restore the focused evaluateCulturalDrift test coverage
- keep the package metadata aligned with current `main`

## Testing
- npm test

## Notes
- Gamma: clean replacement for closed PR #187 because the earlier branch was closed without the code reaching `main`.
