### PR TITLE
Gamma: [MAP-G1] add discoveries and cultural markers overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - `CultureRepositoryPort`, `ResearchRepositoryPort`, `InMemoryCultureRepository` et `InMemoryResearchRepository` fournissent une base hexagonale légère pour stocker cultures et recherches avec copies défensives et ordre stable
 - `loadHistoricalEventsFromJson` et `loadResearchStatesFromJson` chargent des contenus JSON normalisés avec valeurs par défaut utiles et erreurs explicites sur les payloads invalides
 - côté UI, `buildDiscoveriesPanel` expose les concepts découverts, recherches débloquées et événements liés dans une vue structurée réutilisable
+- côté carte, `buildCultureMapOverlay` transforme cultures, recherches et événements historiques en marqueurs régionaux stables pour afficher découvertes et repères culturels sur la carte
 - les tests Gamma couvrent explicitement les use cases de recherche, dérive culturelle, divergence, déclenchement d’événements, ports, adaptateurs mémoire, chargeurs JSON et UI des découvertes
 
 ## Règles Delta, intrigue et opérations clandestines

--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1,0 +1,223 @@
+import { Culture } from '../../domain/culture/Culture.js';
+import { HistoricalEvent } from '../../domain/culture/HistoricalEvent.js';
+import { ResearchState } from '../../domain/culture/ResearchState.js';
+
+const DEFAULT_STYLE_BY_MARKER_TYPE = Object.freeze({
+  innovation: { color: 'violet', icon: '✦', emphasis: 'high' },
+  balanced: { color: 'teal', icon: '◆', emphasis: 'normal' },
+  traditional: { color: 'amber', icon: '⬢', emphasis: 'normal' },
+  fragmented: { color: 'crimson', icon: '✕', emphasis: 'high' },
+  default: { color: 'slate', icon: '•', emphasis: 'normal' },
+});
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeTextArray(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return [...new Set(values.map((value) => requireText(value, label)))].sort();
+}
+
+function normalizeCulture(culture) {
+  if (culture instanceof Culture) {
+    return culture;
+  }
+
+  if (culture === null || typeof culture !== 'object' || Array.isArray(culture)) {
+    throw new TypeError('CultureMapOverlay cultures must be Culture instances or plain objects.');
+  }
+
+  return new Culture(culture);
+}
+
+function normalizeResearchState(researchState) {
+  if (researchState instanceof ResearchState) {
+    return researchState;
+  }
+
+  if (researchState === null || typeof researchState !== 'object' || Array.isArray(researchState)) {
+    throw new TypeError('CultureMapOverlay researchStates must be ResearchState instances or plain objects.');
+  }
+
+  return new ResearchState(researchState);
+}
+
+function normalizeHistoricalEvent(historicalEvent) {
+  if (historicalEvent instanceof HistoricalEvent) {
+    return historicalEvent;
+  }
+
+  if (historicalEvent === null || typeof historicalEvent !== 'object' || Array.isArray(historicalEvent)) {
+    throw new TypeError('CultureMapOverlay historicalEvents must be HistoricalEvent instances or plain objects.');
+  }
+
+  return new HistoricalEvent(historicalEvent);
+}
+
+function normalizeRegionIdsByCulture(options) {
+  const rawRegionIdsByCulture = requireObject(
+    options.regionIdsByCulture ?? {},
+    'CultureMapOverlay regionIdsByCulture',
+  );
+
+  return Object.fromEntries(
+    Object.entries(rawRegionIdsByCulture)
+      .map(([cultureId, regionIds]) => [
+        requireText(cultureId, 'CultureMapOverlay regionIdsByCulture cultureId'),
+        normalizeTextArray(regionIds, `CultureMapOverlay regionIdsByCulture.${cultureId}`),
+      ])
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function normalizeStyle(styleByMarkerType, markerType) {
+  const style = styleByMarkerType[markerType] ?? styleByMarkerType.default ?? DEFAULT_STYLE_BY_MARKER_TYPE.default;
+
+  return {
+    color: String(style.color ?? DEFAULT_STYLE_BY_MARKER_TYPE[markerType]?.color ?? 'slate').trim() || 'slate',
+    icon: String(style.icon ?? DEFAULT_STYLE_BY_MARKER_TYPE[markerType]?.icon ?? '•').trim() || '•',
+    emphasis: String(style.emphasis ?? DEFAULT_STYLE_BY_MARKER_TYPE[markerType]?.emphasis ?? 'normal').trim() || 'normal',
+  };
+}
+
+function buildMarkerType(culture) {
+  if (culture.cohesion <= 30) {
+    return 'fragmented';
+  }
+
+  if (culture.openness >= 60 && culture.researchDrive >= 60) {
+    return 'innovation';
+  }
+
+  if (culture.openness <= 40 && culture.cohesion >= 60) {
+    return 'traditional';
+  }
+
+  return 'balanced';
+}
+
+function summarizeSignals(culture, researchStates, historicalEvents) {
+  const discoveredConceptIds = new Set();
+  const unlockedResearchIds = new Set();
+  let activeResearchCount = 0;
+
+  for (const researchState of researchStates) {
+    for (const conceptId of researchState.discoveredConceptIds) {
+      discoveredConceptIds.add(conceptId);
+    }
+
+    if (researchState.status === 'active') {
+      activeResearchCount += 1;
+    }
+
+    if (researchState.status === 'completed' || researchState.status === 'active') {
+      unlockedResearchIds.add(researchState.topicId);
+    }
+  }
+
+  const eventIds = historicalEvents.map((historicalEvent) => historicalEvent.id).sort();
+  const highlightedDiscoveries = [...new Set([
+    ...[...discoveredConceptIds],
+    ...historicalEvents.flatMap((historicalEvent) => historicalEvent.discoveryIds),
+  ])].sort();
+
+  return {
+    discoveredConceptIds: [...discoveredConceptIds].sort(),
+    unlockedResearchIds: [...unlockedResearchIds].sort(),
+    highlightedDiscoveries,
+    activeResearchCount,
+    eventIds,
+    eventCount: eventIds.length,
+    identityTags: [...new Set([...culture.valueIds, ...culture.traditionIds])].sort(),
+  };
+}
+
+export function buildCultureMapOverlay(payload, options = {}) {
+  const normalizedPayload = requireObject(payload, 'CultureMapOverlay payload');
+  const normalizedOptions = requireObject(options, 'CultureMapOverlay options');
+
+  const rawCultures = normalizedPayload.cultures === undefined ? [] : normalizedPayload.cultures;
+  const rawResearchStates = normalizedPayload.researchStates === undefined ? [] : normalizedPayload.researchStates;
+  const rawHistoricalEvents = normalizedPayload.historicalEvents === undefined ? [] : normalizedPayload.historicalEvents;
+
+  if (!Array.isArray(rawCultures)) {
+    throw new TypeError('CultureMapOverlay payload.cultures must be an array.');
+  }
+
+  if (!Array.isArray(rawResearchStates)) {
+    throw new TypeError('CultureMapOverlay payload.researchStates must be an array.');
+  }
+
+  if (!Array.isArray(rawHistoricalEvents)) {
+    throw new TypeError('CultureMapOverlay payload.historicalEvents must be an array.');
+  }
+
+  const cultures = rawCultures.map(normalizeCulture);
+  const researchStates = rawResearchStates.map(normalizeResearchState);
+  const historicalEvents = rawHistoricalEvents.map(normalizeHistoricalEvent);
+  const regionIdsByCulture = normalizeRegionIdsByCulture(normalizedOptions);
+  const styleByMarkerType = {
+    ...DEFAULT_STYLE_BY_MARKER_TYPE,
+    ...requireObject(normalizedOptions.styleByMarkerType ?? {}, 'CultureMapOverlay styleByMarkerType'),
+  };
+
+  return cultures
+    .flatMap((culture) => {
+      const cultureResearchStates = researchStates.filter((researchState) => researchState.cultureId === culture.id);
+      const cultureHistoricalEvents = historicalEvents.filter((historicalEvent) => historicalEvent.affectsCulture(culture.id));
+      const signals = summarizeSignals(culture, cultureResearchStates, cultureHistoricalEvents);
+      const markerType = buildMarkerType(culture);
+      const regionIds = regionIdsByCulture[culture.id] ?? [];
+
+      return regionIds.map((regionId) => ({
+        overlayId: `${regionId}:${culture.id}`,
+        regionId,
+        cultureId: culture.id,
+        cultureName: culture.name,
+        archetype: culture.archetype,
+        primaryLanguage: culture.primaryLanguage,
+        markerType,
+        label: `${culture.name} (${signals.highlightedDiscoveries.length} découvertes)`,
+        summary: `${signals.activeResearchCount} recherches actives, ${signals.eventCount} événements, ${signals.identityTags.length} repères culturels`,
+        discoveries: signals.highlightedDiscoveries,
+        unlockedResearchIds: signals.unlockedResearchIds,
+        activeResearchCount: signals.activeResearchCount,
+        eventIds: signals.eventIds,
+        eventCount: signals.eventCount,
+        identityTags: signals.identityTags,
+        cultureMetrics: {
+          openness: culture.openness,
+          cohesion: culture.cohesion,
+          researchDrive: culture.researchDrive,
+        },
+        style: normalizeStyle(styleByMarkerType, markerType),
+      }));
+    })
+    .sort((left, right) => {
+      const regionComparison = left.regionId.localeCompare(right.regionId);
+
+      if (regionComparison !== 0) {
+        return regionComparison;
+      }
+
+      return left.cultureId.localeCompare(right.cultureId);
+    });
+}

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -1,0 +1,215 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Culture } from '../../../src/domain/culture/Culture.js';
+import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
+import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
+import { buildCultureMapOverlay } from '../../../src/ui/culture/buildCultureMapOverlay.js';
+
+test('buildCultureMapOverlay expands cultures into stable regional markers with discoveries', () => {
+  const overlay = buildCultureMapOverlay(
+    {
+      cultures: [
+        new Culture({
+          id: 'culture-north',
+          name: 'Northern League',
+          archetype: 'maritime',
+          primaryLanguage: 'north-tongue',
+          valueIds: ['trade', 'navigation'],
+          traditionIds: ['assemblies'],
+          openness: 72,
+          cohesion: 61,
+          researchDrive: 77,
+        }),
+        new Culture({
+          id: 'culture-steppe',
+          name: 'Steppe Houses',
+          archetype: 'nomadic',
+          primaryLanguage: 'horse-speech',
+          valueIds: ['honor'],
+          traditionIds: ['clan-oaths'],
+          openness: 35,
+          cohesion: 67,
+          researchDrive: 40,
+        }),
+      ],
+      researchStates: [
+        new ResearchState({
+          id: 'research-astrolabe',
+          cultureId: 'culture-north',
+          topicId: 'astrolabe',
+          status: 'active',
+          progress: 65,
+          discoveredConceptIds: ['star-maps', 'tidal-ledgers'],
+        }),
+        new ResearchState({
+          id: 'research-saddles',
+          cultureId: 'culture-steppe',
+          topicId: 'composite-saddles',
+          status: 'completed',
+          progress: 100,
+          completedAt: '2026-04-19T00:00:00.000Z',
+          discoveredConceptIds: ['stirrup-drill'],
+        }),
+      ],
+      historicalEvents: [
+        new HistoricalEvent({
+          id: 'event-open-archives',
+          title: 'Open Archives',
+          category: 'knowledge',
+          summary: 'Scholars share navigation routes.',
+          era: 'age-of-sails',
+          importance: 3,
+          triggeredAt: '2026-04-19T00:00:00.000Z',
+          affectedCultureIds: ['culture-north'],
+          discoveryIds: ['public-catalogue'],
+        }),
+      ],
+    },
+    {
+      regionIdsByCulture: {
+        'culture-north': ['north-coast', 'archipelago'],
+        'culture-steppe': ['high-steppe'],
+      },
+    },
+  );
+
+  assert.deepEqual(overlay, [
+    {
+      overlayId: 'archipelago:culture-north',
+      regionId: 'archipelago',
+      cultureId: 'culture-north',
+      cultureName: 'Northern League',
+      archetype: 'maritime',
+      primaryLanguage: 'north-tongue',
+      markerType: 'innovation',
+      label: 'Northern League (3 découvertes)',
+      summary: '1 recherches actives, 1 événements, 3 repères culturels',
+      discoveries: ['public-catalogue', 'star-maps', 'tidal-ledgers'],
+      unlockedResearchIds: ['astrolabe'],
+      activeResearchCount: 1,
+      eventIds: ['event-open-archives'],
+      eventCount: 1,
+      identityTags: ['assemblies', 'navigation', 'trade'],
+      cultureMetrics: {
+        openness: 72,
+        cohesion: 61,
+        researchDrive: 77,
+      },
+      style: {
+        color: 'violet',
+        icon: '✦',
+        emphasis: 'high',
+      },
+    },
+    {
+      overlayId: 'high-steppe:culture-steppe',
+      regionId: 'high-steppe',
+      cultureId: 'culture-steppe',
+      cultureName: 'Steppe Houses',
+      archetype: 'nomadic',
+      primaryLanguage: 'horse-speech',
+      markerType: 'traditional',
+      label: 'Steppe Houses (1 découvertes)',
+      summary: '0 recherches actives, 0 événements, 2 repères culturels',
+      discoveries: ['stirrup-drill'],
+      unlockedResearchIds: ['composite-saddles'],
+      activeResearchCount: 0,
+      eventIds: [],
+      eventCount: 0,
+      identityTags: ['clan-oaths', 'honor'],
+      cultureMetrics: {
+        openness: 35,
+        cohesion: 67,
+        researchDrive: 40,
+      },
+      style: {
+        color: 'amber',
+        icon: '⬢',
+        emphasis: 'normal',
+      },
+    },
+    {
+      overlayId: 'north-coast:culture-north',
+      regionId: 'north-coast',
+      cultureId: 'culture-north',
+      cultureName: 'Northern League',
+      archetype: 'maritime',
+      primaryLanguage: 'north-tongue',
+      markerType: 'innovation',
+      label: 'Northern League (3 découvertes)',
+      summary: '1 recherches actives, 1 événements, 3 repères culturels',
+      discoveries: ['public-catalogue', 'star-maps', 'tidal-ledgers'],
+      unlockedResearchIds: ['astrolabe'],
+      activeResearchCount: 1,
+      eventIds: ['event-open-archives'],
+      eventCount: 1,
+      identityTags: ['assemblies', 'navigation', 'trade'],
+      cultureMetrics: {
+        openness: 72,
+        cohesion: 61,
+        researchDrive: 77,
+      },
+      style: {
+        color: 'violet',
+        icon: '✦',
+        emphasis: 'high',
+      },
+    },
+  ]);
+});
+
+test('buildCultureMapOverlay supports plain payloads and style overrides', () => {
+  const overlay = buildCultureMapOverlay(
+    {
+      cultures: [
+        {
+          id: 'culture-fractured',
+          name: 'Broken Courts',
+          archetype: 'courtly',
+          primaryLanguage: 'court-speech',
+          valueIds: ['prestige'],
+          traditionIds: ['duels'],
+          openness: 50,
+          cohesion: 24,
+          researchDrive: 58,
+        },
+      ],
+      researchStates: [],
+      historicalEvents: [],
+    },
+    {
+      regionIdsByCulture: { 'culture-fractured': ['capital-basin'] },
+      styleByMarkerType: {
+        fragmented: { color: 'ruby', icon: '⚑', emphasis: 'critical' },
+      },
+    },
+  );
+
+  assert.deepEqual(overlay[0].style, {
+    color: 'ruby',
+    icon: '⚑',
+    emphasis: 'critical',
+  });
+  assert.equal(overlay[0].markerType, 'fragmented');
+});
+
+test('buildCultureMapOverlay rejects invalid inputs', () => {
+  assert.throws(() => buildCultureMapOverlay(null), /payload must be an object/);
+  assert.throws(
+    () => buildCultureMapOverlay({ cultures: null, researchStates: [], historicalEvents: [] }),
+    /payload\.cultures must be an array/,
+  );
+  assert.throws(
+    () => buildCultureMapOverlay({ cultures: [null], researchStates: [], historicalEvents: [] }),
+    /Culture instances or plain objects/,
+  );
+  assert.throws(
+    () => buildCultureMapOverlay({ cultures: [], researchStates: [null], historicalEvents: [] }),
+    /ResearchState instances or plain objects/,
+  );
+  assert.throws(
+    () => buildCultureMapOverlay({ cultures: [], researchStates: [], historicalEvents: [] }, { regionIdsByCulture: [] }),
+    /regionIdsByCulture must be an object/,
+  );
+});


### PR DESCRIPTION
## Summary
- add `buildCultureMapOverlay` to turn cultures, research states, and historical events into stable regional map markers
- expose discoveries, unlocked research, cultural identity tags, and marker styling for map rendering
- cover the new overlay builder with focused tests and document it in the README

## Testing
- npm test

Closes #252