### PR TITLE
Epsilon: [E13] Add in-memory myth ledger adapter

### DIFF
--- a/src/adapters/climate/InMemoryMythLedger.js
+++ b/src/adapters/climate/InMemoryMythLedger.js
@@ -1,0 +1,71 @@
+import { MythLedgerPort } from '../../application/ports/MythLedgerPort.js';
+import { Myth } from '../../domain/climate/Myth.js';
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeMyth(myth) {
+  if (myth instanceof Myth) {
+    return new Myth(myth.toJSON());
+  }
+
+  if (myth === null || typeof myth !== 'object' || Array.isArray(myth)) {
+    throw new TypeError('InMemoryMythLedger myth must be a Myth or plain object.');
+  }
+
+  return new Myth(myth);
+}
+
+export class InMemoryMythLedger extends MythLedgerPort {
+  constructor(seed = []) {
+    super();
+
+    if (!Array.isArray(seed)) {
+      throw new TypeError('InMemoryMythLedger seed must be an array.');
+    }
+
+    this.mythsById = new Map();
+    this.mythIdsByOriginEventId = new Map();
+
+    for (const myth of seed) {
+      this.record(myth);
+    }
+  }
+
+  record(myth) {
+    const normalizedMyth = normalizeMyth(myth);
+    this.mythsById.set(normalizedMyth.id, normalizedMyth);
+
+    for (const originEventId of normalizedMyth.originEventIds) {
+      const mythIds = this.mythIdsByOriginEventId.get(originEventId) ?? [];
+      this.mythIdsByOriginEventId.set(originEventId, [...new Set([...mythIds, normalizedMyth.id])]);
+    }
+
+    return new Myth(normalizedMyth.toJSON());
+  }
+
+  findByOriginEventId(originEventId) {
+    const normalizedOriginEventId = requireText(originEventId, 'InMemoryMythLedger.findByOriginEventId originEventId');
+    const mythIds = this.mythIdsByOriginEventId.get(normalizedOriginEventId) ?? [];
+    return mythIds.map((mythId) => new Myth(this.mythsById.get(mythId).toJSON()));
+  }
+
+  findByMythId(mythId) {
+    const normalizedMythId = requireText(mythId, 'InMemoryMythLedger.findByMythId mythId');
+    const myth = this.mythsById.get(normalizedMythId);
+    return myth ? new Myth(myth.toJSON()) : null;
+  }
+
+  snapshot() {
+    return [...this.mythsById.values()]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((myth) => myth.toJSON());
+  }
+}

--- a/test/adapters/climate/InMemoryMythLedger.test.js
+++ b/test/adapters/climate/InMemoryMythLedger.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryMythLedger } from '../../../src/adapters/climate/InMemoryMythLedger.js';
+import { Myth } from '../../../src/domain/climate/Myth.js';
+
+test('InMemoryMythLedger records myths and finds them from origin events', () => {
+  const ledger = new InMemoryMythLedger([
+    new Myth({
+      id: 'myth-storm-001',
+      title: 'The Skyfire Returns',
+      category: 'omen',
+      originEventIds: ['storm-001'],
+      summary: 'A radiant omen seen before the floods.',
+    }),
+  ]);
+
+  const recorded = ledger.record({
+    id: 'myth-flood-002',
+    title: 'The River Without Mercy',
+    category: 'catastrophe',
+    originEventIds: ['flood-002', 'storm-001'],
+    summary: 'A tale born from the great flood.',
+    tags: ['flood'],
+  });
+
+  assert.equal(recorded.id, 'myth-flood-002');
+  assert.deepEqual(ledger.findByOriginEventId('flood-002').map((myth) => myth.id), ['myth-flood-002']);
+  assert.deepEqual(ledger.findByOriginEventId('storm-001').map((myth) => myth.id), ['myth-storm-001', 'myth-flood-002']);
+  assert.equal(ledger.findByMythId('myth-flood-002')?.title, 'The River Without Mercy');
+});
+
+test('InMemoryMythLedger returns defensive copies for recorded and loaded myths', () => {
+  const ledger = new InMemoryMythLedger();
+
+  const recorded = ledger.record({
+    id: 'myth-solstice-003',
+    title: 'The Burning Solstice',
+    category: 'seasonal',
+    originEventIds: ['solstice-003'],
+    summary: 'A tale woven around the hottest summer on record.',
+    tags: ['summer'],
+  });
+
+  recorded.title = 'Tampered title';
+
+  const found = ledger.findByMythId('myth-solstice-003');
+  found.tags.push('mutated');
+
+  assert.equal(ledger.findByMythId('myth-solstice-003')?.title, 'The Burning Solstice');
+  assert.deepEqual(ledger.findByMythId('myth-solstice-003')?.tags, ['summer']);
+});
+
+test('InMemoryMythLedger snapshots canonical myth data and validates identifiers', () => {
+  const ledger = new InMemoryMythLedger([
+    {
+      id: 'myth-blizzard-king',
+      title: 'The Blizzard King',
+      category: 'catastrophe',
+      originEventIds: ['blizzard-7'],
+      summary: 'A tale born from the great white winter.',
+      credibility: 40,
+    },
+  ]);
+
+  assert.deepEqual(ledger.snapshot().map((myth) => myth.id), ['myth-blizzard-king']);
+  assert.deepEqual(ledger.findByOriginEventId('unknown-event'), []);
+
+  assert.throws(
+    () => new InMemoryMythLedger({}),
+    /seed must be an array/,
+  );
+
+  assert.throws(
+    () => new InMemoryMythLedger([null]),
+    /must be a Myth or plain object/,
+  );
+
+  assert.throws(
+    () => ledger.findByOriginEventId(''),
+    /originEventId is required/,
+  );
+
+  assert.throws(
+    () => ledger.findByMythId('  '),
+    /mythId is required/,
+  );
+});


### PR DESCRIPTION
Epsilon: reprise propre depuis main pour l’issue #93.

## Summary
- add InMemoryMythLedger as a concrete adapter for MythLedgerPort
- normalize recorded myths into canonical Myth instances and preserve lookup indexes by origin event
- cover recording, lookups, snapshots, validation, and defensive copies with targeted tests

## Verification
- node --test

Closes #93
