### PR TITLE
Epsilon: [E12] Add in-memory climate adapter

### DIFF
--- a/src/adapters/climate/InMemoryClimateRepository.js
+++ b/src/adapters/climate/InMemoryClimateRepository.js
@@ -1,0 +1,63 @@
+import { ClimateRepositoryPort } from '../../application/ports/ClimateRepositoryPort.js';
+import { ClimateState } from '../../domain/climate/ClimateState.js';
+
+function requireRegionId(regionId, operation) {
+  const normalizedRegionId = String(regionId ?? '').trim();
+
+  if (!normalizedRegionId) {
+    throw new RangeError(`InMemoryClimateRepository.${operation} regionId is required.`);
+  }
+
+  return normalizedRegionId;
+}
+
+function normalizeClimateState(state) {
+  if (state instanceof ClimateState) {
+    return new ClimateState(state.toJSON());
+  }
+
+  if (state === null || typeof state !== 'object' || Array.isArray(state)) {
+    throw new TypeError('InMemoryClimateRepository climate state must be a ClimateState or plain object.');
+  }
+
+  return new ClimateState(state);
+}
+
+export class InMemoryClimateRepository extends ClimateRepositoryPort {
+  constructor(seed = []) {
+    super();
+
+    if (!Array.isArray(seed)) {
+      throw new TypeError('InMemoryClimateRepository seed must be an array.');
+    }
+
+    this.states = new Map();
+
+    for (const state of seed) {
+      this.save(state);
+    }
+  }
+
+  loadByRegionId(regionId) {
+    const normalizedRegionId = requireRegionId(regionId, 'loadByRegionId');
+    const state = this.states.get(normalizedRegionId);
+    return state ? new ClimateState(state.toJSON()) : null;
+  }
+
+  save(climateState) {
+    const normalizedState = normalizeClimateState(climateState);
+    this.states.set(normalizedState.regionId, normalizedState);
+    return new ClimateState(normalizedState.toJSON());
+  }
+
+  deleteByRegionId(regionId) {
+    const normalizedRegionId = requireRegionId(regionId, 'deleteByRegionId');
+    return this.states.delete(normalizedRegionId);
+  }
+
+  snapshot() {
+    return [...this.states.values()]
+      .sort((left, right) => left.regionId.localeCompare(right.regionId))
+      .map((state) => state.toJSON());
+  }
+}

--- a/test/adapters/climate/InMemoryClimateRepository.test.js
+++ b/test/adapters/climate/InMemoryClimateRepository.test.js
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryClimateRepository } from '../../../src/adapters/climate/InMemoryClimateRepository.js';
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+
+test('InMemoryClimateRepository loads and saves climate states by region', () => {
+  const repository = new InMemoryClimateRepository([
+    new ClimateState({
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 66,
+      droughtIndex: 18,
+    }),
+  ]);
+
+  assert.equal(repository.loadByRegionId('north-coast')?.season, 'spring');
+  assert.equal(repository.loadByRegionId('sunreach'), null);
+
+  const saved = repository.save({
+    regionId: 'sunreach',
+    season: 'summer',
+    temperatureC: 33,
+    precipitationLevel: 24,
+    droughtIndex: 58,
+    anomaly: 'heatwave',
+  });
+
+  assert.equal(saved.regionId, 'sunreach');
+  assert.equal(repository.loadByRegionId('sunreach')?.anomaly, 'heatwave');
+  assert.deepEqual(repository.loadMany(['north-coast', 'sunreach']).map((state) => state?.regionId), ['north-coast', 'sunreach']);
+});
+
+test('InMemoryClimateRepository returns defensive copies for loaded and saved states', () => {
+  const repository = new InMemoryClimateRepository();
+
+  const saved = repository.save({
+    regionId: 'delta-marsh',
+    season: 'autumn',
+    temperatureC: 17,
+    precipitationLevel: 73,
+    droughtIndex: 12,
+  });
+
+  saved.anomaly = 'tampered';
+
+  const loaded = repository.loadByRegionId('delta-marsh');
+  loaded.season = 'winter';
+
+  assert.equal(repository.loadByRegionId('delta-marsh')?.anomaly, null);
+  assert.equal(repository.loadByRegionId('delta-marsh')?.season, 'autumn');
+});
+
+test('InMemoryClimateRepository can delete and snapshot stored climate states', () => {
+  const repository = new InMemoryClimateRepository([
+    {
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 66,
+      droughtIndex: 18,
+    },
+    {
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 31,
+      precipitationLevel: 18,
+      droughtIndex: 62,
+    },
+  ]);
+
+  assert.equal(repository.deleteByRegionId('sunreach'), true);
+  assert.equal(repository.deleteByRegionId('sunreach'), false);
+  assert.deepEqual(repository.snapshot().map((state) => state.regionId), ['north-coast']);
+});
+
+test('InMemoryClimateRepository rejects invalid seed values and blank region identifiers', () => {
+  assert.throws(
+    () => new InMemoryClimateRepository({}),
+    /seed must be an array/,
+  );
+
+  assert.throws(
+    () => new InMemoryClimateRepository([null]),
+    /must be a ClimateState or plain object/,
+  );
+
+  const repository = new InMemoryClimateRepository();
+
+  assert.throws(
+    () => repository.loadByRegionId('  '),
+    /regionId is required/,
+  );
+
+  assert.throws(
+    () => repository.deleteByRegionId(''),
+    /regionId is required/,
+  );
+});


### PR DESCRIPTION
Epsilon: reprise propre depuis main pour l’issue #92.

## Summary
- add InMemoryClimateRepository as a concrete adapter for ClimateRepositoryPort
- normalize seeded and saved climate states into ClimateState instances
- cover loading, saving, deletion, snapshots, validation, and defensive copies with targeted tests

## Verification
- node --test

Closes #92