### PR TITLE
Epsilon: [E14] Emit climate events for harvest impact

### DIFF
--- a/src/application/climate/ClimateEventBusPort.js
+++ b/src/application/climate/ClimateEventBusPort.js
@@ -1,0 +1,52 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireInteger(value, label, min, max) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return value;
+}
+
+function requirePayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new TypeError('ClimateEventBusPort payload must be an object.');
+  }
+
+  return payload;
+}
+
+function normalizeHarvestImpactPayload(payload) {
+  const normalizedPayload = requirePayload(payload);
+
+  return {
+    regionId: requireText(normalizedPayload.regionId, 'ClimateEventBusPort regionId'),
+    season: requireText(normalizedPayload.season, 'ClimateEventBusPort season'),
+    resourceId: requireText(normalizedPayload.resourceId, 'ClimateEventBusPort resourceId'),
+    impactLevel: requireInteger(normalizedPayload.impactLevel, 'ClimateEventBusPort impactLevel', -100, 100),
+    droughtIndex: requireInteger(normalizedPayload.droughtIndex, 'ClimateEventBusPort droughtIndex', 0, 100),
+    precipitationLevel: requireInteger(normalizedPayload.precipitationLevel, 'ClimateEventBusPort precipitationLevel', 0, 100),
+    anomaly: normalizedPayload.anomaly === null || normalizedPayload.anomaly === undefined
+      ? null
+      : requireText(normalizedPayload.anomaly, 'ClimateEventBusPort anomaly'),
+    cause: requireText(normalizedPayload.cause ?? 'climate-harvest-impact', 'ClimateEventBusPort cause'),
+  };
+}
+
+export class ClimateEventBusPort {
+  async publish(_eventName, _payload) {
+    throw new Error('ClimateEventBusPort.publish must be implemented by an adapter.');
+  }
+
+  async publishHarvestImpact(payload) {
+    return this.publish('climate.harvest-impact.detected', normalizeHarvestImpactPayload(payload));
+  }
+}

--- a/src/application/climate/EmitHarvestClimateEvents.js
+++ b/src/application/climate/EmitHarvestClimateEvents.js
@@ -1,0 +1,90 @@
+import { ClimateState } from '../../domain/climate/ClimateState.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireEventBus(eventBus) {
+  if (!eventBus || typeof eventBus.publishHarvestImpact !== 'function') {
+    throw new TypeError('EmitHarvestClimateEvents eventBus must expose publishHarvestImpact(payload).');
+  }
+
+  return eventBus;
+}
+
+function normalizeClimateState(climateState) {
+  if (climateState instanceof ClimateState) {
+    return climateState;
+  }
+
+  if (climateState === null || typeof climateState !== 'object' || Array.isArray(climateState)) {
+    throw new TypeError('EmitHarvestClimateEvents climateState must be a ClimateState or plain object.');
+  }
+
+  return new ClimateState(climateState);
+}
+
+function normalizeImpactMap(impactsByResource, label) {
+  requireObject(impactsByResource, label);
+
+  return Object.fromEntries(
+    Object.entries(impactsByResource)
+      .map(([resourceId, impactLevel]) => {
+        const normalizedResourceId = String(resourceId ?? '').trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError(`${label} cannot contain an empty resource id.`);
+        }
+
+        if (!Number.isInteger(impactLevel) || impactLevel < -100 || impactLevel > 100) {
+          throw new RangeError(`${label} impact levels must be integers between -100 and 100.`);
+        }
+
+        return [normalizedResourceId, impactLevel];
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+export async function emitHarvestClimateEvents({
+  eventBus,
+  climateState,
+  impactsByResource,
+  cause = 'climate-harvest-impact',
+} = {}) {
+  const normalizedEventBus = requireEventBus(eventBus);
+  const normalizedClimateState = normalizeClimateState(climateState);
+  const normalizedImpacts = normalizeImpactMap(impactsByResource, 'EmitHarvestClimateEvents impactsByResource');
+  const normalizedCause = String(cause ?? '').trim();
+
+  if (!normalizedCause) {
+    throw new RangeError('EmitHarvestClimateEvents cause is required.');
+  }
+
+  const events = [];
+
+  for (const [resourceId, impactLevel] of Object.entries(normalizedImpacts)) {
+    if (impactLevel === 0) {
+      continue;
+    }
+
+    const event = await normalizedEventBus.publishHarvestImpact({
+      regionId: normalizedClimateState.regionId,
+      season: normalizedClimateState.season,
+      resourceId,
+      impactLevel,
+      droughtIndex: normalizedClimateState.droughtIndex,
+      precipitationLevel: normalizedClimateState.precipitationLevel,
+      anomaly: normalizedClimateState.anomaly,
+      cause: normalizedCause,
+    });
+
+    events.push(event);
+  }
+
+  return events;
+}

--- a/test/application/climate/ClimateEventBusPort.test.js
+++ b/test/application/climate/ClimateEventBusPort.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ClimateEventBusPort } from '../../../src/application/climate/ClimateEventBusPort.js';
+
+class RecordedClimateEventBus extends ClimateEventBusPort {
+  constructor() {
+    super();
+    this.events = [];
+  }
+
+  async publish(eventName, payload) {
+    const event = { eventName, payload };
+    this.events.push(event);
+    return event;
+  }
+}
+
+test('ClimateEventBusPort normalizes harvest impact events before delegation', async () => {
+  const eventBus = new RecordedClimateEventBus();
+
+  const event = await eventBus.publishHarvestImpact({
+    regionId: ' north-coast ',
+    season: ' summer ',
+    resourceId: ' grain ',
+    impactLevel: -24,
+    droughtIndex: 62,
+    precipitationLevel: 18,
+    anomaly: ' heatwave ',
+    cause: ' seasonal-drought ',
+  });
+
+  assert.deepEqual(event, {
+    eventName: 'climate.harvest-impact.detected',
+    payload: {
+      regionId: 'north-coast',
+      season: 'summer',
+      resourceId: 'grain',
+      impactLevel: -24,
+      droughtIndex: 62,
+      precipitationLevel: 18,
+      anomaly: 'heatwave',
+      cause: 'seasonal-drought',
+    },
+  });
+});
+
+test('ClimateEventBusPort base publish method fails fast until implemented', async () => {
+  const eventBus = new ClimateEventBusPort();
+
+  await assert.rejects(
+    () => eventBus.publishHarvestImpact({
+      regionId: 'north-coast',
+      season: 'summer',
+      resourceId: 'grain',
+      impactLevel: -10,
+      droughtIndex: 40,
+      precipitationLevel: 30,
+    }),
+    /publish must be implemented/,
+  );
+});
+
+test('ClimateEventBusPort rejects invalid harvest impact payloads', async () => {
+  const eventBus = new RecordedClimateEventBus();
+
+  await assert.rejects(
+    () => eventBus.publishHarvestImpact(null),
+    /payload must be an object/,
+  );
+
+  await assert.rejects(
+    () => eventBus.publishHarvestImpact({
+      regionId: 'north-coast',
+      season: 'summer',
+      resourceId: 'grain',
+      impactLevel: -101,
+      droughtIndex: 40,
+      precipitationLevel: 30,
+    }),
+    /impactLevel must be an integer between -100 and 100/,
+  );
+});

--- a/test/application/climate/EmitHarvestClimateEvents.test.js
+++ b/test/application/climate/EmitHarvestClimateEvents.test.js
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ClimateEventBusPort } from '../../../src/application/climate/ClimateEventBusPort.js';
+import { emitHarvestClimateEvents } from '../../../src/application/climate/EmitHarvestClimateEvents.js';
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+
+class RecordedClimateEventBus extends ClimateEventBusPort {
+  constructor() {
+    super();
+    this.events = [];
+  }
+
+  async publish(eventName, payload) {
+    const event = { eventName, payload };
+    this.events.push(event);
+    return event;
+  }
+}
+
+test('EmitHarvestClimateEvents publishes one normalized event per non-zero harvest impact', async () => {
+  const eventBus = new RecordedClimateEventBus();
+
+  const events = await emitHarvestClimateEvents({
+    eventBus,
+    climateState: new ClimateState({
+      regionId: 'north-coast',
+      season: 'summer',
+      temperatureC: 29,
+      precipitationLevel: 18,
+      droughtIndex: 62,
+      anomaly: 'heatwave',
+    }),
+    impactsByResource: {
+      grain: -24,
+      olives: -10,
+      grapes: 0,
+    },
+    cause: 'seasonal-drought',
+  });
+
+  assert.deepEqual(events, [
+    {
+      eventName: 'climate.harvest-impact.detected',
+      payload: {
+        regionId: 'north-coast',
+        season: 'summer',
+        resourceId: 'grain',
+        impactLevel: -24,
+        droughtIndex: 62,
+        precipitationLevel: 18,
+        anomaly: 'heatwave',
+        cause: 'seasonal-drought',
+      },
+    },
+    {
+      eventName: 'climate.harvest-impact.detected',
+      payload: {
+        regionId: 'north-coast',
+        season: 'summer',
+        resourceId: 'olives',
+        impactLevel: -10,
+        droughtIndex: 62,
+        precipitationLevel: 18,
+        anomaly: 'heatwave',
+        cause: 'seasonal-drought',
+      },
+    },
+  ]);
+});
+
+test('EmitHarvestClimateEvents accepts plain climate payloads and skips empty impacts', async () => {
+  const eventBus = new RecordedClimateEventBus();
+
+  const events = await emitHarvestClimateEvents({
+    eventBus,
+    climateState: {
+      regionId: 'riverlands',
+      season: 'autumn',
+      temperatureC: 14,
+      precipitationLevel: 74,
+      droughtIndex: 12,
+    },
+    impactsByResource: {
+      grain: 0,
+    },
+  });
+
+  assert.deepEqual(events, []);
+  assert.deepEqual(eventBus.events, []);
+});
+
+test('EmitHarvestClimateEvents rejects invalid event buses, climates, and impact maps', async () => {
+  const climateState = {
+    regionId: 'north-coast',
+    season: 'summer',
+    temperatureC: 29,
+    precipitationLevel: 18,
+    droughtIndex: 62,
+  };
+
+  await assert.rejects(
+    () => emitHarvestClimateEvents({ eventBus: {}, climateState, impactsByResource: {} }),
+    /eventBus must expose publishHarvestImpact/,
+  );
+
+  await assert.rejects(
+    () => emitHarvestClimateEvents({ eventBus: new RecordedClimateEventBus(), climateState: null, impactsByResource: {} }),
+    /climateState must be a ClimateState or plain object/,
+  );
+
+  await assert.rejects(
+    () => emitHarvestClimateEvents({ eventBus: new RecordedClimateEventBus(), climateState, impactsByResource: { grain: -101 } }),
+    /impact levels must be integers between -100 and 100/,
+  );
+
+  await assert.rejects(
+    () => emitHarvestClimateEvents({ eventBus: new RecordedClimateEventBus(), climateState, impactsByResource: {}, cause: ' ' }),
+    /cause is required/,
+  );
+});


### PR DESCRIPTION
Epsilon: reprise propre depuis main pour l’issue #94.

## Summary
- add ClimateEventBusPort with normalized harvest-impact event publishing
- add emitHarvestClimateEvents to turn climate state and per-resource impacts into explicit events
- cover normalization, validation, zero-impact skipping, and payload shaping with targeted tests

## Verification
- node --test

Closes #94
