### PR TITLE
Gamma: [G14] Integrate Clock in Gamma systems

### DIFF
--- a/src/application/culture/ClockPort.js
+++ b/src/application/culture/ClockPort.js
@@ -1,0 +1,25 @@
+function requireIsoTimestamp(value, label) {
+  const normalizedValue = value instanceof Date ? value.toISOString() : String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  const parsedDate = new Date(normalizedValue);
+  if (Number.isNaN(parsedDate.getTime())) {
+    throw new RangeError(`${label} must be a valid ISO timestamp.`);
+  }
+
+  return parsedDate.toISOString();
+}
+
+export class ClockPort {
+  async now() {
+    throw new Error('ClockPort.now must be implemented by an adapter.');
+  }
+
+  async requireNow() {
+    const value = await this.now();
+    return requireIsoTimestamp(value, 'ClockPort now');
+  }
+}

--- a/src/application/culture/triggerHistoricalEvent.js
+++ b/src/application/culture/triggerHistoricalEvent.js
@@ -111,10 +111,10 @@ function normalizeExecution(execution) {
   }
 
   return {
-    triggeredAt: normalizeDate(
-      execution.triggeredAt ?? new Date(),
-      'triggerHistoricalEvent execution.triggeredAt',
-    ),
+    triggeredAt:
+      execution.triggeredAt === null || execution.triggeredAt === undefined
+        ? null
+        : normalizeDate(execution.triggeredAt, 'triggerHistoricalEvent execution.triggeredAt'),
     triggeredBy: requireText(
       execution.triggeredBy ?? 'system',
       'triggerHistoricalEvent execution.triggeredBy',
@@ -132,6 +132,18 @@ function normalizeExecution(execution) {
         ? null
         : requireText(execution.divergenceId, 'triggerHistoricalEvent execution.divergenceId'),
   };
+}
+
+export async function triggerHistoricalEventAtCurrentTime(historicalEvent, execution = {}, clock) {
+  if (!clock || typeof clock.requireNow !== 'function') {
+    throw new TypeError('triggerHistoricalEventAtCurrentTime clock must expose requireNow().');
+  }
+
+  const triggeredAt = await clock.requireNow();
+  return triggerHistoricalEvent(historicalEvent, {
+    ...execution,
+    triggeredAt,
+  });
 }
 
 export async function selectHistoricalEvent(historicalEvents, randomProvider) {
@@ -190,6 +202,7 @@ export function triggerHistoricalEvent(historicalEvent, execution = {}) {
     'triggerHistoricalEvent merged unlocked research ids',
   );
   const divergenceId = normalizedExecution.divergenceId ?? normalizedHistoricalEvent.divergenceId;
+  const triggeredAt = normalizedExecution.triggeredAt ?? normalizeDate(new Date(), 'triggerHistoricalEvent execution.triggeredAt');
 
   return {
     ...normalizedHistoricalEvent,
@@ -197,7 +210,7 @@ export function triggerHistoricalEvent(historicalEvent, execution = {}) {
     unlockedResearchIds,
     divergenceId,
     triggerCount: normalizedHistoricalEvent.triggerCount + 1,
-    lastTriggeredAt: normalizedExecution.triggeredAt,
+    lastTriggeredAt: triggeredAt,
     lastTriggeredBy: normalizedExecution.triggeredBy,
   };
 }

--- a/test/application/culture/ClockPort.test.js
+++ b/test/application/culture/ClockPort.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ClockPort } from '../../../src/application/culture/ClockPort.js';
+
+class FixedClock extends ClockPort {
+  constructor(value) {
+    super();
+    this.value = value;
+  }
+
+  async now() {
+    return this.value;
+  }
+}
+
+test('ClockPort validates timestamps returned by adapters', async () => {
+  const clock = new FixedClock('2026-04-18T14:05:00.000Z');
+  const now = await clock.requireNow();
+
+  assert.equal(now, '2026-04-18T14:05:00.000Z');
+
+  await assert.rejects(
+    () => new FixedClock('not-a-date').requireNow(),
+    /ClockPort now must be a valid ISO timestamp/,
+  );
+});
+
+test('ClockPort base adapter method fails fast until implemented', async () => {
+  const clock = new ClockPort();
+
+  await assert.rejects(() => clock.now(), /must be implemented by an adapter/);
+});

--- a/test/application/culture/triggerHistoricalEvent.test.js
+++ b/test/application/culture/triggerHistoricalEvent.test.js
@@ -1,7 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { selectHistoricalEvent, triggerHistoricalEvent } from '../../../src/application/culture/triggerHistoricalEvent.js';
+import {
+  selectHistoricalEvent,
+  triggerHistoricalEvent,
+  triggerHistoricalEventAtCurrentTime,
+} from '../../../src/application/culture/triggerHistoricalEvent.js';
 
 class FixedRandomProvider {
   constructor(value) {
@@ -66,6 +70,67 @@ test('selectHistoricalEvent rejects invalid candidate lists and random providers
         null,
       ),
     /selectHistoricalEvent randomProvider must expose requireNextFloat\(\)/,
+  );
+});
+
+class FixedClock {
+  constructor(value) {
+    this.value = value;
+  }
+
+  async requireNow() {
+    return this.value;
+  }
+}
+
+test('triggerHistoricalEventAtCurrentTime uses Clock integration for trigger timestamps', async () => {
+  const triggeredEvent = await triggerHistoricalEventAtCurrentTime(
+    {
+      id: 'event-court-reckoning',
+      title: 'Court Reckoning',
+      era: 'early-modern',
+      summary: 'The court reorders its chronicles after a public scandal.',
+      affectedCultureIds: ['culture-east'],
+      consequenceIds: ['archive-census'],
+      unlockedResearchIds: ['statecraft'],
+      repeatable: true,
+      triggerCount: 0,
+      lastTriggeredAt: null,
+      divergenceId: null,
+    },
+    {
+      triggeredBy: 'gamma-council',
+      consequenceIds: ['public-ledger'],
+    },
+    new FixedClock('2026-04-18T14:08:00.000Z'),
+  );
+
+  assert.equal(triggeredEvent.lastTriggeredAt, '2026-04-18T14:08:00.000Z');
+  assert.equal(triggeredEvent.lastTriggeredBy, 'gamma-council');
+  assert.deepEqual(triggeredEvent.consequenceIds, ['archive-census', 'public-ledger']);
+});
+
+test('triggerHistoricalEventAtCurrentTime rejects invalid clocks', async () => {
+  await assert.rejects(
+    () =>
+      triggerHistoricalEventAtCurrentTime(
+        {
+          id: 'event-court-reckoning',
+          title: 'Court Reckoning',
+          era: 'early-modern',
+          summary: 'The court reorders its chronicles after a public scandal.',
+          affectedCultureIds: ['culture-east'],
+          consequenceIds: [],
+          unlockedResearchIds: [],
+          repeatable: true,
+          triggerCount: 0,
+          lastTriggeredAt: null,
+          divergenceId: null,
+        },
+        {},
+        null,
+      ),
+    /triggerHistoricalEventAtCurrentTime clock must expose requireNow\(\)/,
   );
 });
 


### PR DESCRIPTION
## Summary

- Gamma: add `ClockPort` as the dedicated time contract for Gamma systems
- Gamma: integrate the port into historical-event triggering through `triggerHistoricalEventAtCurrentTime`
- Gamma: add targeted tests for clock validation and deterministic timestamp injection without changing existing trigger semantics

## Related issue

- One issue only: #54

## Changes

- Gamma: add `src/application/culture/ClockPort.js`
- Gamma: update `src/application/culture/triggerHistoricalEvent.js`
- Gamma: add `test/application/culture/ClockPort.test.js`
- Gamma: update `test/application/culture/triggerHistoricalEvent.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage des anciennes branches Gamma.
