### PR TITLE
Epsilon: add catastrophe map overlay

### DIFF
--- a/src/ui/climate/buildCatastropheMapOverlay.js
+++ b/src/ui/climate/buildCatastropheMapOverlay.js
@@ -1,0 +1,77 @@
+import { Catastrophe } from '../../domain/climate/Catastrophe.js';
+
+const DEFAULT_STYLE_BY_SEVERITY = Object.freeze({
+  minor: { stroke: 'yellow', fill: 'yellow', opacity: 0.3, icon: '△' },
+  major: { stroke: 'orange', fill: 'orange', opacity: 0.4, icon: '▲' },
+  critical: { stroke: 'crimson', fill: 'crimson', opacity: 0.5, icon: '⚠' },
+  default: { stroke: 'slate', fill: 'slate', opacity: 0.25, icon: '•' },
+});
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeCatastrophe(catastrophe) {
+  if (catastrophe instanceof Catastrophe) {
+    return catastrophe;
+  }
+
+  if (catastrophe === null || typeof catastrophe !== 'object' || Array.isArray(catastrophe)) {
+    throw new TypeError('CatastropheMapOverlay catastrophes must be Catastrophe instances or plain objects.');
+  }
+
+  return new Catastrophe(catastrophe);
+}
+
+function normalizeStyle(styleBySeverity, severity) {
+  const style = styleBySeverity[severity] ?? styleBySeverity.default ?? DEFAULT_STYLE_BY_SEVERITY.default;
+
+  return {
+    stroke: String(style.stroke ?? DEFAULT_STYLE_BY_SEVERITY[severity]?.stroke ?? 'slate').trim() || 'slate',
+    fill: String(style.fill ?? DEFAULT_STYLE_BY_SEVERITY[severity]?.fill ?? 'slate').trim() || 'slate',
+    opacity: Number.isFinite(style.opacity) ? Math.max(0, Math.min(1, style.opacity)) : (DEFAULT_STYLE_BY_SEVERITY[severity]?.opacity ?? 0.25),
+    icon: String(style.icon ?? DEFAULT_STYLE_BY_SEVERITY[severity]?.icon ?? '•').trim() || '•',
+  };
+}
+
+export function buildCatastropheMapOverlay(catastrophes, options = {}) {
+  if (!Array.isArray(catastrophes)) {
+    throw new TypeError('CatastropheMapOverlay catastrophes must be an array.');
+  }
+
+  const normalizedOptions = requireObject(options, 'CatastropheMapOverlay options');
+  const styleBySeverity = {
+    ...DEFAULT_STYLE_BY_SEVERITY,
+    ...requireObject(normalizedOptions.styleBySeverity ?? {}, 'CatastropheMapOverlay styleBySeverity'),
+  };
+
+  return catastrophes
+    .map(normalizeCatastrophe)
+    .filter((catastrophe) => !catastrophe.isResolved)
+    .flatMap((catastrophe) => catastrophe.regionIds.map((regionId) => ({ catastrophe, regionId })))
+    .sort((left, right) => {
+      const regionComparison = left.regionId.localeCompare(right.regionId);
+
+      if (regionComparison !== 0) {
+        return regionComparison;
+      }
+
+      return left.catastrophe.id.localeCompare(right.catastrophe.id);
+    })
+    .map(({ catastrophe, regionId }) => ({
+      overlayId: `${regionId}:${catastrophe.id}`,
+      regionId,
+      catastropheId: catastrophe.id,
+      type: catastrophe.type,
+      severity: catastrophe.severity,
+      status: catastrophe.status,
+      label: `${catastrophe.type} (${catastrophe.severity})`,
+      description: catastrophe.description,
+      impact: { ...catastrophe.impact },
+      style: normalizeStyle(styleBySeverity, catastrophe.severity),
+    }));
+}

--- a/test/ui/climate/buildCatastropheMapOverlay.test.js
+++ b/test/ui/climate/buildCatastropheMapOverlay.test.js
@@ -1,0 +1,124 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Catastrophe } from '../../../src/domain/climate/Catastrophe.js';
+import { buildCatastropheMapOverlay } from '../../../src/ui/climate/buildCatastropheMapOverlay.js';
+
+test('buildCatastropheMapOverlay expands active catastrophes into stable regional overlays', () => {
+  const overlay = buildCatastropheMapOverlay([
+    new Catastrophe({
+      id: 'storm-1',
+      type: 'great-storm',
+      severity: 'major',
+      status: 'active',
+      regionIds: ['north-coast', 'riverlands'],
+      startedAt: '2026-04-19T00:00:00.000Z',
+      impact: { harvest: -25 },
+      description: 'Coastal flooding',
+    }),
+    new Catastrophe({
+      id: 'drought-2',
+      type: 'drought',
+      severity: 'critical',
+      status: 'warning',
+      regionIds: ['ashlands'],
+      startedAt: '2026-04-19T00:00:00.000Z',
+      impact: { harvest: -40, unrest: 12 },
+    }),
+    new Catastrophe({
+      id: 'flood-3',
+      type: 'flood',
+      severity: 'minor',
+      status: 'resolved',
+      regionIds: ['delta'],
+      startedAt: '2026-04-19T00:00:00.000Z',
+      resolvedAt: '2026-04-20T00:00:00.000Z',
+      impact: { infrastructure: -10 },
+    }),
+  ]);
+
+  assert.deepEqual(overlay, [
+    {
+      overlayId: 'ashlands:drought-2',
+      regionId: 'ashlands',
+      catastropheId: 'drought-2',
+      type: 'drought',
+      severity: 'critical',
+      status: 'warning',
+      label: 'drought (critical)',
+      description: null,
+      impact: { harvest: -40, unrest: 12 },
+      style: {
+        stroke: 'crimson',
+        fill: 'crimson',
+        opacity: 0.5,
+        icon: '⚠',
+      },
+    },
+    {
+      overlayId: 'north-coast:storm-1',
+      regionId: 'north-coast',
+      catastropheId: 'storm-1',
+      type: 'great-storm',
+      severity: 'major',
+      status: 'active',
+      label: 'great-storm (major)',
+      description: 'Coastal flooding',
+      impact: { harvest: -25 },
+      style: {
+        stroke: 'orange',
+        fill: 'orange',
+        opacity: 0.4,
+        icon: '▲',
+      },
+    },
+    {
+      overlayId: 'riverlands:storm-1',
+      regionId: 'riverlands',
+      catastropheId: 'storm-1',
+      type: 'great-storm',
+      severity: 'major',
+      status: 'active',
+      label: 'great-storm (major)',
+      description: 'Coastal flooding',
+      impact: { harvest: -25 },
+      style: {
+        stroke: 'orange',
+        fill: 'orange',
+        opacity: 0.4,
+        icon: '▲',
+      },
+    },
+  ]);
+});
+
+test('buildCatastropheMapOverlay supports plain payloads and style overrides', () => {
+  const overlay = buildCatastropheMapOverlay([
+    {
+      id: 'locust-4',
+      type: 'locusts',
+      severity: 'minor',
+      regionIds: ['delta'],
+      startedAt: '2026-04-19T00:00:00.000Z',
+      impact: { harvest: -18 },
+    },
+  ], {
+    styleBySeverity: {
+      minor: { stroke: 'gold', fill: 'goldenrod', opacity: 0.65, icon: 'L' },
+    },
+  });
+
+  assert.deepEqual(overlay[0].style, {
+    stroke: 'gold',
+    fill: 'goldenrod',
+    opacity: 0.65,
+    icon: 'L',
+  });
+});
+
+test('buildCatastropheMapOverlay rejects invalid inputs', () => {
+  assert.throws(() => buildCatastropheMapOverlay(null), /catastrophes must be an array/);
+  assert.throws(() => buildCatastropheMapOverlay([null]), /Catastrophe instances or plain objects/);
+  assert.throws(() => buildCatastropheMapOverlay([], null), /options must be an object/);
+  assert.throws(() => buildCatastropheMapOverlay([], { styleBySeverity: [] }), /styleBySeverity must be an object/);
+});


### PR DESCRIPTION
## Summary

- Epsilon: add a dedicated catastrophe map overlay helper for regional disaster rendering
- Epsilon: cover the overlay with deterministic tests for sorting, filtering, and style overrides

## Related issue

- One issue only: Closes #99

## Changes

- Epsilon: add `buildCatastropheMapOverlay` to expand active and warning catastrophes into per-region map overlay entries
- Epsilon: filter out resolved catastrophes and expose stable labels, impacts, and severity-based styles
- Epsilon: add tests for normalized overlay output, plain payload support, and invalid inputs

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [x] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date
