### PR TITLE
Delta: [D19] Show alert level in UI

### DIFF
--- a/src/ui/intrigue/AlertLevelBadge.js
+++ b/src/ui/intrigue/AlertLevelBadge.js
@@ -16,6 +16,14 @@ const COLOR_BY_CODE = Object.freeze({
   verrouille: '#7F1D1D',
 });
 
+const ICON_BY_CODE = Object.freeze({
+  latent: '○',
+  surveille: '◔',
+  renforce: '◑',
+  critique: '◕',
+  verrouille: '●',
+});
+
 function requireObject(value, label) {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     throw new TypeError(`${label} must be an object.`);
@@ -32,9 +40,12 @@ export function buildAlertLevelBadge(level, options = {}) {
   return {
     text: `${prefix} ${alertLevel.label}`,
     shortText: `${prefix} ${alertLevel.value}`,
+    icon: ICON_BY_CODE[alertLevel.code],
     tone: TONE_BY_CODE[alertLevel.code],
     color: COLOR_BY_CODE[alertLevel.code],
     emphasis: alertLevel.isCritical ? 'high' : 'normal',
+    progressPercent: alertLevel.surveillanceIntensity,
+    ariaLabel: `${prefix} ${alertLevel.label}, niveau ${alertLevel.value} sur ${NiveauAlerte.maximum().value}`,
     tooltip: `Niveau ${alertLevel.value} sur ${NiveauAlerte.maximum().value}, surveillance ${alertLevel.surveillanceIntensity}%`,
     level: alertLevel.toJSON(),
   };

--- a/test/ui/intrigue/AlertLevelBadge.test.js
+++ b/test/ui/intrigue/AlertLevelBadge.test.js
@@ -9,9 +9,12 @@ test('AlertLevelBadge builds UI metadata from a numeric alert level', () => {
   assert.deepEqual(badge, {
     text: 'Alerte Renforcé',
     shortText: 'Alerte 2',
+    icon: '◑',
     tone: 'warning',
     color: '#D97706',
     emphasis: 'normal',
+    progressPercent: 55,
+    ariaLabel: 'Alerte Renforcé, niveau 2 sur 4',
     tooltip: 'Niveau 2 sur 4, surveillance 55%',
     level: {
       value: 2,
@@ -28,9 +31,12 @@ test('AlertLevelBadge supports custom prefixes and critical levels', () => {
   assert.deepEqual(badge, {
     text: 'Sécurité Verrouillé',
     shortText: 'Sécurité 4',
+    icon: '●',
     tone: 'critical',
     color: '#7F1D1D',
     emphasis: 'high',
+    progressPercent: 100,
+    ariaLabel: 'Sécurité Verrouillé, niveau 4 sur 4',
     tooltip: 'Niveau 4 sur 4, surveillance 100%',
     level: {
       value: 4,


### PR DESCRIPTION
Delta: Cette PR fait avancer #79 en enrichissant la représentation UI de `AlertLevelBadge`.

## Changements
- ajout d'un `icon` cohérent avec chaque niveau d'alerte
- ajout d'un `progressPercent` exploitable directement par une barre ou un indicateur UI
- ajout d'un `ariaLabel` pour une restitution plus accessible du niveau d'alerte
- mise à jour des tests ciblés du badge UI

## Vérification
- `npm test -- --test-name-pattern=AlertLevelBadge`

Closes #79