### PR TITLE
Beta: [WEB-B1] enrichir l'overlay villes, ressources et routes dans la démo web

### DIFF
--- a/src/ui/economy/buildCityComparisonPanel.js
+++ b/src/ui/economy/buildCityComparisonPanel.js
@@ -1,0 +1,115 @@
+import { City } from '../../domain/economy/City.js';
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeCity(city) {
+  if (city instanceof City) {
+    return city;
+  }
+
+  if (city === null || typeof city !== 'object' || Array.isArray(city)) {
+    throw new TypeError('CityComparisonPanel cities must contain City instances or plain objects.');
+  }
+
+  return new City(city);
+}
+
+function buildTensionLevel(city, desiredStockByCityId) {
+  const desiredStock = desiredStockByCityId[city.id] ?? {};
+  const resourceIds = new Set([
+    ...Object.keys(city.stockByResource),
+    ...Object.keys(desiredStock),
+  ]);
+
+  let shortageCount = 0;
+  let surplusCount = 0;
+  let tensionScore = 0;
+
+  for (const resourceId of resourceIds) {
+    const current = city.stockByResource[resourceId] ?? 0;
+    const desired = desiredStock[resourceId] ?? 0;
+    const delta = current - desired;
+
+    if (delta < 0) {
+      shortageCount += 1;
+      tensionScore += Math.abs(delta);
+    } else if (delta > 0) {
+      surplusCount += 1;
+    }
+  }
+
+  const level = tensionScore >= 10 ? 'high' : tensionScore > 0 ? 'medium' : 'low';
+
+  return {
+    shortageCount,
+    surplusCount,
+    tensionScore,
+    level,
+  };
+}
+
+export function buildCityComparisonPanel(cities, options = {}) {
+  const normalizedCities = requireArray(cities, 'CityComparisonPanel cities').map(normalizeCity);
+  const normalizedOptions = requireObject(options, 'CityComparisonPanel options');
+  const desiredStockByCityId = requireObject(
+    normalizedOptions.desiredStockByCityId ?? {},
+    'CityComparisonPanel desiredStockByCityId',
+  );
+
+  const rows = normalizedCities
+    .slice()
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((city) => {
+      const totalStock = Object.values(city.stockByResource).reduce((sum, quantity) => sum + quantity, 0);
+      const tension = buildTensionLevel(city, desiredStockByCityId);
+
+      return {
+        cityId: city.id,
+        cityName: city.name,
+        regionId: city.regionId,
+        population: city.population,
+        prosperity: city.prosperity,
+        stability: city.stability,
+        totalStock,
+        scarcityRatio: Number(city.scarcityRatio.toFixed(2)),
+        shortageCount: tension.shortageCount,
+        surplusCount: tension.surplusCount,
+        tensionScore: tension.tensionScore,
+        tensionLevel: tension.level,
+        label: `${city.name}, stock ${totalStock}, tension ${tension.level}`,
+      };
+    });
+
+  const highestScarcity = rows.reduce((current, row) => (row.scarcityRatio > current.scarcityRatio ? row : current), rows[0] ?? null);
+  const highestTension = rows.reduce((current, row) => (row.tensionScore > current.tensionScore ? row : current), rows[0] ?? null);
+
+  return {
+    title: 'Comparatif des villes',
+    summary: `${rows.length} villes suivies, ${rows.filter((row) => row.tensionLevel !== 'low').length} sous tension`,
+    rows,
+    highlights: {
+      highestScarcityCityId: highestScarcity?.cityId ?? null,
+      highestTensionCityId: highestTension?.cityId ?? null,
+    },
+    metrics: {
+      cityCount: rows.length,
+      totalPopulation: rows.reduce((sum, row) => sum + row.population, 0),
+      totalStock: rows.reduce((sum, row) => sum + row.totalStock, 0),
+      highTensionCount: rows.filter((row) => row.tensionLevel === 'high').length,
+    },
+  };
+}

--- a/test/ui/economy/buildCityComparisonPanel.test.js
+++ b/test/ui/economy/buildCityComparisonPanel.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { City } from '../../../src/domain/economy/City.js';
+import { buildCityComparisonPanel } from '../../../src/ui/economy/buildCityComparisonPanel.js';
+
+test('buildCityComparisonPanel compares stock pressure across cities', () => {
+  const panel = buildCityComparisonPanel([
+    new City({
+      id: 'city-harbor',
+      name: 'Harbor',
+      regionId: 'coast',
+      population: 120,
+      prosperity: 74,
+      stability: 61,
+      stockByResource: { fish: 14, wood: 6 },
+    }),
+    new City({
+      id: 'city-mill',
+      name: 'Mill',
+      regionId: 'riverlands',
+      population: 80,
+      prosperity: 52,
+      stability: 38,
+      stockByResource: { grain: 4, flour: 2 },
+    }),
+  ], {
+    desiredStockByCityId: {
+      'city-harbor': { fish: 10, wood: 4 },
+      'city-mill': { grain: 10, flour: 6 },
+    },
+  });
+
+  assert.equal(panel.summary, '2 villes suivies, 1 sous tension');
+  assert.deepEqual(panel.rows, [
+    {
+      cityId: 'city-harbor',
+      cityName: 'Harbor',
+      regionId: 'coast',
+      population: 120,
+      prosperity: 74,
+      stability: 61,
+      totalStock: 20,
+      scarcityRatio: 0.17,
+      shortageCount: 0,
+      surplusCount: 2,
+      tensionScore: 0,
+      tensionLevel: 'low',
+      label: 'Harbor, stock 20, tension low',
+    },
+    {
+      cityId: 'city-mill',
+      cityName: 'Mill',
+      regionId: 'riverlands',
+      population: 80,
+      prosperity: 52,
+      stability: 38,
+      totalStock: 6,
+      scarcityRatio: 0.07,
+      shortageCount: 2,
+      surplusCount: 0,
+      tensionScore: 10,
+      tensionLevel: 'high',
+      label: 'Mill, stock 6, tension high',
+    },
+  ]);
+  assert.deepEqual(panel.highlights, {
+    highestScarcityCityId: 'city-harbor',
+    highestTensionCityId: 'city-mill',
+  });
+  assert.deepEqual(panel.metrics, {
+    cityCount: 2,
+    totalPopulation: 200,
+    totalStock: 26,
+    highTensionCount: 1,
+  });
+});
+
+test('buildCityComparisonPanel supports plain payloads and validates inputs', () => {
+  const panel = buildCityComparisonPanel([
+    {
+      id: 'city-delta',
+      name: 'Delta',
+      regionId: 'delta',
+      population: 50,
+      stockByResource: { salt: 3 },
+    },
+  ]);
+
+  assert.equal(panel.rows[0].tensionLevel, 'low');
+  assert.throws(() => buildCityComparisonPanel(null), /cities must be an array/);
+  assert.throws(() => buildCityComparisonPanel([null]), /City instances or plain objects/);
+  assert.throws(() => buildCityComparisonPanel([], null), /options must be an object/);
+  assert.throws(() => buildCityComparisonPanel([], { desiredStockByCityId: [] }), /desiredStockByCityId must be an object/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1,5 +1,10 @@
 import { Province } from '../src/domain/war/Province.js';
+import { City } from '../src/domain/economy/City.js';
+import { TradeRoute } from '../src/domain/economy/TradeRoute.js';
 import { buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
+import { buildEconomyMapOverlay } from '../src/ui/economy/buildEconomyMapOverlay.js';
+import { buildCityStockPanel } from '../src/ui/economy/buildCityStockPanel.js';
+import { buildCityComparisonPanel } from '../src/ui/economy/buildCityComparisonPanel.js';
 
 const paletteByFaction = {
   aurora: { fill: '#2F6BFF', border: '#8FB3FF' },
@@ -91,6 +96,95 @@ const overlayLabels = {
   'culture-overlay': 'Culture',
   'economy-overlay': 'Économie',
   'intrigue-overlay': 'Intrigue',
+};
+
+const cityLayoutsById = {
+  'crown-port': { x: 49.5, y: 28 },
+  'river-gate-city': { x: 34, y: 56 },
+  'iron-plain-city': { x: 62, y: 55 },
+  'southern-crossing': { x: 47, y: 79 },
+};
+
+const cities = [
+  new City({
+    id: 'crown-port',
+    name: 'Port de Couronne',
+    regionId: 'crown-heart',
+    population: 145,
+    prosperity: 78,
+    stability: 72,
+    stockByResource: { grain: 12, fish: 14, timber: 7 },
+    tradeRouteIds: ['aurora-river', 'southern-grainway'],
+    capital: true,
+  }),
+  new City({
+    id: 'river-gate-city',
+    name: 'Porte du Fleuve',
+    regionId: 'river-gate',
+    population: 102,
+    prosperity: 49,
+    stability: 37,
+    stockByResource: { grain: 3, tools: 2, timber: 4 },
+    tradeRouteIds: ['aurora-river', 'ember-foundry-line'],
+  }),
+  new City({
+    id: 'iron-plain-city',
+    name: 'Forge des Plaines',
+    regionId: 'iron-plain',
+    population: 93,
+    prosperity: 57,
+    stability: 52,
+    stockByResource: { ore: 11, tools: 5, grain: 2 },
+    tradeRouteIds: ['ember-foundry-line'],
+  }),
+  new City({
+    id: 'southern-crossing',
+    name: 'Passage du Sud',
+    regionId: 'southern-reach',
+    population: 81,
+    prosperity: 43,
+    stability: 41,
+    stockByResource: { grain: 2, horses: 4, timber: 1 },
+    tradeRouteIds: ['southern-grainway'],
+  }),
+];
+
+const routes = [
+  new TradeRoute({
+    id: 'aurora-river',
+    name: 'Artère fluviale',
+    stopCityIds: ['crown-port', 'river-gate-city'],
+    distance: 5,
+    capacityByResource: { grain: 6, fish: 5, timber: 3 },
+    transportMode: 'river',
+    riskLevel: 24,
+  }),
+  new TradeRoute({
+    id: 'ember-foundry-line',
+    name: 'Ligne des fonderies',
+    stopCityIds: ['river-gate-city', 'iron-plain-city'],
+    distance: 4,
+    capacityByResource: { ore: 5, tools: 3, grain: 2 },
+    transportMode: 'land',
+    riskLevel: 61,
+  }),
+  new TradeRoute({
+    id: 'southern-grainway',
+    name: 'Route des moissons',
+    stopCityIds: ['crown-port', 'southern-crossing'],
+    distance: 6,
+    capacityByResource: { grain: 4, timber: 2, horses: 2 },
+    transportMode: 'land',
+    riskLevel: 42,
+    active: false,
+  }),
+];
+
+const desiredStockByCityId = {
+  'crown-port': { grain: 10, fish: 10, timber: 5 },
+  'river-gate-city': { grain: 9, tools: 4, timber: 5 },
+  'iron-plain-city': { ore: 8, tools: 4, grain: 5 },
+  'southern-crossing': { grain: 7, horses: 3, timber: 3 },
 };
 
 const state = {
@@ -221,18 +315,158 @@ function renderActiveProvince(shell) {
   `;
 }
 
-function renderOverlayPanel() {
+function getEconomyViewModel() {
+  const overlay = buildEconomyMapOverlay(cities, routes, { cityPositionById: cityLayoutsById });
+  const comparison = buildCityComparisonPanel(cities, { desiredStockByCityId });
+  const stockPanels = Object.fromEntries(
+    cities.map((city) => [city.id, buildCityStockPanel(city, { desiredStockByResource: desiredStockByCityId[city.id] ?? {} })]),
+  );
+
+  return { overlay, comparison, stockPanels };
+}
+
+function renderEconomyMapOverlay(economyView) {
+  if (state.activeOverlaySlot !== 'economy-overlay') {
+    return '';
+  }
+
+  const routeLines = economyView.overlay.routes.map((route) => {
+    const origin = cityLayoutsById[route.originCityId];
+    const destination = cityLayoutsById[route.destinationCityId];
+
+    if (!origin || !destination) {
+      return '';
+    }
+
+    const dashArray = route.style.pattern === 'dashed'
+      ? '10 7'
+      : route.style.pattern === 'wave'
+        ? '7 5'
+        : '0';
+
+    return `
+      <line
+        class="economy-route"
+        x1="${origin.x}%"
+        y1="${origin.y}%"
+        x2="${destination.x}%"
+        y2="${destination.y}%"
+        stroke="${route.style.stroke}"
+        stroke-width="${route.style.width * 3}"
+        stroke-dasharray="${dashArray}"
+        opacity="${route.style.opacity}"
+      />
+    `;
+  }).join('');
+
+  const cityNodes = economyView.overlay.cities.map((city) => {
+    const position = city.marker.position;
+
+    if (!position) {
+      return '';
+    }
+
+    return `
+      <g class="economy-city-group" data-city-id="${city.cityId}">
+        <circle class="economy-city economy-city--${city.marker.tone}" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 8}" />
+        <text class="economy-city-label" x="${position.x}%" y="calc(${position.y}% - 14px)" text-anchor="middle">${city.cityName}</text>
+        <text class="economy-city-resource" x="${position.x}%" y="calc(${position.y}% + 18px)" text-anchor="middle">${city.resources.primaryResourceId ?? 'stock vide'}</text>
+      </g>
+    `;
+  }).join('');
+
   return `
-    <section class="panel overlay-panel">
+    <svg class="economy-map-layer" viewBox="0 0 100 100" aria-label="Overlay économie et logistique">
+      ${routeLines}
+      ${cityNodes}
+    </svg>
+  `;
+}
+
+function renderEconomySidePanel(economyView) {
+  if (state.activeOverlaySlot !== 'economy-overlay') {
+    return `
+      <section class="panel overlay-panel">
+        <div class="panel-header">
+          <h3>Overlay actif, ${overlayLabels[state.activeOverlaySlot]}</h3>
+          <p>${getOverlayDescription(state.activeOverlaySlot)}</p>
+        </div>
+        <div class="overlay-anchor-grid">
+          <div class="overlay-anchor"><span>HUD haut</span><strong>#top-hud</strong></div>
+          <div class="overlay-anchor"><span>Rail gauche</span><strong>#left-rail</strong></div>
+          <div class="overlay-anchor"><span>Rail droit</span><strong>#right-rail</strong></div>
+          <div class="overlay-anchor"><span>Barre basse</span><strong>#bottom-tray</strong></div>
+        </div>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="panel overlay-panel overlay-panel--economy">
       <div class="panel-header">
-        <h3>Overlay actif, ${overlayLabels[state.activeOverlaySlot]}</h3>
-        <p>${getOverlayDescription(state.activeOverlaySlot)}</p>
+        <h3>Overlay actif, Économie</h3>
+        <p>${economyView.overlay.summary}</p>
       </div>
-      <div class="overlay-anchor-grid">
-        <div class="overlay-anchor"><span>HUD haut</span><strong>#top-hud</strong></div>
-        <div class="overlay-anchor"><span>Rail gauche</span><strong>#left-rail</strong></div>
-        <div class="overlay-anchor"><span>Rail droit</span><strong>#right-rail</strong></div>
-        <div class="overlay-anchor"><span>Barre basse</span><strong>#bottom-tray</strong></div>
+      <div class="economy-quick-stats">
+        <div class="overlay-anchor"><span>Villes</span><strong>${economyView.overlay.metrics.cityCount}</strong></div>
+        <div class="overlay-anchor"><span>Routes actives</span><strong>${economyView.overlay.metrics.activeRouteCount}/${economyView.overlay.metrics.routeCount}</strong></div>
+        <div class="overlay-anchor"><span>Tensions fortes</span><strong>${economyView.comparison.metrics.highTensionCount}</strong></div>
+        <div class="overlay-anchor"><span>Capacité</span><strong>${economyView.overlay.metrics.totalRouteCapacity}</strong></div>
+      </div>
+      <div class="economy-route-list">
+        ${economyView.overlay.routes.map((route) => `
+          <article class="economy-route-card ${route.active ? '' : 'is-inactive'}">
+            <strong>${route.routeName}</strong>
+            <span>${route.transportMode}, risque ${route.riskLevel}</span>
+            <span>capacité ${route.totalCapacity}</span>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
+function renderBottomTray(economyView) {
+  if (state.activeOverlaySlot !== 'economy-overlay') {
+    return '<div class="overlay-anchor-shell overlay-anchor-shell--bottom">Bottom tray</div>';
+  }
+
+  return `
+    <section id="bottom-tray" class="overlay-anchor-shell overlay-anchor-shell--bottom overlay-anchor-shell--economy">
+      <div class="bottom-tray-grid">
+        <div class="bottom-tray-table">
+          <h4>${economyView.comparison.title}</h4>
+          <p>${economyView.comparison.summary}</p>
+          <table>
+            <thead>
+              <tr><th>Ville</th><th>Stock</th><th>Ratio</th><th>Tension</th></tr>
+            </thead>
+            <tbody>
+              ${economyView.comparison.rows.map((row) => `
+                <tr>
+                  <td>${row.cityName}</td>
+                  <td>${row.totalStock}</td>
+                  <td>${row.scarcityRatio}</td>
+                  <td><span class="tension-pill tension-pill--${row.tensionLevel}">${row.tensionLevel}</span></td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+        <div class="bottom-tray-stocks">
+          ${economyView.overlay.cities.map((city) => {
+            const panel = economyView.stockPanels[city.cityId];
+            return `
+              <article class="stock-mini-card">
+                <h4>${panel.cityName}</h4>
+                <p>${panel.summary}</p>
+                <ul>
+                  ${panel.rows.slice(0, 3).map((row) => `<li class="${row.status}"><span>${row.resourceId}</span><strong>${row.detail}</strong></li>`).join('')}
+                </ul>
+              </article>
+            `;
+          }).join('')}
+        </div>
       </div>
     </section>
   `;
@@ -240,6 +474,7 @@ function renderOverlayPanel() {
 
 function render() {
   const shell = getShell();
+  const economyView = getEconomyViewModel();
 
   document.querySelector('#app').innerHTML = `
     <main class="shell-root">
@@ -271,7 +506,8 @@ function render() {
             <div id="top-hud" class="overlay-anchor-shell overlay-anchor-shell--top">Top HUD</div>
             <div id="left-rail" class="overlay-anchor-shell overlay-anchor-shell--left">Left rail</div>
             <div id="right-rail" class="overlay-anchor-shell overlay-anchor-shell--right">Right rail</div>
-            <div id="bottom-tray" class="overlay-anchor-shell overlay-anchor-shell--bottom">Bottom tray</div>
+            ${renderEconomyMapOverlay(economyView)}
+            ${renderBottomTray(economyView)}
             ${shell.provinces.map(renderProvinceCard).join('')}
           </div>
         </section>
@@ -279,7 +515,7 @@ function render() {
         <aside class="side-column">
           ${renderLegend(shell)}
           ${renderActiveProvince(shell)}
-          ${renderOverlayPanel()}
+          ${renderEconomySidePanel(economyView)}
         </aside>
       </section>
     </main>

--- a/web/styles.css
+++ b/web/styles.css
@@ -139,10 +139,43 @@ button { font: inherit; }
   align-items: center;
   justify-content: center;
 }
+.economy-map-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: visible;
+}
+.economy-route {
+  filter: drop-shadow(0 0 8px rgba(125, 211, 252, 0.24));
+}
+.economy-city {
+  stroke: rgba(255, 255, 255, 0.88);
+  stroke-width: 1.6;
+}
+.economy-city--positive { fill: #22c55e; }
+.economy-city--warning { fill: #f97316; }
+.economy-city--neutral { fill: #38bdf8; }
+.economy-city-label,
+.economy-city-resource {
+  fill: #eff6ff;
+  font-size: 4px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.economy-city-resource { fill: #bfdbfe; }
 .overlay-anchor-shell--top { left: 18%; top: 3%; width: 64%; height: 9%; }
 .overlay-anchor-shell--left { left: 3%; top: 18%; width: 12%; height: 58%; }
 .overlay-anchor-shell--right { right: 3%; top: 18%; width: 12%; height: 58%; }
 .overlay-anchor-shell--bottom { left: 20%; bottom: 4%; width: 60%; height: 11%; }
+.overlay-anchor-shell--economy {
+  align-items: stretch;
+  justify-content: stretch;
+  padding: 12px;
+  color: var(--text);
+  text-transform: none;
+  letter-spacing: 0;
+  background: rgba(8, 15, 28, 0.72);
+}
 .province-node {
   position: absolute;
   z-index: 2;
@@ -227,6 +260,92 @@ button { font: inherit; }
   border: 1px solid rgba(148, 163, 184, 0.14);
 }
 .overlay-anchor span { display: block; color: var(--muted); margin-bottom: 4px; }
+.economy-quick-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+.economy-route-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+.economy-route-card {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(15, 23, 42, 0.55);
+}
+.economy-route-card.is-inactive {
+  opacity: 0.68;
+}
+.bottom-tray-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 14px;
+  width: 100%;
+}
+.bottom-tray-table h4,
+.stock-mini-card h4 {
+  margin: 0 0 4px;
+}
+.bottom-tray-table p,
+.stock-mini-card p,
+.economy-route-card span {
+  margin: 0;
+  color: var(--muted);
+}
+.bottom-tray-table table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+  font-size: 12px;
+}
+.bottom-tray-table th,
+.bottom-tray-table td {
+  text-align: left;
+  padding: 6px 4px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+.bottom-tray-stocks {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+.stock-mini-card {
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.stock-mini-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: grid;
+  gap: 6px;
+}
+.stock-mini-card li {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+}
+.stock-mini-card li.shortage strong { color: var(--danger); }
+.stock-mini-card li.surplus strong { color: var(--success); }
+.tension-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+.tension-pill--low { background: rgba(34, 197, 94, 0.14); color: #86efac; }
+.tension-pill--medium { background: rgba(245, 158, 11, 0.14); color: #fde68a; }
+.tension-pill--high { background: rgba(251, 113, 133, 0.14); color: #fda4af; }
 @media (max-width: 1100px) {
   .hero, .layout-grid { grid-template-columns: 1fr; }
   .panel-header--spread { flex-direction: column; }
@@ -234,6 +353,6 @@ button { font: inherit; }
 @media (max-width: 720px) {
   .shell-root { width: min(100vw - 16px, 100%); padding-top: 8px; }
   .hero, .map-panel, .legend-panel, .province-details, .overlay-panel { padding: 14px; }
-  .hero-stats, .legend-columns, .province-facts, .overlay-tabs { grid-template-columns: 1fr; }
+  .hero-stats, .legend-columns, .province-facts, .overlay-tabs, .economy-quick-stats, .bottom-tray-grid, .bottom-tray-stocks { grid-template-columns: 1fr; }
   .map-stage { min-height: 680px; }
 }


### PR DESCRIPTION
## Summary
- add a lightweight Vite web demo that renders the strategic map shell with Beta city and logistics overlays
- add a city comparison panel plus richer stock and route presentation for the local economy view
- keep the demo wired to existing UI builders and cover the new comparison builder with tests

## Testing
- npm test
- npm run dev

Closes #262