### PR TITLE
Gamma: [G13] Integrate RandomProvider in Gamma systems

### DIFF
--- a/src/application/culture/RandomProviderPort.js
+++ b/src/application/culture/RandomProviderPort.js
@@ -1,0 +1,18 @@
+function requireUnitInterval(value, label) {
+  if (typeof value !== 'number' || Number.isNaN(value) || value < 0 || value >= 1) {
+    throw new RangeError(`${label} must be a number greater than or equal to 0 and lower than 1.`);
+  }
+
+  return value;
+}
+
+export class RandomProviderPort {
+  async nextFloat() {
+    throw new Error('RandomProviderPort.nextFloat must be implemented by an adapter.');
+  }
+
+  async requireNextFloat() {
+    const value = await this.nextFloat();
+    return requireUnitInterval(value, 'RandomProviderPort nextFloat');
+  }
+}

--- a/src/application/culture/triggerHistoricalEvent.js
+++ b/src/application/culture/triggerHistoricalEvent.js
@@ -134,6 +134,33 @@ function normalizeExecution(execution) {
   };
 }
 
+export async function selectHistoricalEvent(historicalEvents, randomProvider) {
+  if (!Array.isArray(historicalEvents) || historicalEvents.length === 0) {
+    throw new RangeError('selectHistoricalEvent historicalEvents must be a non-empty array.');
+  }
+
+  if (!randomProvider || typeof randomProvider.requireNextFloat !== 'function') {
+    throw new TypeError('selectHistoricalEvent randomProvider must expose requireNextFloat().');
+  }
+
+  const normalizedEvents = historicalEvents.map((historicalEvent) => normalizeHistoricalEvent(historicalEvent));
+  const randomValue = await randomProvider.requireNextFloat();
+  const selectedIndex = Math.min(
+    normalizedEvents.length - 1,
+    Math.floor(randomValue * normalizedEvents.length),
+  );
+
+  return {
+    selectedEvent: {
+      ...normalizedEvents[selectedIndex],
+      selectionRoll: randomValue,
+      selectionIndex: selectedIndex,
+    },
+    selectionRoll: randomValue,
+    selectionIndex: selectedIndex,
+  };
+}
+
 export function triggerHistoricalEvent(historicalEvent, execution = {}) {
   const normalizedHistoricalEvent = normalizeHistoricalEvent(historicalEvent);
   const normalizedExecution = normalizeExecution(execution);

--- a/test/application/culture/RandomProviderPort.test.js
+++ b/test/application/culture/RandomProviderPort.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { RandomProviderPort } from '../../../src/application/culture/RandomProviderPort.js';
+
+class FixedRandomProvider extends RandomProviderPort {
+  constructor(value) {
+    super();
+    this.value = value;
+  }
+
+  async nextFloat() {
+    return this.value;
+  }
+}
+
+test('RandomProviderPort validates the float returned by adapters', async () => {
+  const validProvider = new FixedRandomProvider(0.42);
+  const value = await validProvider.requireNextFloat();
+
+  assert.equal(value, 0.42);
+
+  await assert.rejects(
+    () => new FixedRandomProvider(1).requireNextFloat(),
+    /RandomProviderPort nextFloat must be a number greater than or equal to 0 and lower than 1/,
+  );
+  await assert.rejects(
+    () => new FixedRandomProvider(-0.1).requireNextFloat(),
+    /RandomProviderPort nextFloat must be a number greater than or equal to 0 and lower than 1/,
+  );
+});
+
+test('RandomProviderPort base adapter method fails fast until implemented', async () => {
+  const provider = new RandomProviderPort();
+
+  await assert.rejects(() => provider.nextFloat(), /must be implemented by an adapter/);
+});

--- a/test/application/culture/triggerHistoricalEvent.test.js
+++ b/test/application/culture/triggerHistoricalEvent.test.js
@@ -1,7 +1,73 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { triggerHistoricalEvent } from '../../../src/application/culture/triggerHistoricalEvent.js';
+import { selectHistoricalEvent, triggerHistoricalEvent } from '../../../src/application/culture/triggerHistoricalEvent.js';
+
+class FixedRandomProvider {
+  constructor(value) {
+    this.value = value;
+  }
+
+  async requireNextFloat() {
+    return this.value;
+  }
+}
+
+
+test('selectHistoricalEvent chooses an event through RandomProvider integration', async () => {
+  const { selectedEvent, selectionIndex, selectionRoll } = await selectHistoricalEvent(
+    [
+      {
+        id: 'event-first',
+        title: 'First Turning',
+        era: 'classical',
+        summary: 'The first branch remains dormant.',
+        affectedCultureIds: ['culture-north'],
+        consequenceIds: [],
+        unlockedResearchIds: [],
+        repeatable: true,
+        triggerCount: 0,
+        lastTriggeredAt: null,
+        divergenceId: null,
+      },
+      {
+        id: 'event-second',
+        title: 'Second Turning',
+        era: 'classical',
+        summary: 'The second branch becomes active.',
+        affectedCultureIds: ['culture-south'],
+        consequenceIds: ['canon-shift'],
+        unlockedResearchIds: ['astronomy'],
+        repeatable: true,
+        triggerCount: 0,
+        lastTriggeredAt: null,
+        divergenceId: null,
+      },
+    ],
+    new FixedRandomProvider(0.75),
+  );
+
+  assert.equal(selectionIndex, 1);
+  assert.equal(selectionRoll, 0.75);
+  assert.equal(selectedEvent.id, 'event-second');
+  assert.equal(selectedEvent.selectionIndex, 1);
+  assert.equal(selectedEvent.selectionRoll, 0.75);
+});
+
+test('selectHistoricalEvent rejects invalid candidate lists and random providers', async () => {
+  await assert.rejects(
+    () => selectHistoricalEvent([], new FixedRandomProvider(0.2)),
+    /selectHistoricalEvent historicalEvents must be a non-empty array/,
+  );
+  await assert.rejects(
+    () =>
+      selectHistoricalEvent(
+        [{ id: 'event', title: 'Event', era: 'classical', summary: 'x', affectedCultureIds: [], consequenceIds: [], unlockedResearchIds: [], repeatable: true, triggerCount: 0, lastTriggeredAt: null, divergenceId: null }],
+        null,
+      ),
+    /selectHistoricalEvent randomProvider must expose requireNextFloat\(\)/,
+  );
+});
 
 test('triggerHistoricalEvent merges consequences and unlocked research immutably', () => {
   const historicalEvent = {


### PR DESCRIPTION
## Summary

- Gamma: add `RandomProviderPort` as the dedicated randomness contract for Gamma systems
- Gamma: integrate the port into historical-event selection through a focused `selectHistoricalEvent` helper
- Gamma: add targeted tests for provider validation and deterministic event selection

## Related issue

- One issue only: #53

## Changes

- Gamma: add `src/application/culture/RandomProviderPort.js`
- Gamma: update `src/application/culture/triggerHistoricalEvent.js`
- Gamma: add `test/application/culture/RandomProviderPort.test.js`
- Gamma: update `test/application/culture/triggerHistoricalEvent.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage des anciennes branches Gamma.
