### PR TITLE
Delta: [D12] Create RandomPort

### DIFF
--- a/src/application/ports/RandomPort.js
+++ b/src/application/ports/RandomPort.js
@@ -1,0 +1,84 @@
+function requireFunction(value, label) {
+  if (typeof value !== 'function') {
+    throw new TypeError(`${label} must be a function.`);
+  }
+
+  return value;
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function ensureRollResult(result) {
+  const normalizedResult = requireObject(result, 'RandomPort roll result');
+
+  if (!Number.isInteger(normalizedResult.value)) {
+    throw new RangeError('RandomPort roll result.value must be an integer.');
+  }
+
+  if (!Number.isInteger(normalizedResult.min)) {
+    throw new RangeError('RandomPort roll result.min must be an integer.');
+  }
+
+  if (!Number.isInteger(normalizedResult.max)) {
+    throw new RangeError('RandomPort roll result.max must be an integer.');
+  }
+
+  if (normalizedResult.min > normalizedResult.max) {
+    throw new RangeError('RandomPort roll result.min must be less than or equal to max.');
+  }
+
+  if (normalizedResult.value < normalizedResult.min || normalizedResult.value > normalizedResult.max) {
+    throw new RangeError('RandomPort roll result.value must be between min and max.');
+  }
+
+  return { ...normalizedResult };
+}
+
+function normalizeBounds(bounds = {}) {
+  const normalizedBounds = requireObject(bounds, 'RandomPort bounds');
+  const min = normalizedBounds.min ?? 0;
+  const max = normalizedBounds.max ?? 100;
+
+  if (!Number.isInteger(min)) {
+    throw new RangeError('RandomPort bounds.min must be an integer.');
+  }
+
+  if (!Number.isInteger(max)) {
+    throw new RangeError('RandomPort bounds.max must be an integer.');
+  }
+
+  if (min > max) {
+    throw new RangeError('RandomPort bounds.min must be less than or equal to max.');
+  }
+
+  return { min, max };
+}
+
+export function createRandomPort({ roll }) {
+  const normalizedRoll = requireFunction(roll, 'RandomPort roll');
+
+  return {
+    roll(bounds = {}) {
+      const normalizedBounds = normalizeBounds(bounds);
+      return ensureRollResult(normalizedRoll({ ...normalizedBounds }));
+    },
+  };
+}
+
+export function assertRandomPort(port) {
+  const normalizedPort = requireObject(port, 'RandomPort');
+  const roll = requireFunction(normalizedPort.roll, 'RandomPort roll');
+
+  return {
+    roll(bounds = {}) {
+      const normalizedBounds = normalizeBounds(bounds);
+      return ensureRollResult(roll.call(normalizedPort, { ...normalizedBounds }));
+    },
+  };
+}

--- a/test/application/ports/RandomPort.test.js
+++ b/test/application/ports/RandomPort.test.js
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { assertRandomPort, createRandomPort } from '../../../src/application/ports/RandomPort.js';
+
+test('createRandomPort wraps a roller and returns validated immutable results', () => {
+  const receivedBounds = [];
+  const port = createRandomPort({
+    roll(bounds) {
+      receivedBounds.push(bounds);
+      return {
+        value: bounds.min + 2,
+        min: bounds.min,
+        max: bounds.max,
+        seed: 'seed-42',
+      };
+    },
+  });
+
+  const result = port.roll({ min: 3, max: 8 });
+  result.value = 99;
+
+  assert.deepEqual(receivedBounds, [{ min: 3, max: 8 }]);
+  assert.deepEqual(port.roll({ min: 1, max: 4 }), {
+    value: 3,
+    min: 1,
+    max: 4,
+    seed: 'seed-42',
+  });
+});
+
+test('assertRandomPort validates the contract and preserves context', () => {
+  const port = {
+    offset: 1,
+    roll(bounds) {
+      return {
+        value: bounds.min + this.offset,
+        min: bounds.min,
+        max: bounds.max,
+      };
+    },
+  };
+
+  const validatedPort = assertRandomPort(port);
+
+  assert.deepEqual(validatedPort.roll({ min: 4, max: 9 }), {
+    value: 5,
+    min: 4,
+    max: 9,
+  });
+
+  assert.throws(() => assertRandomPort({}), /RandomPort roll must be a function/);
+  assert.throws(() => validatedPort.roll(null), /RandomPort bounds must be an object/);
+  assert.throws(() => validatedPort.roll({ min: 9, max: 4 }), /RandomPort bounds.min must be less than or equal to max/);
+});
+
+test('RandomPort rejects invalid roll results and invalid factories', () => {
+  const port = createRandomPort({
+    roll() {
+      return { value: 12, min: 1, max: 6 };
+    },
+  });
+
+  assert.throws(() => port.roll({ min: 1, max: 6 }), /RandomPort roll result.value must be between min and max/);
+  assert.throws(
+    () => createRandomPort({ roll: 'nope' }),
+    /RandomPort roll must be a function/,
+  );
+});


### PR DESCRIPTION
Delta: Cette PR fait avancer #72 en ajoutant un port `RandomPort` explicite pour la tranche intrigue.

## Changements
- ajout de `createRandomPort` pour encapsuler une implémentation de tirage aléatoire
- ajout de `assertRandomPort` pour valider le contrat et préserver le contexte d'appel
- validation des bornes demandées et des résultats retournés par l'adaptateur
- ajout de tests ciblés pour les cas valides, le contexte, et les erreurs de contrat

## Vérification
- `npm test -- --test-name-pattern=RandomPort`

Closes #72