### PR TITLE
Epsilon: [E15] Emit climate events for unrest impact

### DIFF
--- a/src/application/climate/ClimateEventBusPort.js
+++ b/src/application/climate/ClimateEventBusPort.js
@@ -24,20 +24,41 @@ function requirePayload(payload) {
   return payload;
 }
 
-function normalizeHarvestImpactPayload(payload) {
+function normalizeBasePayload(payload) {
   const normalizedPayload = requirePayload(payload);
 
   return {
     regionId: requireText(normalizedPayload.regionId, 'ClimateEventBusPort regionId'),
     season: requireText(normalizedPayload.season, 'ClimateEventBusPort season'),
-    resourceId: requireText(normalizedPayload.resourceId, 'ClimateEventBusPort resourceId'),
-    impactLevel: requireInteger(normalizedPayload.impactLevel, 'ClimateEventBusPort impactLevel', -100, 100),
     droughtIndex: requireInteger(normalizedPayload.droughtIndex, 'ClimateEventBusPort droughtIndex', 0, 100),
     precipitationLevel: requireInteger(normalizedPayload.precipitationLevel, 'ClimateEventBusPort precipitationLevel', 0, 100),
     anomaly: normalizedPayload.anomaly === null || normalizedPayload.anomaly === undefined
       ? null
       : requireText(normalizedPayload.anomaly, 'ClimateEventBusPort anomaly'),
+  };
+}
+
+function normalizeHarvestImpactPayload(payload) {
+  const normalizedPayload = requirePayload(payload);
+  const basePayload = normalizeBasePayload(normalizedPayload);
+
+  return {
+    ...basePayload,
+    resourceId: requireText(normalizedPayload.resourceId, 'ClimateEventBusPort resourceId'),
+    impactLevel: requireInteger(normalizedPayload.impactLevel, 'ClimateEventBusPort impactLevel', -100, 100),
     cause: requireText(normalizedPayload.cause ?? 'climate-harvest-impact', 'ClimateEventBusPort cause'),
+  };
+}
+
+function normalizeUnrestImpactPayload(payload) {
+  const normalizedPayload = requirePayload(payload);
+  const basePayload = normalizeBasePayload(normalizedPayload);
+
+  return {
+    ...basePayload,
+    unrestDelta: requireInteger(normalizedPayload.unrestDelta, 'ClimateEventBusPort unrestDelta', -100, 100),
+    severity: requireText(normalizedPayload.severity ?? 'moderate', 'ClimateEventBusPort severity'),
+    cause: requireText(normalizedPayload.cause ?? 'climate-unrest-impact', 'ClimateEventBusPort cause'),
   };
 }
 
@@ -48,5 +69,9 @@ export class ClimateEventBusPort {
 
   async publishHarvestImpact(payload) {
     return this.publish('climate.harvest-impact.detected', normalizeHarvestImpactPayload(payload));
+  }
+
+  async publishUnrestImpact(payload) {
+    return this.publish('climate.unrest-impact.detected', normalizeUnrestImpactPayload(payload));
   }
 }

--- a/src/application/climate/EmitUnrestClimateEvents.js
+++ b/src/application/climate/EmitUnrestClimateEvents.js
@@ -1,0 +1,78 @@
+import { ClimateState } from '../../domain/climate/ClimateState.js';
+
+function requireEventBus(eventBus) {
+  if (!eventBus || typeof eventBus.publishUnrestImpact !== 'function') {
+    throw new TypeError('EmitUnrestClimateEvents eventBus must expose publishUnrestImpact(payload).');
+  }
+
+  return eventBus;
+}
+
+function normalizeClimateState(climateState) {
+  if (climateState instanceof ClimateState) {
+    return climateState;
+  }
+
+  if (climateState === null || typeof climateState !== 'object' || Array.isArray(climateState)) {
+    throw new TypeError('EmitUnrestClimateEvents climateState must be a ClimateState or plain object.');
+  }
+
+  return new ClimateState(climateState);
+}
+
+function normalizeUnrestDelta(unrestDelta) {
+  if (!Number.isInteger(unrestDelta) || unrestDelta < -100 || unrestDelta > 100) {
+    throw new RangeError('EmitUnrestClimateEvents unrestDelta must be an integer between -100 and 100.');
+  }
+
+  return unrestDelta;
+}
+
+function normalizeSeverity(severity) {
+  const normalizedSeverity = String(severity ?? '').trim();
+
+  if (!normalizedSeverity) {
+    throw new RangeError('EmitUnrestClimateEvents severity is required.');
+  }
+
+  return normalizedSeverity;
+}
+
+function normalizeCause(cause) {
+  const normalizedCause = String(cause ?? '').trim();
+
+  if (!normalizedCause) {
+    throw new RangeError('EmitUnrestClimateEvents cause is required.');
+  }
+
+  return normalizedCause;
+}
+
+export async function emitUnrestClimateEvents({
+  eventBus,
+  climateState,
+  unrestDelta,
+  severity,
+  cause = 'climate-unrest-impact',
+} = {}) {
+  const normalizedEventBus = requireEventBus(eventBus);
+  const normalizedClimateState = normalizeClimateState(climateState);
+  const normalizedUnrestDelta = normalizeUnrestDelta(unrestDelta);
+
+  if (normalizedUnrestDelta === 0) {
+    return [];
+  }
+
+  const event = await normalizedEventBus.publishUnrestImpact({
+    regionId: normalizedClimateState.regionId,
+    season: normalizedClimateState.season,
+    unrestDelta: normalizedUnrestDelta,
+    droughtIndex: normalizedClimateState.droughtIndex,
+    precipitationLevel: normalizedClimateState.precipitationLevel,
+    anomaly: normalizedClimateState.anomaly,
+    severity: normalizeSeverity(severity ?? 'moderate'),
+    cause: normalizeCause(cause),
+  });
+
+  return [event];
+}

--- a/test/application/climate/ClimateEventBusPort.test.js
+++ b/test/application/climate/ClimateEventBusPort.test.js
@@ -45,6 +45,35 @@ test('ClimateEventBusPort normalizes harvest impact events before delegation', a
   });
 });
 
+test('ClimateEventBusPort normalizes unrest impact events before delegation', async () => {
+  const eventBus = new RecordedClimateEventBus();
+
+  const event = await eventBus.publishUnrestImpact({
+    regionId: ' sunreach ',
+    season: ' summer ',
+    unrestDelta: 18,
+    droughtIndex: 71,
+    precipitationLevel: 9,
+    anomaly: ' heatwave ',
+    severity: ' high ',
+    cause: ' harvest-failure ',
+  });
+
+  assert.deepEqual(event, {
+    eventName: 'climate.unrest-impact.detected',
+    payload: {
+      regionId: 'sunreach',
+      season: 'summer',
+      unrestDelta: 18,
+      droughtIndex: 71,
+      precipitationLevel: 9,
+      anomaly: 'heatwave',
+      severity: 'high',
+      cause: 'harvest-failure',
+    },
+  });
+});
+
 test('ClimateEventBusPort base publish method fails fast until implemented', async () => {
   const eventBus = new ClimateEventBusPort();
 
@@ -59,9 +88,20 @@ test('ClimateEventBusPort base publish method fails fast until implemented', asy
     }),
     /publish must be implemented/,
   );
+
+  await assert.rejects(
+    () => eventBus.publishUnrestImpact({
+      regionId: 'north-coast',
+      season: 'summer',
+      unrestDelta: 12,
+      droughtIndex: 40,
+      precipitationLevel: 30,
+    }),
+    /publish must be implemented/,
+  );
 });
 
-test('ClimateEventBusPort rejects invalid harvest impact payloads', async () => {
+test('ClimateEventBusPort rejects invalid climate impact payloads', async () => {
   const eventBus = new RecordedClimateEventBus();
 
   await assert.rejects(
@@ -79,5 +119,16 @@ test('ClimateEventBusPort rejects invalid harvest impact payloads', async () => 
       precipitationLevel: 30,
     }),
     /impactLevel must be an integer between -100 and 100/,
+  );
+
+  await assert.rejects(
+    () => eventBus.publishUnrestImpact({
+      regionId: 'north-coast',
+      season: 'summer',
+      unrestDelta: 101,
+      droughtIndex: 40,
+      precipitationLevel: 30,
+    }),
+    /unrestDelta must be an integer between -100 and 100/,
   );
 });

--- a/test/application/climate/EmitUnrestClimateEvents.test.js
+++ b/test/application/climate/EmitUnrestClimateEvents.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ClimateEventBusPort } from '../../../src/application/climate/ClimateEventBusPort.js';
+import { emitUnrestClimateEvents } from '../../../src/application/climate/EmitUnrestClimateEvents.js';
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+
+class RecordedClimateEventBus extends ClimateEventBusPort {
+  constructor() {
+    super();
+    this.events = [];
+  }
+
+  async publish(eventName, payload) {
+    const event = { eventName, payload };
+    this.events.push(event);
+    return event;
+  }
+}
+
+test('EmitUnrestClimateEvents publishes one normalized event for a non-zero unrest impact', async () => {
+  const eventBus = new RecordedClimateEventBus();
+
+  const events = await emitUnrestClimateEvents({
+    eventBus,
+    climateState: new ClimateState({
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 31,
+      precipitationLevel: 9,
+      droughtIndex: 71,
+      anomaly: 'heatwave',
+    }),
+    unrestDelta: 18,
+    severity: 'high',
+    cause: 'harvest-failure',
+  });
+
+  assert.deepEqual(events, [
+    {
+      eventName: 'climate.unrest-impact.detected',
+      payload: {
+        regionId: 'sunreach',
+        season: 'summer',
+        unrestDelta: 18,
+        droughtIndex: 71,
+        precipitationLevel: 9,
+        anomaly: 'heatwave',
+        severity: 'high',
+        cause: 'harvest-failure',
+      },
+    },
+  ]);
+});
+
+test('EmitUnrestClimateEvents accepts plain climate payloads and skips zero-impact events', async () => {
+  const eventBus = new RecordedClimateEventBus();
+
+  const events = await emitUnrestClimateEvents({
+    eventBus,
+    climateState: {
+      regionId: 'riverlands',
+      season: 'autumn',
+      temperatureC: 14,
+      precipitationLevel: 74,
+      droughtIndex: 12,
+    },
+    unrestDelta: 0,
+  });
+
+  assert.deepEqual(events, []);
+  assert.deepEqual(eventBus.events, []);
+});
+
+test('EmitUnrestClimateEvents rejects invalid event buses, climates, and unrest payloads', async () => {
+  const climateState = {
+    regionId: 'north-coast',
+    season: 'summer',
+    temperatureC: 29,
+    precipitationLevel: 18,
+    droughtIndex: 62,
+  };
+
+  await assert.rejects(
+    () => emitUnrestClimateEvents({ eventBus: {}, climateState, unrestDelta: 10 }),
+    /eventBus must expose publishUnrestImpact/,
+  );
+
+  await assert.rejects(
+    () => emitUnrestClimateEvents({ eventBus: new RecordedClimateEventBus(), climateState: null, unrestDelta: 10 }),
+    /climateState must be a ClimateState or plain object/,
+  );
+
+  await assert.rejects(
+    () => emitUnrestClimateEvents({ eventBus: new RecordedClimateEventBus(), climateState, unrestDelta: 101 }),
+    /unrestDelta must be an integer between -100 and 100/,
+  );
+
+  await assert.rejects(
+    () => emitUnrestClimateEvents({ eventBus: new RecordedClimateEventBus(), climateState, unrestDelta: 10, severity: ' ' }),
+    /severity is required/,
+  );
+
+  await assert.rejects(
+    () => emitUnrestClimateEvents({ eventBus: new RecordedClimateEventBus(), climateState, unrestDelta: 10, cause: ' ' }),
+    /cause is required/,
+  );
+});


### PR DESCRIPTION
Epsilon: reprise propre depuis main pour l’issue #95.

## Summary
- extend ClimateEventBusPort with normalized unrest-impact event publishing
- add emitUnrestClimateEvents to turn climate pressure into an explicit unrest event
- cover normalization, validation, zero-impact skipping, and payload shaping with targeted tests

## Verification
- node --test

Closes #95
