### PR TITLE
Delta: [D09] Implement CollecterRenseignement use case

### DIFF
--- a/src/application/intrigue/CollecterRenseignement.js
+++ b/src/application/intrigue/CollecterRenseignement.js
@@ -1,0 +1,114 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireScore(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new RangeError(`${label} must be an integer between 0 and 100.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+export function collecterRenseignement({
+  operation,
+  agent,
+  target,
+  randomFactor = 0,
+  intelTags = [],
+}) {
+  const normalizedOperation = requireObject(operation, 'CollecterRenseignement operation');
+  const normalizedAgent = requireObject(agent, 'CollecterRenseignement agent');
+  const normalizedTarget = requireObject(target, 'CollecterRenseignement target');
+  const normalizedRandomFactor = requireScore(randomFactor, 'CollecterRenseignement randomFactor');
+  const normalizedIntelTags = normalizeUniqueTexts(intelTags, 'CollecterRenseignement intelTags');
+
+  const operationId = requireText(normalizedOperation.id, 'CollecterRenseignement operation id');
+  const agentId = requireText(normalizedAgent.id, 'CollecterRenseignement agent id');
+  const targetId = requireText(normalizedTarget.id, 'CollecterRenseignement target id');
+  const detectionRisk = requireScore(
+    normalizedOperation.detectionRisk ?? 0,
+    'CollecterRenseignement operation detectionRisk',
+  );
+  const progress = requireScore(
+    normalizedOperation.progress ?? 0,
+    'CollecterRenseignement operation progress',
+  );
+  const heat = requireScore(normalizedOperation.heat ?? 0, 'CollecterRenseignement operation heat');
+  const agentDiscretion = requireScore(normalizedAgent.discretion ?? 0, 'CollecterRenseignement agent discretion');
+  const agentInfluence = requireScore(normalizedAgent.influence ?? 0, 'CollecterRenseignement agent influence');
+  const targetSecrecy = requireScore(normalizedTarget.secrecy ?? 0, 'CollecterRenseignement target secrecy');
+  const targetStability = requireScore(normalizedTarget.stability ?? 0, 'CollecterRenseignement target stability');
+
+  const intelScore = Math.max(
+    0,
+    Math.min(
+      100,
+      Math.round((agentDiscretion + agentInfluence + progress + normalizedRandomFactor - targetSecrecy) / 3),
+    ),
+  );
+  const successful = intelScore >= 35;
+  const credibility = successful
+    ? Math.min(100, Math.max(30, intelScore + Math.round((100 - targetStability) / 5)))
+    : Math.max(0, Math.round(intelScore / 2));
+  const heatIncrease = Math.min(100 - heat, successful ? Math.max(3, Math.round(detectionRisk / 8)) : Math.max(8, Math.round(detectionRisk / 5)));
+  const nextHeat = heat + heatIncrease;
+  const discoveredTags = successful
+    ? normalizedIntelTags.slice(0, Math.max(1, Math.ceil(intelScore / 30)))
+    : [];
+
+  return {
+    collected: successful,
+    outcome: successful ? 'intel-collected' : 'intel-compromised',
+    operation: {
+      ...normalizedOperation,
+      id: operationId,
+      heat: nextHeat,
+      progress: Math.min(100, progress + (successful ? 20 : 10)),
+    },
+    agent: {
+      ...normalizedAgent,
+      id: agentId,
+    },
+    target: {
+      ...normalizedTarget,
+      id: targetId,
+    },
+    report: {
+      credibility,
+      intelScore,
+      discoveredTags,
+    },
+    summary: successful
+      ? `Collected ${discoveredTags.length} actionable intelligence tag(s).`
+      : 'The intelligence sweep produced fragmented or compromised information.',
+  };
+}

--- a/test/application/intrigue/CollecterRenseignement.test.js
+++ b/test/application/intrigue/CollecterRenseignement.test.js
@@ -1,0 +1,133 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { collecterRenseignement } from '../../../src/application/intrigue/CollecterRenseignement.js';
+
+test('CollecterRenseignement returns actionable intelligence on success', () => {
+  const result = collecterRenseignement({
+    operation: {
+      id: 'op-silence',
+      detectionRisk: 28,
+      progress: 42,
+      heat: 9,
+    },
+    agent: {
+      id: 'agent-cendre',
+      discretion: 82,
+      influence: 66,
+    },
+    target: {
+      id: 'faction-aube',
+      secrecy: 47,
+      stability: 38,
+    },
+    randomFactor: 21,
+    intelTags: ['supply-lines', 'council-rifts', 'border-weakness'],
+  });
+
+  assert.deepEqual(result, {
+    collected: true,
+    outcome: 'intel-collected',
+    operation: {
+      id: 'op-silence',
+      detectionRisk: 28,
+      progress: 62,
+      heat: 13,
+    },
+    agent: {
+      id: 'agent-cendre',
+      discretion: 82,
+      influence: 66,
+    },
+    target: {
+      id: 'faction-aube',
+      secrecy: 47,
+      stability: 38,
+    },
+    report: {
+      credibility: 67,
+      intelScore: 55,
+      discoveredTags: ['border-weakness', 'council-rifts'],
+    },
+    summary: 'Collected 2 actionable intelligence tag(s).',
+  });
+});
+
+test('CollecterRenseignement surfaces compromised intelligence when the sweep fails', () => {
+  const result = collecterRenseignement({
+    operation: {
+      id: 'op-silence',
+      detectionRisk: 40,
+      progress: 12,
+      heat: 11,
+    },
+    agent: {
+      id: 'agent-cendre',
+      discretion: 31,
+      influence: 28,
+    },
+    target: {
+      id: 'faction-aube',
+      secrecy: 80,
+      stability: 66,
+    },
+    randomFactor: 4,
+    intelTags: ['supply-lines'],
+  });
+
+  assert.deepEqual(result, {
+    collected: false,
+    outcome: 'intel-compromised',
+    operation: {
+      id: 'op-silence',
+      detectionRisk: 40,
+      progress: 22,
+      heat: 19,
+    },
+    agent: {
+      id: 'agent-cendre',
+      discretion: 31,
+      influence: 28,
+    },
+    target: {
+      id: 'faction-aube',
+      secrecy: 80,
+      stability: 66,
+    },
+    report: {
+      credibility: 0,
+      intelScore: 0,
+      discoveredTags: [],
+    },
+    summary: 'The intelligence sweep produced fragmented or compromised information.',
+  });
+});
+
+test('CollecterRenseignement validates inputs', () => {
+  assert.throws(
+    () => collecterRenseignement({ operation: null, agent: {}, target: {} }),
+    /CollecterRenseignement operation must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      collecterRenseignement({
+        operation: { id: 'op-silence', detectionRisk: 10, progress: 0, heat: 0 },
+        agent: { id: 'agent-cendre', discretion: 50, influence: 50 },
+        target: { id: 'faction-aube', secrecy: 50, stability: 50 },
+        randomFactor: 101,
+      }),
+    /CollecterRenseignement randomFactor must be an integer between 0 and 100/,
+  );
+
+  assert.throws(
+    () =>
+      collecterRenseignement({
+        operation: { id: 'op-silence', detectionRisk: 10, progress: 0, heat: 0 },
+        agent: { id: 'agent-cendre', discretion: 50, influence: 50 },
+        target: { id: 'faction-aube', secrecy: 50, stability: 50 },
+        intelTags: ['valid-tag', ''],
+      }),
+    /CollecterRenseignement intelTags cannot contain empty values/,
+  );
+});


### PR DESCRIPTION
Delta: Cette PR fait avancer #69 en ajoutant le use case `CollecterRenseignement`.

## Changements
- ajout de `collecterRenseignement` pour résoudre une collecte de renseignement à partir d'une opération, d'un agent et d'une cible
- résultat structuré pour les cas de réussite et de renseignement compromis
- calcul de score de renseignement, crédibilité, tags découverts, progression et heat
- ajout de tests ciblés pour succès, échec et validation des entrées

## Vérification
- `npm test -- --test-name-pattern=CollecterRenseignement`

Closes #69