### PR TITLE
Gamma: [G09] Create CultureRepository port

### DIFF
--- a/src/domain/culture/CultureRepositoryPort.js
+++ b/src/domain/culture/CultureRepositoryPort.js
@@ -1,0 +1,38 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireCulture(culture) {
+  if (!culture || typeof culture !== 'object' || Array.isArray(culture)) {
+    throw new TypeError('CultureRepositoryPort culture must be an object.');
+  }
+
+  return {
+    ...culture,
+    id: requireText(culture.id, 'CultureRepositoryPort culture.id'),
+    name: requireText(culture.name, 'CultureRepositoryPort culture.name'),
+  };
+}
+
+export class CultureRepositoryPort {
+  async getById(cultureId) {
+    requireText(cultureId, 'CultureRepositoryPort cultureId');
+    throw new Error('CultureRepositoryPort.getById must be implemented by an adapter.');
+  }
+
+  async save(culture) {
+    requireCulture(culture);
+    throw new Error('CultureRepositoryPort.save must be implemented by an adapter.');
+  }
+
+  async listByEra(eraId) {
+    requireText(eraId, 'CultureRepositoryPort eraId');
+    throw new Error('CultureRepositoryPort.listByEra must be implemented by an adapter.');
+  }
+}

--- a/test/domain/culture/CultureRepositoryPort.test.js
+++ b/test/domain/culture/CultureRepositoryPort.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CultureRepositoryPort } from '../../../src/domain/culture/CultureRepositoryPort.js';
+
+test('CultureRepositoryPort validates identifiers before delegating to adapters', async () => {
+  const port = new CultureRepositoryPort();
+
+  await assert.rejects(() => port.getById(''), /CultureRepositoryPort cultureId is required/);
+  await assert.rejects(() => port.listByEra('   '), /CultureRepositoryPort eraId is required/);
+});
+
+test('CultureRepositoryPort validates culture payloads before save', async () => {
+  const port = new CultureRepositoryPort();
+
+  await assert.rejects(() => port.save(null), /CultureRepositoryPort culture must be an object/);
+  await assert.rejects(
+    () => port.save({ id: 'culture-north', name: ' ' }),
+    /CultureRepositoryPort culture.name is required/,
+  );
+  await assert.rejects(
+    () => port.save({ id: ' ', name: 'Northern Scriptorium' }),
+    /CultureRepositoryPort culture.id is required/,
+  );
+});
+
+test('CultureRepositoryPort exposes explicit adapter implementation errors', async () => {
+  const port = new CultureRepositoryPort();
+  const culture = { id: 'culture-north', name: 'Northern Scriptorium', eraId: 'late-medieval' };
+
+  await assert.rejects(
+    () => port.getById('culture-north'),
+    /CultureRepositoryPort\.getById must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.save(culture),
+    /CultureRepositoryPort\.save must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.listByEra('late-medieval'),
+    /CultureRepositoryPort\.listByEra must be implemented by an adapter/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add `CultureRepositoryPort` as the dedicated culture repository contract for Gamma systems
- Gamma: validate repository identifiers and save payloads before adapter delegation
- Gamma: add focused port tests for validation paths and explicit adapter implementation errors

## Related issue

- One issue only: #49

## Changes

- Gamma: add `src/domain/culture/CultureRepositoryPort.js`
- Gamma: add `test/domain/culture/CultureRepositoryPort.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [x] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage des anciennes branches Gamma.
