### PR TITLE
Gamma: [G16] Build JSON content loader for research

### DIFF
--- a/src/application/culture/loadResearchStatesFromJson.js
+++ b/src/application/culture/loadResearchStatesFromJson.js
@@ -1,0 +1,84 @@
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeTextArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return [...new Set(value.map((item) => requireText(item, label)))].sort();
+}
+
+function normalizeResearchState(researchState, index) {
+  const normalizedResearchState = requireObject(
+    researchState,
+    `loadResearchStatesFromJson researchState[${index}]`,
+  );
+
+  return {
+    id: requireText(
+      normalizedResearchState.id,
+      `loadResearchStatesFromJson researchState[${index}].id`,
+    ),
+    cultureId: requireText(
+      normalizedResearchState.cultureId,
+      `loadResearchStatesFromJson researchState[${index}].cultureId`,
+    ),
+    focusIds: normalizeTextArray(
+      normalizedResearchState.focusIds ?? [],
+      `loadResearchStatesFromJson researchState[${index}].focusIds`,
+    ),
+    unlockedResearchIds: normalizeTextArray(
+      normalizedResearchState.unlockedResearchIds ?? [],
+      `loadResearchStatesFromJson researchState[${index}].unlockedResearchIds`,
+    ),
+    activeProjectId:
+      normalizedResearchState.activeProjectId === null ||
+      normalizedResearchState.activeProjectId === undefined
+        ? null
+        : requireText(
+            normalizedResearchState.activeProjectId,
+            `loadResearchStatesFromJson researchState[${index}].activeProjectId`,
+          ),
+    knowledgePoints: Number.isFinite(normalizedResearchState.knowledgePoints)
+      ? normalizedResearchState.knowledgePoints
+      : 0,
+  };
+}
+
+export function loadResearchStatesFromJson(jsonText) {
+  const normalizedJsonText = requireText(jsonText, 'loadResearchStatesFromJson jsonText');
+
+  let parsed;
+  try {
+    parsed = JSON.parse(normalizedJsonText);
+  } catch (error) {
+    throw new SyntaxError(`loadResearchStatesFromJson could not parse JSON: ${error.message}`);
+  }
+
+  const root = requireObject(parsed, 'loadResearchStatesFromJson root');
+  const rawResearchStates = root.researchStates;
+
+  if (!Array.isArray(rawResearchStates)) {
+    throw new TypeError('loadResearchStatesFromJson root.researchStates must be an array.');
+  }
+
+  return rawResearchStates.map((researchState, index) =>
+    normalizeResearchState(researchState, index),
+  );
+}

--- a/test/application/culture/loadResearchStatesFromJson.test.js
+++ b/test/application/culture/loadResearchStatesFromJson.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { loadResearchStatesFromJson } from '../../../src/application/culture/loadResearchStatesFromJson.js';
+
+test('loadResearchStatesFromJson parses and normalizes research states', () => {
+  const researchStates = loadResearchStatesFromJson(`{
+    "researchStates": [
+      {
+        "id": "research-state-north",
+        "cultureId": "culture-north",
+        "focusIds": ["astronomy", "archives", "astronomy"],
+        "unlockedResearchIds": ["paper-ledgers", "navigation"],
+        "activeProjectId": "project-star-census",
+        "knowledgePoints": 14
+      }
+    ]
+  }`);
+
+  assert.equal(researchStates.length, 1);
+  assert.deepEqual(researchStates[0], {
+    id: 'research-state-north',
+    cultureId: 'culture-north',
+    focusIds: ['archives', 'astronomy'],
+    unlockedResearchIds: ['navigation', 'paper-ledgers'],
+    activeProjectId: 'project-star-census',
+    knowledgePoints: 14,
+  });
+});
+
+test('loadResearchStatesFromJson applies defaults for optional fields', () => {
+  const researchStates = loadResearchStatesFromJson(`{
+    "researchStates": [
+      {
+        "id": "research-state-south",
+        "cultureId": "culture-south"
+      }
+    ]
+  }`);
+
+  assert.deepEqual(researchStates[0], {
+    id: 'research-state-south',
+    cultureId: 'culture-south',
+    focusIds: [],
+    unlockedResearchIds: [],
+    activeProjectId: null,
+    knowledgePoints: 0,
+  });
+});
+
+test('loadResearchStatesFromJson rejects invalid JSON and invalid research state shapes', () => {
+  assert.throws(
+    () => loadResearchStatesFromJson('{broken'),
+    /loadResearchStatesFromJson could not parse JSON/,
+  );
+
+  assert.throws(
+    () => loadResearchStatesFromJson('{"researchStates":{}}'),
+    /loadResearchStatesFromJson root.researchStates must be an array/,
+  );
+
+  assert.throws(
+    () =>
+      loadResearchStatesFromJson(`{
+        "researchStates": [
+          {
+            "id": " ",
+            "cultureId": "culture-north"
+          }
+        ]
+      }`),
+    /loadResearchStatesFromJson researchState\[0\]\.id is required/,
+  );
+
+  assert.throws(
+    () =>
+      loadResearchStatesFromJson(`{
+        "researchStates": [
+          {
+            "id": "research-state-north",
+            "cultureId": "culture-north",
+            "focusIds": [""]
+          }
+        ]
+      }`),
+    /loadResearchStatesFromJson researchState\[0\]\.focusIds is required/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add `loadResearchStatesFromJson` to load and normalize research content from JSON
- Gamma: validate research-state shapes, normalize text arrays, and apply defaults for optional fields
- Gamma: add focused tests for valid loading, default behavior, and malformed JSON or payload rejection

## Related issue

- One issue only: #56

## Changes

- Gamma: add `src/application/culture/loadResearchStatesFromJson.js`
- Gamma: add `test/application/culture/loadResearchStatesFromJson.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage des anciennes branches Gamma.
