### PR TITLE
Epsilon: [WEB-E1] mieux représenter saisons, anomalies et catastrophes

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -55,6 +55,40 @@ function buildAnomalyEntry(state) {
   };
 }
 
+function buildStrategicImpact(state, catastropheEntries) {
+  if (catastropheEntries.length > 0 || state.droughtIndex >= 60) {
+    return 'critical';
+  }
+
+  if (state.hasAnomaly() || state.precipitationLevel < 20) {
+    return 'strained';
+  }
+
+  return 'stable';
+}
+
+function buildSeasonSummary(states, seasonLabels) {
+  const countsBySeason = Object.create(null);
+
+  for (const state of states) {
+    countsBySeason[state.season] = (countsBySeason[state.season] ?? 0) + 1;
+  }
+
+  const seasons = Object.entries(countsBySeason)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([season, regionCount]) => ({
+      season,
+      label: seasonLabels[season] ?? season,
+      regionCount,
+    }));
+
+  return {
+    title: 'Situation saisonnière',
+    summary: seasons.map((entry) => `${entry.label}: ${entry.regionCount}`).join(', '),
+    seasons,
+  };
+}
+
 export function buildClimateMapOverlay(climateStates, options = {}) {
   const states = requireArray(climateStates, 'ClimateMapOverlay climateStates').map(normalizeClimateState);
   const normalizedOptions = requireObject(options, 'ClimateMapOverlay options');
@@ -68,6 +102,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
   }));
 
   const stateEntries = states
+    .slice()
     .sort((left, right) => left.regionId.localeCompare(right.regionId))
     .flatMap((state) => {
       const entries = [buildSeasonEntry(state, seasonLabels)];
@@ -80,7 +115,28 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
       return entries;
     });
 
+  const regions = states
+    .slice()
+    .sort((left, right) => left.regionId.localeCompare(right.regionId))
+    .map((state) => {
+      const regionalCatastrophes = catastropheEntries.filter((entry) => entry.regionId === state.regionId);
+
+      return {
+        regionId: state.regionId,
+        season: state.season,
+        seasonLabel: seasonLabels[state.season] ?? state.season,
+        anomaly: state.anomaly,
+        activeCatastropheIds: regionalCatastrophes.map((entry) => entry.catastropheId),
+        strategicImpact: buildStrategicImpact(state, regionalCatastrophes),
+        temperatureC: state.temperatureC,
+        precipitationLevel: state.precipitationLevel,
+        droughtIndex: state.droughtIndex,
+      };
+    });
+
   return {
+    title: 'Carte climat et catastrophes',
+    summary: `${states.length} régions, ${catastropheEntries.length} catastrophes visibles, ${regions.filter((region) => region.anomaly !== null).length} anomalies`,
     entries: [...stateEntries, ...catastropheEntries].sort((left, right) => {
       const regionComparison = left.regionId.localeCompare(right.regionId);
 
@@ -90,11 +146,14 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
 
       return left.overlayId.localeCompare(right.overlayId);
     }),
+    regions,
+    seasonalPanel: buildSeasonSummary(states, seasonLabels),
     metrics: {
       regionCount: states.length,
       seasonCount: states.length,
       anomalyCount: stateEntries.filter((entry) => entry.kind === 'anomaly').length,
       catastropheCount: catastropheEntries.length,
+      criticalRegionCount: regions.filter((region) => region.strategicImpact === 'critical').length,
     },
   };
 }

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -40,6 +40,8 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
   });
 
   assert.deepEqual(overlay, {
+    title: 'Carte climat et catastrophes',
+    summary: '2 régions, 2 catastrophes visibles, 1 anomalies',
     entries: [
       {
         overlayId: 'north-coast:season',
@@ -102,11 +104,52 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         },
       },
     ],
+    regions: [
+      {
+        regionId: 'north-coast',
+        season: 'spring',
+        seasonLabel: 'Printemps',
+        anomaly: null,
+        activeCatastropheIds: ['storm-1'],
+        strategicImpact: 'critical',
+        temperatureC: 12,
+        precipitationLevel: 63,
+        droughtIndex: 18,
+      },
+      {
+        regionId: 'sunreach',
+        season: 'summer',
+        seasonLabel: 'Été',
+        anomaly: 'heatwave',
+        activeCatastropheIds: ['storm-1'],
+        strategicImpact: 'critical',
+        temperatureC: 33,
+        precipitationLevel: 11,
+        droughtIndex: 74,
+      },
+    ],
+    seasonalPanel: {
+      title: 'Situation saisonnière',
+      summary: 'Printemps: 1, Été: 1',
+      seasons: [
+        {
+          season: 'spring',
+          label: 'Printemps',
+          regionCount: 1,
+        },
+        {
+          season: 'summer',
+          label: 'Été',
+          regionCount: 1,
+        },
+      ],
+    },
     metrics: {
       regionCount: 2,
       seasonCount: 2,
       anomalyCount: 1,
       catastropheCount: 2,
+      criticalRegionCount: 2,
     },
   });
 });
@@ -126,7 +169,22 @@ test('buildClimateMapOverlay supports empty catastrophes and validated options',
 
   assert.equal(overlay.entries.length, 1);
   assert.equal(overlay.metrics.catastropheCount, 0);
+  assert.equal(overlay.metrics.criticalRegionCount, 0);
   assert.equal(overlay.entries[0].overlayId, 'delta:season');
+  assert.equal(overlay.seasonalPanel.summary, 'autumn: 1');
+  assert.deepEqual(overlay.regions, [
+    {
+      regionId: 'delta',
+      season: 'autumn',
+      seasonLabel: 'autumn',
+      anomaly: null,
+      activeCatastropheIds: [],
+      strategicImpact: 'stable',
+      temperatureC: 18,
+      precipitationLevel: 48,
+      droughtIndex: 29,
+    },
+  ]);
 });
 
 test('buildClimateMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
## Summary

- Epsilon: enrichit `buildClimateMapOverlay` avec un résumé lisible pour la carte climat
- Epsilon: ajoute un panneau saisonnier simple et une vue régionale avec impact stratégique
- Epsilon: garde les overlays catastrophes et anomalies compatibles avec les modèles du domaine

## Related issue

- One issue only: #265

## Changes

- Epsilon: ajoute `title`, `summary`, `regions` et `seasonalPanel` à l'overlay climat
- Epsilon: relie anomalies, catastrophes actives et pression climatique à un `strategicImpact` par région
- Epsilon: met à jour les tests pour couvrir la nouvelle lecture de carte et le panneau saisonnier

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [ ] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date

## Notes

- Epsilon: `npm test`
