### PR TITLE
Gamma: [G06] Implement EvolveCulture use case

### DIFF
--- a/src/application/culture/evolveCulture.js
+++ b/src/application/culture/evolveCulture.js
@@ -1,0 +1,109 @@
+import { Culture } from '../../domain/culture/Culture.js';
+import { evaluateCulturalDrift } from './evaluateCulturalDrift.js';
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => requireText(value, label)))];
+  return normalizedValues.sort();
+}
+
+function clampScore(value) {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function normalizeEvolutionInputs(evolutionInputs) {
+  if (!evolutionInputs || typeof evolutionInputs !== 'object' || Array.isArray(evolutionInputs)) {
+    throw new TypeError('evolveCulture evolutionInputs must be an object.');
+  }
+
+  return {
+    driftInputs: evolutionInputs.driftInputs ?? {},
+    adoptedValueIds: normalizeUniqueTexts(
+      evolutionInputs.adoptedValueIds ?? [],
+      'evolveCulture evolutionInputs.adoptedValueIds',
+    ),
+    retiredTraditionIds: normalizeUniqueTexts(
+      evolutionInputs.retiredTraditionIds ?? [],
+      'evolveCulture evolutionInputs.retiredTraditionIds',
+    ),
+    emergentTraditionIds: normalizeUniqueTexts(
+      evolutionInputs.emergentTraditionIds ?? [],
+      'evolveCulture evolutionInputs.emergentTraditionIds',
+    ),
+    evolvedAt: evolutionInputs.evolvedAt ?? new Date(),
+  };
+}
+
+function mergeValueIds(culture, adoptedValueIds, drift) {
+  const merged = new Set(culture.valueIds);
+
+  for (const valueId of adoptedValueIds) {
+    merged.add(valueId);
+  }
+
+  if ((drift.values.openness ?? 0) >= 60) {
+    merged.add('exchange');
+  }
+
+  if ((drift.values.researchDrive ?? 0) >= 60) {
+    merged.add('innovation');
+  }
+
+  if ((drift.values.cohesion ?? 0) >= 60) {
+    merged.add('continuity');
+  }
+
+  return [...merged].sort();
+}
+
+function evolveTraditions(culture, retiredTraditionIds, emergentTraditionIds) {
+  const retired = new Set(retiredTraditionIds);
+  const nextTraditions = culture.traditionIds.filter((traditionId) => !retired.has(traditionId));
+
+  return [...new Set([...nextTraditions, ...emergentTraditionIds])].sort();
+}
+
+export function evolveCulture(cultureState, evolutionInputs) {
+  const culture = cultureState instanceof Culture ? cultureState : new Culture(cultureState);
+  const normalizedEvolutionInputs = normalizeEvolutionInputs(evolutionInputs);
+
+  const drift = evaluateCulturalDrift(
+    {
+      id: `${culture.id}-drift`,
+      cultureId: culture.id,
+      stability: culture.cohesion,
+      values: {
+        openness: culture.openness,
+        cohesion: culture.cohesion,
+        researchDrive: culture.researchDrive,
+      },
+    },
+    normalizedEvolutionInputs.driftInputs,
+  );
+
+  return culture.withEvolution({
+    openness: clampScore(drift.values.openness ?? culture.openness),
+    cohesion: clampScore(drift.stability),
+    researchDrive: clampScore(drift.values.researchDrive ?? culture.researchDrive),
+    valueIds: mergeValueIds(culture, normalizedEvolutionInputs.adoptedValueIds, drift),
+    traditionIds: evolveTraditions(
+      culture,
+      normalizedEvolutionInputs.retiredTraditionIds,
+      normalizedEvolutionInputs.emergentTraditionIds,
+    ),
+    lastEvolvedAt: normalizedEvolutionInputs.evolvedAt,
+  });
+}

--- a/test/application/culture/evolveCulture.test.js
+++ b/test/application/culture/evolveCulture.test.js
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evolveCulture } from '../../../src/application/culture/evolveCulture.js';
+import { Culture } from '../../../src/domain/culture/Culture.js';
+
+test('evolveCulture updates culture scores and traditions immutably from drift inputs', () => {
+  const culture = new Culture({
+    id: 'culture-aurora',
+    name: 'Aurora Compact',
+    archetype: 'mercantile',
+    primaryLanguage: 'trade-speech',
+    valueIds: ['craft'],
+    traditionIds: ['harvest-song', 'harbor-oath'],
+    openness: 54,
+    cohesion: 58,
+    researchDrive: 57,
+  });
+
+  const evolvedCulture = evolveCulture(culture, {
+    driftInputs: {
+      pressure: {
+        openness: 6,
+        researchDrive: 5,
+        cohesion: -1,
+      },
+      contact: {
+        openness: 3,
+        researchDrive: 2,
+      },
+      resilience: 1,
+    },
+    adoptedValueIds: ['seafaring'],
+    retiredTraditionIds: ['harbor-oath'],
+    emergentTraditionIds: ['river-moot'],
+    evolvedAt: '2026-04-18T17:00:00.000Z',
+  });
+
+  assert.notEqual(evolvedCulture, culture);
+  assert.equal(evolvedCulture.openness, 62);
+  assert.equal(evolvedCulture.researchDrive, 63);
+  assert.equal(evolvedCulture.cohesion, 56);
+  assert.deepEqual(evolvedCulture.valueIds, ['craft', 'exchange', 'innovation', 'seafaring']);
+  assert.deepEqual(evolvedCulture.traditionIds, ['harvest-song', 'river-moot']);
+  assert.equal(evolvedCulture.lastEvolvedAt?.toISOString(), '2026-04-18T17:00:00.000Z');
+
+  assert.deepEqual(culture.valueIds, ['craft']);
+  assert.deepEqual(culture.traditionIds, ['harbor-oath', 'harvest-song']);
+});
+
+test('evolveCulture clamps scores inside culture bounds and can derive continuity', () => {
+  const evolvedCulture = evolveCulture(
+    {
+      id: 'culture-cedar',
+      name: 'Cedar Chorus',
+      archetype: 'ritualist',
+      primaryLanguage: 'cedar-tongue',
+      valueIds: [],
+      traditionIds: ['solstice-chant'],
+      openness: 2,
+      cohesion: 64,
+      researchDrive: 1,
+    },
+    {
+      driftInputs: {
+        pressure: {
+          openness: -10,
+          researchDrive: -2,
+          cohesion: 4,
+        },
+        contact: {
+          cohesion: 1,
+        },
+        resilience: 0,
+      },
+      emergentTraditionIds: ['ancestral-ledger'],
+    },
+  );
+
+  assert.equal(evolvedCulture.openness, 0);
+  assert.equal(evolvedCulture.researchDrive, 0);
+  assert.equal(evolvedCulture.cohesion, 62);
+  assert.deepEqual(evolvedCulture.valueIds, ['continuity']);
+  assert.deepEqual(evolvedCulture.traditionIds, ['ancestral-ledger', 'solstice-chant']);
+});
+
+test('evolveCulture rejects invalid evolution payloads', () => {
+  assert.throws(() => evolveCulture(null, {}), /Cannot destructure property 'id'/);
+
+  assert.throws(
+    () =>
+      evolveCulture(
+        {
+          id: 'culture-aurora',
+          name: 'Aurora Compact',
+          archetype: 'mercantile',
+          primaryLanguage: 'trade-speech',
+        },
+        null,
+      ),
+    /evolveCulture evolutionInputs must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      evolveCulture(
+        {
+          id: 'culture-aurora',
+          name: 'Aurora Compact',
+          archetype: 'mercantile',
+          primaryLanguage: 'trade-speech',
+        },
+        {
+          adoptedValueIds: [''],
+        },
+      ),
+    /evolveCulture evolutionInputs.adoptedValueIds is required/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: implement `evolveCulture` as a dedicated Gamma use case built on top of `Culture` and `evaluateCulturalDrift`
- Gamma: update value and tradition sets immutably while clamping evolved culture scores into domain bounds
- Gamma: add focused tests for drift-driven evolution, clamping, and invalid payloads

## Related issue

- One issue only: #46

## Changes

- Gamma: add `src/application/culture/evolveCulture.js`
- Gamma: add `test/application/culture/evolveCulture.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [x] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage du flux Gamma.
