### PR TITLE
Beta: [MAP-B1] add city, resource, and logistics map overlay

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -1,0 +1,177 @@
+import { City } from '../../domain/economy/City.js';
+import { TradeRoute } from '../../domain/economy/TradeRoute.js';
+
+const DEFAULT_CITY_MARKER = Object.freeze({
+  icon: 'city',
+  tone: 'neutral',
+  size: 1,
+});
+
+const DEFAULT_ROUTE_STYLE_BY_MODE = Object.freeze({
+  land: { stroke: 'ochre', width: 2, pattern: 'solid', opacity: 0.85 },
+  river: { stroke: 'blue', width: 2, pattern: 'wave', opacity: 0.85 },
+  sea: { stroke: 'navy', width: 3, pattern: 'solid', opacity: 0.85 },
+  default: { stroke: 'slate', width: 2, pattern: 'solid', opacity: 0.85 },
+  inactive: { stroke: 'slate', width: 1, pattern: 'dashed', opacity: 0.45 },
+});
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function normalizeCity(city) {
+  if (city instanceof City) {
+    return city;
+  }
+
+  if (city === null || typeof city !== 'object' || Array.isArray(city)) {
+    throw new TypeError('EconomyMapOverlay cities must be City instances or plain objects.');
+  }
+
+  return new City(city);
+}
+
+function normalizeRoute(route) {
+  if (route instanceof TradeRoute) {
+    return route;
+  }
+
+  if (route === null || typeof route !== 'object' || Array.isArray(route)) {
+    throw new TypeError('EconomyMapOverlay routes must be TradeRoute instances or plain objects.');
+  }
+
+  return new TradeRoute(route);
+}
+
+function buildResourceSummary(stockByResource) {
+  const entries = Object.entries(stockByResource)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([resourceId, quantity]) => ({ resourceId, quantity }));
+
+  const totalStock = entries.reduce((sum, entry) => sum + entry.quantity, 0);
+  const primaryResourceId = entries[0]?.resourceId ?? null;
+  const primaryResourceQuantity = entries[0]?.quantity ?? 0;
+
+  return {
+    entries,
+    totalStock,
+    resourceCount: entries.length,
+    primaryResourceId,
+    primaryResourceQuantity,
+  };
+}
+
+function normalizeMarker(marker) {
+  return {
+    icon: String(marker.icon ?? DEFAULT_CITY_MARKER.icon).trim() || DEFAULT_CITY_MARKER.icon,
+    tone: String(marker.tone ?? DEFAULT_CITY_MARKER.tone).trim() || DEFAULT_CITY_MARKER.tone,
+    size: Number.isFinite(marker.size) && marker.size > 0 ? marker.size : DEFAULT_CITY_MARKER.size,
+  };
+}
+
+function buildCityMarker(city, cityPositionById) {
+  const position = cityPositionById[city.id] ?? null;
+  const tone = city.prosperity >= 70 ? 'positive' : city.stability < 40 ? 'warning' : 'neutral';
+  const size = city.capital ? 2 : 1;
+
+  return {
+    ...normalizeMarker({ tone, size }),
+    position,
+  };
+}
+
+function normalizeRouteStyle(route, styleByTransportMode) {
+  const style = route.active
+    ? (styleByTransportMode[route.transportMode] ?? styleByTransportMode.default ?? DEFAULT_ROUTE_STYLE_BY_MODE.default)
+    : (styleByTransportMode.inactive ?? DEFAULT_ROUTE_STYLE_BY_MODE.inactive);
+
+  return {
+    stroke: String(style.stroke ?? DEFAULT_ROUTE_STYLE_BY_MODE.default.stroke).trim() || DEFAULT_ROUTE_STYLE_BY_MODE.default.stroke,
+    width: Number.isInteger(style.width) && style.width > 0 ? style.width : DEFAULT_ROUTE_STYLE_BY_MODE.default.width,
+    pattern: String(style.pattern ?? DEFAULT_ROUTE_STYLE_BY_MODE.default.pattern).trim() || DEFAULT_ROUTE_STYLE_BY_MODE.default.pattern,
+    opacity: Number.isFinite(style.opacity) ? Math.max(0, Math.min(1, style.opacity)) : DEFAULT_ROUTE_STYLE_BY_MODE.default.opacity,
+  };
+}
+
+export function buildEconomyMapOverlay(cities, routes, options = {}) {
+  const normalizedCities = requireArray(cities, 'EconomyMapOverlay cities').map(normalizeCity);
+  const normalizedRoutes = requireArray(routes, 'EconomyMapOverlay routes').map(normalizeRoute);
+  const normalizedOptions = requireObject(options, 'EconomyMapOverlay options');
+  const cityPositionById = requireObject(normalizedOptions.cityPositionById ?? {}, 'EconomyMapOverlay cityPositionById');
+  const styleByTransportMode = {
+    ...DEFAULT_ROUTE_STYLE_BY_MODE,
+    ...requireObject(normalizedOptions.styleByTransportMode ?? {}, 'EconomyMapOverlay styleByTransportMode'),
+  };
+
+  const cityOverlays = normalizedCities
+    .slice()
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((city) => {
+      const resources = buildResourceSummary(city.stockByResource);
+
+      return {
+        overlayId: `city:${city.id}`,
+        type: 'city',
+        cityId: city.id,
+        cityName: city.name,
+        regionId: city.regionId,
+        population: city.population,
+        prosperity: city.prosperity,
+        stability: city.stability,
+        capital: city.capital,
+        label: city.capital ? `${city.name} ★` : city.name,
+        resources,
+        tradeRouteIds: [...city.tradeRouteIds],
+        marker: buildCityMarker(city, cityPositionById),
+      };
+    });
+
+  const routeOverlays = normalizedRoutes
+    .slice()
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((route) => ({
+      overlayId: `route:${route.id}`,
+      type: 'route',
+      routeId: route.id,
+      routeName: route.name,
+      cityIds: [...route.stopCityIds],
+      originCityId: route.originCityId,
+      destinationCityId: route.destinationCityId,
+      active: route.active,
+      transportMode: route.transportMode,
+      riskLevel: route.riskLevel,
+      totalCapacity: route.totalCapacity,
+      resources: Object.entries(route.capacityByResource)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([resourceId, capacity]) => ({ resourceId, capacity })),
+      label: `${route.name} (${route.transportMode})`,
+      style: normalizeRouteStyle(route, styleByTransportMode),
+    }));
+
+  return {
+    title: 'Carte économie et logistique',
+    summary: `${cityOverlays.length} villes, ${routeOverlays.length} routes logistiques`,
+    cities: cityOverlays,
+    routes: routeOverlays,
+    metrics: {
+      cityCount: cityOverlays.length,
+      capitalCount: cityOverlays.filter((city) => city.capital).length,
+      routeCount: routeOverlays.length,
+      activeRouteCount: routeOverlays.filter((route) => route.active).length,
+      totalStock: cityOverlays.reduce((sum, city) => sum + city.resources.totalStock, 0),
+      totalRouteCapacity: routeOverlays.reduce((sum, route) => sum + route.totalCapacity, 0),
+    },
+  };
+}

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1,0 +1,233 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { City } from '../../../src/domain/economy/City.js';
+import { TradeRoute } from '../../../src/domain/economy/TradeRoute.js';
+import { buildEconomyMapOverlay } from '../../../src/ui/economy/buildEconomyMapOverlay.js';
+
+test('buildEconomyMapOverlay builds stable city and route overlays', () => {
+  const overlay = buildEconomyMapOverlay([
+    new City({
+      id: 'city-harbor',
+      name: 'Harbor',
+      regionId: 'coast',
+      population: 120,
+      prosperity: 74,
+      stability: 61,
+      stockByResource: {
+        fish: 14,
+        wood: 6,
+      },
+      tradeRouteIds: ['route-river'],
+      capital: true,
+    }),
+    new City({
+      id: 'city-mill',
+      name: 'Mill',
+      regionId: 'riverlands',
+      population: 80,
+      prosperity: 55,
+      stability: 33,
+      stockByResource: {
+        grain: 10,
+      },
+      tradeRouteIds: ['route-river', 'route-coast'],
+    }),
+  ], [
+    new TradeRoute({
+      id: 'route-river',
+      name: 'River Run',
+      stopCityIds: ['city-harbor', 'city-mill'],
+      distance: 5,
+      capacityByResource: {
+        fish: 4,
+        grain: 7,
+      },
+      transportMode: 'river',
+      riskLevel: 18,
+      active: true,
+    }),
+    new TradeRoute({
+      id: 'route-coast',
+      name: 'Coast Caravan',
+      stopCityIds: ['city-mill', 'city-harbor'],
+      distance: 8,
+      capacityByResource: {
+        wood: 3,
+      },
+      transportMode: 'land',
+      riskLevel: 41,
+      active: false,
+    }),
+  ], {
+    cityPositionById: {
+      'city-harbor': { x: 10, y: 4 },
+      'city-mill': { x: 14, y: 9 },
+    },
+  });
+
+  assert.equal(overlay.title, 'Carte économie et logistique');
+  assert.equal(overlay.summary, '2 villes, 2 routes logistiques');
+  assert.deepEqual(overlay.cities, [
+    {
+      overlayId: 'city:city-harbor',
+      type: 'city',
+      cityId: 'city-harbor',
+      cityName: 'Harbor',
+      regionId: 'coast',
+      population: 120,
+      prosperity: 74,
+      stability: 61,
+      capital: true,
+      label: 'Harbor ★',
+      resources: {
+        entries: [
+          { resourceId: 'fish', quantity: 14 },
+          { resourceId: 'wood', quantity: 6 },
+        ],
+        totalStock: 20,
+        resourceCount: 2,
+        primaryResourceId: 'fish',
+        primaryResourceQuantity: 14,
+      },
+      tradeRouteIds: ['route-river'],
+      marker: {
+        icon: 'city',
+        tone: 'positive',
+        size: 2,
+        position: { x: 10, y: 4 },
+      },
+    },
+    {
+      overlayId: 'city:city-mill',
+      type: 'city',
+      cityId: 'city-mill',
+      cityName: 'Mill',
+      regionId: 'riverlands',
+      population: 80,
+      prosperity: 55,
+      stability: 33,
+      capital: false,
+      label: 'Mill',
+      resources: {
+        entries: [
+          { resourceId: 'grain', quantity: 10 },
+        ],
+        totalStock: 10,
+        resourceCount: 1,
+        primaryResourceId: 'grain',
+        primaryResourceQuantity: 10,
+      },
+      tradeRouteIds: ['route-coast', 'route-river'],
+      marker: {
+        icon: 'city',
+        tone: 'warning',
+        size: 1,
+        position: { x: 14, y: 9 },
+      },
+    },
+  ]);
+
+  assert.deepEqual(overlay.routes, [
+    {
+      overlayId: 'route:route-coast',
+      type: 'route',
+      routeId: 'route-coast',
+      routeName: 'Coast Caravan',
+      cityIds: ['city-mill', 'city-harbor'],
+      originCityId: 'city-mill',
+      destinationCityId: 'city-harbor',
+      active: false,
+      transportMode: 'land',
+      riskLevel: 41,
+      totalCapacity: 3,
+      resources: [
+        { resourceId: 'wood', capacity: 3 },
+      ],
+      label: 'Coast Caravan (land)',
+      style: {
+        stroke: 'slate',
+        width: 1,
+        pattern: 'dashed',
+        opacity: 0.45,
+      },
+    },
+    {
+      overlayId: 'route:route-river',
+      type: 'route',
+      routeId: 'route-river',
+      routeName: 'River Run',
+      cityIds: ['city-harbor', 'city-mill'],
+      originCityId: 'city-harbor',
+      destinationCityId: 'city-mill',
+      active: true,
+      transportMode: 'river',
+      riskLevel: 18,
+      totalCapacity: 11,
+      resources: [
+        { resourceId: 'fish', capacity: 4 },
+        { resourceId: 'grain', capacity: 7 },
+      ],
+      label: 'River Run (river)',
+      style: {
+        stroke: 'blue',
+        width: 2,
+        pattern: 'wave',
+        opacity: 0.85,
+      },
+    },
+  ]);
+
+  assert.deepEqual(overlay.metrics, {
+    cityCount: 2,
+    capitalCount: 1,
+    routeCount: 2,
+    activeRouteCount: 1,
+    totalStock: 30,
+    totalRouteCapacity: 14,
+  });
+});
+
+test('buildEconomyMapOverlay supports plain payloads and style overrides', () => {
+  const overlay = buildEconomyMapOverlay([
+    {
+      id: 'city-delta',
+      name: 'Delta',
+      regionId: 'delta',
+      population: 40,
+      stockByResource: { salt: 5 },
+    },
+  ], [
+    {
+      id: 'route-sea',
+      name: 'Sea Lane',
+      stopCityIds: ['city-delta', 'city-port'],
+      distance: 12,
+      capacityByResource: { salt: 9 },
+      transportMode: 'sea',
+      riskLevel: 12,
+    },
+  ], {
+    styleByTransportMode: {
+      sea: { stroke: 'teal', width: 4, pattern: 'current', opacity: 0.7 },
+    },
+  });
+
+  assert.deepEqual(overlay.routes[0].style, {
+    stroke: 'teal',
+    width: 4,
+    pattern: 'current',
+    opacity: 0.7,
+  });
+  assert.equal(overlay.cities[0].resources.primaryResourceId, 'salt');
+});
+
+test('buildEconomyMapOverlay rejects invalid inputs', () => {
+  assert.throws(() => buildEconomyMapOverlay(null, []), /EconomyMapOverlay cities must be an array/);
+  assert.throws(() => buildEconomyMapOverlay([], null), /EconomyMapOverlay routes must be an array/);
+  assert.throws(() => buildEconomyMapOverlay([null], []), /City instances or plain objects/);
+  assert.throws(() => buildEconomyMapOverlay([], [null]), /TradeRoute instances or plain objects/);
+  assert.throws(() => buildEconomyMapOverlay([], [], null), /EconomyMapOverlay options must be an object/);
+  assert.throws(() => buildEconomyMapOverlay([], [], { cityPositionById: [] }), /cityPositionById must be an object/);
+  assert.throws(() => buildEconomyMapOverlay([], [], { styleByTransportMode: [] }), /styleByTransportMode must be an object/);
+});


### PR DESCRIPTION
## Summary
- add `buildEconomyMapOverlay` to derive stable city and logistics overlay data for the strategy map
- expose city resource summaries, marker metadata, and route styling for multiple transport modes
- cover stable sorting, style overrides, and invalid input handling with tests

## Testing
- npm test

Closes #251