### PR TITLE
Epsilon: add climate status UI panel

### DIFF
--- a/src/ui/climate/buildClimateStatusPanel.js
+++ b/src/ui/climate/buildClimateStatusPanel.js
@@ -1,0 +1,98 @@
+import { ClimateState } from '../../domain/climate/ClimateState.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeClimateState(climateState) {
+  if (climateState instanceof ClimateState) {
+    return climateState;
+  }
+
+  if (climateState === null || typeof climateState !== 'object' || Array.isArray(climateState)) {
+    throw new TypeError('ClimateStatusPanel climateState must be a ClimateState or plain object.');
+  }
+
+  return new ClimateState(climateState);
+}
+
+function buildAnomalySummary(anomaly, activeCatastropheIds) {
+  const anomalies = [];
+
+  if (anomaly !== null) {
+    anomalies.push({
+      type: 'anomaly',
+      id: anomaly,
+      label: anomaly,
+      tone: 'warning',
+    });
+  }
+
+  for (const catastropheId of activeCatastropheIds) {
+    anomalies.push({
+      type: 'catastrophe',
+      id: catastropheId,
+      label: catastropheId,
+      tone: 'danger',
+    });
+  }
+
+  return anomalies;
+}
+
+export function buildClimateStatusPanel(climateState, options = {}) {
+  const normalizedClimateState = normalizeClimateState(climateState);
+  const normalizedOptions = requireObject(options, 'ClimateStatusPanel options');
+  const regionName = requireText(
+    normalizedOptions.regionName ?? normalizedClimateState.regionId,
+    'ClimateStatusPanel regionName',
+  );
+  const seasonLabel = requireText(
+    normalizedOptions.seasonLabels?.[normalizedClimateState.season] ?? normalizedClimateState.season,
+    'ClimateStatusPanel season label',
+  );
+  const anomalies = buildAnomalySummary(
+    normalizedClimateState.anomaly,
+    [...normalizedClimateState.activeCatastropheIds].sort(),
+  );
+  const anomalySummary = anomalies.length === 0
+    ? 'Aucune anomalie'
+    : anomalies.map((entry) => entry.label).join(', ');
+
+  return {
+    regionId: normalizedClimateState.regionId,
+    regionName,
+    title: `Climat de ${regionName}`,
+    summary: `${seasonLabel}, ${anomalySummary}`,
+    season: {
+      id: normalizedClimateState.season,
+      label: seasonLabel,
+    },
+    readings: {
+      temperatureC: normalizedClimateState.temperatureC,
+      precipitationLevel: normalizedClimateState.precipitationLevel,
+      droughtIndex: normalizedClimateState.droughtIndex,
+      stability: normalizedClimateState.isStable() ? 'stable' : 'volatile',
+    },
+    anomalies,
+    metrics: {
+      anomalyCount: anomalies.length,
+      activeCatastropheCount: normalizedClimateState.activeCatastropheIds.length,
+      hasAnomaly: normalizedClimateState.hasAnomaly(),
+    },
+  };
+}

--- a/test/ui/climate/buildClimateStatusPanel.test.js
+++ b/test/ui/climate/buildClimateStatusPanel.test.js
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+import { buildClimateStatusPanel } from '../../../src/ui/climate/buildClimateStatusPanel.js';
+
+test('buildClimateStatusPanel summarizes season, anomaly, and active catastrophes', () => {
+  const panel = buildClimateStatusPanel(new ClimateState({
+    regionId: 'sunreach',
+    season: 'summer',
+    temperatureC: 33,
+    precipitationLevel: 11,
+    droughtIndex: 74,
+    anomaly: 'heatwave',
+    activeCatastropheIds: ['locusts', 'wildfire'],
+  }), {
+    regionName: 'Sunreach',
+    seasonLabels: {
+      summer: 'Été',
+    },
+  });
+
+  assert.deepEqual(panel, {
+    regionId: 'sunreach',
+    regionName: 'Sunreach',
+    title: 'Climat de Sunreach',
+    summary: 'Été, heatwave, locusts, wildfire',
+    season: {
+      id: 'summer',
+      label: 'Été',
+    },
+    readings: {
+      temperatureC: 33,
+      precipitationLevel: 11,
+      droughtIndex: 74,
+      stability: 'volatile',
+    },
+    anomalies: [
+      {
+        type: 'anomaly',
+        id: 'heatwave',
+        label: 'heatwave',
+        tone: 'warning',
+      },
+      {
+        type: 'catastrophe',
+        id: 'locusts',
+        label: 'locusts',
+        tone: 'danger',
+      },
+      {
+        type: 'catastrophe',
+        id: 'wildfire',
+        label: 'wildfire',
+        tone: 'danger',
+      },
+    ],
+    metrics: {
+      anomalyCount: 3,
+      activeCatastropheCount: 2,
+      hasAnomaly: true,
+    },
+  });
+});
+
+test('buildClimateStatusPanel supports plain payloads without anomalies', () => {
+  const panel = buildClimateStatusPanel({
+    regionId: 'north-coast',
+    season: 'spring',
+    temperatureC: 12,
+    precipitationLevel: 63,
+    droughtIndex: 18,
+  });
+
+  assert.equal(panel.summary, 'spring, Aucune anomalie');
+  assert.deepEqual(panel.anomalies, []);
+  assert.deepEqual(panel.metrics, {
+    anomalyCount: 0,
+    activeCatastropheCount: 0,
+    hasAnomaly: false,
+  });
+  assert.equal(panel.readings.stability, 'stable');
+});
+
+test('buildClimateStatusPanel rejects invalid payloads', () => {
+  assert.throws(
+    () => buildClimateStatusPanel(null),
+    /ClimateStatusPanel climateState must be a ClimateState or plain object/,
+  );
+
+  assert.throws(
+    () => buildClimateStatusPanel({
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 63,
+      droughtIndex: 18,
+    }, null),
+    /ClimateStatusPanel options must be an object/,
+  );
+
+  assert.throws(
+    () => buildClimateStatusPanel({
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 63,
+      droughtIndex: 18,
+    }, {
+      regionName: ' ',
+    }),
+    /ClimateStatusPanel regionName is required/,
+  );
+});


### PR DESCRIPTION
## Summary

- Epsilon: add a dedicated climate UI helper for season, anomaly, and catastrophe status
- Epsilon: cover the new climate panel with deterministic UI tests

## Related issue

- One issue only: Closes #98

## Changes

- Epsilon: add `buildClimateStatusPanel` for rendering climate season and anomaly state from `ClimateState`
- Epsilon: expose stable anomaly and active catastrophe rows with simple severity tones
- Epsilon: add tests for normalized output, plain payload support, and invalid inputs

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [x] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date
