### PR TITLE
Gamma: [G10] Create ResearchRepository port

### DIFF
--- a/src/domain/culture/ResearchRepositoryPort.js
+++ b/src/domain/culture/ResearchRepositoryPort.js
@@ -1,0 +1,60 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function normalizeUniqueTexts(values, label) {
+  const normalizedValues = [...new Set(requireArray(values, label).map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+function requireResearchState(researchState) {
+  if (!researchState || typeof researchState !== 'object' || Array.isArray(researchState)) {
+    throw new TypeError('ResearchRepositoryPort researchState must be an object.');
+  }
+
+  return {
+    ...researchState,
+    id: requireText(researchState.id, 'ResearchRepositoryPort researchState.id'),
+    cultureId: requireText(researchState.cultureId, 'ResearchRepositoryPort researchState.cultureId'),
+    focusIds: normalizeUniqueTexts(
+      researchState.focusIds ?? [],
+      'ResearchRepositoryPort researchState.focusIds',
+    ),
+  };
+}
+
+export class ResearchRepositoryPort {
+  async getById(researchStateId) {
+    requireText(researchStateId, 'ResearchRepositoryPort researchStateId');
+    throw new Error('ResearchRepositoryPort.getById must be implemented by an adapter.');
+  }
+
+  async save(researchState) {
+    requireResearchState(researchState);
+    throw new Error('ResearchRepositoryPort.save must be implemented by an adapter.');
+  }
+
+  async listByCulture(cultureId) {
+    requireText(cultureId, 'ResearchRepositoryPort cultureId');
+    throw new Error('ResearchRepositoryPort.listByCulture must be implemented by an adapter.');
+  }
+}

--- a/test/domain/culture/ResearchRepositoryPort.test.js
+++ b/test/domain/culture/ResearchRepositoryPort.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ResearchRepositoryPort } from '../../../src/domain/culture/ResearchRepositoryPort.js';
+
+test('ResearchRepositoryPort validates identifiers before delegating to adapters', async () => {
+  const port = new ResearchRepositoryPort();
+
+  await assert.rejects(() => port.getById(''), /ResearchRepositoryPort researchStateId is required/);
+  await assert.rejects(() => port.listByCulture('   '), /ResearchRepositoryPort cultureId is required/);
+});
+
+test('ResearchRepositoryPort validates research state payloads before save', async () => {
+  const port = new ResearchRepositoryPort();
+
+  await assert.rejects(() => port.save(null), /ResearchRepositoryPort researchState must be an object/);
+  await assert.rejects(
+    () => port.save({ id: 'research-state-1', cultureId: 'culture-north', focusIds: ['archives', ' '] }),
+    /ResearchRepositoryPort researchState.focusIds cannot contain empty values/,
+  );
+  await assert.rejects(
+    () => port.save({ id: ' ', cultureId: 'culture-north', focusIds: [] }),
+    /ResearchRepositoryPort researchState.id is required/,
+  );
+  await assert.rejects(
+    () => port.save({ id: 'research-state-1', cultureId: ' ', focusIds: [] }),
+    /ResearchRepositoryPort researchState.cultureId is required/,
+  );
+});
+
+test('ResearchRepositoryPort exposes explicit adapter implementation errors', async () => {
+  const port = new ResearchRepositoryPort();
+  const researchState = {
+    id: 'research-state-1',
+    cultureId: 'culture-north',
+    focusIds: ['archives', 'astronomy'],
+  };
+
+  await assert.rejects(
+    () => port.getById('research-state-1'),
+    /ResearchRepositoryPort\.getById must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.save(researchState),
+    /ResearchRepositoryPort\.save must be implemented by an adapter/,
+  );
+  await assert.rejects(
+    () => port.listByCulture('culture-north'),
+    /ResearchRepositoryPort\.listByCulture must be implemented by an adapter/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add `ResearchRepositoryPort` as the dedicated research repository contract for Gamma systems
- Gamma: validate repository identifiers and research-state save payloads before adapter delegation
- Gamma: add focused port tests for validation paths and explicit adapter implementation errors

## Related issue

- One issue only: #50

## Changes

- Gamma: add `src/domain/culture/ResearchRepositoryPort.js`
- Gamma: add `test/domain/culture/ResearchRepositoryPort.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [x] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage des anciennes branches Gamma.
