### PR TITLE
Epsilon: [E02] Define SeasonCycle model

### DIFF
--- a/src/domain/climate/SeasonCycle.js
+++ b/src/domain/climate/SeasonCycle.js
@@ -1,0 +1,115 @@
+const DEFAULT_SEASONS = ['spring', 'summer', 'autumn', 'winter'];
+
+function normalizeSeasonOrder(seasonOrder) {
+  if (!Array.isArray(seasonOrder) || seasonOrder.length === 0) {
+    throw new RangeError('SeasonCycle seasonOrder must be a non-empty array.');
+  }
+
+  const normalizedOrder = seasonOrder.map((season) => SeasonCycle.requireText(season, 'SeasonCycle seasonOrder value'));
+
+  if (new Set(normalizedOrder).size !== normalizedOrder.length) {
+    throw new RangeError('SeasonCycle seasonOrder cannot contain duplicates.');
+  }
+
+  return normalizedOrder;
+}
+
+export class SeasonCycle {
+  constructor({
+    currentSeason,
+    year = 1,
+    dayOfSeason = 1,
+    seasonLengthDays = 30,
+    seasonOrder = DEFAULT_SEASONS,
+  } = {}) {
+    this.seasonOrder = normalizeSeasonOrder(seasonOrder);
+    this.currentSeason = SeasonCycle.requireText(currentSeason, 'SeasonCycle currentSeason');
+
+    if (!this.seasonOrder.includes(this.currentSeason)) {
+      throw new RangeError('SeasonCycle currentSeason must be included in seasonOrder.');
+    }
+
+    this.year = SeasonCycle.requireIntegerInRange(year, 'SeasonCycle year', 1, Number.MAX_SAFE_INTEGER);
+    this.dayOfSeason = SeasonCycle.requireIntegerInRange(dayOfSeason, 'SeasonCycle dayOfSeason', 1, Number.MAX_SAFE_INTEGER);
+    this.seasonLengthDays = SeasonCycle.requireIntegerInRange(seasonLengthDays, 'SeasonCycle seasonLengthDays', 1, 366);
+
+    if (this.dayOfSeason > this.seasonLengthDays) {
+      throw new RangeError('SeasonCycle dayOfSeason cannot exceed seasonLengthDays.');
+    }
+  }
+
+  get progressRatio() {
+    return this.dayOfSeason / this.seasonLengthDays;
+  }
+
+  get nextSeason() {
+    const currentIndex = this.seasonOrder.indexOf(this.currentSeason);
+    return this.seasonOrder[(currentIndex + 1) % this.seasonOrder.length];
+  }
+
+  advanceDays(days = 1) {
+    const normalizedDays = SeasonCycle.requireIntegerInRange(days, 'SeasonCycle advance days', 1, Number.MAX_SAFE_INTEGER);
+
+    let currentSeason = this.currentSeason;
+    let dayOfSeason = this.dayOfSeason;
+    let year = this.year;
+
+    for (let day = 0; day < normalizedDays; day += 1) {
+      dayOfSeason += 1;
+
+      if (dayOfSeason > this.seasonLengthDays) {
+        dayOfSeason = 1;
+
+        const currentIndex = this.seasonOrder.indexOf(currentSeason);
+        const nextIndex = (currentIndex + 1) % this.seasonOrder.length;
+        currentSeason = this.seasonOrder[nextIndex];
+
+        if (nextIndex === 0) {
+          year += 1;
+        }
+      }
+    }
+
+    return new SeasonCycle({
+      currentSeason,
+      year,
+      dayOfSeason,
+      seasonLengthDays: this.seasonLengthDays,
+      seasonOrder: this.seasonOrder,
+    });
+  }
+
+  advanceSeason() {
+    return this.advanceDays(this.seasonLengthDays - this.dayOfSeason + 1);
+  }
+
+  toJSON() {
+    return {
+      currentSeason: this.currentSeason,
+      year: this.year,
+      dayOfSeason: this.dayOfSeason,
+      seasonLengthDays: this.seasonLengthDays,
+      seasonOrder: [...this.seasonOrder],
+      nextSeason: this.nextSeason,
+      progressRatio: this.progressRatio,
+    };
+  }
+
+  static requireText(value, label) {
+    const normalizedValue = String(value ?? '').trim();
+
+    if (!normalizedValue) {
+      throw new RangeError(`${label} is required.`);
+    }
+
+    return normalizedValue;
+  }
+
+  static requireIntegerInRange(value, label, min, max) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+    }
+
+    return value;
+  }
+}

--- a/src/domain/climate/index.js
+++ b/src/domain/climate/index.js
@@ -1,3 +1,4 @@
 export { ClimateState } from './ClimateState.js';
 export { Catastrophe } from './Catastrophe.js';
 export { Myth } from './Myth.js';
+export { SeasonCycle } from './SeasonCycle.js';

--- a/test/domain/climate/SeasonCycle.test.js
+++ b/test/domain/climate/SeasonCycle.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { SeasonCycle } from '../../../src/domain/climate/SeasonCycle.js';
+
+test('SeasonCycle normalizes and exposes seasonal progression fields', () => {
+  const cycle = new SeasonCycle({
+    currentSeason: ' spring ',
+    year: 3,
+    dayOfSeason: 7,
+    seasonLengthDays: 20,
+  });
+
+  assert.deepEqual(cycle.toJSON(), {
+    currentSeason: 'spring',
+    year: 3,
+    dayOfSeason: 7,
+    seasonLengthDays: 20,
+    seasonOrder: ['spring', 'summer', 'autumn', 'winter'],
+    nextSeason: 'summer',
+    progressRatio: 7 / 20,
+  });
+});
+
+test('SeasonCycle advances across season and year boundaries immutably', () => {
+  const cycle = new SeasonCycle({
+    currentSeason: 'winter',
+    year: 8,
+    dayOfSeason: 29,
+    seasonLengthDays: 30,
+  });
+
+  const nextDay = cycle.advanceDays();
+  const nextSeason = nextDay.advanceDays();
+
+  assert.notEqual(nextDay, cycle);
+  assert.equal(nextDay.currentSeason, 'winter');
+  assert.equal(nextDay.dayOfSeason, 30);
+  assert.equal(nextDay.year, 8);
+
+  assert.equal(nextSeason.currentSeason, 'spring');
+  assert.equal(nextSeason.dayOfSeason, 1);
+  assert.equal(nextSeason.year, 9);
+
+  assert.equal(cycle.currentSeason, 'winter');
+  assert.equal(cycle.dayOfSeason, 29);
+  assert.equal(cycle.year, 8);
+});
+
+test('SeasonCycle can advance directly to the next season', () => {
+  const cycle = new SeasonCycle({
+    currentSeason: 'summer',
+    year: 2,
+    dayOfSeason: 12,
+    seasonLengthDays: 15,
+  });
+
+  const advanced = cycle.advanceSeason();
+
+  assert.equal(advanced.currentSeason, 'autumn');
+  assert.equal(advanced.dayOfSeason, 1);
+  assert.equal(advanced.year, 2);
+});
+
+test('SeasonCycle rejects invalid configuration', () => {
+  assert.throws(
+    () => new SeasonCycle({ currentSeason: '', year: 1 }),
+    /SeasonCycle currentSeason is required/,
+  );
+
+  assert.throws(
+    () => new SeasonCycle({ currentSeason: 'monsoon', seasonOrder: ['spring', 'summer'] }),
+    /currentSeason must be included in seasonOrder/,
+  );
+
+  assert.throws(
+    () => new SeasonCycle({ currentSeason: 'spring', dayOfSeason: 31, seasonLengthDays: 30 }),
+    /dayOfSeason cannot exceed seasonLengthDays/,
+  );
+
+  assert.throws(
+    () => new SeasonCycle({ currentSeason: 'spring', seasonOrder: ['spring', 'spring'] }),
+    /seasonOrder cannot contain duplicates/,
+  );
+});


### PR DESCRIPTION
Epsilon: reprise propre depuis main pour l’issue #82.

## Summary
- add the SeasonCycle climate domain model
- expose seasonal progression, next-season derivation, and immutable advancement helpers
- cover normalization, year rollover, direct season advancement, and invalid configuration with targeted tests

## Verification
- node --test

Closes #82
