### PR TITLE
Epsilon: add catastrophe trigger tests

### DIFF
--- a/test/application/climate/RegisterMythFromEvent.test.js
+++ b/test/application/climate/RegisterMythFromEvent.test.js
@@ -54,6 +54,30 @@ test('RegisterMythFromEvent accepts plain event payloads and adapts credibility'
   assert.equal(result.myth.title, 'The River Without Mercy');
 });
 
+test('RegisterMythFromEvent turns non-flood catastrophes into omen myths with sorted metadata', () => {
+  const useCase = new RegisterMythFromEvent();
+
+  const result = useCase.execute({
+    event: {
+      id: 'ashlands-heatwave',
+      type: 'heatwave',
+      severity: 'minor',
+      status: 'warning',
+      regionIds: ['south-ridge', 'ashlands'],
+      startedAt: '2026-04-18T10:00:00.000Z',
+      impact: { harvest: -8 },
+    },
+    createdAt: '2026-04-18T12:10:00.000Z',
+  });
+
+  assert.equal(result.myth.category, 'omen');
+  assert.equal(result.myth.title, 'The Burning Sky');
+  assert.equal(result.myth.credibility, 43);
+  assert.deepEqual(result.myth.regions, ['ashlands', 'south-ridge']);
+  assert.deepEqual(result.myth.tags, ['heatwave', 'minor', 'warning']);
+  assert.match(result.myth.summary, /south-ridge/);
+});
+
 test('RegisterMythFromEvent rejects invalid events', () => {
   const useCase = new RegisterMythFromEvent();
 

--- a/test/domain/climate/Catastrophe.test.js
+++ b/test/domain/climate/Catastrophe.test.js
@@ -54,6 +54,27 @@ test('Catastrophe transitions from warning to active to resolved immutably', () 
   assert.equal(resolved.resolvedAt?.toISOString(), '2026-04-19T09:00:00.000Z');
 });
 
+test('Catastrophe keeps expected end dates and sorts triggered regions after activation', () => {
+  const warning = new Catastrophe({
+    id: 'locust-003',
+    type: 'locusts',
+    severity: 'major',
+    regionIds: ['delta', 'ashlands', 'delta'],
+    startedAt: '2026-04-18T05:00:00.000Z',
+    expectedEndAt: '2026-04-22T05:00:00.000Z',
+    impact: { harvest: -33 },
+  });
+
+  const active = warning.activate();
+
+  assert.equal(active.expectedEndAt?.toISOString(), '2026-04-22T05:00:00.000Z');
+  assert.deepEqual(active.regionIds, ['ashlands', 'delta']);
+  assert.equal(active.affectsRegion('ashlands'), true);
+  assert.equal(active.affectsRegion('delta'), true);
+  assert.equal(active.affectsRegion('riverlands'), false);
+  assert.equal(warning.status, 'warning');
+});
+
 test('Catastrophe rejects invalid values and timelines', () => {
   assert.throws(
     () => new Catastrophe({ id: '', type: 'storm', severity: 'major', regionIds: ['north'], startedAt: new Date(), impact: {} }),
@@ -78,5 +99,15 @@ test('Catastrophe rejects invalid values and timelines', () => {
   assert.throws(
     () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'major', regionIds: ['north'], startedAt: '2026-04-18T12:00:00.000Z', resolvedAt: '2026-04-17T12:00:00.000Z', impact: {} }),
     /resolvedAt cannot be earlier than startedAt/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'major', regionIds: ['north'], startedAt: 'not-a-date', impact: {} }),
+    /startedAt must be a valid date/,
+  );
+
+  assert.throws(
+    () => new Catastrophe({ id: 'c1', type: 'storm', severity: 'major', regionIds: ['north'], startedAt: '2026-04-18T12:00:00.000Z', impact: { harvest: Number.NaN } }),
+    /impact harvest must be a finite number/,
   );
 });


### PR DESCRIPTION
## Summary

- Epsilon: extend catastrophe coverage for activation metadata and invalid trigger inputs
- Epsilon: verify myth registration from catastrophe triggers keeps category, credibility, and sorted metadata consistent

## Related issue

- One issue only: Closes #97

## Changes

- Epsilon: add domain tests for catastrophe activation, region normalization, and invalid trigger payloads
- Epsilon: add application tests for myth generation from resolved floods and warning heatwaves

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [x] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date
