### PR TITLE
Gamma: [G17] Add tests for research unlocks

### DIFF
--- a/src/application/culture/evaluateResearchUnlocks.js
+++ b/src/application/culture/evaluateResearchUnlocks.js
@@ -1,0 +1,102 @@
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function requireFiniteNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new RangeError(`${label} must be a finite number.`);
+  }
+
+  return value;
+}
+
+function normalizeUniqueTexts(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return [...new Set(values.map((value) => requireText(value, label)))].sort();
+}
+
+function normalizeResearchState(researchState) {
+  if (!researchState || typeof researchState !== 'object' || Array.isArray(researchState)) {
+    throw new TypeError('evaluateResearchUnlocks researchState must be an object.');
+  }
+
+  return {
+    ...researchState,
+    id: requireText(researchState.id, 'evaluateResearchUnlocks researchState.id'),
+    cultureId: requireText(researchState.cultureId, 'evaluateResearchUnlocks researchState.cultureId'),
+    focusIds: normalizeUniqueTexts(
+      researchState.focusIds ?? [],
+      'evaluateResearchUnlocks researchState.focusIds',
+    ),
+    unlockedResearchIds: normalizeUniqueTexts(
+      researchState.unlockedResearchIds ?? [],
+      'evaluateResearchUnlocks researchState.unlockedResearchIds',
+    ),
+    activeProjectId:
+      researchState.activeProjectId === null || researchState.activeProjectId === undefined
+        ? null
+        : requireText(
+            researchState.activeProjectId,
+            'evaluateResearchUnlocks researchState.activeProjectId',
+          ),
+    knowledgePoints: requireFiniteNumber(
+      researchState.knowledgePoints ?? 0,
+      'evaluateResearchUnlocks researchState.knowledgePoints',
+    ),
+  };
+}
+
+function normalizeResearchProject(researchProject, index) {
+  if (!researchProject || typeof researchProject !== 'object' || Array.isArray(researchProject)) {
+    throw new TypeError(`evaluateResearchUnlocks researchProjects[${index}] must be an object.`);
+  }
+
+  return {
+    ...researchProject,
+    id: requireText(researchProject.id, `evaluateResearchUnlocks researchProjects[${index}].id`),
+    requiredKnowledgePoints: requireFiniteNumber(
+      researchProject.requiredKnowledgePoints,
+      `evaluateResearchUnlocks researchProjects[${index}].requiredKnowledgePoints`,
+    ),
+  };
+}
+
+export function evaluateResearchUnlocks(researchState, researchProjects) {
+  const normalizedResearchState = normalizeResearchState(researchState);
+
+  if (!Array.isArray(researchProjects)) {
+    throw new TypeError('evaluateResearchUnlocks researchProjects must be an array.');
+  }
+
+  const normalizedResearchProjects = researchProjects.map((researchProject, index) =>
+    normalizeResearchProject(researchProject, index),
+  );
+
+  const unlockedResearchIds = new Set(normalizedResearchState.unlockedResearchIds);
+  const newlyUnlockedResearchIds = [];
+
+  for (const researchProject of normalizedResearchProjects) {
+    if (
+      normalizedResearchState.knowledgePoints >= researchProject.requiredKnowledgePoints &&
+      !unlockedResearchIds.has(researchProject.id)
+    ) {
+      unlockedResearchIds.add(researchProject.id);
+      newlyUnlockedResearchIds.push(researchProject.id);
+    }
+  }
+
+  return {
+    ...normalizedResearchState,
+    unlockedResearchIds: [...unlockedResearchIds].sort(),
+    newlyUnlockedResearchIds: newlyUnlockedResearchIds.sort(),
+  };
+}

--- a/test/application/culture/evaluateResearchUnlocks.test.js
+++ b/test/application/culture/evaluateResearchUnlocks.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evaluateResearchUnlocks } from '../../../src/application/culture/evaluateResearchUnlocks.js';
+
+test('evaluateResearchUnlocks unlocks projects that match current knowledge points', () => {
+  const result = evaluateResearchUnlocks(
+    {
+      id: 'research-state-north',
+      cultureId: 'culture-north',
+      focusIds: ['astronomy'],
+      unlockedResearchIds: ['paper-ledgers'],
+      activeProjectId: 'project-observatory',
+      knowledgePoints: 18,
+    },
+    [
+      { id: 'paper-ledgers', requiredKnowledgePoints: 4 },
+      { id: 'observatory-maps', requiredKnowledgePoints: 10 },
+      { id: 'stellar-census', requiredKnowledgePoints: 18 },
+      { id: 'deep-vaults', requiredKnowledgePoints: 25 },
+    ],
+  );
+
+  assert.deepEqual(result.unlockedResearchIds, [
+    'observatory-maps',
+    'paper-ledgers',
+    'stellar-census',
+  ]);
+  assert.deepEqual(result.newlyUnlockedResearchIds, ['observatory-maps', 'stellar-census']);
+});
+
+test('evaluateResearchUnlocks returns no new unlocks when thresholds are unmet', () => {
+  const result = evaluateResearchUnlocks(
+    {
+      id: 'research-state-south',
+      cultureId: 'culture-south',
+      focusIds: [],
+      unlockedResearchIds: [],
+      activeProjectId: null,
+      knowledgePoints: 3,
+    },
+    [
+      { id: 'paper-ledgers', requiredKnowledgePoints: 4 },
+      { id: 'observatory-maps', requiredKnowledgePoints: 10 },
+    ],
+  );
+
+  assert.deepEqual(result.unlockedResearchIds, []);
+  assert.deepEqual(result.newlyUnlockedResearchIds, []);
+});
+
+test('evaluateResearchUnlocks rejects invalid research state and project shapes', () => {
+  assert.throws(
+    () => evaluateResearchUnlocks(null, []),
+    /evaluateResearchUnlocks researchState must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      evaluateResearchUnlocks(
+        {
+          id: 'research-state-east',
+          cultureId: 'culture-east',
+          focusIds: [],
+          unlockedResearchIds: [],
+          activeProjectId: null,
+          knowledgePoints: 'not-a-number',
+        },
+        [],
+      ),
+    /evaluateResearchUnlocks researchState.knowledgePoints must be a finite number/,
+  );
+
+  assert.throws(
+    () =>
+      evaluateResearchUnlocks(
+        {
+          id: 'research-state-east',
+          cultureId: 'culture-east',
+          focusIds: [],
+          unlockedResearchIds: [],
+          activeProjectId: null,
+          knowledgePoints: 8,
+        },
+        [{ id: 'observatory-maps', requiredKnowledgePoints: '10' }],
+      ),
+    /evaluateResearchUnlocks researchProjects\[0\]\.requiredKnowledgePoints must be a finite number/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add focused tests for `evaluateResearchUnlocks` across successful unlocks, no-op thresholds, and invalid payloads
- Gamma: include the underlying use case file in this clean PR so the tested behavior is available directly from `main`
- Gamma: verify unlock ordering and error handling stay deterministic

## Related issue

- One issue only: #57

## Changes

- Gamma: add `src/application/culture/evaluateResearchUnlocks.js`
- Gamma: add `test/application/culture/evaluateResearchUnlocks.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage des anciennes branches Gamma.
