### PR TITLE
Beta: add in-memory route adapter

### DIFF
--- a/src/adapters/economy/InMemoryRouteRepository.js
+++ b/src/adapters/economy/InMemoryRouteRepository.js
@@ -1,0 +1,68 @@
+import { RouteRepositoryPort } from '../../domain/economy/RouteRepositoryPort.js';
+import { TradeRoute } from '../../domain/economy/TradeRoute.js';
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeRoute(route) {
+  if (route instanceof TradeRoute) {
+    return new TradeRoute(route.toJSON());
+  }
+
+  if (route === null || typeof route !== 'object' || Array.isArray(route)) {
+    throw new TypeError('InMemoryRouteRepository route must be an object.');
+  }
+
+  return new TradeRoute(route);
+}
+
+export class InMemoryRouteRepository extends RouteRepositoryPort {
+  constructor({ routes = [] } = {}) {
+    super();
+
+    if (!Array.isArray(routes)) {
+      throw new TypeError('InMemoryRouteRepository routes must be an array.');
+    }
+
+    this.routesById = new Map();
+
+    for (const route of routes) {
+      const normalizedRoute = normalizeRoute(route);
+      this.routesById.set(normalizedRoute.id, normalizedRoute);
+    }
+  }
+
+  async getById(routeId) {
+    const normalizedRouteId = requireText(routeId, 'RouteRepositoryPort routeId');
+    const route = this.routesById.get(normalizedRouteId);
+    return route ? new TradeRoute(route.toJSON()) : null;
+  }
+
+  async save(route) {
+    if (route === null || typeof route !== 'object' || Array.isArray(route)) {
+      throw new TypeError('RouteRepositoryPort route must be an object.');
+    }
+
+    requireText(route.id, 'RouteRepositoryPort route.id');
+
+    const normalizedRoute = normalizeRoute(route);
+    this.routesById.set(normalizedRoute.id, normalizedRoute);
+    return new TradeRoute(normalizedRoute.toJSON());
+  }
+
+  async listByCity(cityId) {
+    const normalizedCityId = requireText(cityId, 'RouteRepositoryPort cityId');
+
+    return [...this.routesById.values()]
+      .filter((route) => route.connects(normalizedCityId))
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((route) => new TradeRoute(route.toJSON()));
+  }
+}

--- a/test/adapters/economy/InMemoryRouteRepository.test.js
+++ b/test/adapters/economy/InMemoryRouteRepository.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryRouteRepository } from '../../../src/adapters/economy/InMemoryRouteRepository.js';
+import { TradeRoute } from '../../../src/domain/economy/TradeRoute.js';
+
+test('InMemoryRouteRepository loads routes and returns defensive copies', async () => {
+  const repository = new InMemoryRouteRepository({
+    routes: [
+      {
+        id: 'route-river',
+        name: 'River Run',
+        stopCityIds: ['city-harbor', 'city-granary'],
+        distance: 4,
+        capacityByResource: { grain: 12 },
+      },
+    ],
+  });
+
+  const route = await repository.getById('route-river');
+
+  assert.ok(route instanceof TradeRoute);
+  assert.equal(route.id, 'route-river');
+  assert.deepEqual(route.capacityByResource, { grain: 12 });
+
+  route.capacityByResource.grain = 0;
+
+  const reloadedRoute = await repository.getById('route-river');
+  assert.deepEqual(reloadedRoute.capacityByResource, { grain: 12 });
+  assert.equal(await repository.getById('unknown-route'), null);
+});
+
+test('InMemoryRouteRepository saves routes and filters them by city', async () => {
+  const repository = new InMemoryRouteRepository();
+
+  await repository.save({
+    id: 'route-river',
+    name: 'River Run',
+    stopCityIds: ['city-harbor', 'city-granary'],
+    distance: 4,
+    capacityByResource: { grain: 12 },
+  });
+
+  await repository.save(
+    new TradeRoute({
+      id: 'route-coastal',
+      name: 'Coastal Link',
+      stopCityIds: ['city-harbor', 'city-hillfort'],
+      distance: 7,
+      capacityByResource: { fish: 9 },
+    }),
+  );
+
+  await repository.save({
+    id: 'route-inland',
+    name: 'Inland Way',
+    stopCityIds: ['city-granary', 'city-forest'],
+    distance: 6,
+    capacityByResource: { wood: 15 },
+  });
+
+  const harborRoutes = await repository.listByCity('city-harbor');
+
+  assert.deepEqual(
+    harborRoutes.map((route) => route.id),
+    ['route-coastal', 'route-river'],
+  );
+  assert.ok(harborRoutes.every((route) => route instanceof TradeRoute));
+});
+
+test('InMemoryRouteRepository rejects malformed constructor and save payloads', async () => {
+  assert.throws(
+    () => new InMemoryRouteRepository({ routes: {} }),
+    /InMemoryRouteRepository routes must be an array/,
+  );
+
+  const repository = new InMemoryRouteRepository();
+
+  await assert.rejects(
+    () => repository.save(null),
+    /RouteRepositoryPort route must be an object/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: add the in-memory route adapter for Beta economy work.
Beta:
Beta: ## Changes
Beta: - add `InMemoryRouteRepository` as a concrete adapter for `RouteRepositoryPort`
Beta: - support seeded trade routes, defensive copies on reads, and route lookup by connected city
Beta: - normalize saved payloads through the `TradeRoute` model and preserve in-memory storage by id
Beta: - add node tests for loading, saving, filtering, defensive copies, and invalid payload handling
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #33
