### PR TITLE
Delta: [D18] Add tests for network exposure

### DIFF
--- a/test/domain/intrigue/Cellule.test.js
+++ b/test/domain/intrigue/Cellule.test.js
@@ -78,16 +78,40 @@ test('Cellule marks network exposure when heat crosses the compromise threshold'
     status: 'active',
   });
 
+  const thresholdCellule = cellule.withExposure(69);
   const exposedCellule = cellule.withExposure(70);
   const deeplyExposedCellule = exposedCellule.withExposure(92);
 
   assert.equal(cellule.isExposed, false);
+  assert.equal(thresholdCellule.isExposed, false);
+  assert.equal(thresholdCellule.status, 'active');
+  assert.equal(thresholdCellule.operationalReadiness, 64);
   assert.equal(exposedCellule.isExposed, true);
   assert.equal(exposedCellule.status, 'compromised');
   assert.equal(exposedCellule.operationalReadiness, 63);
   assert.equal(deeplyExposedCellule.isExposed, true);
   assert.equal(deeplyExposedCellule.status, 'compromised');
   assert.equal(deeplyExposedCellule.operationalReadiness, 56);
+});
+
+test('Cellule keeps compromised network status explicit even when exposure later drops', () => {
+  const cellule = new Cellule({
+    id: 'cellule-ombre',
+    factionId: 'faction-nocturne',
+    codename: 'Les Lanternes',
+    locationId: 'district-cendre',
+    secrecy: 61,
+    loyalty: 74,
+    exposure: 73,
+    status: 'compromised',
+  });
+
+  const cooledDownCellule = cellule.withExposure(18);
+
+  assert.equal(cooledDownCellule.exposure, 18);
+  assert.equal(cooledDownCellule.status, 'compromised');
+  assert.equal(cooledDownCellule.isExposed, true);
+  assert.equal(cooledDownCellule.operationalReadiness, 72);
 });
 
 test('Cellule keeps a dismantled network dismantled even when exposure changes', () => {


### PR DESCRIPTION
Delta: Cette PR fait avancer #78 en renforçant les tests du domaine `Cellule` autour de l'exposition réseau.

## Changements
- ajout d'un cas frontière à 69 vs 70 pour verrouiller le seuil d'exposition
- ajout d'un test vérifiant qu'une cellule compromise reste explicitement compromise même si son exposition redescend ensuite
- lot strictement limité aux tests domaine de `Cellule`

## Vérification
- `npm test -- --test-name-pattern=Cellule`

Closes #78