### PR TITLE
Alpha: [MAP-A1] build strategic map shell and province renderer

### DIFF
--- a/src/ui/war/ProvinceRenderer.js
+++ b/src/ui/war/ProvinceRenderer.js
@@ -1,0 +1,83 @@
+import { Province } from '../../domain/war/Province.js';
+
+const DEFAULT_FILL = '#94A3B8';
+const DEFAULT_BORDER = '#334155';
+
+const SUPPLY_TONE_BY_LEVEL = Object.freeze({
+  stable: 'ready',
+  strained: 'fragile',
+  disrupted: 'critical',
+  collapsed: 'isolated',
+});
+
+function requireProvince(province) {
+  if (!(province instanceof Province)) {
+    throw new TypeError('ProvinceRenderer province must be a Province instance.');
+  }
+
+  return province;
+}
+
+function requireOptions(options) {
+  if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+    throw new TypeError('ProvinceRenderer options must be an object.');
+  }
+
+  return options;
+}
+
+function getFactionPalette(paletteByFaction, factionId) {
+  const palette = paletteByFaction[factionId] ?? paletteByFaction.default ?? {};
+
+  return {
+    fill: String(palette.fill ?? DEFAULT_FILL).trim() || DEFAULT_FILL,
+    border: String(palette.border ?? DEFAULT_BORDER).trim() || DEFAULT_BORDER,
+  };
+}
+
+export function renderProvince(province, options = {}) {
+  const normalizedProvince = requireProvince(province);
+  const normalizedOptions = requireOptions(options);
+  const paletteByFaction = normalizedOptions.paletteByFaction ?? {};
+
+  if (!paletteByFaction || typeof paletteByFaction !== 'object' || Array.isArray(paletteByFaction)) {
+    throw new TypeError('ProvinceRenderer paletteByFaction must be an object.');
+  }
+
+  const supplyToneByLevel = normalizedOptions.supplyToneByLevel ?? SUPPLY_TONE_BY_LEVEL;
+
+  if (!supplyToneByLevel || typeof supplyToneByLevel !== 'object' || Array.isArray(supplyToneByLevel)) {
+    throw new TypeError('ProvinceRenderer supplyToneByLevel must be an object.');
+  }
+
+  const ownerPalette = getFactionPalette(paletteByFaction, normalizedProvince.ownerFactionId);
+  const controllerPalette = getFactionPalette(paletteByFaction, normalizedProvince.controllingFactionId);
+
+  return {
+    provinceId: normalizedProvince.id,
+    label: normalizedProvince.name,
+    ownerFactionId: normalizedProvince.ownerFactionId,
+    controllingFactionId: normalizedProvince.controllingFactionId,
+    occupied: normalizedProvince.isOccupied,
+    contested: normalizedProvince.contested,
+    supplyLevel: normalizedProvince.supplyLevel,
+    supplyTone: String(supplyToneByLevel[normalizedProvince.supplyLevel] ?? normalizedProvince.supplyLevel).trim()
+      || normalizedProvince.supplyLevel,
+    loyalty: normalizedProvince.loyalty,
+    strategicValue: normalizedProvince.strategicValue,
+    neighborIds: [...normalizedProvince.neighborIds],
+    style: {
+      fill: controllerPalette.fill,
+      border: ownerPalette.border,
+      borderStyle: normalizedProvince.contested ? 'dashed' : 'solid',
+      pattern: normalizedProvince.isOccupied ? 'occupation-stripes' : 'solid',
+      accent: normalizedProvince.contested ? 'contested-glow' : 'stable-frame',
+    },
+    badges: [
+      normalizedProvince.contested ? 'contested' : null,
+      normalizedProvince.isOccupied ? 'occupied' : null,
+      `supply:${normalizedProvince.supplyLevel}`,
+      `value:${normalizedProvince.strategicValue}`,
+    ].filter(Boolean),
+  };
+}

--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1,0 +1,78 @@
+import { Province } from '../../domain/war/Province.js';
+import { renderProvince } from './ProvinceRenderer.js';
+
+function requireOptions(options) {
+  if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+    throw new TypeError('StrategicMapShell options must be an object.');
+  }
+
+  return options;
+}
+
+function requireProvinceList(provinces) {
+  if (!Array.isArray(provinces)) {
+    throw new TypeError('StrategicMapShell provinces must be an array.');
+  }
+
+  return provinces.map((province) => {
+    if (!(province instanceof Province)) {
+      throw new TypeError('StrategicMapShell provinces must contain Province instances.');
+    }
+
+    return province;
+  });
+}
+
+function buildLegend(renderedProvinces) {
+  const controllingFactionIds = [...new Set(renderedProvinces.map((province) => province.controllingFactionId))].sort();
+
+  return {
+    factions: controllingFactionIds,
+    states: [
+      { code: 'stable', label: 'Contrôle stable' },
+      { code: 'occupied', label: 'Occupation' },
+      { code: 'contested', label: 'Front contesté' },
+    ],
+  };
+}
+
+export function buildStrategicMapShell(provinces, options = {}) {
+  const normalizedProvinces = requireProvinceList(provinces);
+  const normalizedOptions = requireOptions(options);
+  const title = String(normalizedOptions.title ?? 'Carte stratégique').trim() || 'Carte stratégique';
+  const subtitle = String(normalizedOptions.subtitle ?? 'Vue d’ensemble des provinces et lignes de front').trim()
+    || 'Vue d’ensemble des provinces et lignes de front';
+
+  const renderedProvinces = normalizedProvinces
+    .slice()
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((province) => renderProvince(province, normalizedOptions));
+
+  const stats = renderedProvinces.reduce(
+    (summary, province) => ({
+      provinceCount: summary.provinceCount + 1,
+      contestedCount: summary.contestedCount + (province.contested ? 1 : 0),
+      occupiedCount: summary.occupiedCount + (province.occupied ? 1 : 0),
+      averageLoyalty: summary.averageLoyalty + province.loyalty,
+    }),
+    {
+      provinceCount: 0,
+      contestedCount: 0,
+      occupiedCount: 0,
+      averageLoyalty: 0,
+    },
+  );
+
+  return {
+    title,
+    subtitle,
+    provinces: renderedProvinces,
+    stats: {
+      provinceCount: stats.provinceCount,
+      contestedCount: stats.contestedCount,
+      occupiedCount: stats.occupiedCount,
+      averageLoyalty: stats.provinceCount === 0 ? 0 : Math.round(stats.averageLoyalty / stats.provinceCount),
+    },
+    legend: buildLegend(renderedProvinces),
+  };
+}

--- a/test/ui/war/ProvinceRenderer.test.js
+++ b/test/ui/war/ProvinceRenderer.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Province } from '../../../src/domain/war/Province.js';
+import { renderProvince } from '../../../src/ui/war/ProvinceRenderer.js';
+
+function createProvince(overrides = {}) {
+  return new Province({
+    id: 'prov-a',
+    name: 'Marches du Nord',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    loyalty: 68,
+    strategicValue: 4,
+    neighborIds: ['prov-c', 'prov-b'],
+    contested: false,
+    ...overrides,
+  });
+}
+
+test('ProvinceRenderer builds deterministic UI data for a stable province', () => {
+  const rendered = renderProvince(
+    createProvince(),
+    {
+      paletteByFaction: {
+        'faction-a': { fill: '#2563EB', border: '#1E3A8A' },
+      },
+    },
+  );
+
+  assert.deepEqual(rendered, {
+    provinceId: 'prov-a',
+    label: 'Marches du Nord',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    occupied: false,
+    contested: false,
+    supplyLevel: 'stable',
+    supplyTone: 'ready',
+    loyalty: 68,
+    strategicValue: 4,
+    neighborIds: ['prov-b', 'prov-c'],
+    style: {
+      fill: '#2563EB',
+      border: '#1E3A8A',
+      borderStyle: 'solid',
+      pattern: 'solid',
+      accent: 'stable-frame',
+    },
+    badges: ['supply:stable', 'value:4'],
+  });
+});
+
+test('ProvinceRenderer highlights contested occupation states and supports supply tone overrides', () => {
+  const rendered = renderProvince(
+    createProvince({
+      controllingFactionId: 'faction-b',
+      contested: true,
+      supplyLevel: 'disrupted',
+      loyalty: 31,
+    }),
+    {
+      paletteByFaction: {
+        'faction-a': { fill: '#2563EB', border: '#1E3A8A' },
+        'faction-b': { fill: '#DC2626', border: '#7F1D1D' },
+      },
+      supplyToneByLevel: {
+        disrupted: 'breaking',
+      },
+    },
+  );
+
+  assert.deepEqual(rendered.style, {
+    fill: '#DC2626',
+    border: '#1E3A8A',
+    borderStyle: 'dashed',
+    pattern: 'occupation-stripes',
+    accent: 'contested-glow',
+  });
+  assert.deepEqual(rendered.badges, ['contested', 'occupied', 'supply:disrupted', 'value:4']);
+  assert.equal(rendered.supplyTone, 'breaking');
+});
+
+test('ProvinceRenderer rejects invalid inputs', () => {
+  assert.throws(() => renderProvince({}, {}), /ProvinceRenderer province must be a Province instance/);
+  assert.throws(() => renderProvince(createProvince(), null), /ProvinceRenderer options must be an object/);
+  assert.throws(() => renderProvince(createProvince(), { paletteByFaction: [] }), /paletteByFaction must be an object/);
+  assert.throws(() => renderProvince(createProvince(), { supplyToneByLevel: [] }), /supplyToneByLevel must be an object/);
+});

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Province } from '../../../src/domain/war/Province.js';
+import { buildStrategicMapShell } from '../../../src/ui/war/StrategicMapShell.js';
+
+function createProvince(overrides = {}) {
+  return new Province({
+    id: 'prov-b',
+    name: 'Bastion',
+    ownerFactionId: 'faction-a',
+    controllingFactionId: 'faction-a',
+    supplyLevel: 'stable',
+    loyalty: 70,
+    strategicValue: 4,
+    neighborIds: ['prov-a'],
+    contested: false,
+    ...overrides,
+  });
+}
+
+test('StrategicMapShell sorts provinces and derives headline stats', () => {
+  const shell = buildStrategicMapShell(
+    [
+      createProvince({
+        id: 'prov-c',
+        name: 'Colline rouge',
+        controllingFactionId: 'faction-b',
+        contested: true,
+        supplyLevel: 'strained',
+        loyalty: 40,
+      }),
+      createProvince({ id: 'prov-a', name: 'Avant-poste', loyalty: 82, strategicValue: 2 }),
+    ],
+    {
+      title: 'Théâtre nord',
+      paletteByFaction: {
+        'faction-a': { fill: '#2563EB', border: '#1E3A8A' },
+        'faction-b': { fill: '#DC2626', border: '#7F1D1D' },
+      },
+    },
+  );
+
+  assert.equal(shell.title, 'Théâtre nord');
+  assert.equal(shell.subtitle, 'Vue d’ensemble des provinces et lignes de front');
+  assert.deepEqual(shell.provinces.map((province) => province.provinceId), ['prov-a', 'prov-c']);
+  assert.deepEqual(shell.stats, {
+    provinceCount: 2,
+    contestedCount: 1,
+    occupiedCount: 1,
+    averageLoyalty: 61,
+  });
+  assert.deepEqual(shell.legend, {
+    factions: ['faction-a', 'faction-b'],
+    states: [
+      { code: 'stable', label: 'Contrôle stable' },
+      { code: 'occupied', label: 'Occupation' },
+      { code: 'contested', label: 'Front contesté' },
+    ],
+  });
+});
+
+test('StrategicMapShell falls back to default title and validates inputs', () => {
+  const shell = buildStrategicMapShell([], {});
+
+  assert.equal(shell.title, 'Carte stratégique');
+  assert.equal(shell.stats.provinceCount, 0);
+  assert.throws(() => buildStrategicMapShell(null), /StrategicMapShell provinces must be an array/);
+  assert.throws(() => buildStrategicMapShell([{}]), /StrategicMapShell provinces must contain Province instances/);
+  assert.throws(() => buildStrategicMapShell([], null), /StrategicMapShell options must be an object/);
+});


### PR DESCRIPTION
## Summary
- add a deterministic ProvinceRenderer helper for strategic map provinces
- add a StrategicMapShell helper that sorts provinces and derives map headline stats
- cover stable, occupied, contested, and validation flows with node tests

## Testing
- npm test

Closes #250