### PR TITLE
Delta: [D08] Implement DiffuserRumeur use case

### DIFF
--- a/src/application/intrigue/DiffuserRumeur.js
+++ b/src/application/intrigue/DiffuserRumeur.js
@@ -1,0 +1,105 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireScore(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new RangeError(`${label} must be an integer between 0 and 100.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  const normalizedValues = [...new Set(values.map((value) => String(value).trim()))];
+
+  if (normalizedValues.some((value) => value.length === 0)) {
+    throw new RangeError(`${label} cannot contain empty values.`);
+  }
+
+  return normalizedValues.sort();
+}
+
+export function diffuserRumeur({
+  rumeur,
+  cellule,
+  alertLevel = 0,
+  randomFactor = 0,
+  relayIds = [],
+  affectedPopulationIds = rumeur?.affectedPopulationIds ?? [],
+}) {
+  const normalizedRumeur = requireObject(rumeur, 'DiffuserRumeur rumeur');
+  const normalizedCellule = requireObject(cellule, 'DiffuserRumeur cellule');
+  const normalizedAlertLevel = requireScore(alertLevel, 'DiffuserRumeur alertLevel');
+  const normalizedRandomFactor = requireScore(randomFactor, 'DiffuserRumeur randomFactor');
+  const normalizedRelayIds = normalizeUniqueTexts(relayIds, 'DiffuserRumeur relayIds');
+  const normalizedExistingRelayIds = normalizeUniqueTexts(
+    normalizedRumeur.relayIds ?? [],
+    'DiffuserRumeur rumeur relayIds',
+  );
+  const normalizedPopulationIds = normalizeUniqueTexts(
+    affectedPopulationIds,
+    'DiffuserRumeur affectedPopulationIds',
+  );
+  const normalizedExistingPopulationIds = normalizeUniqueTexts(
+    normalizedRumeur.affectedPopulationIds ?? [],
+    'DiffuserRumeur rumeur affectedPopulationIds',
+  );
+
+  const rumeurId = requireText(normalizedRumeur.id, 'DiffuserRumeur rumeur id');
+  requireText(normalizedCellule.id, 'DiffuserRumeur cellule id');
+  const credibility = requireScore(normalizedRumeur.credibility ?? 0, 'DiffuserRumeur rumeur credibility');
+  const propagation = requireScore(normalizedRumeur.propagation ?? 0, 'DiffuserRumeur rumeur propagation');
+  const tension = requireScore(normalizedRumeur.tension ?? 0, 'DiffuserRumeur rumeur tension');
+  const celluleSecrecy = requireScore(normalizedCellule.secrecy ?? 0, 'DiffuserRumeur cellule secrecy');
+  const celluleExposure = requireScore(normalizedCellule.exposure ?? 0, 'DiffuserRumeur cellule exposure');
+
+  const spreadScore = Math.max(
+    0,
+    Math.min(
+      100,
+      credibility + Math.round(celluleSecrecy / 4) + normalizedRandomFactor - normalizedAlertLevel - Math.round(celluleExposure / 2),
+    ),
+  );
+  const nextPropagation = Math.min(100, propagation + Math.max(8, Math.round(spreadScore / 5)));
+  const nextTension = Math.min(100, tension + Math.max(4, Math.round((normalizedRandomFactor + normalizedAlertLevel) / 6)));
+  const nextStatus = spreadScore >= 45 ? 'amplified' : 'contained';
+  const nextRelayIds = [...new Set([...normalizedExistingRelayIds, ...normalizedRelayIds])].sort();
+  const nextPopulationIds = [...new Set([...normalizedExistingPopulationIds, ...normalizedPopulationIds, ...nextRelayIds])].sort();
+
+  return {
+    spread: spreadScore >= 45,
+    outcome: spreadScore >= 45 ? 'rumor-amplified' : 'rumor-contained',
+    rumeur: {
+      ...normalizedRumeur,
+      id: rumeurId,
+      relayIds: nextRelayIds,
+      affectedPopulationIds: nextPopulationIds,
+      propagation: nextPropagation,
+      tension: nextTension,
+      status: nextStatus,
+    },
+    summary: spreadScore >= 45
+      ? `Rumor spread through ${nextRelayIds.length} relay node(s).`
+      : 'Rumor circulation was contained before broad amplification.',
+    spreadScore,
+  };
+}

--- a/test/application/intrigue/DiffuserRumeur.test.js
+++ b/test/application/intrigue/DiffuserRumeur.test.js
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { diffuserRumeur } from '../../../src/application/intrigue/DiffuserRumeur.js';
+
+test('DiffuserRumeur amplifies a rumor through relay nodes when spread conditions are favorable', () => {
+  const result = diffuserRumeur({
+    rumeur: {
+      id: 'rumeur-cendre',
+      relayIds: ['relay-marche'],
+      affectedPopulationIds: ['dockers'],
+      credibility: 62,
+      propagation: 24,
+      tension: 18,
+      status: 'circulating',
+    },
+    cellule: {
+      id: 'cellule-ombre',
+      secrecy: 78,
+      exposure: 16,
+    },
+    alertLevel: 12,
+    randomFactor: 19,
+    relayIds: ['relay-guilde', 'relay-port'],
+    affectedPopulationIds: ['guildes', 'citadins'],
+  });
+
+  assert.deepEqual(result, {
+    spread: true,
+    outcome: 'rumor-amplified',
+    rumeur: {
+      id: 'rumeur-cendre',
+      relayIds: ['relay-guilde', 'relay-marche', 'relay-port'],
+      affectedPopulationIds: ['citadins', 'dockers', 'guildes', 'relay-guilde', 'relay-marche', 'relay-port'],
+      credibility: 62,
+      propagation: 40,
+      tension: 23,
+      status: 'amplified',
+    },
+    summary: 'Rumor spread through 3 relay node(s).',
+    spreadScore: 81,
+  });
+});
+
+test('DiffuserRumeur can contain a rumor under pressure', () => {
+  const result = diffuserRumeur({
+    rumeur: {
+      id: 'rumeur-cendre',
+      relayIds: [],
+      affectedPopulationIds: ['dockers'],
+      credibility: 28,
+      propagation: 20,
+      tension: 17,
+      status: 'circulating',
+    },
+    cellule: {
+      id: 'cellule-ombre',
+      secrecy: 30,
+      exposure: 48,
+    },
+    alertLevel: 35,
+    randomFactor: 2,
+    relayIds: ['relay-guilde'],
+  });
+
+  assert.deepEqual(result, {
+    spread: false,
+    outcome: 'rumor-contained',
+    rumeur: {
+      id: 'rumeur-cendre',
+      relayIds: ['relay-guilde'],
+      affectedPopulationIds: ['dockers', 'relay-guilde'],
+      credibility: 28,
+      propagation: 28,
+      tension: 23,
+      status: 'contained',
+    },
+    summary: 'Rumor circulation was contained before broad amplification.',
+    spreadScore: 0,
+  });
+});
+
+test('DiffuserRumeur validates inputs', () => {
+  assert.throws(
+    () => diffuserRumeur({ rumeur: null, cellule: {} }),
+    /DiffuserRumeur rumeur must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      diffuserRumeur({
+        rumeur: { id: 'rumeur-cendre', credibility: 50, propagation: 10, tension: 10, relayIds: [], affectedPopulationIds: [] },
+        cellule: { id: 'cellule-ombre', secrecy: 50, exposure: 10 },
+        alertLevel: 101,
+      }),
+    /DiffuserRumeur alertLevel must be an integer between 0 and 100/,
+  );
+
+  assert.throws(
+    () =>
+      diffuserRumeur({
+        rumeur: { id: 'rumeur-cendre', credibility: 50, propagation: 10, tension: 10, relayIds: [''], affectedPopulationIds: [] },
+        cellule: { id: 'cellule-ombre', secrecy: 50, exposure: 10 },
+      }),
+    /DiffuserRumeur rumeur relayIds cannot contain empty values/,
+  );
+});


### PR DESCRIPTION
Delta: Cette PR fait avancer #68 en ajoutant le use case `DiffuserRumeur`.

## Changements
- ajout de `diffuserRumeur` pour résoudre la diffusion d'une rumeur selon la crédibilité, la discrétion de la cellule, l'alerte et l'exposition
- résultat structuré pour les cas de rumeur amplifiée et de rumeur contenue
- normalisation et validation des relais et populations affectées
- ajout de tests ciblés pour succès, contention et validation des entrées

## Vérification
- `npm test -- --test-name-pattern=DiffuserRumeur`

Closes #68