### PR TITLE
Delta: [D11] Create FactionReadPort

### DIFF
--- a/src/application/ports/FactionReadPort.js
+++ b/src/application/ports/FactionReadPort.js
@@ -1,0 +1,48 @@
+function requireFunction(value, label) {
+  if (typeof value !== 'function') {
+    throw new TypeError(`${label} must be a function.`);
+  }
+
+  return value;
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function ensureSnapshot(snapshot) {
+  const normalizedSnapshot = requireObject(snapshot, 'FactionReadPort snapshot');
+
+  if (!('factionId' in normalizedSnapshot)) {
+    throw new RangeError('FactionReadPort snapshot.factionId is required.');
+  }
+
+  return { ...normalizedSnapshot };
+}
+
+export function createFactionReadPort({ readFaction }) {
+  const normalizedReadFaction = requireFunction(readFaction, 'FactionReadPort readFaction');
+
+  return {
+    readFaction(query = {}) {
+      requireObject(query, 'FactionReadPort query');
+      return ensureSnapshot(normalizedReadFaction({ ...query }));
+    },
+  };
+}
+
+export function assertFactionReadPort(port) {
+  const normalizedPort = requireObject(port, 'FactionReadPort');
+  const readFaction = requireFunction(normalizedPort.readFaction, 'FactionReadPort readFaction');
+
+  return {
+    readFaction(query = {}) {
+      requireObject(query, 'FactionReadPort query');
+      return ensureSnapshot(readFaction.call(normalizedPort, { ...query }));
+    },
+  };
+}

--- a/test/application/ports/FactionReadPort.test.js
+++ b/test/application/ports/FactionReadPort.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { assertFactionReadPort, createFactionReadPort } from '../../../src/application/ports/FactionReadPort.js';
+
+test('createFactionReadPort wraps a reader and returns immutable snapshots', () => {
+  const receivedQueries = [];
+  const port = createFactionReadPort({
+    readFaction(query) {
+      receivedQueries.push(query);
+      return {
+        factionId: 'faction-delta',
+        alertLevel: 2,
+        celluleIds: ['cellule-ombre'],
+      };
+    },
+  });
+
+  const snapshot = port.readFaction({ factionId: 'faction-delta' });
+  snapshot.alertLevel = 99;
+
+  assert.deepEqual(receivedQueries, [{ factionId: 'faction-delta' }]);
+  assert.deepEqual(port.readFaction({ factionId: 'faction-delta', tick: 8 }), {
+    factionId: 'faction-delta',
+    alertLevel: 2,
+    celluleIds: ['cellule-ombre'],
+  });
+});
+
+test('assertFactionReadPort validates the contract and preserves context', () => {
+  const port = {
+    prefix: 'faction',
+    readFaction(query) {
+      return {
+        factionId: `${this.prefix}-${query.code}`,
+        code: query.code,
+      };
+    },
+  };
+
+  const validatedPort = assertFactionReadPort(port);
+
+  assert.deepEqual(validatedPort.readFaction({ code: 'delta' }), {
+    factionId: 'faction-delta',
+    code: 'delta',
+  });
+
+  assert.throws(() => assertFactionReadPort({}), /FactionReadPort readFaction must be a function/);
+  assert.throws(() => validatedPort.readFaction(null), /FactionReadPort query must be an object/);
+});
+
+test('FactionReadPort rejects invalid snapshots', () => {
+  const port = createFactionReadPort({
+    readFaction() {
+      return { alertLevel: 2 };
+    },
+  });
+
+  assert.throws(() => port.readFaction({}), /FactionReadPort snapshot.factionId is required/);
+  assert.throws(
+    () => createFactionReadPort({ readFaction: 'nope' }),
+    /FactionReadPort readFaction must be a function/,
+  );
+});


### PR DESCRIPTION
Delta: Cette PR fait avancer #71 en ajoutant un port `FactionReadPort` explicite pour la tranche intrigue.

## Changements
- ajout de `createFactionReadPort` pour encapsuler une lecture de faction
- ajout de `assertFactionReadPort` pour valider le contrat et préserver le contexte d'appel
- validation des requêtes et des snapshots retournés, avec exigence d'un `factionId`
- ajout de tests ciblés pour les cas valides, le contexte et les erreurs de contrat

## Vérification
- `npm test -- --test-name-pattern=FactionReadPort`

Closes #71