### PR TITLE
Beta: emit economy events for shortages

### DIFF
--- a/src/application/economy/EconomyEventBusPort.js
+++ b/src/application/economy/EconomyEventBusPort.js
@@ -1,0 +1,63 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+function requirePayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new TypeError('EconomyEventBusPort payload must be an object.');
+  }
+
+  return payload;
+}
+
+function normalizeShortagePayload(payload) {
+  const normalizedPayload = requirePayload(payload);
+
+  return {
+    cityId: requireText(normalizedPayload.cityId, 'EconomyEventBusPort cityId'),
+    resourceId: requireText(normalizedPayload.resourceId, 'EconomyEventBusPort resourceId'),
+    shortageQuantity: requireInteger(
+      normalizedPayload.shortageQuantity,
+      'EconomyEventBusPort shortageQuantity',
+      1,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    requiredQuantity: requireInteger(
+      normalizedPayload.requiredQuantity ?? normalizedPayload.shortageQuantity,
+      'EconomyEventBusPort requiredQuantity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    availableQuantity: requireInteger(
+      normalizedPayload.availableQuantity ?? 0,
+      'EconomyEventBusPort availableQuantity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    cause: requireText(normalizedPayload.cause ?? 'consumption-shortage', 'EconomyEventBusPort cause'),
+  };
+}
+
+export class EconomyEventBusPort {
+  async publish(_eventName, _payload) {
+    throw new Error('EconomyEventBusPort.publish must be implemented by an adapter.');
+  }
+
+  async publishShortage(payload) {
+    return this.publish('economy.shortage.detected', normalizeShortagePayload(payload));
+  }
+}

--- a/src/application/economy/EmitShortageEvents.js
+++ b/src/application/economy/EmitShortageEvents.js
@@ -1,0 +1,85 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeResourceMap(resources, label) {
+  requireObject(resources, label);
+
+  return Object.fromEntries(
+    Object.entries(resources)
+      .map(([resourceId, quantity]) => {
+        const normalizedResourceId = String(resourceId).trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError(`${label} cannot contain an empty resource id.`);
+        }
+
+        if (!Number.isInteger(quantity) || quantity < 0) {
+          throw new RangeError(`${label} quantities must be integers greater than or equal to 0.`);
+        }
+
+        return [normalizedResourceId, quantity];
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function requireEventBus(eventBus) {
+  if (!eventBus || typeof eventBus.publishShortage !== 'function') {
+    throw new TypeError('EmitShortageEvents eventBus must expose publishShortage(payload).');
+  }
+
+  return eventBus;
+}
+
+export async function emitShortageEvents({
+  eventBus,
+  city,
+  shortagesByResource,
+  requiredByResource = {},
+  availableByResource = {},
+  cause = 'consumption-shortage',
+}) {
+  const normalizedEventBus = requireEventBus(eventBus);
+  const normalizedCity = requireObject(city, 'EmitShortageEvents city');
+  const normalizedCityId = requireText(normalizedCity.id, 'EmitShortageEvents city.id');
+  const normalizedShortages = normalizeResourceMap(shortagesByResource, 'EmitShortageEvents shortagesByResource');
+  const normalizedRequired = normalizeResourceMap(requiredByResource, 'EmitShortageEvents requiredByResource');
+  const normalizedAvailable = normalizeResourceMap(availableByResource, 'EmitShortageEvents availableByResource');
+  const normalizedCause = requireText(cause, 'EmitShortageEvents cause');
+
+  const events = [];
+
+  for (const [resourceId, shortageQuantity] of Object.entries(normalizedShortages)) {
+    if (shortageQuantity === 0) {
+      continue;
+    }
+
+    const event = await normalizedEventBus.publishShortage({
+      cityId: normalizedCityId,
+      resourceId,
+      shortageQuantity,
+      requiredQuantity: normalizedRequired[resourceId] ?? shortageQuantity,
+      availableQuantity: normalizedAvailable[resourceId] ?? 0,
+      cause: normalizedCause,
+    });
+
+    events.push(event);
+  }
+
+  return events;
+}

--- a/test/application/economy/EconomyEventBusPort.test.js
+++ b/test/application/economy/EconomyEventBusPort.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { EconomyEventBusPort } from '../../../src/application/economy/EconomyEventBusPort.js';
+
+class RecordedEconomyEventBus extends EconomyEventBusPort {
+  constructor() {
+    super();
+    this.events = [];
+  }
+
+  async publish(eventName, payload) {
+    const event = { eventName, payload };
+    this.events.push(event);
+    return event;
+  }
+}
+
+test('EconomyEventBusPort normalizes shortage events before delegation', async () => {
+  const eventBus = new RecordedEconomyEventBus();
+
+  const event = await eventBus.publishShortage({
+    cityId: ' city-harbor ',
+    resourceId: ' grain ',
+    shortageQuantity: 4,
+    requiredQuantity: 10,
+    availableQuantity: 6,
+    cause: ' food-crisis ',
+    note: 'ignored',
+  });
+
+  assert.deepEqual(event, {
+    eventName: 'economy.shortage.detected',
+    payload: {
+      cityId: 'city-harbor',
+      resourceId: 'grain',
+      shortageQuantity: 4,
+      requiredQuantity: 10,
+      availableQuantity: 6,
+      cause: 'food-crisis',
+    },
+  });
+});
+
+test('EconomyEventBusPort base publish method fails fast until implemented', async () => {
+  const eventBus = new EconomyEventBusPort();
+
+  await assert.rejects(
+    () => eventBus.publish('economy.shortage.detected', { cityId: 'city-harbor' }),
+    /must be implemented by an adapter/,
+  );
+});
+
+test('EconomyEventBusPort rejects invalid shortage payloads', async () => {
+  const eventBus = new RecordedEconomyEventBus();
+
+  await assert.rejects(() => eventBus.publishShortage(null), /payload must be an object/);
+  await assert.rejects(() => eventBus.publishShortage({ resourceId: 'grain', shortageQuantity: 1 }), /cityId is required/);
+  await assert.rejects(() => eventBus.publishShortage({ cityId: 'city-harbor', shortageQuantity: 1 }), /resourceId is required/);
+  await assert.rejects(
+    () => eventBus.publishShortage({ cityId: 'city-harbor', resourceId: 'grain', shortageQuantity: 0 }),
+    /shortageQuantity must be an integer between 1 and/,
+  );
+});

--- a/test/application/economy/EmitShortageEvents.test.js
+++ b/test/application/economy/EmitShortageEvents.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { EconomyEventBusPort } from '../../../src/application/economy/EconomyEventBusPort.js';
+import { emitShortageEvents } from '../../../src/application/economy/EmitShortageEvents.js';
+
+class RecordedEconomyEventBus extends EconomyEventBusPort {
+  constructor() {
+    super();
+    this.events = [];
+  }
+
+  async publish(eventName, payload) {
+    const event = { eventName, payload };
+    this.events.push(event);
+    return event;
+  }
+}
+
+test('EmitShortageEvents publishes one normalized event per shortage', async () => {
+  const eventBus = new RecordedEconomyEventBus();
+
+  const events = await emitShortageEvents({
+    eventBus,
+    city: { id: ' city-harbor ' },
+    shortagesByResource: {
+      grain: 4,
+      fish: 2,
+    },
+    requiredByResource: {
+      grain: 10,
+      fish: 5,
+    },
+    availableByResource: {
+      grain: 6,
+      fish: 3,
+    },
+    cause: 'civil-unrest',
+  });
+
+  assert.deepEqual(events, [
+    {
+      eventName: 'economy.shortage.detected',
+      payload: {
+        cityId: 'city-harbor',
+        resourceId: 'fish',
+        shortageQuantity: 2,
+        requiredQuantity: 5,
+        availableQuantity: 3,
+        cause: 'civil-unrest',
+      },
+    },
+    {
+      eventName: 'economy.shortage.detected',
+      payload: {
+        cityId: 'city-harbor',
+        resourceId: 'grain',
+        shortageQuantity: 4,
+        requiredQuantity: 10,
+        availableQuantity: 6,
+        cause: 'civil-unrest',
+      },
+    },
+  ]);
+});
+
+test('EmitShortageEvents skips empty shortage maps', async () => {
+  const eventBus = new RecordedEconomyEventBus();
+
+  const events = await emitShortageEvents({
+    eventBus,
+    city: { id: 'city-harbor' },
+    shortagesByResource: {},
+  });
+
+  assert.deepEqual(events, []);
+  assert.deepEqual(eventBus.events, []);
+});
+
+test('EmitShortageEvents rejects invalid event buses, cities, and resource maps', async () => {
+  await assert.rejects(
+    () => emitShortageEvents({ eventBus: {}, city: { id: 'city-harbor' }, shortagesByResource: {} }),
+    /eventBus must expose publishShortage/,
+  );
+
+  await assert.rejects(
+    () => emitShortageEvents({ eventBus: new RecordedEconomyEventBus(), city: {}, shortagesByResource: {} }),
+    /city.id is required/,
+  );
+
+  await assert.rejects(
+    () => emitShortageEvents({ eventBus: new RecordedEconomyEventBus(), city: { id: 'city-harbor' }, shortagesByResource: { grain: -1 } }),
+    /shortagesByResource quantities must be integers greater than or equal to 0/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: emit economy shortage events through a dedicated economy event bus contract.
Beta:
Beta: ## Changes
Beta: - add `EconomyEventBusPort` with normalized `publishShortage` semantics for shortage events
Beta: - add `emitShortageEvents` to publish one event per missing resource for a city
Beta: - validate shortage, required, and available resource maps with stable normalized payloads
Beta: - add node tests for event normalization, delegation, empty shortages, and invalid inputs
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #34
