### PR TITLE
Delta: [D16] Emit intrigue events for sabotage

### DIFF
--- a/src/application/intrigue/ResoudreSabotage.js
+++ b/src/application/intrigue/ResoudreSabotage.js
@@ -42,6 +42,53 @@ function deriveOutcomeSeverity({ readiness, targetStability, targetSecurity, ran
   return Math.max(0, readiness + randomFactor - Math.round((targetStability + targetSecurity) / 2));
 }
 
+function buildSabotageEvents({
+  operationId,
+  targetId,
+  outcome,
+  damage,
+}) {
+  const events = [
+    {
+      type: 'intrigue.sabotage.resolved',
+      operationId,
+      targetId,
+      outcome,
+      damage: { ...damage },
+    },
+  ];
+
+  if (outcome === 'sabotage-succeeded') {
+    events.push({
+      type: 'intrigue.sabotage.damage-inflicted',
+      operationId,
+      targetId,
+      industryLoss: damage.industryLoss,
+      stabilityLoss: damage.stabilityLoss,
+      disruptedInfrastructureIds: [...damage.disruptedInfrastructureIds],
+    });
+  }
+
+  if (outcome === 'sabotage-failed') {
+    events.push({
+      type: 'intrigue.sabotage.failed',
+      operationId,
+      targetId,
+      heatIncrease: damage.heatIncrease,
+    });
+  }
+
+  if (outcome === 'no-target-infrastructure') {
+    events.push({
+      type: 'intrigue.sabotage.no-target',
+      operationId,
+      targetId,
+    });
+  }
+
+  return events;
+}
+
 export function resoudreSabotage({
   operation,
   target,
@@ -64,18 +111,26 @@ export function resoudreSabotage({
   const targetIndustry = requireScore(normalizedTarget.industry ?? 0, 'ResoudreSabotage target industry');
 
   if (normalizedInfrastructureIds.length === 0) {
+    const damage = {
+      industryLoss: 0,
+      stabilityLoss: 0,
+      heatIncrease: 0,
+      disruptedInfrastructureIds: [],
+    };
+
     return {
       resolved: false,
       outcome: 'no-target-infrastructure',
       target: { ...normalizedTarget },
       operation: { ...normalizedOperation },
       summary: 'No sabotage target was available.',
-      damage: {
-        industryLoss: 0,
-        stabilityLoss: 0,
-        heatIncrease: 0,
-        disruptedInfrastructureIds: [],
-      },
+      damage,
+      events: buildSabotageEvents({
+        operationId,
+        targetId,
+        outcome: 'no-target-infrastructure',
+        damage,
+      }),
     };
   }
 
@@ -94,9 +149,17 @@ export function resoudreSabotage({
   const heatIncrease = Math.min(100 - heat, success ? Math.max(8, 18 - Math.round(readiness / 10)) : 14);
   const nextHeat = heat + heatIncrease;
 
+  const outcome = success ? 'sabotage-succeeded' : 'sabotage-failed';
+  const damage = {
+    industryLoss,
+    stabilityLoss,
+    heatIncrease,
+    disruptedInfrastructureIds,
+  };
+
   return {
     resolved: true,
-    outcome: success ? 'sabotage-succeeded' : 'sabotage-failed',
+    outcome,
     operation: {
       ...normalizedOperation,
       id: operationId,
@@ -114,11 +177,12 @@ export function resoudreSabotage({
     summary: success
       ? `Sabotage disrupted ${disruptedInfrastructureIds.length} infrastructure target(s).`
       : 'Sabotage failed to create lasting damage.',
-    damage: {
-      industryLoss,
-      stabilityLoss,
-      heatIncrease,
-      disruptedInfrastructureIds,
-    },
+    damage,
+    events: buildSabotageEvents({
+      operationId,
+      targetId,
+      outcome,
+      damage,
+    }),
   };
 }

--- a/test/application/intrigue/ResoudreSabotage.test.js
+++ b/test/application/intrigue/ResoudreSabotage.test.js
@@ -46,6 +46,28 @@ test('ResoudreSabotage produces explicit damage on success', () => {
       heatIncrease: 10,
       disruptedInfrastructureIds: ['arsenal', 'rail-hub'],
     },
+    events: [
+      {
+        type: 'intrigue.sabotage.resolved',
+        operationId: 'op-cendre',
+        targetId: 'city-aster-port',
+        outcome: 'sabotage-succeeded',
+        damage: {
+          industryLoss: 16,
+          stabilityLoss: 12,
+          heatIncrease: 10,
+          disruptedInfrastructureIds: ['arsenal', 'rail-hub'],
+        },
+      },
+      {
+        type: 'intrigue.sabotage.damage-inflicted',
+        operationId: 'op-cendre',
+        targetId: 'city-aster-port',
+        industryLoss: 16,
+        stabilityLoss: 12,
+        disruptedInfrastructureIds: ['arsenal', 'rail-hub'],
+      },
+    ],
   });
 });
 
@@ -92,6 +114,26 @@ test('ResoudreSabotage keeps failure outcomes explicit', () => {
       heatIncrease: 14,
       disruptedInfrastructureIds: [],
     },
+    events: [
+      {
+        type: 'intrigue.sabotage.resolved',
+        operationId: 'op-cendre',
+        targetId: 'city-aster-port',
+        outcome: 'sabotage-failed',
+        damage: {
+          industryLoss: 0,
+          stabilityLoss: 0,
+          heatIncrease: 14,
+          disruptedInfrastructureIds: [],
+        },
+      },
+      {
+        type: 'intrigue.sabotage.failed',
+        operationId: 'op-cendre',
+        targetId: 'city-aster-port',
+        heatIncrease: 14,
+      },
+    ],
   });
 });
 
@@ -152,5 +194,24 @@ test('ResoudreSabotage validates inputs and handles missing infrastructure', () 
       heatIncrease: 0,
       disruptedInfrastructureIds: [],
     },
+    events: [
+      {
+        type: 'intrigue.sabotage.resolved',
+        operationId: 'op-cendre',
+        targetId: 'city-aster-port',
+        outcome: 'no-target-infrastructure',
+        damage: {
+          industryLoss: 0,
+          stabilityLoss: 0,
+          heatIncrease: 0,
+          disruptedInfrastructureIds: [],
+        },
+      },
+      {
+        type: 'intrigue.sabotage.no-target',
+        operationId: 'op-cendre',
+        targetId: 'city-aster-port',
+      },
+    ],
   });
 });


### PR DESCRIPTION
Delta: Cette PR fait avancer #76 en ajoutant des événements explicites à `ResoudreSabotage` pour les trois issues possibles: sabotage réussi, sabotage échoué, et absence de cible exploitable.

## Changements
- ajout d'un tableau `events` structuré dans le résultat de `ResoudreSabotage`
- émission d'un événement commun `intrigue.sabotage.resolved`
- émission d'événements spécialisés selon l'issue (`damage-inflicted`, `failed`, `no-target`)
- extension des tests pour verrouiller ces événements

## Vérification
- `npm test`

Closes #76