### PR TITLE
Gamma: [G19] Show discoveries in UI

### DIFF
--- a/src/ui/culture/buildDiscoveriesPanel.js
+++ b/src/ui/culture/buildDiscoveriesPanel.js
@@ -1,0 +1,90 @@
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeTextArray(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return [...new Set(values.map((value) => requireText(value, label)))].sort();
+}
+
+function normalizeHistoricalEvents(events) {
+  if (!Array.isArray(events)) {
+    throw new TypeError('DiscoveriesPanel historicalEvents must be an array.');
+  }
+
+  return events.map((event, index) => {
+    const normalizedEvent = requireObject(event, `DiscoveriesPanel historicalEvents[${index}]`);
+
+    return {
+      id: requireText(normalizedEvent.id, `DiscoveriesPanel historicalEvents[${index}].id`),
+      title: requireText(
+        normalizedEvent.title,
+        `DiscoveriesPanel historicalEvents[${index}].title`,
+      ),
+      discoveryIds: normalizeTextArray(
+        normalizedEvent.discoveryIds ?? [],
+        `DiscoveriesPanel historicalEvents[${index}].discoveryIds`,
+      ),
+      unlockedResearchIds: normalizeTextArray(
+        normalizedEvent.unlockedResearchIds ?? [],
+        `DiscoveriesPanel historicalEvents[${index}].unlockedResearchIds`,
+      ),
+    };
+  });
+}
+
+export function buildDiscoveriesPanel(researchState, options = {}) {
+  const normalizedResearchState = requireObject(researchState, 'DiscoveriesPanel researchState');
+  const normalizedOptions = requireObject(options, 'DiscoveriesPanel options');
+  const discoveredConceptIds = normalizeTextArray(
+    normalizedResearchState.discoveredConceptIds ?? [],
+    'DiscoveriesPanel researchState.discoveredConceptIds',
+  );
+  const unlockedResearchIds = normalizeTextArray(
+    normalizedResearchState.unlockedResearchIds ?? [],
+    'DiscoveriesPanel researchState.unlockedResearchIds',
+  );
+  const historicalEvents = normalizeHistoricalEvents(normalizedOptions.historicalEvents ?? []);
+
+  const eventRows = historicalEvents.map((event) => ({
+    eventId: event.id,
+    eventTitle: event.title,
+    discoveryCount: event.discoveryIds.length,
+    discoveries: event.discoveryIds,
+    unlockedResearchIds: event.unlockedResearchIds,
+    label: `${event.title} (${event.discoveryIds.length} découverte${event.discoveryIds.length > 1 ? 's' : ''})`,
+  }));
+
+  return {
+    cultureId: requireText(normalizedResearchState.cultureId, 'DiscoveriesPanel researchState.cultureId'),
+    title: 'Découvertes',
+    summary: `${discoveredConceptIds.length} concepts, ${unlockedResearchIds.length} recherches, ${eventRows.length} événements`,
+    sections: {
+      concepts: discoveredConceptIds,
+      research: unlockedResearchIds,
+      events: eventRows,
+    },
+    metrics: {
+      conceptCount: discoveredConceptIds.length,
+      unlockedResearchCount: unlockedResearchIds.length,
+      eventCount: eventRows.length,
+    },
+  };
+}

--- a/test/ui/culture/buildDiscoveriesPanel.test.js
+++ b/test/ui/culture/buildDiscoveriesPanel.test.js
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildDiscoveriesPanel } from '../../../src/ui/culture/buildDiscoveriesPanel.js';
+
+test('buildDiscoveriesPanel summarizes research discoveries and event discoveries', () => {
+  const panel = buildDiscoveriesPanel(
+    {
+      cultureId: 'culture-north',
+      discoveredConceptIds: ['bronze-smelting', ' star-maps ', 'bronze-smelting'],
+      unlockedResearchIds: ['observatory-maps', 'paper-ledgers'],
+    },
+    {
+      historicalEvents: [
+        {
+          id: 'event-open-archives',
+          title: 'Open Archives',
+          discoveryIds: ['public-catalogue', 'scholar-oath'],
+          unlockedResearchIds: ['paper-ledgers'],
+        },
+      ],
+    },
+  );
+
+  assert.deepEqual(panel, {
+    cultureId: 'culture-north',
+    title: 'Découvertes',
+    summary: '2 concepts, 2 recherches, 1 événements',
+    sections: {
+      concepts: ['bronze-smelting', 'star-maps'],
+      research: ['observatory-maps', 'paper-ledgers'],
+      events: [
+        {
+          eventId: 'event-open-archives',
+          eventTitle: 'Open Archives',
+          discoveryCount: 2,
+          discoveries: ['public-catalogue', 'scholar-oath'],
+          unlockedResearchIds: ['paper-ledgers'],
+          label: 'Open Archives (2 découvertes)',
+        },
+      ],
+    },
+    metrics: {
+      conceptCount: 2,
+      unlockedResearchCount: 2,
+      eventCount: 1,
+    },
+  });
+});
+
+test('buildDiscoveriesPanel supports empty discovery collections', () => {
+  const panel = buildDiscoveriesPanel(
+    {
+      cultureId: 'culture-south',
+      discoveredConceptIds: [],
+      unlockedResearchIds: [],
+    },
+    {
+      historicalEvents: [],
+    },
+  );
+
+  assert.equal(panel.summary, '0 concepts, 0 recherches, 0 événements');
+  assert.deepEqual(panel.sections.events, []);
+});
+
+test('buildDiscoveriesPanel rejects invalid payloads', () => {
+  assert.throws(
+    () => buildDiscoveriesPanel(null, {}),
+    /DiscoveriesPanel researchState must be an object/,
+  );
+
+  assert.throws(
+    () =>
+      buildDiscoveriesPanel(
+        {
+          cultureId: 'culture-north',
+          discoveredConceptIds: [''],
+          unlockedResearchIds: [],
+        },
+        {},
+      ),
+    /DiscoveriesPanel researchState.discoveredConceptIds is required/,
+  );
+
+  assert.throws(
+    () =>
+      buildDiscoveriesPanel(
+        {
+          cultureId: 'culture-north',
+          discoveredConceptIds: [],
+          unlockedResearchIds: [],
+        },
+        {
+          historicalEvents: [{ id: 'event-open-archives', title: ' ', discoveryIds: [] }],
+        },
+      ),
+    /DiscoveriesPanel historicalEvents\[0\]\.title is required/,
+  );
+});


### PR DESCRIPTION
## Summary

- Gamma: add a dedicated culture UI builder to surface discoveries in a structured panel
- Gamma: expose discovered concepts, unlocked research, and event-linked discoveries in one normalized view
- Gamma: add focused UI tests for populated, empty, and invalid discovery payloads

## Related issue

- One issue only: #59

## Changes

- Gamma: add `src/ui/culture/buildDiscoveriesPanel.js`
- Gamma: add `test/ui/culture/buildDiscoveriesPanel.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

- Gamma: `npm test -- --test-reporter tap`

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [x] A message was sent to Zeta to signal that this work is finished and ready for validation
- [x] Zeta has been asked for validation before merge

## Notes

- Gamma: reprise propre depuis `main` après nettoyage des anciennes branches Gamma.
