### PR TITLE
Delta: [MAP-D1] add intrigue presence and sabotage risk overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - une cellule devient exposée dès qu'elle passe en état `compromised` ou que son exposition franchit le seuil critique métier, et ce statut compromis reste explicite dans le modèle même si l'exposition redescend ensuite
 - `NiveauAlerte` suit une échelle stable de `latent` à `verrouille`, avec une intensité de surveillance associée à chaque palier
 - côté UI, le niveau d'alerte peut être transformé en badge lisible avec texte, ton, couleur, emphase, icône, progression et libellé accessible
+- côté UI, `buildIntrigueMapOverlay` agrège par lieu la présence de cellules et la menace de sabotage active dans une vue stable avec métriques, styles et niveaux de risque réutilisables pour la carte
 - l'adaptateur `InMemoryIntrigueRepository` permet de stocker cellules et opérations clandestines en mémoire avec copies défensives et ordre de listing stable pour les tests et assemblages locaux
 - les tests Delta couvrent explicitement le risque de détection, l'exposition réseau, l'adaptateur mémoire intrigue et l'affichage du niveau d'alerte
 

--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -1,0 +1,180 @@
+import { Cellule } from '../../domain/intrigue/Cellule.js';
+import { OperationClandestine } from '../../domain/intrigue/OperationClandestine.js';
+
+const DEFAULT_STYLE_BY_PRESENCE = Object.freeze({
+  none: { marker: '○', color: '#6B7280', opacity: 0.2 },
+  low: { marker: '◔', color: '#2563EB', opacity: 0.35 },
+  medium: { marker: '◑', color: '#7C3AED', opacity: 0.5 },
+  high: { marker: '●', color: '#DC2626', opacity: 0.65 },
+});
+
+const DEFAULT_STYLE_BY_RISK = Object.freeze({
+  none: { stroke: '#6B7280', fill: '#6B7280', emphasis: 'low' },
+  low: { stroke: '#2563EB', fill: '#93C5FD', emphasis: 'normal' },
+  medium: { stroke: '#D97706', fill: '#FCD34D', emphasis: 'elevated' },
+  high: { stroke: '#DC2626', fill: '#FCA5A5', emphasis: 'high' },
+});
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeCellule(cellule) {
+  if (cellule instanceof Cellule) {
+    return cellule;
+  }
+
+  if (cellule === null || typeof cellule !== 'object' || Array.isArray(cellule)) {
+    throw new TypeError('IntrigueMapOverlay cellules must be Cellule instances or plain objects.');
+  }
+
+  return new Cellule(cellule);
+}
+
+function normalizeOperation(operation) {
+  if (operation instanceof OperationClandestine) {
+    return operation;
+  }
+
+  if (operation === null || typeof operation !== 'object' || Array.isArray(operation)) {
+    throw new TypeError('IntrigueMapOverlay operations must be OperationClandestine instances or plain objects.');
+  }
+
+  return new OperationClandestine(operation);
+}
+
+function clampPercent(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function resolvePresenceLevel(cellCount) {
+  if (cellCount <= 0) {
+    return 'none';
+  }
+
+  if (cellCount === 1) {
+    return 'low';
+  }
+
+  if (cellCount === 2) {
+    return 'medium';
+  }
+
+  return 'high';
+}
+
+function resolveRiskLevel(score) {
+  if (score <= 0) {
+    return 'none';
+  }
+
+  if (score < 35) {
+    return 'low';
+  }
+
+  if (score < 70) {
+    return 'medium';
+  }
+
+  return 'high';
+}
+
+function buildSabotageThreatScore(operation) {
+  return clampPercent((operation.progress + operation.heat + (100 - operation.detectionRisk)) / 3);
+}
+
+function normalizeStyle(styleMap, key, defaults) {
+  const style = styleMap[key] ?? styleMap.default ?? defaults[key] ?? defaults.none;
+  const fallback = defaults[key] ?? defaults.none;
+
+  return Object.fromEntries(
+    Object.entries({ ...fallback, ...style }).map(([styleKey, styleValue]) => [
+      styleKey,
+      typeof fallback[styleKey] === 'number'
+        ? Number.isFinite(styleValue) ? styleValue : fallback[styleKey]
+        : String(styleValue ?? fallback[styleKey]).trim() || fallback[styleKey],
+    ]),
+  );
+}
+
+export function buildIntrigueMapOverlay(cellules, operations = [], options = {}) {
+  if (!Array.isArray(cellules)) {
+    throw new TypeError('IntrigueMapOverlay cellules must be an array.');
+  }
+
+  if (!Array.isArray(operations)) {
+    throw new TypeError('IntrigueMapOverlay operations must be an array.');
+  }
+
+  const normalizedOptions = requireObject(options, 'IntrigueMapOverlay options');
+  const styleByPresence = {
+    ...DEFAULT_STYLE_BY_PRESENCE,
+    ...requireObject(normalizedOptions.styleByPresence ?? {}, 'IntrigueMapOverlay styleByPresence'),
+  };
+  const styleByRisk = {
+    ...DEFAULT_STYLE_BY_RISK,
+    ...requireObject(normalizedOptions.styleByRisk ?? {}, 'IntrigueMapOverlay styleByRisk'),
+  };
+  const locationNames = requireObject(normalizedOptions.locationNames ?? {}, 'IntrigueMapOverlay locationNames');
+
+  const normalizedCellules = cellules
+    .map(normalizeCellule)
+    .filter((cellule) => cellule.status !== 'dismantled');
+  const normalizedOperations = operations
+    .map(normalizeOperation)
+    .filter((operation) => operation.type === 'sabotage' && !operation.isResolved);
+
+  const locationIds = new Set([
+    ...normalizedCellules.map((cellule) => cellule.locationId),
+    ...normalizedOperations.map((operation) => operation.theaterId),
+  ]);
+
+  return [...locationIds]
+    .sort((left, right) => left.localeCompare(right))
+    .map((locationId) => {
+      const locationCellules = normalizedCellules
+        .filter((cellule) => cellule.locationId === locationId)
+        .sort((left, right) => left.id.localeCompare(right.id));
+      const locationOperations = normalizedOperations
+        .filter((operation) => operation.theaterId === locationId)
+        .sort((left, right) => left.id.localeCompare(right.id));
+      const sabotageRiskScore = locationOperations.length === 0
+        ? 0
+        : Math.max(...locationOperations.map(buildSabotageThreatScore));
+      const presenceLevel = resolvePresenceLevel(locationCellules.length);
+      const riskLevel = resolveRiskLevel(sabotageRiskScore);
+      const exposedCellCount = locationCellules.filter((cellule) => cellule.isExposed).length;
+      const sleeperCellCount = locationCellules.filter((cellule) => cellule.sleeper).length;
+      const locationName = String(locationNames[locationId] ?? locationId).trim() || locationId;
+
+      return {
+        overlayId: `intrigue:${locationId}`,
+        locationId,
+        locationName,
+        label: `${locationName}, présence ${presenceLevel}, risque sabotage ${riskLevel}`,
+        presenceLevel,
+        sabotageRiskLevel: riskLevel,
+        sabotageRiskScore,
+        celluleIds: locationCellules.map((cellule) => cellule.id),
+        operationIds: locationOperations.map((operation) => operation.id),
+        metrics: {
+          celluleCount: locationCellules.length,
+          exposedCellCount,
+          sleeperCellCount,
+          sabotageOperationCount: locationOperations.length,
+        },
+        style: {
+          presence: normalizeStyle(styleByPresence, presenceLevel, DEFAULT_STYLE_BY_PRESENCE),
+          risk: normalizeStyle(styleByRisk, riskLevel, DEFAULT_STYLE_BY_RISK),
+        },
+      };
+    });
+}

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -1,0 +1,232 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Cellule } from '../../../src/domain/intrigue/Cellule.js';
+import { OperationClandestine } from '../../../src/domain/intrigue/OperationClandestine.js';
+import { buildIntrigueMapOverlay } from '../../../src/ui/intrigue/buildIntrigueMapOverlay.js';
+
+test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threat by location', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-ash-1',
+      factionId: 'shadow-league',
+      codename: 'Veil',
+      locationId: 'ashlands',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      secrecy: 72,
+      loyalty: 66,
+      exposure: 21,
+    }),
+    new Cellule({
+      id: 'cell-ash-2',
+      factionId: 'shadow-league',
+      codename: 'Cinder',
+      locationId: 'ashlands',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      secrecy: 49,
+      loyalty: 55,
+      exposure: 74,
+      sleeper: true,
+    }),
+    new Cellule({
+      id: 'cell-river-1',
+      factionId: 'shadow-league',
+      codename: 'Mist',
+      locationId: 'riverlands',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      secrecy: 61,
+      loyalty: 62,
+      exposure: 15,
+    }),
+    new Cellule({
+      id: 'cell-old',
+      factionId: 'shadow-league',
+      codename: 'Ash',
+      locationId: 'north-coast',
+      memberIds: ['ag-4'],
+      assetIds: ['asset-4'],
+      status: 'dismantled',
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-ash-1',
+      celluleId: 'cell-ash-1',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Cut the signal towers',
+      theaterId: 'ashlands',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 20,
+      progress: 58,
+      heat: 44,
+      phase: 'execution',
+    }),
+    new OperationClandestine({
+      id: 'op-river-1',
+      celluleId: 'cell-river-1',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Poison the ferries',
+      theaterId: 'riverlands',
+      assignedAgentIds: ['ag-3'],
+      requiredAssetIds: ['asset-3'],
+      detectionRisk: 70,
+      progress: 20,
+      heat: 10,
+      phase: 'infiltration',
+    }),
+    new OperationClandestine({
+      id: 'op-river-rumor',
+      celluleId: 'cell-river-1',
+      targetFactionId: 'sun-empire',
+      type: 'rumor',
+      objective: 'Spread false orders',
+      theaterId: 'riverlands',
+      assignedAgentIds: ['ag-3'],
+      requiredAssetIds: ['asset-3'],
+    }),
+    new OperationClandestine({
+      id: 'op-old',
+      celluleId: 'cell-ash-2',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Burn supply cache',
+      theaterId: 'north-coast',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      phase: 'completed',
+    }),
+  ], {
+    locationNames: {
+      ashlands: 'Ashlands',
+      riverlands: 'Riverlands',
+    },
+  });
+
+  assert.deepEqual(overlay, [
+    {
+      overlayId: 'intrigue:ashlands',
+      locationId: 'ashlands',
+      locationName: 'Ashlands',
+      label: 'Ashlands, présence medium, risque sabotage medium',
+      presenceLevel: 'medium',
+      sabotageRiskLevel: 'medium',
+      sabotageRiskScore: 61,
+      celluleIds: ['cell-ash-1', 'cell-ash-2'],
+      operationIds: ['op-ash-1'],
+      metrics: {
+        celluleCount: 2,
+        exposedCellCount: 1,
+        sleeperCellCount: 1,
+        sabotageOperationCount: 1,
+      },
+      style: {
+        presence: {
+          marker: '◑',
+          color: '#7C3AED',
+          opacity: 0.5,
+        },
+        risk: {
+          stroke: '#D97706',
+          fill: '#FCD34D',
+          emphasis: 'elevated',
+        },
+      },
+    },
+    {
+      overlayId: 'intrigue:riverlands',
+      locationId: 'riverlands',
+      locationName: 'Riverlands',
+      label: 'Riverlands, présence low, risque sabotage low',
+      presenceLevel: 'low',
+      sabotageRiskLevel: 'low',
+      sabotageRiskScore: 20,
+      celluleIds: ['cell-river-1'],
+      operationIds: ['op-river-1'],
+      metrics: {
+        celluleCount: 1,
+        exposedCellCount: 0,
+        sleeperCellCount: 0,
+        sabotageOperationCount: 1,
+      },
+      style: {
+        presence: {
+          marker: '◔',
+          color: '#2563EB',
+          opacity: 0.35,
+        },
+        risk: {
+          stroke: '#2563EB',
+          fill: '#93C5FD',
+          emphasis: 'normal',
+        },
+      },
+    },
+  ]);
+});
+
+test('buildIntrigueMapOverlay supports plain payloads and style overrides', () => {
+  const overlay = buildIntrigueMapOverlay([
+    {
+      id: 'cell-delta-1',
+      factionId: 'shadow-league',
+      codename: 'Wake',
+      locationId: 'delta',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      secrecy: 60,
+      loyalty: 60,
+      exposure: 10,
+    },
+  ], [
+    {
+      id: 'op-delta-1',
+      celluleId: 'cell-delta-1',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Disable the sluice gates',
+      theaterId: 'delta',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 5,
+      progress: 90,
+      heat: 30,
+      phase: 'execution',
+    },
+  ], {
+    styleByPresence: {
+      low: { marker: '✦', color: '#10B981', opacity: 0.7 },
+    },
+    styleByRisk: {
+      high: { stroke: '#111827', fill: '#F59E0B', emphasis: 'critical' },
+    },
+  });
+
+  assert.deepEqual(overlay[0].style, {
+    presence: {
+      marker: '✦',
+      color: '#10B981',
+      opacity: 0.7,
+    },
+    risk: {
+      stroke: '#111827',
+      fill: '#F59E0B',
+      emphasis: 'critical',
+    },
+  });
+});
+
+test('buildIntrigueMapOverlay rejects invalid inputs', () => {
+  assert.throws(() => buildIntrigueMapOverlay(null), /cellules must be an array/);
+  assert.throws(() => buildIntrigueMapOverlay([], null), /operations must be an array/);
+  assert.throws(() => buildIntrigueMapOverlay([null]), /Cellule instances or plain objects/);
+  assert.throws(() => buildIntrigueMapOverlay([], [null]), /OperationClandestine instances or plain objects/);
+  assert.throws(() => buildIntrigueMapOverlay([], [], null), /options must be an object/);
+  assert.throws(() => buildIntrigueMapOverlay([], [], { styleByPresence: [] }), /styleByPresence must be an object/);
+  assert.throws(() => buildIntrigueMapOverlay([], [], { styleByRisk: [] }), /styleByRisk must be an object/);
+  assert.throws(() => buildIntrigueMapOverlay([], [], { locationNames: [] }), /locationNames must be an object/);
+});


### PR DESCRIPTION
Closes #253

## Summary
- add `buildIntrigueMapOverlay` to aggregate cellule presence and active sabotage threat by location
- include stable overlay metadata, metrics, and customizable styles for map rendering
- document the new Delta UI helper and cover it with focused tests

## Testing
- npm test