### PR TITLE
Gamma: [G08] Implement TriggerHistoricalEvent use case

### DIFF
--- a/src/application/culture/triggerHistoricalEvent.js
+++ b/src/application/culture/triggerHistoricalEvent.js
@@ -1,0 +1,176 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireBoolean(value, label) {
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`${label} must be a boolean.`);
+  }
+
+  return value;
+}
+
+function requireInteger(value, label, min = 0) {
+  if (!Number.isInteger(value) || value < min) {
+    throw new RangeError(`${label} must be an integer greater than or equal to ${min}.`);
+  }
+
+  return value;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function normalizeDate(value, label) {
+  const normalizedValue = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(normalizedValue.getTime())) {
+    throw new RangeError(`${label} must be a valid date.`);
+  }
+
+  return normalizedValue.toISOString();
+}
+
+function normalizeHistoricalEvent(historicalEvent) {
+  if (!historicalEvent || typeof historicalEvent !== 'object') {
+    throw new TypeError('triggerHistoricalEvent historicalEvent must be an object.');
+  }
+
+  const normalizedHistoricalEvent = {
+    ...historicalEvent,
+    id: requireText(historicalEvent.id, 'triggerHistoricalEvent historicalEvent.id'),
+    title: requireText(historicalEvent.title, 'triggerHistoricalEvent historicalEvent.title'),
+    era: requireText(historicalEvent.era, 'triggerHistoricalEvent historicalEvent.era'),
+    summary: requireText(historicalEvent.summary, 'triggerHistoricalEvent historicalEvent.summary'),
+    affectedCultureIds: normalizeUniqueTexts(
+      historicalEvent.affectedCultureIds ?? [],
+      'triggerHistoricalEvent historicalEvent.affectedCultureIds',
+    ),
+    consequenceIds: normalizeUniqueTexts(
+      historicalEvent.consequenceIds ?? [],
+      'triggerHistoricalEvent historicalEvent.consequenceIds',
+    ),
+    unlockedResearchIds: normalizeUniqueTexts(
+      historicalEvent.unlockedResearchIds ?? [],
+      'triggerHistoricalEvent historicalEvent.unlockedResearchIds',
+    ),
+    repeatable: requireBoolean(
+      historicalEvent.repeatable ?? false,
+      'triggerHistoricalEvent historicalEvent.repeatable',
+    ),
+    triggerCount: requireInteger(
+      historicalEvent.triggerCount ?? 0,
+      'triggerHistoricalEvent historicalEvent.triggerCount',
+      0,
+    ),
+    lastTriggeredAt:
+      historicalEvent.lastTriggeredAt === null || historicalEvent.lastTriggeredAt === undefined
+        ? null
+        : normalizeDate(
+            historicalEvent.lastTriggeredAt,
+            'triggerHistoricalEvent historicalEvent.lastTriggeredAt',
+          ),
+    divergenceId:
+      historicalEvent.divergenceId === null || historicalEvent.divergenceId === undefined
+        ? null
+        : requireText(
+            historicalEvent.divergenceId,
+            'triggerHistoricalEvent historicalEvent.divergenceId',
+          ),
+  };
+
+  if (!normalizedHistoricalEvent.repeatable && normalizedHistoricalEvent.triggerCount > 1) {
+    throw new RangeError(
+      'triggerHistoricalEvent historicalEvent.triggerCount cannot exceed 1 for a non-repeatable event.',
+    );
+  }
+
+  return normalizedHistoricalEvent;
+}
+
+function normalizeExecution(execution) {
+  if (!execution || typeof execution !== 'object') {
+    throw new TypeError('triggerHistoricalEvent execution must be an object.');
+  }
+
+  return {
+    triggeredAt: normalizeDate(
+      execution.triggeredAt ?? new Date(),
+      'triggerHistoricalEvent execution.triggeredAt',
+    ),
+    triggeredBy: requireText(
+      execution.triggeredBy ?? 'system',
+      'triggerHistoricalEvent execution.triggeredBy',
+    ),
+    consequenceIds: normalizeUniqueTexts(
+      execution.consequenceIds ?? [],
+      'triggerHistoricalEvent execution.consequenceIds',
+    ),
+    unlockedResearchIds: normalizeUniqueTexts(
+      execution.unlockedResearchIds ?? [],
+      'triggerHistoricalEvent execution.unlockedResearchIds',
+    ),
+    divergenceId:
+      execution.divergenceId === null || execution.divergenceId === undefined
+        ? null
+        : requireText(execution.divergenceId, 'triggerHistoricalEvent execution.divergenceId'),
+  };
+}
+
+export function triggerHistoricalEvent(historicalEvent, execution = {}) {
+  const normalizedHistoricalEvent = normalizeHistoricalEvent(historicalEvent);
+  const normalizedExecution = normalizeExecution(execution);
+
+  if (!normalizedHistoricalEvent.repeatable && normalizedHistoricalEvent.triggerCount >= 1) {
+    throw new RangeError(
+      'triggerHistoricalEvent cannot re-trigger a non-repeatable event once it has already fired.',
+    );
+  }
+
+  if (
+    normalizedHistoricalEvent.divergenceId !== null &&
+    normalizedExecution.divergenceId !== null &&
+    normalizedHistoricalEvent.divergenceId !== normalizedExecution.divergenceId
+  ) {
+    throw new RangeError(
+      'triggerHistoricalEvent execution.divergenceId must match the event divergenceId when one is already attached.',
+    );
+  }
+
+  const consequenceIds = normalizeUniqueTexts(
+    [...normalizedHistoricalEvent.consequenceIds, ...normalizedExecution.consequenceIds],
+    'triggerHistoricalEvent merged consequence ids',
+  );
+  const unlockedResearchIds = normalizeUniqueTexts(
+    [...normalizedHistoricalEvent.unlockedResearchIds, ...normalizedExecution.unlockedResearchIds],
+    'triggerHistoricalEvent merged unlocked research ids',
+  );
+  const divergenceId = normalizedExecution.divergenceId ?? normalizedHistoricalEvent.divergenceId;
+
+  return {
+    ...normalizedHistoricalEvent,
+    consequenceIds,
+    unlockedResearchIds,
+    divergenceId,
+    triggerCount: normalizedHistoricalEvent.triggerCount + 1,
+    lastTriggeredAt: normalizedExecution.triggeredAt,
+    lastTriggeredBy: normalizedExecution.triggeredBy,
+  };
+}

--- a/test/application/culture/triggerHistoricalEvent.test.js
+++ b/test/application/culture/triggerHistoricalEvent.test.js
@@ -1,0 +1,162 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { triggerHistoricalEvent } from '../../../src/application/culture/triggerHistoricalEvent.js';
+
+test('triggerHistoricalEvent merges consequences and unlocked research immutably', () => {
+  const historicalEvent = {
+    id: 'event-library-revolt',
+    title: 'Library Revolt',
+    era: 'late-medieval',
+    summary: 'Scribes force the court to open its archives to guild schools.',
+    affectedCultureIds: ['culture-north'],
+    consequenceIds: ['archive-reform'],
+    unlockedResearchIds: ['paper-ledgers'],
+    repeatable: true,
+    triggerCount: 0,
+    lastTriggeredAt: null,
+    divergenceId: null,
+  };
+
+  const triggeredEvent = triggerHistoricalEvent(historicalEvent, {
+    triggeredAt: '2026-04-18T13:15:00.000Z',
+    triggeredBy: 'gamma-simulation',
+    consequenceIds: ['public-archives', 'archive-reform'],
+    unlockedResearchIds: ['paper-ledgers', 'civic-literacy'],
+    divergenceId: 'divergence-open-archives',
+  });
+
+  assert.notEqual(triggeredEvent, historicalEvent);
+  assert.deepEqual(triggeredEvent.consequenceIds, ['archive-reform', 'public-archives']);
+  assert.deepEqual(triggeredEvent.unlockedResearchIds, ['civic-literacy', 'paper-ledgers']);
+  assert.equal(triggeredEvent.divergenceId, 'divergence-open-archives');
+  assert.equal(triggeredEvent.triggerCount, 1);
+  assert.equal(triggeredEvent.lastTriggeredAt, '2026-04-18T13:15:00.000Z');
+  assert.equal(triggeredEvent.lastTriggeredBy, 'gamma-simulation');
+  assert.deepEqual(historicalEvent.consequenceIds, ['archive-reform']);
+  assert.deepEqual(historicalEvent.unlockedResearchIds, ['paper-ledgers']);
+});
+
+test('triggerHistoricalEvent preserves an attached divergence id when execution omits it', () => {
+  const triggeredEvent = triggerHistoricalEvent(
+    {
+      id: 'event-court-translation-drive',
+      title: 'Court Translation Drive',
+      era: 'early-modern',
+      summary: 'A royal bureau sponsors translations of rival chronicles.',
+      affectedCultureIds: ['culture-east'],
+      consequenceIds: [],
+      unlockedResearchIds: ['linguistics'],
+      repeatable: true,
+      triggerCount: 1,
+      lastTriggeredAt: '2026-04-18T12:00:00.000Z',
+      divergenceId: 'divergence-shared-canon',
+    },
+    {
+      triggeredAt: '2026-04-18T13:20:00.000Z',
+      triggeredBy: 'council-gamma',
+      consequenceIds: ['canon-debate'],
+    },
+  );
+
+  assert.equal(triggeredEvent.divergenceId, 'divergence-shared-canon');
+  assert.equal(triggeredEvent.triggerCount, 2);
+  assert.equal(triggeredEvent.lastTriggeredBy, 'council-gamma');
+});
+
+test('triggerHistoricalEvent rejects re-triggering a non-repeatable event', () => {
+  assert.throws(
+    () =>
+      triggerHistoricalEvent(
+        {
+          id: 'event-broken-seal',
+          title: 'Broken Seal',
+          era: 'classical',
+          summary: 'An imperial seal is broken and reveals forbidden annals.',
+          affectedCultureIds: ['culture-south'],
+          consequenceIds: [],
+          unlockedResearchIds: [],
+          repeatable: false,
+          triggerCount: 1,
+          lastTriggeredAt: '2026-04-18T12:00:00.000Z',
+          divergenceId: null,
+        },
+        {
+          triggeredAt: '2026-04-18T13:25:00.000Z',
+        },
+      ),
+    /triggerHistoricalEvent cannot re-trigger a non-repeatable event once it has already fired/,
+  );
+});
+
+test('triggerHistoricalEvent rejects mismatched divergence ids and invalid payloads', () => {
+  assert.throws(
+    () =>
+      triggerHistoricalEvent(
+        {
+          id: 'event-broken-seal',
+          title: 'Broken Seal',
+          era: 'classical',
+          summary: 'An imperial seal is broken and reveals forbidden annals.',
+          affectedCultureIds: ['culture-south'],
+          consequenceIds: [],
+          unlockedResearchIds: [],
+          repeatable: true,
+          triggerCount: 0,
+          lastTriggeredAt: null,
+          divergenceId: 'divergence-sealed-archives',
+        },
+        {
+          triggeredAt: '2026-04-18T13:25:00.000Z',
+          divergenceId: 'divergence-rival-archives',
+        },
+      ),
+    /triggerHistoricalEvent execution.divergenceId must match the event divergenceId when one is already attached/,
+  );
+
+  assert.throws(
+    () =>
+      triggerHistoricalEvent(
+        {
+          id: 'event-broken-seal',
+          title: 'Broken Seal',
+          era: 'classical',
+          summary: 'An imperial seal is broken and reveals forbidden annals.',
+          affectedCultureIds: ['culture-south'],
+          consequenceIds: [],
+          unlockedResearchIds: [],
+          repeatable: 'no',
+          triggerCount: 0,
+          lastTriggeredAt: null,
+          divergenceId: null,
+        },
+        {
+          triggeredAt: '2026-04-18T13:25:00.000Z',
+        },
+      ),
+    /triggerHistoricalEvent historicalEvent.repeatable must be a boolean/,
+  );
+
+  assert.throws(
+    () =>
+      triggerHistoricalEvent(
+        {
+          id: 'event-broken-seal',
+          title: 'Broken Seal',
+          era: 'classical',
+          summary: 'An imperial seal is broken and reveals forbidden annals.',
+          affectedCultureIds: ['culture-south'],
+          consequenceIds: [],
+          unlockedResearchIds: [''],
+          repeatable: true,
+          triggerCount: 0,
+          lastTriggeredAt: null,
+          divergenceId: null,
+        },
+        {
+          triggeredAt: '2026-04-18T13:25:00.000Z',
+        },
+      ),
+    /triggerHistoricalEvent historicalEvent.unlockedResearchIds cannot contain empty values/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: implement `triggerHistoricalEvent` as a focused Gamma use case for one event execution
- Gamma: validate event and execution payloads, merge consequences and unlocked research immutably, and track trigger metadata
- Gamma: reject invalid re-triggers and divergence mismatches with targeted tests

## Related issue

- One issue only: #48

## Changes

- Gamma: add `src/application/culture/triggerHistoricalEvent.js`
- Gamma: add `test/application/culture/triggerHistoricalEvent.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [x] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage des anciennes branches Gamma.
