### PR TITLE
Delta: [D15] Emit intrigue events for exposure

### DIFF
--- a/src/application/intrigue/LancerOperation.js
+++ b/src/application/intrigue/LancerOperation.js
@@ -36,6 +36,60 @@ function getMissingEntries(requiredIds, availableIds, key) {
     .map((id) => ({ [key]: id }));
 }
 
+function buildExposureEvents({
+  cellule,
+  operation,
+  launched,
+  reason,
+  readiness,
+  alertLevel,
+  nextOperation,
+}) {
+  const operationId = String(operation.id ?? '').trim() || null;
+  const celluleId = String(cellule.id ?? '').trim() || null;
+  const currentHeat = operation.heat ?? 0;
+  const nextHeat = nextOperation.heat ?? currentHeat;
+  const heatIncrease = Math.max(0, nextHeat - currentHeat);
+  const assessedEvent = {
+    type: 'intrigue.exposure.assessed',
+    operationId,
+    celluleId,
+    launched,
+    reason,
+    readiness,
+    celluleExposure: cellule.exposure ?? 0,
+    detectionRisk: operation.detectionRisk ?? 0,
+    alertLevel,
+    heatIncrease,
+  };
+  const events = [assessedEvent];
+
+  if (launched && (cellule.exposure > 0 || operation.detectionRisk > 0 || alertLevel > 0 || heatIncrease > 0)) {
+    events.push({
+      type: 'intrigue.exposure.risk-detected',
+      operationId,
+      celluleId,
+      readiness,
+      celluleExposure: cellule.exposure ?? 0,
+      detectionRisk: operation.detectionRisk ?? 0,
+      alertLevel,
+      heatIncrease,
+    });
+  }
+
+  if (!launched && reason === 'cellule-unavailable') {
+    events.push({
+      type: 'intrigue.exposure.cellule-blocked',
+      operationId,
+      celluleId,
+      celluleStatus: String(cellule.status ?? '').trim(),
+      celluleExposure: cellule.exposure ?? 0,
+    });
+  }
+
+  return events;
+}
+
 export function lancerOperation({
   cellule,
   operation,
@@ -78,46 +132,90 @@ export function lancerOperation({
   }
 
   if (normalizedAssignedAgentIds.length === 0) {
+    const nextOperation = { ...normalizedOperation };
+
     return {
       launched: false,
       reason: 'no-assigned-agents',
-      nextOperation: { ...normalizedOperation },
+      nextOperation,
       readiness: 0,
       blockers: [],
+      events: buildExposureEvents({
+        cellule: normalizedCellule,
+        operation: normalizedOperation,
+        launched: false,
+        reason: 'no-assigned-agents',
+        readiness: 0,
+        alertLevel: normalizedAlertLevel,
+        nextOperation,
+      }),
     };
   }
 
   if (celluleStatus === 'compromised' || celluleStatus === 'dismantled') {
+    const nextOperation = { ...normalizedOperation };
+
     return {
       launched: false,
       reason: 'cellule-unavailable',
-      nextOperation: { ...normalizedOperation },
+      nextOperation,
       readiness: 0,
       blockers: [{ status: celluleStatus }],
+      events: buildExposureEvents({
+        cellule: normalizedCellule,
+        operation: normalizedOperation,
+        launched: false,
+        reason: 'cellule-unavailable',
+        readiness: 0,
+        alertLevel: normalizedAlertLevel,
+        nextOperation,
+      }),
     };
   }
 
   const missingAgents = getMissingEntries(normalizedAssignedAgentIds, normalizedAvailableAgentIds, 'agentId');
 
   if (missingAgents.length > 0) {
+    const nextOperation = { ...normalizedOperation };
+
     return {
       launched: false,
       reason: 'missing-agents',
-      nextOperation: { ...normalizedOperation },
+      nextOperation,
       readiness: 0,
       blockers: missingAgents,
+      events: buildExposureEvents({
+        cellule: normalizedCellule,
+        operation: normalizedOperation,
+        launched: false,
+        reason: 'missing-agents',
+        readiness: 0,
+        alertLevel: normalizedAlertLevel,
+        nextOperation,
+      }),
     };
   }
 
   const missingAssets = getMissingEntries(normalizedRequiredAssetIds, normalizedAvailableAssetIds, 'assetId');
 
   if (missingAssets.length > 0) {
+    const nextOperation = { ...normalizedOperation };
+
     return {
       launched: false,
       reason: 'missing-assets',
-      nextOperation: { ...normalizedOperation },
+      nextOperation,
       readiness: 0,
       blockers: missingAssets,
+      events: buildExposureEvents({
+        cellule: normalizedCellule,
+        operation: normalizedOperation,
+        launched: false,
+        reason: 'missing-assets',
+        readiness: 0,
+        alertLevel: normalizedAlertLevel,
+        nextOperation,
+      }),
     };
   }
 
@@ -131,16 +229,27 @@ export function lancerOperation({
   const nextPhase = normalizedOperation.phase === 'planning' ? 'infiltration' : normalizedOperation.phase;
   const nextProgress = nextPhase === 'infiltration' ? Math.max(normalizedOperation.progress ?? 0, 10) : normalizedOperation.progress ?? 0;
 
+  const nextOperation = {
+    ...normalizedOperation,
+    phase: nextPhase,
+    progress: nextProgress,
+    heat: Math.min(100, (normalizedOperation.heat ?? 0) + Math.round(normalizedAlertLevel / 10)),
+  };
+
   return {
     launched: true,
     reason: 'operation-launched',
     readiness,
     blockers: [],
-    nextOperation: {
-      ...normalizedOperation,
-      phase: nextPhase,
-      progress: nextProgress,
-      heat: Math.min(100, (normalizedOperation.heat ?? 0) + Math.round(normalizedAlertLevel / 10)),
-    },
+    nextOperation,
+    events: buildExposureEvents({
+      cellule: normalizedCellule,
+      operation: normalizedOperation,
+      launched: true,
+      reason: 'operation-launched',
+      readiness,
+      alertLevel: normalizedAlertLevel,
+      nextOperation,
+    }),
   };
 }

--- a/test/application/intrigue/LancerOperation.test.js
+++ b/test/application/intrigue/LancerOperation.test.js
@@ -40,6 +40,30 @@ test('LancerOperation moves a prepared operation into infiltration', () => {
       phase: 'infiltration',
       heat: 6,
     },
+    events: [
+      {
+        type: 'intrigue.exposure.assessed',
+        operationId: 'op-cendre',
+        celluleId: 'cellule-ombre',
+        launched: true,
+        reason: 'operation-launched',
+        readiness: 28,
+        celluleExposure: 12,
+        detectionRisk: 17,
+        alertLevel: 15,
+        heatIncrease: 2,
+      },
+      {
+        type: 'intrigue.exposure.risk-detected',
+        operationId: 'op-cendre',
+        celluleId: 'cellule-ombre',
+        readiness: 28,
+        celluleExposure: 12,
+        detectionRisk: 17,
+        alertLevel: 15,
+        heatIncrease: 2,
+      },
+    ],
   });
 });
 
@@ -77,6 +101,20 @@ test('LancerOperation reports blockers for unavailable cellule resources', () =>
       phase: 'planning',
       heat: 0,
     },
+    events: [
+      {
+        type: 'intrigue.exposure.assessed',
+        operationId: null,
+        celluleId: null,
+        launched: false,
+        reason: 'missing-agents',
+        readiness: 0,
+        celluleExposure: 22,
+        detectionRisk: 10,
+        alertLevel: 10,
+        heatIncrease: 0,
+      },
+    ],
   });
 
   const missingAssetsResult = lancerOperation({
@@ -112,6 +150,20 @@ test('LancerOperation reports blockers for unavailable cellule resources', () =>
       phase: 'planning',
       heat: 0,
     },
+    events: [
+      {
+        type: 'intrigue.exposure.assessed',
+        operationId: null,
+        celluleId: null,
+        launched: false,
+        reason: 'missing-assets',
+        readiness: 0,
+        celluleExposure: 22,
+        detectionRisk: 10,
+        alertLevel: 10,
+        heatIncrease: 0,
+      },
+    ],
   });
 });
 
@@ -173,6 +225,30 @@ test('LancerOperation detection risk lowers readiness without changing launch se
     phase: 'infiltration',
     heat: 3,
   });
+  assert.deepEqual(highRiskResult.events, [
+    {
+      type: 'intrigue.exposure.assessed',
+      operationId: 'op-brume',
+      celluleId: null,
+      launched: true,
+      reason: 'operation-launched',
+      readiness: 17,
+      celluleExposure: 8,
+      detectionRisk: 45,
+      alertLevel: 10,
+      heatIncrease: 1,
+    },
+    {
+      type: 'intrigue.exposure.risk-detected',
+      operationId: 'op-brume',
+      celluleId: null,
+      readiness: 17,
+      celluleExposure: 8,
+      detectionRisk: 45,
+      alertLevel: 10,
+      heatIncrease: 1,
+    },
+  ]);
 });
 
 test('LancerOperation rejects invalid inputs and blocks unavailable cellules', () => {
@@ -235,5 +311,26 @@ test('LancerOperation rejects invalid inputs and blocks unavailable cellules', (
       phase: 'planning',
       heat: 0,
     },
+    events: [
+      {
+        type: 'intrigue.exposure.assessed',
+        operationId: null,
+        celluleId: null,
+        launched: false,
+        reason: 'cellule-unavailable',
+        readiness: 0,
+        celluleExposure: 71,
+        detectionRisk: 5,
+        alertLevel: 20,
+        heatIncrease: 0,
+      },
+      {
+        type: 'intrigue.exposure.cellule-blocked',
+        operationId: null,
+        celluleId: null,
+        celluleStatus: 'compromised',
+        celluleExposure: 71,
+      },
+    ],
   });
 });


### PR DESCRIPTION
Delta: Cette PR fait avancer #75 en ajoutant des événements d'exposition structurés à `LancerOperation`.

## Changements
- ajout d'un tableau `events` dans le résultat de `LancerOperation`
- émission d'un événement commun `intrigue.exposure.assessed` pour toute évaluation
- émission d'événements spécialisés pour le risque détecté et pour les cellules indisponibles car compromises
- extension des tests de `LancerOperation` pour verrouiller ces événements

## Vérification
- `npm test`

Closes #75