### PR TITLE
Alpha: [A18] Render contested borders in UI

### DIFF
--- a/src/domain/war/buildContestedBorderOverlay.js
+++ b/src/domain/war/buildContestedBorderOverlay.js
@@ -1,0 +1,43 @@
+import { BorderSegment } from './BorderSegment.js';
+
+function requireSegment(segment) {
+  if (!(segment instanceof BorderSegment)) {
+    throw new TypeError('buildContestedBorderOverlay segments must be BorderSegment instances.');
+  }
+
+  return segment;
+}
+
+function normalizeStyle(styleByTerrain, terrainType) {
+  const terrainStyle = styleByTerrain[terrainType] ?? styleByTerrain.default ?? {};
+
+  return {
+    stroke: String(terrainStyle.stroke ?? 'amber').trim() || 'amber',
+    width: Number.isInteger(terrainStyle.width) && terrainStyle.width > 0 ? terrainStyle.width : 2,
+    pattern: String(terrainStyle.pattern ?? 'solid').trim() || 'solid',
+  };
+}
+
+export function buildContestedBorderOverlay(segments, styleByTerrain = {}) {
+  if (!Array.isArray(segments)) {
+    throw new TypeError('buildContestedBorderOverlay segments must be an array.');
+  }
+
+  if (!styleByTerrain || typeof styleByTerrain !== 'object' || Array.isArray(styleByTerrain)) {
+    throw new TypeError('buildContestedBorderOverlay styleByTerrain must be an object.');
+  }
+
+  return segments
+    .map(requireSegment)
+    .filter((segment) => segment.contested)
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((segment) => ({
+      segmentId: segment.id,
+      provinces: [segment.provinceAId, segment.provinceBId],
+      pressure: segment.pressure,
+      dominantProvinceId: segment.dominantProvinceId,
+      terrainType: segment.terrainType,
+      chokepoint: segment.chokepoint,
+      style: normalizeStyle(styleByTerrain, segment.terrainType),
+    }));
+}

--- a/test/domain/war/buildContestedBorderOverlay.test.js
+++ b/test/domain/war/buildContestedBorderOverlay.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BorderSegment } from '../../../src/domain/war/BorderSegment.js';
+import { buildContestedBorderOverlay } from '../../../src/domain/war/buildContestedBorderOverlay.js';
+
+function createSegment(overrides = {}) {
+  return new BorderSegment({
+    provinceAId: 'prov-a',
+    provinceBId: 'prov-b',
+    terrainType: 'plain',
+    pressure: 0,
+    contested: false,
+    ...overrides,
+  });
+}
+
+test('buildContestedBorderOverlay keeps only contested borders and derives stable overlay entries', () => {
+  const overlay = buildContestedBorderOverlay([
+    createSegment({ provinceAId: 'prov-c', provinceBId: 'prov-d', contested: true, pressure: -8, terrainType: 'river' }),
+    createSegment({ provinceAId: 'prov-a', provinceBId: 'prov-b', contested: false, pressure: 0 }),
+    createSegment({ provinceAId: 'prov-e', provinceBId: 'prov-f', contested: true, pressure: 14, chokepoint: true }),
+  ]);
+
+  assert.deepEqual(overlay, [
+    {
+      segmentId: 'prov-c::prov-d',
+      provinces: ['prov-c', 'prov-d'],
+      pressure: -8,
+      dominantProvinceId: 'prov-d',
+      terrainType: 'river',
+      chokepoint: false,
+      style: {
+        stroke: 'amber',
+        width: 2,
+        pattern: 'solid',
+      },
+    },
+    {
+      segmentId: 'prov-e::prov-f',
+      provinces: ['prov-e', 'prov-f'],
+      pressure: 14,
+      dominantProvinceId: 'prov-e',
+      terrainType: 'plain',
+      chokepoint: true,
+      style: {
+        stroke: 'amber',
+        width: 2,
+        pattern: 'solid',
+      },
+    },
+  ]);
+});
+
+test('buildContestedBorderOverlay applies terrain-specific style overrides', () => {
+  const overlay = buildContestedBorderOverlay(
+    [createSegment({ contested: true, terrainType: 'river', pressure: 9 })],
+    {
+      river: { stroke: 'blue', width: 3, pattern: 'dashed' },
+      default: { stroke: 'red', width: 1, pattern: 'solid' },
+    },
+  );
+
+  assert.deepEqual(overlay[0].style, {
+    stroke: 'blue',
+    width: 3,
+    pattern: 'dashed',
+  });
+});
+
+test('buildContestedBorderOverlay rejects invalid inputs', () => {
+  assert.throws(() => buildContestedBorderOverlay(null), /segments must be an array/);
+  assert.throws(() => buildContestedBorderOverlay([{}]), /segments must be BorderSegment instances/);
+  assert.throws(() => buildContestedBorderOverlay([], []), /styleByTerrain must be an object/);
+});


### PR DESCRIPTION
Alpha: ## Summary
Alpha: Add a reusable overlay builder for contested borders so UI integration can stay deterministic and small.
Alpha:
Alpha: ## Changes
Alpha: Add `buildContestedBorderOverlay` to derive render-ready entries from contested `BorderSegment` instances.
Alpha: Support terrain-specific style overrides while keeping a stable default overlay format.
Alpha: Add focused tests for contested filtering, style overrides, stable output, and invalid inputs.
Alpha:
Alpha: ## Testing
Alpha: - [x] `npm test`
Alpha:
Alpha: ## Tracking
Alpha: Closes #18
