### PR TITLE
Gamma: [G07] Implement RegisterDivergence use case

### DIFF
--- a/src/application/culture/registerDivergence.js
+++ b/src/application/culture/registerDivergence.js
@@ -44,12 +44,8 @@ function normalizeRegistration(registration) {
   return {
     divergencePoint,
     discoveryIds: registration.discoveryIds ?? [],
-    triggeredAt: registration.triggeredAt ?? historicalEventTriggeredAtFallback(registration),
+    triggeredAt: registration.triggeredAt,
   };
-}
-
-function historicalEventTriggeredAtFallback(registration) {
-  return registration?.historicalEvent?.triggeredAt ?? new Date();
 }
 
 export function registerDivergence(historicalEventState, registration) {
@@ -87,7 +83,7 @@ export function registerDivergence(historicalEventState, registration) {
   const registeredDivergencePoint = divergencePoint.withDiscovery(historicalEvent.id);
   const registeredHistoricalEvent = new HistoricalEvent({
     ...historicalEvent.toJSON(),
-    triggeredAt: normalizedRegistration.triggeredAt,
+    triggeredAt: normalizedRegistration.triggeredAt ?? historicalEvent.triggeredAt,
     divergencePointId: divergencePoint.id,
     discoveryIds: normalizeDiscoveryIds(historicalEvent, normalizedRegistration),
   });

--- a/src/application/culture/registerDivergence.js
+++ b/src/application/culture/registerDivergence.js
@@ -1,0 +1,99 @@
+import { DivergencePoint } from '../../domain/culture/DivergencePoint.js';
+import { HistoricalEvent } from '../../domain/culture/HistoricalEvent.js';
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => requireText(value, label)))];
+  return normalizedValues.sort();
+}
+
+function normalizeDiscoveryIds(historicalEvent, registration) {
+  return normalizeUniqueTexts(
+    [
+      ...historicalEvent.discoveryIds,
+      ...(registration.discoveryIds ?? []),
+      ...registration.divergencePoint.consequenceIds,
+    ],
+    'registerDivergence registration.discoveryIds',
+  );
+}
+
+function normalizeRegistration(registration) {
+  if (!registration || typeof registration !== 'object' || Array.isArray(registration)) {
+    throw new TypeError('registerDivergence registration must be an object.');
+  }
+
+  const divergencePoint =
+    registration.divergencePoint instanceof DivergencePoint
+      ? registration.divergencePoint
+      : new DivergencePoint(registration.divergencePoint);
+
+  return {
+    divergencePoint,
+    discoveryIds: registration.discoveryIds ?? [],
+    triggeredAt: registration.triggeredAt ?? historicalEventTriggeredAtFallback(registration),
+  };
+}
+
+function historicalEventTriggeredAtFallback(registration) {
+  return registration?.historicalEvent?.triggeredAt ?? new Date();
+}
+
+export function registerDivergence(historicalEventState, registration) {
+  const historicalEvent =
+    historicalEventState instanceof HistoricalEvent
+      ? historicalEventState
+      : new HistoricalEvent(historicalEventState);
+
+  const normalizedRegistration = normalizeRegistration(registration);
+  const divergencePoint = normalizedRegistration.divergencePoint;
+
+  if (divergencePoint.discovered) {
+    throw new RangeError('registerDivergence cannot register an already discovered divergence point.');
+  }
+
+  if (
+    historicalEvent.divergencePointId !== null &&
+    historicalEvent.divergencePointId !== divergencePoint.id
+  ) {
+    throw new RangeError(
+      'registerDivergence cannot overwrite a historical event already linked to another divergence point.',
+    );
+  }
+
+  const mismatchedCultureIds = divergencePoint.affectedCultureIds.filter(
+    (cultureId) => !historicalEvent.affectedCultureIds.includes(cultureId),
+  );
+
+  if (mismatchedCultureIds.length > 0) {
+    throw new RangeError(
+      'registerDivergence divergencePoint affectedCultureIds must be covered by the historical event.',
+    );
+  }
+
+  const registeredDivergencePoint = divergencePoint.withDiscovery(historicalEvent.id);
+  const registeredHistoricalEvent = new HistoricalEvent({
+    ...historicalEvent.toJSON(),
+    triggeredAt: normalizedRegistration.triggeredAt,
+    divergencePointId: divergencePoint.id,
+    discoveryIds: normalizeDiscoveryIds(historicalEvent, normalizedRegistration),
+  });
+
+  return {
+    divergencePoint: registeredDivergencePoint,
+    historicalEvent: registeredHistoricalEvent,
+  };
+}

--- a/test/application/culture/registerDivergence.test.js
+++ b/test/application/culture/registerDivergence.test.js
@@ -1,0 +1,165 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { registerDivergence } from '../../../src/application/culture/registerDivergence.js';
+import { DivergencePoint } from '../../../src/domain/culture/DivergencePoint.js';
+import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
+
+test('registerDivergence links a divergence point to a historical event immutably', () => {
+  const divergencePoint = new DivergencePoint({
+    id: 'divergence-fork-01',
+    title: 'The Silent Armada',
+    era: 'late-antiquity',
+    baselineSummary: 'Maritime trade routes remain stable across the inner sea.',
+    divergenceSummary: 'A volcanic winter strands the western fleets for a generation.',
+    affectedCultureIds: ['culture-east', 'culture-west'],
+    consequenceIds: ['grain-shortage'],
+    severity: 4,
+    registeredAt: '2026-04-18T12:10:00.000Z',
+  });
+
+  const historicalEvent = new HistoricalEvent({
+    id: 'event-ashen-harbors',
+    title: 'Ashen Harbors',
+    category: 'catastrophe',
+    summary: 'Coastal ports close after a season of volcanic ash and failed harvests.',
+    era: 'late-antiquity',
+    importance: 4,
+    triggeredAt: '2026-04-18T12:20:00.000Z',
+    affectedCultureIds: ['culture-west', 'culture-east'],
+    discoveryIds: ['ash-navigation'],
+  });
+
+  const registered = registerDivergence(historicalEvent, {
+    divergencePoint,
+    discoveryIds: ['harbor-rationing', ' grain-shortage '],
+  });
+
+  assert.notEqual(registered.divergencePoint, divergencePoint);
+  assert.notEqual(registered.historicalEvent, historicalEvent);
+  assert.equal(registered.divergencePoint.discovered, true);
+  assert.equal(registered.divergencePoint.triggeredEventId, 'event-ashen-harbors');
+  assert.equal(registered.historicalEvent.divergencePointId, 'divergence-fork-01');
+  assert.deepEqual(registered.historicalEvent.discoveryIds, [
+    'ash-navigation',
+    'grain-shortage',
+    'harbor-rationing',
+  ]);
+
+  assert.equal(divergencePoint.discovered, false);
+  assert.equal(historicalEvent.divergencePointId, null);
+  assert.deepEqual(historicalEvent.discoveryIds, ['ash-navigation']);
+});
+
+test('registerDivergence accepts plain payloads and explicit triggeredAt overrides', () => {
+  const registered = registerDivergence(
+    {
+      id: 'event-copper-schism',
+      title: 'Copper Schism',
+      category: 'political',
+      summary: 'Guild rivalries split control of metallurgical rites.',
+      era: 'early-iron-age',
+      importance: 3,
+      triggeredAt: '2026-04-18T12:40:00.000Z',
+      affectedCultureIds: ['culture-delta'],
+      discoveryIds: [],
+    },
+    {
+      divergencePoint: {
+        id: 'divergence-fork-02',
+        title: 'The Copper Schism',
+        era: 'early-iron-age',
+        baselineSummary: 'Guild reforms remain unified.',
+        divergenceSummary: 'Regional guilds secede and hoard furnace techniques.',
+        affectedCultureIds: ['culture-delta'],
+        severity: 2,
+        registeredAt: '2026-04-18T12:35:00.000Z',
+      },
+      discoveryIds: ['ritual-metallurgy'],
+      triggeredAt: '2026-04-18T12:45:00.000Z',
+    },
+  );
+
+  assert.equal(registered.divergencePoint.triggeredEventId, 'event-copper-schism');
+  assert.equal(
+    registered.historicalEvent.triggeredAt?.toISOString(),
+    '2026-04-18T12:45:00.000Z',
+  );
+  assert.deepEqual(registered.historicalEvent.discoveryIds, ['ritual-metallurgy']);
+});
+
+test('registerDivergence rejects invalid or conflicting registrations', () => {
+  const historicalEvent = new HistoricalEvent({
+    id: 'event-ashen-harbors',
+    title: 'Ashen Harbors',
+    category: 'catastrophe',
+    summary: 'Coastal ports close after a season of volcanic ash and failed harvests.',
+    era: 'late-antiquity',
+    importance: 4,
+    triggeredAt: '2026-04-18T12:20:00.000Z',
+    affectedCultureIds: ['culture-west'],
+  });
+
+  const discoveredDivergence = new DivergencePoint({
+    id: 'divergence-fork-01',
+    title: 'The Silent Armada',
+    era: 'late-antiquity',
+    baselineSummary: 'Baseline',
+    divergenceSummary: 'Divergence',
+    affectedCultureIds: ['culture-west'],
+    severity: 4,
+    discovered: true,
+    registeredAt: '2026-04-18T12:10:00.000Z',
+    triggeredEventId: 'event-old',
+  });
+
+  assert.throws(
+    () => registerDivergence(historicalEvent, { divergencePoint: discoveredDivergence }),
+    /registerDivergence cannot register an already discovered divergence point/,
+  );
+
+  assert.throws(
+    () =>
+      registerDivergence(
+        {
+          ...historicalEvent.toJSON(),
+          divergencePointId: 'divergence-other',
+        },
+        {
+          divergencePoint: {
+            id: 'divergence-fork-01',
+            title: 'The Silent Armada',
+            era: 'late-antiquity',
+            baselineSummary: 'Baseline',
+            divergenceSummary: 'Divergence',
+            affectedCultureIds: ['culture-west'],
+            severity: 4,
+            registeredAt: '2026-04-18T12:10:00.000Z',
+          },
+        },
+      ),
+    /registerDivergence cannot overwrite a historical event already linked to another divergence point/,
+  );
+
+  assert.throws(
+    () =>
+      registerDivergence(historicalEvent, {
+        divergencePoint: {
+          id: 'divergence-fork-03',
+          title: 'Southern Break',
+          era: 'late-antiquity',
+          baselineSummary: 'Baseline',
+          divergenceSummary: 'Divergence',
+          affectedCultureIds: ['culture-south'],
+          severity: 3,
+          registeredAt: '2026-04-18T12:10:00.000Z',
+        },
+      }),
+    /registerDivergence divergencePoint affectedCultureIds must be covered by the historical event/,
+  );
+
+  assert.throws(
+    () => registerDivergence(historicalEvent, null),
+    /registerDivergence registration must be an object/,
+  );
+});

--- a/test/application/culture/registerDivergence.test.js
+++ b/test/application/culture/registerDivergence.test.js
@@ -40,6 +40,10 @@ test('registerDivergence links a divergence point to a historical event immutabl
   assert.equal(registered.divergencePoint.discovered, true);
   assert.equal(registered.divergencePoint.triggeredEventId, 'event-ashen-harbors');
   assert.equal(registered.historicalEvent.divergencePointId, 'divergence-fork-01');
+  assert.equal(
+    registered.historicalEvent.triggeredAt?.toISOString(),
+    '2026-04-18T12:20:00.000Z',
+  );
   assert.deepEqual(registered.historicalEvent.discoveryIds, [
     'ash-navigation',
     'grain-shortage',


### PR DESCRIPTION
## Summary

- Gamma: implement `registerDivergence` as a focused culture use case linking a divergence point to a historical event
- Gamma: keep divergence discovery, event linkage, and discovery aggregation immutable and validated
- Gamma: add focused tests for successful registration, plain payload support, and conflict rejection

## Related issue

- One issue only: #47

## Changes

- Gamma: add `src/application/culture/registerDivergence.js`
- Gamma: add `test/application/culture/registerDivergence.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [x] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage des anciennes branches Gamma.
