### PR TITLE
Beta: emit economy events for surpluses

### DIFF
--- a/src/application/economy/EconomyEventBusPort.js
+++ b/src/application/economy/EconomyEventBusPort.js
@@ -52,6 +52,34 @@ function normalizeShortagePayload(payload) {
   };
 }
 
+function normalizeSurplusPayload(payload) {
+  const normalizedPayload = requirePayload(payload);
+
+  return {
+    cityId: requireText(normalizedPayload.cityId, 'EconomyEventBusPort cityId'),
+    resourceId: requireText(normalizedPayload.resourceId, 'EconomyEventBusPort resourceId'),
+    surplusQuantity: requireInteger(
+      normalizedPayload.surplusQuantity,
+      'EconomyEventBusPort surplusQuantity',
+      1,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    availableQuantity: requireInteger(
+      normalizedPayload.availableQuantity ?? normalizedPayload.surplusQuantity,
+      'EconomyEventBusPort availableQuantity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    desiredQuantity: requireInteger(
+      normalizedPayload.desiredQuantity ?? 0,
+      'EconomyEventBusPort desiredQuantity',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    cause: requireText(normalizedPayload.cause ?? 'stock-surplus', 'EconomyEventBusPort cause'),
+  };
+}
+
 export class EconomyEventBusPort {
   async publish(_eventName, _payload) {
     throw new Error('EconomyEventBusPort.publish must be implemented by an adapter.');
@@ -59,5 +87,9 @@ export class EconomyEventBusPort {
 
   async publishShortage(payload) {
     return this.publish('economy.shortage.detected', normalizeShortagePayload(payload));
+  }
+
+  async publishSurplus(payload) {
+    return this.publish('economy.surplus.detected', normalizeSurplusPayload(payload));
   }
 }

--- a/src/application/economy/EmitSurplusEvents.js
+++ b/src/application/economy/EmitSurplusEvents.js
@@ -1,0 +1,85 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeResourceMap(resources, label) {
+  requireObject(resources, label);
+
+  return Object.fromEntries(
+    Object.entries(resources)
+      .map(([resourceId, quantity]) => {
+        const normalizedResourceId = String(resourceId).trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError(`${label} cannot contain an empty resource id.`);
+        }
+
+        if (!Number.isInteger(quantity) || quantity < 0) {
+          throw new RangeError(`${label} quantities must be integers greater than or equal to 0.`);
+        }
+
+        return [normalizedResourceId, quantity];
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function requireEventBus(eventBus) {
+  if (!eventBus || typeof eventBus.publishSurplus !== 'function') {
+    throw new TypeError('EmitSurplusEvents eventBus must expose publishSurplus(payload).');
+  }
+
+  return eventBus;
+}
+
+export async function emitSurplusEvents({
+  eventBus,
+  city,
+  surplusesByResource,
+  desiredByResource = {},
+  availableByResource = {},
+  cause = 'stock-surplus',
+}) {
+  const normalizedEventBus = requireEventBus(eventBus);
+  const normalizedCity = requireObject(city, 'EmitSurplusEvents city');
+  const normalizedCityId = requireText(normalizedCity.id, 'EmitSurplusEvents city.id');
+  const normalizedSurpluses = normalizeResourceMap(surplusesByResource, 'EmitSurplusEvents surplusesByResource');
+  const normalizedDesired = normalizeResourceMap(desiredByResource, 'EmitSurplusEvents desiredByResource');
+  const normalizedAvailable = normalizeResourceMap(availableByResource, 'EmitSurplusEvents availableByResource');
+  const normalizedCause = requireText(cause, 'EmitSurplusEvents cause');
+
+  const events = [];
+
+  for (const [resourceId, surplusQuantity] of Object.entries(normalizedSurpluses)) {
+    if (surplusQuantity === 0) {
+      continue;
+    }
+
+    const event = await normalizedEventBus.publishSurplus({
+      cityId: normalizedCityId,
+      resourceId,
+      surplusQuantity,
+      availableQuantity: normalizedAvailable[resourceId] ?? surplusQuantity,
+      desiredQuantity: normalizedDesired[resourceId] ?? 0,
+      cause: normalizedCause,
+    });
+
+    events.push(event);
+  }
+
+  return events;
+}

--- a/test/application/economy/EconomyEventBusPort.test.js
+++ b/test/application/economy/EconomyEventBusPort.test.js
@@ -51,7 +51,32 @@ test('EconomyEventBusPort base publish method fails fast until implemented', asy
   );
 });
 
-test('EconomyEventBusPort rejects invalid shortage payloads', async () => {
+test('EconomyEventBusPort normalizes surplus events before delegation', async () => {
+  const eventBus = new RecordedEconomyEventBus();
+
+  const event = await eventBus.publishSurplus({
+    cityId: ' city-harbor ',
+    resourceId: ' grain ',
+    surplusQuantity: 9,
+    availableQuantity: 14,
+    desiredQuantity: 5,
+    cause: ' export-ready ',
+  });
+
+  assert.deepEqual(event, {
+    eventName: 'economy.surplus.detected',
+    payload: {
+      cityId: 'city-harbor',
+      resourceId: 'grain',
+      surplusQuantity: 9,
+      availableQuantity: 14,
+      desiredQuantity: 5,
+      cause: 'export-ready',
+    },
+  });
+});
+
+test('EconomyEventBusPort rejects invalid shortage and surplus payloads', async () => {
   const eventBus = new RecordedEconomyEventBus();
 
   await assert.rejects(() => eventBus.publishShortage(null), /payload must be an object/);
@@ -60,5 +85,12 @@ test('EconomyEventBusPort rejects invalid shortage payloads', async () => {
   await assert.rejects(
     () => eventBus.publishShortage({ cityId: 'city-harbor', resourceId: 'grain', shortageQuantity: 0 }),
     /shortageQuantity must be an integer between 1 and/,
+  );
+
+  await assert.rejects(() => eventBus.publishSurplus(null), /payload must be an object/);
+  await assert.rejects(() => eventBus.publishSurplus({ resourceId: 'grain', surplusQuantity: 1 }), /cityId is required/);
+  await assert.rejects(
+    () => eventBus.publishSurplus({ cityId: 'city-harbor', resourceId: 'grain', surplusQuantity: 0 }),
+    /surplusQuantity must be an integer between 1 and/,
   );
 });

--- a/test/application/economy/EmitSurplusEvents.test.js
+++ b/test/application/economy/EmitSurplusEvents.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { EconomyEventBusPort } from '../../../src/application/economy/EconomyEventBusPort.js';
+import { emitSurplusEvents } from '../../../src/application/economy/EmitSurplusEvents.js';
+
+class RecordedEconomyEventBus extends EconomyEventBusPort {
+  constructor() {
+    super();
+    this.events = [];
+  }
+
+  async publish(eventName, payload) {
+    const event = { eventName, payload };
+    this.events.push(event);
+    return event;
+  }
+}
+
+test('EmitSurplusEvents publishes one normalized event per surplus', async () => {
+  const eventBus = new RecordedEconomyEventBus();
+
+  const events = await emitSurplusEvents({
+    eventBus,
+    city: { id: ' city-harbor ' },
+    surplusesByResource: {
+      fish: 7,
+      grain: 4,
+    },
+    desiredByResource: {
+      fish: 3,
+      grain: 6,
+    },
+    availableByResource: {
+      fish: 10,
+      grain: 10,
+    },
+    cause: 'trade-window',
+  });
+
+  assert.deepEqual(events, [
+    {
+      eventName: 'economy.surplus.detected',
+      payload: {
+        cityId: 'city-harbor',
+        resourceId: 'fish',
+        surplusQuantity: 7,
+        availableQuantity: 10,
+        desiredQuantity: 3,
+        cause: 'trade-window',
+      },
+    },
+    {
+      eventName: 'economy.surplus.detected',
+      payload: {
+        cityId: 'city-harbor',
+        resourceId: 'grain',
+        surplusQuantity: 4,
+        availableQuantity: 10,
+        desiredQuantity: 6,
+        cause: 'trade-window',
+      },
+    },
+  ]);
+});
+
+test('EmitSurplusEvents skips empty surplus maps', async () => {
+  const eventBus = new RecordedEconomyEventBus();
+
+  const events = await emitSurplusEvents({
+    eventBus,
+    city: { id: 'city-harbor' },
+    surplusesByResource: {},
+  });
+
+  assert.deepEqual(events, []);
+  assert.deepEqual(eventBus.events, []);
+});
+
+test('EmitSurplusEvents rejects invalid event buses, cities, and resource maps', async () => {
+  await assert.rejects(
+    () => emitSurplusEvents({ eventBus: {}, city: { id: 'city-harbor' }, surplusesByResource: {} }),
+    /eventBus must expose publishSurplus/,
+  );
+
+  await assert.rejects(
+    () => emitSurplusEvents({ eventBus: new RecordedEconomyEventBus(), city: {}, surplusesByResource: {} }),
+    /city.id is required/,
+  );
+
+  await assert.rejects(
+    () => emitSurplusEvents({ eventBus: new RecordedEconomyEventBus(), city: { id: 'city-harbor' }, surplusesByResource: { grain: -1 } }),
+    /surplusesByResource quantities must be integers greater than or equal to 0/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: emit economy surplus events through the existing economy event bus contract.
Beta:
Beta: ## Changes
Beta: - extend `EconomyEventBusPort` with normalized `publishSurplus` semantics for surplus events
Beta: - add `emitSurplusEvents` to publish one event per surplus resource for a city
Beta: - validate surplus, desired, and available resource maps with stable normalized payloads
Beta: - add node tests for surplus event normalization, delegation, empty surpluses, and invalid inputs
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #35
