### PR TITLE
Epsilon: add climate map overlay

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1,0 +1,100 @@
+import { ClimateState } from '../../domain/climate/ClimateState.js';
+import { buildCatastropheMapOverlay } from './buildCatastropheMapOverlay.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function normalizeClimateState(climateState) {
+  if (climateState instanceof ClimateState) {
+    return climateState;
+  }
+
+  if (climateState === null || typeof climateState !== 'object' || Array.isArray(climateState)) {
+    throw new TypeError('ClimateMapOverlay climateStates must contain ClimateState instances or plain objects.');
+  }
+
+  return new ClimateState(climateState);
+}
+
+function buildSeasonEntry(state, seasonLabels) {
+  return {
+    overlayId: `${state.regionId}:season`,
+    regionId: state.regionId,
+    kind: 'season',
+    label: seasonLabels[state.season] ?? state.season,
+    season: state.season,
+    tone: 'info',
+  };
+}
+
+function buildAnomalyEntry(state) {
+  if (!state.hasAnomaly()) {
+    return null;
+  }
+
+  return {
+    overlayId: `${state.regionId}:anomaly:${state.anomaly}`,
+    regionId: state.regionId,
+    kind: 'anomaly',
+    label: state.anomaly,
+    season: state.season,
+    tone: 'warning',
+  };
+}
+
+export function buildClimateMapOverlay(climateStates, options = {}) {
+  const states = requireArray(climateStates, 'ClimateMapOverlay climateStates').map(normalizeClimateState);
+  const normalizedOptions = requireObject(options, 'ClimateMapOverlay options');
+  const seasonLabels = requireObject(normalizedOptions.seasonLabels ?? {}, 'ClimateMapOverlay seasonLabels');
+  const catastropheEntries = buildCatastropheMapOverlay(
+    normalizedOptions.catastrophes ?? [],
+    { styleBySeverity: normalizedOptions.styleBySeverity ?? {} },
+  ).map((entry) => ({
+    ...entry,
+    kind: 'catastrophe',
+  }));
+
+  const stateEntries = states
+    .sort((left, right) => left.regionId.localeCompare(right.regionId))
+    .flatMap((state) => {
+      const entries = [buildSeasonEntry(state, seasonLabels)];
+      const anomalyEntry = buildAnomalyEntry(state);
+
+      if (anomalyEntry) {
+        entries.push(anomalyEntry);
+      }
+
+      return entries;
+    });
+
+  return {
+    entries: [...stateEntries, ...catastropheEntries].sort((left, right) => {
+      const regionComparison = left.regionId.localeCompare(right.regionId);
+
+      if (regionComparison !== 0) {
+        return regionComparison;
+      }
+
+      return left.overlayId.localeCompare(right.overlayId);
+    }),
+    metrics: {
+      regionCount: states.length,
+      seasonCount: states.length,
+      anomalyCount: stateEntries.filter((entry) => entry.kind === 'anomaly').length,
+      catastropheCount: catastropheEntries.length,
+    },
+  };
+}

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -1,0 +1,137 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildClimateMapOverlay } from '../../../src/ui/climate/buildClimateMapOverlay.js';
+import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
+
+test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into stable regional entries', () => {
+  const overlay = buildClimateMapOverlay([
+    new ClimateState({
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 33,
+      precipitationLevel: 11,
+      droughtIndex: 74,
+      anomaly: 'heatwave',
+    }),
+    {
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 63,
+      droughtIndex: 18,
+    },
+  ], {
+    seasonLabels: {
+      spring: 'Printemps',
+      summer: 'Été',
+    },
+    catastrophes: [
+      {
+        id: 'storm-1',
+        type: 'great-storm',
+        severity: 'major',
+        status: 'active',
+        regionIds: ['north-coast', 'sunreach'],
+        startedAt: '2026-04-19T00:00:00.000Z',
+        impact: { harvest: -12 },
+      },
+    ],
+  });
+
+  assert.deepEqual(overlay, {
+    entries: [
+      {
+        overlayId: 'north-coast:season',
+        regionId: 'north-coast',
+        kind: 'season',
+        label: 'Printemps',
+        season: 'spring',
+        tone: 'info',
+      },
+      {
+        overlayId: 'north-coast:storm-1',
+        regionId: 'north-coast',
+        catastropheId: 'storm-1',
+        kind: 'catastrophe',
+        type: 'great-storm',
+        severity: 'major',
+        status: 'active',
+        label: 'great-storm (major)',
+        description: null,
+        impact: { harvest: -12 },
+        style: {
+          stroke: 'orange',
+          fill: 'orange',
+          opacity: 0.4,
+          icon: '▲',
+        },
+      },
+      {
+        overlayId: 'sunreach:anomaly:heatwave',
+        regionId: 'sunreach',
+        kind: 'anomaly',
+        label: 'heatwave',
+        season: 'summer',
+        tone: 'warning',
+      },
+      {
+        overlayId: 'sunreach:season',
+        regionId: 'sunreach',
+        kind: 'season',
+        label: 'Été',
+        season: 'summer',
+        tone: 'info',
+      },
+      {
+        overlayId: 'sunreach:storm-1',
+        regionId: 'sunreach',
+        catastropheId: 'storm-1',
+        kind: 'catastrophe',
+        type: 'great-storm',
+        severity: 'major',
+        status: 'active',
+        label: 'great-storm (major)',
+        description: null,
+        impact: { harvest: -12 },
+        style: {
+          stroke: 'orange',
+          fill: 'orange',
+          opacity: 0.4,
+          icon: '▲',
+        },
+      },
+    ],
+    metrics: {
+      regionCount: 2,
+      seasonCount: 2,
+      anomalyCount: 1,
+      catastropheCount: 2,
+    },
+  });
+});
+
+test('buildClimateMapOverlay supports empty catastrophes and validated options', () => {
+  const overlay = buildClimateMapOverlay([
+    {
+      regionId: 'delta',
+      season: 'autumn',
+      temperatureC: 18,
+      precipitationLevel: 48,
+      droughtIndex: 29,
+    },
+  ], {
+    catastrophes: [],
+  });
+
+  assert.equal(overlay.entries.length, 1);
+  assert.equal(overlay.metrics.catastropheCount, 0);
+  assert.equal(overlay.entries[0].overlayId, 'delta:season');
+});
+
+test('buildClimateMapOverlay rejects invalid inputs', () => {
+  assert.throws(() => buildClimateMapOverlay(null), /climateStates must be an array/);
+  assert.throws(() => buildClimateMapOverlay([null]), /ClimateState instances or plain objects/);
+  assert.throws(() => buildClimateMapOverlay([], null), /options must be an object/);
+  assert.throws(() => buildClimateMapOverlay([], { seasonLabels: [] }), /seasonLabels must be an object/);
+});


### PR DESCRIPTION
## Summary

- Epsilon: add a combined climate map overlay helper for seasons, anomalies, and disasters
- Epsilon: cover the new overlay with deterministic tests for stable rendering and validation

## Related issue

- One issue only: Closes #254

## Changes

- Epsilon: add `buildClimateMapOverlay` to merge per-region season entries, anomaly markers, and catastrophe overlays
- Epsilon: reuse existing climate state and catastrophe helpers to keep normalization and style behavior consistent
- Epsilon: add tests for combined output, empty catastrophe lists, and invalid inputs

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [x] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date

## Notes

- Epsilon: replaces closed PR #258 after the open-feature-PR count dropped back below the limit.
