### PR TITLE
Alpha: [A19] Render front pressure indicators

### DIFF
--- a/src/domain/war/buildFrontPressureIndicators.js
+++ b/src/domain/war/buildFrontPressureIndicators.js
@@ -1,0 +1,99 @@
+import { BorderSegment } from './BorderSegment.js';
+
+function requireSegment(segment) {
+  if (!(segment instanceof BorderSegment)) {
+    throw new TypeError('buildFrontPressureIndicators segments must be BorderSegment instances.');
+  }
+
+  return segment;
+}
+
+function normalizeThreshold(value, fallback, label) {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!Number.isInteger(value) || value < 1 || value > 100) {
+    throw new RangeError(`${label} must be an integer between 1 and 100.`);
+  }
+
+  return value;
+}
+
+function normalizeOptions(options) {
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    throw new TypeError('buildFrontPressureIndicators options must be an object.');
+  }
+
+  const mediumThreshold = normalizeThreshold(options.mediumThreshold, 25, 'buildFrontPressureIndicators mediumThreshold');
+  const highThreshold = normalizeThreshold(options.highThreshold, 60, 'buildFrontPressureIndicators highThreshold');
+
+  if (mediumThreshold >= highThreshold) {
+    throw new RangeError('buildFrontPressureIndicators mediumThreshold must be lower than highThreshold.');
+  }
+
+  const appearanceByIntensity = options.appearanceByIntensity ?? {};
+
+  if (!appearanceByIntensity || typeof appearanceByIntensity !== 'object' || Array.isArray(appearanceByIntensity)) {
+    throw new TypeError('buildFrontPressureIndicators appearanceByIntensity must be an object.');
+  }
+
+  return {
+    mediumThreshold,
+    highThreshold,
+    appearanceByIntensity,
+  };
+}
+
+function getIntensity(pressureValue, thresholds) {
+  if (pressureValue >= thresholds.highThreshold) {
+    return 'high';
+  }
+
+  if (pressureValue >= thresholds.mediumThreshold) {
+    return 'medium';
+  }
+
+  return 'low';
+}
+
+function normalizeAppearance(appearanceByIntensity, intensity) {
+  const appearance = appearanceByIntensity[intensity] ?? {};
+
+  return {
+    icon: String(appearance.icon ?? 'pressure').trim() || 'pressure',
+    color: String(appearance.color ?? 'amber').trim() || 'amber',
+    scale: Number.isInteger(appearance.scale) && appearance.scale > 0 ? appearance.scale : 1,
+  };
+}
+
+export function buildFrontPressureIndicators(segments, options = {}) {
+  if (!Array.isArray(segments)) {
+    throw new TypeError('buildFrontPressureIndicators segments must be an array.');
+  }
+
+  const normalizedOptions = normalizeOptions(options);
+
+  return segments
+    .map(requireSegment)
+    .filter((segment) => segment.pressure !== 0)
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((segment) => {
+      const pressureValue = Math.abs(segment.pressure);
+      const intensity = getIntensity(pressureValue, normalizedOptions);
+
+      return {
+        segmentId: segment.id,
+        provinces: [segment.provinceAId, segment.provinceBId],
+        dominantProvinceId: segment.dominantProvinceId,
+        pressure: segment.pressure,
+        pressureValue,
+        intensity,
+        anchor: {
+          position: segment.position,
+          length: segment.length,
+        },
+        appearance: normalizeAppearance(normalizedOptions.appearanceByIntensity, intensity),
+      };
+    });
+}

--- a/test/domain/war/buildFrontPressureIndicators.test.js
+++ b/test/domain/war/buildFrontPressureIndicators.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BorderSegment } from '../../../src/domain/war/BorderSegment.js';
+import { buildFrontPressureIndicators } from '../../../src/domain/war/buildFrontPressureIndicators.js';
+
+function createSegment(overrides = {}) {
+  return new BorderSegment({
+    provinceAId: 'prov-a',
+    provinceBId: 'prov-b',
+    terrainType: 'plain',
+    pressure: 0,
+    contested: false,
+    length: 2,
+    position: 1,
+    ...overrides,
+  });
+}
+
+test('buildFrontPressureIndicators derives stable indicators for pressured borders', () => {
+  const indicators = buildFrontPressureIndicators([
+    createSegment({ provinceAId: 'prov-c', provinceBId: 'prov-d', pressure: -12, position: 4, length: 3 }),
+    createSegment({ provinceAId: 'prov-a', provinceBId: 'prov-b', pressure: 0 }),
+    createSegment({ provinceAId: 'prov-e', provinceBId: 'prov-f', pressure: 71, chokepoint: true, position: 8, length: 1 }),
+  ]);
+
+  assert.deepEqual(indicators, [
+    {
+      segmentId: 'prov-c::prov-d',
+      provinces: ['prov-c', 'prov-d'],
+      dominantProvinceId: 'prov-d',
+      pressure: -12,
+      pressureValue: 12,
+      intensity: 'low',
+      anchor: {
+        position: 4,
+        length: 3,
+      },
+      appearance: {
+        icon: 'pressure',
+        color: 'amber',
+        scale: 1,
+      },
+    },
+    {
+      segmentId: 'prov-e::prov-f',
+      provinces: ['prov-e', 'prov-f'],
+      dominantProvinceId: 'prov-e',
+      pressure: 71,
+      pressureValue: 71,
+      intensity: 'high',
+      anchor: {
+        position: 8,
+        length: 1,
+      },
+      appearance: {
+        icon: 'pressure',
+        color: 'amber',
+        scale: 1,
+      },
+    },
+  ]);
+});
+
+test('buildFrontPressureIndicators supports configurable thresholds and appearance', () => {
+  const indicators = buildFrontPressureIndicators(
+    [
+      createSegment({ pressure: 18 }),
+      createSegment({ provinceAId: 'prov-c', provinceBId: 'prov-d', pressure: 44 }),
+    ],
+    {
+      mediumThreshold: 15,
+      highThreshold: 40,
+      appearanceByIntensity: {
+        medium: { icon: 'chevrons', color: 'orange', scale: 2 },
+        high: { icon: 'burst', color: 'red', scale: 3 },
+      },
+    },
+  );
+
+  assert.equal(indicators[0].intensity, 'medium');
+  assert.deepEqual(indicators[0].appearance, {
+    icon: 'chevrons',
+    color: 'orange',
+    scale: 2,
+  });
+
+  assert.equal(indicators[1].intensity, 'high');
+  assert.deepEqual(indicators[1].appearance, {
+    icon: 'burst',
+    color: 'red',
+    scale: 3,
+  });
+});
+
+test('buildFrontPressureIndicators rejects invalid inputs', () => {
+  assert.throws(() => buildFrontPressureIndicators(null), /segments must be an array/);
+  assert.throws(() => buildFrontPressureIndicators([{}]), /segments must be BorderSegment instances/);
+  assert.throws(() => buildFrontPressureIndicators([], []), /options must be an object/);
+  assert.throws(() => buildFrontPressureIndicators([], { mediumThreshold: 0 }), /mediumThreshold must be an integer between 1 and 100/);
+  assert.throws(() => buildFrontPressureIndicators([], { mediumThreshold: 50, highThreshold: 40 }), /mediumThreshold must be lower than highThreshold/);
+});


### PR DESCRIPTION
Alpha: ## Summary
Alpha: Add a reusable builder for front pressure indicators so UI integration can expose border pressure cleanly.
Alpha:
Alpha: ## Changes
Alpha: Add `buildFrontPressureIndicators` to derive render-ready pressure markers from `BorderSegment` instances.
Alpha: Support configurable intensity thresholds and appearance overrides while keeping a stable default format.
Alpha: Add focused tests for stable output, threshold mapping, custom appearance, and invalid inputs.
Alpha:
Alpha: ## Testing
Alpha: - [x] `npm test`
Alpha:
Alpha: ## Tracking
Alpha: Closes #19
