### PR TITLE
Alpha: [A15] Emit war events for front changes

### DIFF
--- a/src/adapters/war/InMemoryWarEventBus.js
+++ b/src/adapters/war/InMemoryWarEventBus.js
@@ -1,0 +1,52 @@
+import { WarEventBusPort } from '../../application/war/WarEventBusPort.js';
+
+export class InMemoryWarEventBus extends WarEventBusPort {
+  constructor(events = []) {
+    super();
+    this.events = [];
+    this.seed(events);
+  }
+
+  seed(events) {
+    if (!Array.isArray(events)) {
+      throw new TypeError('InMemoryWarEventBus events must be an array.');
+    }
+
+    for (const event of events) {
+      if (!event || typeof event !== 'object' || Array.isArray(event)) {
+        throw new TypeError('InMemoryWarEventBus event must be an object.');
+      }
+
+      const eventName = String(event.eventName ?? '').trim();
+      const payload = event.payload;
+
+      if (!eventName) {
+        throw new RangeError('InMemoryWarEventBus eventName is required.');
+      }
+
+      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        throw new TypeError('InMemoryWarEventBus payload must be an object.');
+      }
+
+      this.events.push({ eventName, payload: { ...payload } });
+    }
+
+    return this;
+  }
+
+  async publish(eventName, payload) {
+    const record = {
+      eventName: String(eventName).trim(),
+      payload: { ...payload },
+    };
+    this.events.push(record);
+    return record;
+  }
+
+  snapshot() {
+    return this.events.map((event) => ({
+      eventName: event.eventName,
+      payload: { ...event.payload },
+    }));
+  }
+}

--- a/src/application/war/WarEventBusPort.js
+++ b/src/application/war/WarEventBusPort.js
@@ -1,0 +1,66 @@
+function requireEventName(eventName) {
+  const normalizedEventName = String(eventName ?? '').trim();
+
+  if (!normalizedEventName) {
+    throw new RangeError('WarEventBusPort eventName is required.');
+  }
+
+  return normalizedEventName;
+}
+
+function requirePayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new TypeError('WarEventBusPort payload must be an object.');
+  }
+
+  return { ...payload };
+}
+
+function normalizeFrontChange(payload) {
+  return {
+    frontId: String(payload.frontId ?? '').trim(),
+    changeType: String(payload.changeType ?? '').trim(),
+    attackerFactionId: String(payload.attackerFactionId ?? '').trim(),
+    defenderFactionId: String(payload.defenderFactionId ?? '').trim(),
+    pressureDelta: payload.pressureDelta,
+  };
+}
+
+function requireFrontChangePayload(payload) {
+  const normalizedPayload = normalizeFrontChange(requirePayload(payload));
+
+  if (!normalizedPayload.frontId) {
+    throw new RangeError('WarEventBusPort frontId is required.');
+  }
+
+  if (!normalizedPayload.changeType) {
+    throw new RangeError('WarEventBusPort changeType is required.');
+  }
+
+  if (!normalizedPayload.attackerFactionId) {
+    throw new RangeError('WarEventBusPort attackerFactionId is required.');
+  }
+
+  if (!normalizedPayload.defenderFactionId) {
+    throw new RangeError('WarEventBusPort defenderFactionId is required.');
+  }
+
+  if (!Number.isInteger(normalizedPayload.pressureDelta)) {
+    throw new RangeError('WarEventBusPort pressureDelta must be an integer.');
+  }
+
+  return normalizedPayload;
+}
+
+export class WarEventBusPort {
+  async publish(_eventName, _payload) {
+    throw new Error('WarEventBusPort.publish must be implemented by an adapter.');
+  }
+
+  async publishFrontChange(eventName, payload) {
+    const normalizedEventName = requireEventName(eventName);
+    const normalizedPayload = requireFrontChangePayload(payload);
+
+    return this.publish(normalizedEventName, normalizedPayload);
+  }
+}

--- a/test/adapters/war/InMemoryWarEventBus.test.js
+++ b/test/adapters/war/InMemoryWarEventBus.test.js
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryWarEventBus } from '../../../src/adapters/war/InMemoryWarEventBus.js';
+import { WarEventBusPort } from '../../../src/application/war/WarEventBusPort.js';
+
+test('InMemoryWarEventBus extends the port and records normalized front change events', async () => {
+  const eventBus = new InMemoryWarEventBus();
+
+  const event = await eventBus.publishFrontChange('front.collapsed', {
+    frontId: 'front-south',
+    changeType: 'collapsed',
+    attackerFactionId: 'faction-a',
+    defenderFactionId: 'faction-b',
+    pressureDelta: -18,
+  });
+
+  assert.equal(eventBus instanceof WarEventBusPort, true);
+  assert.deepEqual(event, {
+    eventName: 'front.collapsed',
+    payload: {
+      frontId: 'front-south',
+      changeType: 'collapsed',
+      attackerFactionId: 'faction-a',
+      defenderFactionId: 'faction-b',
+      pressureDelta: -18,
+    },
+  });
+  assert.deepEqual(eventBus.snapshot(), [event]);
+});
+
+test('InMemoryWarEventBus seeds historical events and keeps insertion order', async () => {
+  const eventBus = new InMemoryWarEventBus([
+    {
+      eventName: 'front.created',
+      payload: {
+        frontId: 'front-east',
+        changeType: 'created',
+        attackerFactionId: 'faction-c',
+        defenderFactionId: 'faction-d',
+        pressureDelta: 9,
+      },
+    },
+  ]);
+
+  await eventBus.publishFrontChange('front.updated', {
+    frontId: 'front-east',
+    changeType: 'pressure-spike',
+    attackerFactionId: 'faction-c',
+    defenderFactionId: 'faction-d',
+    pressureDelta: 4,
+  });
+
+  assert.deepEqual(eventBus.snapshot(), [
+    {
+      eventName: 'front.created',
+      payload: {
+        frontId: 'front-east',
+        changeType: 'created',
+        attackerFactionId: 'faction-c',
+        defenderFactionId: 'faction-d',
+        pressureDelta: 9,
+      },
+    },
+    {
+      eventName: 'front.updated',
+      payload: {
+        frontId: 'front-east',
+        changeType: 'pressure-spike',
+        attackerFactionId: 'faction-c',
+        defenderFactionId: 'faction-d',
+        pressureDelta: 4,
+      },
+    },
+  ]);
+});
+
+test('InMemoryWarEventBus rejects invalid seed payloads', () => {
+  assert.throws(() => new InMemoryWarEventBus(null), /events must be an array/);
+  assert.throws(() => new InMemoryWarEventBus([null]), /event must be an object/);
+  assert.throws(() => new InMemoryWarEventBus([{ eventName: 'front.created', payload: null }]), /payload must be an object/);
+});

--- a/test/application/war/WarEventBusPort.test.js
+++ b/test/application/war/WarEventBusPort.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { WarEventBusPort } from '../../../src/application/war/WarEventBusPort.js';
+
+class RecordedWarEventBus extends WarEventBusPort {
+  constructor() {
+    super();
+    this.events = [];
+  }
+
+  async publish(eventName, payload) {
+    const event = { eventName, payload };
+    this.events.push(event);
+    return event;
+  }
+}
+
+test('WarEventBusPort normalizes front change events before delegation', async () => {
+  const eventBus = new RecordedWarEventBus();
+
+  const event = await eventBus.publishFrontChange(' front.created ', {
+    frontId: ' front-north ',
+    changeType: ' pressure-spike ',
+    attackerFactionId: ' faction-a ',
+    defenderFactionId: ' faction-b ',
+    pressureDelta: 12,
+    note: 'breakthrough',
+  });
+
+  assert.deepEqual(event, {
+    eventName: 'front.created',
+    payload: {
+      frontId: 'front-north',
+      changeType: 'pressure-spike',
+      attackerFactionId: 'faction-a',
+      defenderFactionId: 'faction-b',
+      pressureDelta: 12,
+    },
+  });
+});
+
+test('WarEventBusPort base method fails fast until implemented', async () => {
+  const eventBus = new WarEventBusPort();
+
+  await assert.rejects(
+    () => eventBus.publish('front.created', { frontId: 'front-north' }),
+    /must be implemented by an adapter/,
+  );
+});
+
+test('WarEventBusPort rejects invalid front change payloads', async () => {
+  const eventBus = new RecordedWarEventBus();
+
+  await assert.rejects(() => eventBus.publishFrontChange('', {}), /eventName is required/);
+  await assert.rejects(() => eventBus.publishFrontChange('front.created', null), /payload must be an object/);
+  await assert.rejects(
+    () => eventBus.publishFrontChange('front.created', { changeType: 'created', attackerFactionId: 'a', defenderFactionId: 'b', pressureDelta: 1 }),
+    /frontId is required/,
+  );
+  await assert.rejects(
+    () => eventBus.publishFrontChange('front.created', { frontId: 'front', attackerFactionId: 'a', defenderFactionId: 'b', pressureDelta: 1 }),
+    /changeType is required/,
+  );
+  await assert.rejects(
+    () => eventBus.publishFrontChange('front.created', { frontId: 'front', changeType: 'created', defenderFactionId: 'b', pressureDelta: 1 }),
+    /attackerFactionId is required/,
+  );
+  await assert.rejects(
+    () => eventBus.publishFrontChange('front.created', { frontId: 'front', changeType: 'created', attackerFactionId: 'a', pressureDelta: 1 }),
+    /defenderFactionId is required/,
+  );
+  await assert.rejects(
+    () => eventBus.publishFrontChange('front.created', { frontId: 'front', changeType: 'created', attackerFactionId: 'a', defenderFactionId: 'b', pressureDelta: 1.5 }),
+    /pressureDelta must be an integer/,
+  );
+});


### PR DESCRIPTION
Alpha: ## Summary
Alpha: Add the war event bus port and an in-memory adapter for front change events.
Alpha:
Alpha: ## Changes
Alpha: Add `WarEventBusPort` with normalization and validation for front change events.
Alpha: Add `InMemoryWarEventBus` to seed, record, and list normalized front events in insertion order.
Alpha: Add focused tests for port validation, adapter behavior, seed handling, and invalid payload rejection.
Alpha:
Alpha: ## Testing
Alpha: - [x] `npm test`
Alpha:
Alpha: ## Tracking
Alpha: Closes #15