### PR TITLE
Delta: [D14] Add in-memory intrigue adapter

### DIFF
--- a/src/adapters/intrigue/InMemoryIntrigueRepository.js
+++ b/src/adapters/intrigue/InMemoryIntrigueRepository.js
@@ -1,0 +1,114 @@
+import { Cellule } from '../../domain/intrigue/Cellule.js';
+import { OperationClandestine } from '../../domain/intrigue/OperationClandestine.js';
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeCellule(cellule) {
+  if (cellule instanceof Cellule) {
+    return new Cellule(cellule.toJSON());
+  }
+
+  if (cellule === null || typeof cellule !== 'object' || Array.isArray(cellule)) {
+    throw new TypeError('InMemoryIntrigueRepository cellule must be an object.');
+  }
+
+  return new Cellule(cellule);
+}
+
+function normalizeOperation(operation) {
+  if (operation instanceof OperationClandestine) {
+    return new OperationClandestine(operation.toJSON());
+  }
+
+  if (operation === null || typeof operation !== 'object' || Array.isArray(operation)) {
+    throw new TypeError('InMemoryIntrigueRepository operation must be an object.');
+  }
+
+  return new OperationClandestine(operation);
+}
+
+export class InMemoryIntrigueRepository {
+  constructor({ cellules = [], operations = [] } = {}) {
+    if (!Array.isArray(cellules)) {
+      throw new TypeError('InMemoryIntrigueRepository cellules must be an array.');
+    }
+
+    if (!Array.isArray(operations)) {
+      throw new TypeError('InMemoryIntrigueRepository operations must be an array.');
+    }
+
+    this.cellulesById = new Map();
+    this.operationsById = new Map();
+
+    for (const cellule of cellules) {
+      const normalizedCellule = normalizeCellule(cellule);
+      this.cellulesById.set(normalizedCellule.id, normalizedCellule);
+    }
+
+    for (const operation of operations) {
+      const normalizedOperation = normalizeOperation(operation);
+      this.operationsById.set(normalizedOperation.id, normalizedOperation);
+    }
+  }
+
+  async getCelluleById(celluleId) {
+    const normalizedCelluleId = requireText(celluleId, 'InMemoryIntrigueRepository celluleId');
+    const cellule = this.cellulesById.get(normalizedCelluleId);
+    return cellule ? new Cellule(cellule.toJSON()) : null;
+  }
+
+  async saveCellule(cellule) {
+    const normalizedCellule = normalizeCellule(cellule);
+    this.cellulesById.set(normalizedCellule.id, normalizedCellule);
+    return new Cellule(normalizedCellule.toJSON());
+  }
+
+  async listCellulesByFaction(factionId) {
+    const normalizedFactionId = requireText(factionId, 'InMemoryIntrigueRepository factionId');
+
+    return [...this.cellulesById.values()]
+      .filter((cellule) => cellule.factionId === normalizedFactionId)
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((cellule) => new Cellule(cellule.toJSON()));
+  }
+
+  async getOperationById(operationId) {
+    const normalizedOperationId = requireText(operationId, 'InMemoryIntrigueRepository operationId');
+    const operation = this.operationsById.get(normalizedOperationId);
+    return operation ? new OperationClandestine(operation.toJSON()) : null;
+  }
+
+  async saveOperation(operation) {
+    const normalizedOperation = normalizeOperation(operation);
+    this.operationsById.set(normalizedOperation.id, normalizedOperation);
+    return new OperationClandestine(normalizedOperation.toJSON());
+  }
+
+  async listOperationsByCellule(celluleId) {
+    const normalizedCelluleId = requireText(celluleId, 'InMemoryIntrigueRepository celluleId');
+
+    return [...this.operationsById.values()]
+      .filter((operation) => operation.celluleId === normalizedCelluleId)
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((operation) => new OperationClandestine(operation.toJSON()));
+  }
+
+  snapshot() {
+    return {
+      cellules: [...this.cellulesById.values()]
+        .sort((left, right) => left.id.localeCompare(right.id))
+        .map((cellule) => cellule.toJSON()),
+      operations: [...this.operationsById.values()]
+        .sort((left, right) => left.id.localeCompare(right.id))
+        .map((operation) => operation.toJSON()),
+    };
+  }
+}

--- a/test/adapters/intrigue/InMemoryIntrigueRepository.test.js
+++ b/test/adapters/intrigue/InMemoryIntrigueRepository.test.js
@@ -1,0 +1,208 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryIntrigueRepository } from '../../../src/adapters/intrigue/InMemoryIntrigueRepository.js';
+import { Cellule } from '../../../src/domain/intrigue/Cellule.js';
+import { OperationClandestine } from '../../../src/domain/intrigue/OperationClandestine.js';
+
+test('InMemoryIntrigueRepository loads intrigue state and returns defensive copies', async () => {
+  const repository = new InMemoryIntrigueRepository({
+    cellules: [
+      {
+        id: ' cellule-brume ',
+        factionId: ' faction-delta ',
+        codename: ' Brume ',
+        locationId: ' port-nord ',
+        memberIds: ['agent-2', ' agent-1 '],
+        assetIds: ['safehouse-port'],
+      },
+    ],
+    operations: [
+      {
+        id: ' op-cendre ',
+        celluleId: ' cellule-brume ',
+        targetFactionId: ' faction-rivale ',
+        type: 'sabotage',
+        objective: ' Couper le ravitaillement ',
+        theaterId: ' port-nord ',
+        assignedAgentIds: ['agent-2', ' agent-1 '],
+        requiredAssetIds: ['safehouse-port'],
+      },
+    ],
+  });
+
+  const cellule = await repository.getCelluleById('cellule-brume');
+  const operation = await repository.getOperationById('op-cendre');
+
+  assert.equal(cellule instanceof Cellule, true);
+  assert.equal(operation instanceof OperationClandestine, true);
+  assert.deepEqual(cellule?.toJSON(), {
+    id: 'cellule-brume',
+    factionId: 'faction-delta',
+    codename: 'Brume',
+    locationId: 'port-nord',
+    memberIds: ['agent-1', 'agent-2'],
+    assetIds: ['safehouse-port'],
+    operationIds: [],
+    secrecy: 50,
+    loyalty: 50,
+    exposure: 0,
+    status: 'active',
+    sleeper: false,
+  });
+  assert.deepEqual(operation?.toJSON(), {
+    id: 'op-cendre',
+    celluleId: 'cellule-brume',
+    targetFactionId: 'faction-rivale',
+    type: 'sabotage',
+    objective: 'Couper le ravitaillement',
+    theaterId: 'port-nord',
+    assignedAgentIds: ['agent-1', 'agent-2'],
+    requiredAssetIds: ['safehouse-port'],
+    difficulty: 50,
+    detectionRisk: 25,
+    progress: 0,
+    phase: 'planning',
+    heat: 0,
+  });
+
+  cellule.memberIds.push('mutated');
+  operation.assignedAgentIds.push('mutated');
+
+  assert.deepEqual((await repository.getCelluleById('cellule-brume'))?.memberIds, ['agent-1', 'agent-2']);
+  assert.deepEqual((await repository.getOperationById('op-cendre'))?.assignedAgentIds, ['agent-1', 'agent-2']);
+});
+
+test('InMemoryIntrigueRepository saves and lists cellules and operations in stable order', async () => {
+  const repository = new InMemoryIntrigueRepository();
+
+  await repository.saveCellule({
+    id: 'cellule-zeta',
+    factionId: 'faction-delta',
+    codename: 'Zeta',
+    locationId: 'front-est',
+    memberIds: ['agent-z'],
+  });
+
+  await repository.saveCellule({
+    id: 'cellule-alpha',
+    factionId: 'faction-delta',
+    codename: 'Alpha',
+    locationId: 'port-nord',
+    memberIds: ['agent-a'],
+  });
+
+  await repository.saveOperation({
+    id: 'op-2',
+    celluleId: 'cellule-alpha',
+    targetFactionId: 'faction-rivale',
+    type: 'intelligence',
+    objective: 'Observer le port',
+    theaterId: 'port-nord',
+  });
+
+  await repository.saveOperation({
+    id: 'op-1',
+    celluleId: 'cellule-alpha',
+    targetFactionId: 'faction-rivale',
+    type: 'rumor',
+    objective: 'Semer le doute',
+    theaterId: 'port-nord',
+  });
+
+  const celluleIds = (await repository.listCellulesByFaction('faction-delta')).map((cellule) => cellule.id);
+  const operationIds = (await repository.listOperationsByCellule('cellule-alpha')).map((operation) => operation.id);
+
+  assert.deepEqual(celluleIds, ['cellule-alpha', 'cellule-zeta']);
+  assert.deepEqual(operationIds, ['op-1', 'op-2']);
+  assert.deepEqual(repository.snapshot(), {
+    cellules: [
+      {
+        id: 'cellule-alpha',
+        factionId: 'faction-delta',
+        codename: 'Alpha',
+        locationId: 'port-nord',
+        memberIds: ['agent-a'],
+        assetIds: [],
+        operationIds: [],
+        secrecy: 50,
+        loyalty: 50,
+        exposure: 0,
+        status: 'active',
+        sleeper: false,
+      },
+      {
+        id: 'cellule-zeta',
+        factionId: 'faction-delta',
+        codename: 'Zeta',
+        locationId: 'front-est',
+        memberIds: ['agent-z'],
+        assetIds: [],
+        operationIds: [],
+        secrecy: 50,
+        loyalty: 50,
+        exposure: 0,
+        status: 'active',
+        sleeper: false,
+      },
+    ],
+    operations: [
+      {
+        id: 'op-1',
+        celluleId: 'cellule-alpha',
+        targetFactionId: 'faction-rivale',
+        type: 'rumor',
+        objective: 'Semer le doute',
+        theaterId: 'port-nord',
+        assignedAgentIds: [],
+        requiredAssetIds: [],
+        difficulty: 50,
+        detectionRisk: 25,
+        progress: 0,
+        phase: 'planning',
+        heat: 0,
+      },
+      {
+        id: 'op-2',
+        celluleId: 'cellule-alpha',
+        targetFactionId: 'faction-rivale',
+        type: 'intelligence',
+        objective: 'Observer le port',
+        theaterId: 'port-nord',
+        assignedAgentIds: [],
+        requiredAssetIds: [],
+        difficulty: 50,
+        detectionRisk: 25,
+        progress: 0,
+        phase: 'planning',
+        heat: 0,
+      },
+    ],
+  });
+});
+
+test('InMemoryIntrigueRepository rejects invalid constructor and save payloads', async () => {
+  assert.throws(() => new InMemoryIntrigueRepository({ cellules: null }), /cellules must be an array/);
+  assert.throws(() => new InMemoryIntrigueRepository({ operations: null }), /operations must be an array/);
+  assert.throws(() => new InMemoryIntrigueRepository({ cellules: [null] }), /cellule must be an object/);
+  assert.throws(() => new InMemoryIntrigueRepository({ operations: [null] }), /operation must be an object/);
+
+  const repository = new InMemoryIntrigueRepository();
+
+  await assert.rejects(
+    () => repository.saveCellule({ factionId: 'faction-delta', codename: 'Brume', locationId: 'port-nord' }),
+    /Cellule id is required/,
+  );
+
+  await assert.rejects(
+    () =>
+      repository.saveOperation({
+        id: 'op-cendre',
+        celluleId: 'cellule-brume',
+        targetFactionId: 'faction-rivale',
+        type: 'sabotage',
+        objective: 'Couper le ravitaillement',
+      }),
+    /OperationClandestine theaterId is required/,
+  );
+});


### PR DESCRIPTION
Delta: Cette PR fait avancer #74 en ajoutant un adaptateur mémoire pour la tranche intrigue.

## Changements
- ajout de `InMemoryIntrigueRepository` pour stocker cellules et opérations clandestines en mémoire
- lecture, sauvegarde, listing stable et snapshots pour les données intrigue
- normalisation des entrées et copies défensives via `Cellule` et `OperationClandestine`
- ajout de tests ciblés pour le chargement, la persistance, l'ordre stable et les erreurs de validation

## Vérification
- `npm test`

Closes #74