### PR TITLE
Beta: show city stock in UI

### DIFF
--- a/src/ui/economy/buildCityStockPanel.js
+++ b/src/ui/economy/buildCityStockPanel.js
@@ -1,0 +1,95 @@
+import { City } from '../../domain/economy/City.js';
+
+const TONE_BY_STATUS = Object.freeze({
+  surplus: 'positive',
+  balanced: 'neutral',
+  shortage: 'warning',
+});
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireNonNegativeInteger(value, label) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${label} must be an integer greater than or equal to 0.`);
+  }
+
+  return value;
+}
+
+function normalizeDesiredStock(desiredStockByResource) {
+  const normalizedDesiredStock = requireObject(desiredStockByResource, 'CityStockPanel desiredStockByResource');
+
+  return Object.fromEntries(
+    Object.entries(normalizedDesiredStock)
+      .map(([resourceId, quantity]) => {
+        const normalizedResourceId = String(resourceId).trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError('CityStockPanel desiredStockByResource cannot contain an empty resource id.');
+        }
+
+        return [normalizedResourceId, requireNonNegativeInteger(quantity, `CityStockPanel desired stock ${normalizedResourceId}`)];
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function buildStockRow(resourceId, currentQuantity, desiredQuantity) {
+  const delta = currentQuantity - desiredQuantity;
+  const status = delta > 0 ? 'surplus' : delta < 0 ? 'shortage' : 'balanced';
+
+  return {
+    resourceId,
+    currentQuantity,
+    desiredQuantity,
+    delta,
+    status,
+    tone: TONE_BY_STATUS[status],
+    label: `${resourceId}: ${currentQuantity}/${desiredQuantity}`,
+    detail: delta === 0
+      ? 'Objectif atteint'
+      : delta > 0
+        ? `Surplus de ${delta}`
+        : `Manque de ${Math.abs(delta)}`,
+  };
+}
+
+export function buildCityStockPanel(city, options = {}) {
+  const normalizedOptions = requireObject(options, 'CityStockPanel options');
+  const normalizedCity = city instanceof City ? city : new City(city ?? {});
+  const desiredStockByResource = normalizeDesiredStock(normalizedOptions.desiredStockByResource ?? {});
+  const resourceIds = new Set([
+    ...Object.keys(normalizedCity.stockByResource),
+    ...Object.keys(desiredStockByResource),
+  ]);
+
+  const rows = [...resourceIds]
+    .sort((left, right) => left.localeCompare(right))
+    .map((resourceId) => buildStockRow(
+      resourceId,
+      normalizedCity.stockByResource[resourceId] ?? 0,
+      desiredStockByResource[resourceId] ?? 0,
+    ));
+
+  const shortages = rows.filter((row) => row.status === 'shortage').length;
+  const surpluses = rows.filter((row) => row.status === 'surplus').length;
+
+  return {
+    cityId: normalizedCity.id,
+    cityName: normalizedCity.name,
+    title: `Stocks de ${normalizedCity.name}`,
+    summary: `${rows.length} ressources, ${shortages} en manque, ${surpluses} en surplus`,
+    rows,
+    metrics: {
+      resourceCount: rows.length,
+      shortageCount: shortages,
+      surplusCount: surpluses,
+    },
+  };
+}

--- a/test/ui/economy/buildCityStockPanel.test.js
+++ b/test/ui/economy/buildCityStockPanel.test.js
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { City } from '../../../src/domain/economy/City.js';
+import { buildCityStockPanel } from '../../../src/ui/economy/buildCityStockPanel.js';
+
+test('buildCityStockPanel derives stock rows and summary for a city', () => {
+  const panel = buildCityStockPanel(new City({
+    id: 'city-harbor',
+    name: 'Harbor',
+    regionId: 'region-coast',
+    population: 120,
+    stockByResource: {
+      fish: 14,
+      grain: 3,
+      wood: 6,
+    },
+  }), {
+    desiredStockByResource: {
+      fish: 10,
+      grain: 8,
+      wood: 6,
+    },
+  });
+
+  assert.deepEqual(panel, {
+    cityId: 'city-harbor',
+    cityName: 'Harbor',
+    title: 'Stocks de Harbor',
+    summary: '3 ressources, 1 en manque, 1 en surplus',
+    rows: [
+      {
+        resourceId: 'fish',
+        currentQuantity: 14,
+        desiredQuantity: 10,
+        delta: 4,
+        status: 'surplus',
+        tone: 'positive',
+        label: 'fish: 14/10',
+        detail: 'Surplus de 4',
+      },
+      {
+        resourceId: 'grain',
+        currentQuantity: 3,
+        desiredQuantity: 8,
+        delta: -5,
+        status: 'shortage',
+        tone: 'warning',
+        label: 'grain: 3/8',
+        detail: 'Manque de 5',
+      },
+      {
+        resourceId: 'wood',
+        currentQuantity: 6,
+        desiredQuantity: 6,
+        delta: 0,
+        status: 'balanced',
+        tone: 'neutral',
+        label: 'wood: 6/6',
+        detail: 'Objectif atteint',
+      },
+    ],
+    metrics: {
+      resourceCount: 3,
+      shortageCount: 1,
+      surplusCount: 1,
+    },
+  });
+});
+
+test('buildCityStockPanel includes desired-only resources and plain city payloads', () => {
+  const panel = buildCityStockPanel({
+    id: 'city-mill',
+    name: 'Mill',
+    regionId: 'region-river',
+    population: 90,
+    stockByResource: {
+      flour: 5,
+    },
+  }, {
+    desiredStockByResource: {
+      flour: 5,
+      grain: 7,
+    },
+  });
+
+  assert.deepEqual(panel.rows, [
+    {
+      resourceId: 'flour',
+      currentQuantity: 5,
+      desiredQuantity: 5,
+      delta: 0,
+      status: 'balanced',
+      tone: 'neutral',
+      label: 'flour: 5/5',
+      detail: 'Objectif atteint',
+    },
+    {
+      resourceId: 'grain',
+      currentQuantity: 0,
+      desiredQuantity: 7,
+      delta: -7,
+      status: 'shortage',
+      tone: 'warning',
+      label: 'grain: 0/7',
+      detail: 'Manque de 7',
+    },
+  ]);
+  assert.deepEqual(panel.metrics, {
+    resourceCount: 2,
+    shortageCount: 1,
+    surplusCount: 0,
+  });
+});
+
+test('buildCityStockPanel rejects invalid options and desired stock maps', () => {
+  assert.throws(() => buildCityStockPanel({
+    id: 'city-a',
+    name: 'A',
+    regionId: 'region-a',
+    population: 1,
+  }, null), /CityStockPanel options must be an object/);
+
+  assert.throws(() => buildCityStockPanel({
+    id: 'city-a',
+    name: 'A',
+    regionId: 'region-a',
+    population: 1,
+  }, {
+    desiredStockByResource: { ' ': 1 },
+  }), /CityStockPanel desiredStockByResource cannot contain an empty resource id/);
+
+  assert.throws(() => buildCityStockPanel({
+    id: 'city-a',
+    name: 'A',
+    regionId: 'region-a',
+    population: 1,
+  }, {
+    desiredStockByResource: { grain: -1 },
+  }), /CityStockPanel desired stock grain must be an integer greater than or equal to 0/);
+});


### PR DESCRIPTION
Beta: ## Summary
Beta: add a small reusable UI builder to show a city stock view.
Beta:
Beta: ## Changes
Beta: - add `buildCityStockPanel` to derive UI-ready stock rows, statuses, and summary metrics from a city
Beta: - support shortages, balanced stock, surpluses, and desired-only resources in a stable sorted shape
Beta: - add focused UI tests for normalized panel output and invalid desired stock inputs
Beta:
Beta: ## Testing
Beta: - `npm test`
Beta:
Beta: Closes #39
