### PR TITLE
Epsilon: add seasonal progression tests

### DIFF
--- a/test/application/climate/UpdateRegionalClimate.test.js
+++ b/test/application/climate/UpdateRegionalClimate.test.js
@@ -99,6 +99,42 @@ test('UpdateRegionalClimate clamps precipitation and drought indicators', () => 
   assert.equal(result.updatedRegionalStates[0].season, 'winter');
 });
 
+test('UpdateRegionalClimate supports season rollover while preserving active climate events', () => {
+  const useCase = new UpdateRegionalClimate();
+
+  const result = useCase.execute({
+    regionalStates: [
+      {
+        regionId: 'ember-steppe',
+        season: 'winter',
+        temperatureC: 3,
+        precipitationLevel: 35,
+        droughtIndex: 41,
+        anomaly: 'ashfall',
+        activeCatastropheIds: ['locusts'],
+        updatedAt: '2026-04-18T00:00:00.000Z',
+      },
+    ],
+    nextSeason: 'spring',
+    defaultShift: {
+      temperatureDelta: 6,
+      precipitationDelta: 12,
+      droughtDelta: -9,
+    },
+  });
+
+  assert.deepEqual(result.updatedRegionalStates[0].toJSON(), {
+    regionId: 'ember-steppe',
+    season: 'spring',
+    temperatureC: 9,
+    precipitationLevel: 47,
+    droughtIndex: 32,
+    anomaly: 'ashfall',
+    activeCatastropheIds: ['locusts'],
+    updatedAt: result.updatedRegionalStates[0].updatedAt,
+  });
+});
+
 test('UpdateRegionalClimate rejects invalid regional state collections', () => {
   const useCase = new UpdateRegionalClimate();
 

--- a/test/domain/climate/SeasonCycle.test.js
+++ b/test/domain/climate/SeasonCycle.test.js
@@ -62,6 +62,42 @@ test('SeasonCycle can advance directly to the next season', () => {
   assert.equal(advanced.year, 2);
 });
 
+test('SeasonCycle advances across multiple seasons with custom order', () => {
+  const cycle = new SeasonCycle({
+    currentSeason: 'dry',
+    year: 5,
+    dayOfSeason: 2,
+    seasonLengthDays: 4,
+    seasonOrder: ['flood', 'dry', 'storm'],
+  });
+
+  const advanced = cycle.advanceDays(7);
+
+  assert.equal(advanced.currentSeason, 'flood');
+  assert.equal(advanced.dayOfSeason, 1);
+  assert.equal(advanced.year, 6);
+  assert.equal(advanced.nextSeason, 'dry');
+
+  assert.equal(cycle.currentSeason, 'dry');
+  assert.equal(cycle.dayOfSeason, 2);
+  assert.equal(cycle.year, 5);
+});
+
+test('SeasonCycle advanceSeason rolls the year when leaving the last season', () => {
+  const cycle = new SeasonCycle({
+    currentSeason: 'winter',
+    year: 11,
+    dayOfSeason: 30,
+    seasonLengthDays: 30,
+  });
+
+  const advanced = cycle.advanceSeason();
+
+  assert.equal(advanced.currentSeason, 'spring');
+  assert.equal(advanced.dayOfSeason, 1);
+  assert.equal(advanced.year, 12);
+});
+
 test('SeasonCycle rejects invalid configuration', () => {
   assert.throws(
     () => new SeasonCycle({ currentSeason: '', year: 1 }),


### PR DESCRIPTION
## Summary

- Epsilon: extend `SeasonCycle` coverage for multi-season jumps, custom calendars, and year rollover
- Epsilon: verify `UpdateRegionalClimate` handles seasonal rollover while preserving anomalies and active catastrophes

## Related issue

- One issue only: Closes #96

## Changes

- Epsilon: add seasonal progression regression tests in `test/domain/climate/SeasonCycle.test.js`
- Epsilon: add a climate update rollover test in `test/application/climate/UpdateRegionalClimate.test.js`

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [x] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date
