### PR TITLE
Alpha: [WEB-A1] faire évoluer la coque carte en écran stratégique interactif

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Historia, écran stratégique Alpha</title>
+    <link rel="stylesheet" href="./web/styles.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./web/app.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Historia strategy/simulation prototype",
   "type": "module",
   "scripts": {
+    "dev": "node scripts/dev-server.mjs",
+    "play": "node scripts/dev-server.mjs",
     "test": "node --test"
   }
 }

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -1,0 +1,42 @@
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { extname, join, normalize } from 'node:path';
+import { createServer } from 'node:http';
+
+const host = process.env.HOST ?? '127.0.0.1';
+const port = Number(process.env.PORT ?? 4173);
+const root = process.cwd();
+
+const MIME_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+};
+
+function resolvePath(urlPath) {
+  const requestedPath = urlPath === '/' ? '/index.html' : urlPath;
+  const normalizedPath = normalize(requestedPath).replace(/^([.][.][/\\])+/, '');
+  return join(root, normalizedPath);
+}
+
+const server = createServer((request, response) => {
+  const filePath = resolvePath(new URL(request.url, `http://${request.headers.host}`).pathname);
+
+  if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
+    response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+    response.end('Not found');
+    return;
+  }
+
+  response.writeHead(200, {
+    'content-type': MIME_TYPES[extname(filePath)] ?? 'application/octet-stream',
+    'cache-control': 'no-store',
+  });
+
+  createReadStream(filePath).pipe(response);
+});
+
+server.listen(port, host, () => {
+  console.log(`Historia dev server running at http://${host}:${port}`);
+});

--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1,6 +1,13 @@
 import { Province } from '../../domain/war/Province.js';
 import { renderProvince } from './ProvinceRenderer.js';
 
+const DEFAULT_OVERLAY_SLOTS = Object.freeze([
+  'climate-overlay',
+  'culture-overlay',
+  'economy-overlay',
+  'intrigue-overlay',
+]);
+
 function requireOptions(options) {
   if (options === null || typeof options !== 'object' || Array.isArray(options)) {
     throw new TypeError('StrategicMapShell options must be an object.');
@@ -23,16 +30,60 @@ function requireProvinceList(provinces) {
   });
 }
 
-function buildLegend(renderedProvinces) {
+function normalizeTextMap(value, label) {
+  if (value === undefined) {
+    return {};
+  }
+
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function normalizeOverlaySlots(overlaySlots) {
+  if (overlaySlots === undefined) {
+    return [...DEFAULT_OVERLAY_SLOTS];
+  }
+
+  if (!Array.isArray(overlaySlots)) {
+    throw new TypeError('StrategicMapShell overlaySlots must be an array.');
+  }
+
+  return [...new Set(overlaySlots.map((slot) => String(slot).trim()).filter(Boolean))];
+}
+
+function buildLegend(renderedProvinces, options) {
+  const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
+  const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
   const controllingFactionIds = [...new Set(renderedProvinces.map((province) => province.controllingFactionId))].sort();
 
   return {
-    factions: controllingFactionIds,
+    factions: controllingFactionIds.map((factionId) => ({
+      factionId,
+      label: String(factionMetaById[factionId]?.label ?? factionId).trim() || factionId,
+      color: String(paletteByFaction[factionId]?.fill ?? '#94A3B8').trim() || '#94A3B8',
+      border: String(paletteByFaction[factionId]?.border ?? '#334155').trim() || '#334155',
+    })),
     states: [
       { code: 'stable', label: 'Contrôle stable' },
       { code: 'occupied', label: 'Occupation' },
       { code: 'contested', label: 'Front contesté' },
     ],
+  };
+}
+
+function enhanceProvince(renderedProvince, options) {
+  const selectedProvinceId = String(options.selectedProvinceId ?? '').trim();
+  const focusedProvinceId = String(options.focusedProvinceId ?? '').trim();
+
+  return {
+    ...renderedProvince,
+    selectionState: {
+      selected: renderedProvince.provinceId === selectedProvinceId,
+      focused: renderedProvince.provinceId === focusedProvinceId,
+    },
   };
 }
 
@@ -42,11 +93,12 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const title = String(normalizedOptions.title ?? 'Carte stratégique').trim() || 'Carte stratégique';
   const subtitle = String(normalizedOptions.subtitle ?? 'Vue d’ensemble des provinces et lignes de front').trim()
     || 'Vue d’ensemble des provinces et lignes de front';
+  const overlaySlots = normalizeOverlaySlots(normalizedOptions.overlaySlots);
 
   const renderedProvinces = normalizedProvinces
     .slice()
     .sort((left, right) => left.id.localeCompare(right.id))
-    .map((province) => renderProvince(province, normalizedOptions));
+    .map((province) => enhanceProvince(renderProvince(province, normalizedOptions), normalizedOptions));
 
   const stats = renderedProvinces.reduce(
     (summary, province) => ({
@@ -73,6 +125,16 @@ export function buildStrategicMapShell(provinces, options = {}) {
       occupiedCount: stats.occupiedCount,
       averageLoyalty: stats.provinceCount === 0 ? 0 : Math.round(stats.averageLoyalty / stats.provinceCount),
     },
-    legend: buildLegend(renderedProvinces),
+    legend: buildLegend(renderedProvinces, normalizedOptions),
+    overlays: {
+      slots: overlaySlots.map((slotId) => ({
+        slotId,
+        label: slotId.replace(/-/g, ' '),
+        enabled: true,
+      })),
+    },
+    activeProvince: renderedProvinces.find(
+      (province) => province.selectionState.selected || province.selectionState.focused,
+    ) ?? null,
   };
 }

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -19,7 +19,7 @@ function createProvince(overrides = {}) {
   });
 }
 
-test('StrategicMapShell sorts provinces and derives headline stats', () => {
+test('StrategicMapShell sorts provinces, derives headline stats and exposes overlay-ready state', () => {
   const shell = buildStrategicMapShell(
     [
       createProvince({
@@ -34,6 +34,12 @@ test('StrategicMapShell sorts provinces and derives headline stats', () => {
     ],
     {
       title: 'Théâtre nord',
+      selectedProvinceId: 'prov-c',
+      focusedProvinceId: 'prov-a',
+      factionMetaById: {
+        'faction-a': { label: 'Alliance d’Azur' },
+        'faction-b': { label: 'Ligue cramoisie' },
+      },
       paletteByFaction: {
         'faction-a': { fill: '#2563EB', border: '#1E3A8A' },
         'faction-b': { fill: '#DC2626', border: '#7F1D1D' },
@@ -44,6 +50,10 @@ test('StrategicMapShell sorts provinces and derives headline stats', () => {
   assert.equal(shell.title, 'Théâtre nord');
   assert.equal(shell.subtitle, 'Vue d’ensemble des provinces et lignes de front');
   assert.deepEqual(shell.provinces.map((province) => province.provinceId), ['prov-a', 'prov-c']);
+  assert.deepEqual(shell.provinces.map((province) => province.selectionState), [
+    { selected: false, focused: true },
+    { selected: true, focused: false },
+  ]);
   assert.deepEqual(shell.stats, {
     provinceCount: 2,
     contestedCount: 1,
@@ -51,13 +61,33 @@ test('StrategicMapShell sorts provinces and derives headline stats', () => {
     averageLoyalty: 61,
   });
   assert.deepEqual(shell.legend, {
-    factions: ['faction-a', 'faction-b'],
+    factions: [
+      {
+        factionId: 'faction-a',
+        label: 'Alliance d’Azur',
+        color: '#2563EB',
+        border: '#1E3A8A',
+      },
+      {
+        factionId: 'faction-b',
+        label: 'Ligue cramoisie',
+        color: '#DC2626',
+        border: '#7F1D1D',
+      },
+    ],
     states: [
       { code: 'stable', label: 'Contrôle stable' },
       { code: 'occupied', label: 'Occupation' },
       { code: 'contested', label: 'Front contesté' },
     ],
   });
+  assert.deepEqual(shell.overlays.slots.map((slot) => slot.slotId), [
+    'climate-overlay',
+    'culture-overlay',
+    'economy-overlay',
+    'intrigue-overlay',
+  ]);
+  assert.equal(shell.activeProvince.provinceId, 'prov-a');
 });
 
 test('StrategicMapShell falls back to default title and validates inputs', () => {
@@ -65,7 +95,10 @@ test('StrategicMapShell falls back to default title and validates inputs', () =>
 
   assert.equal(shell.title, 'Carte stratégique');
   assert.equal(shell.stats.provinceCount, 0);
+  assert.equal(shell.activeProvince, null);
   assert.throws(() => buildStrategicMapShell(null), /StrategicMapShell provinces must be an array/);
   assert.throws(() => buildStrategicMapShell([{}]), /StrategicMapShell provinces must contain Province instances/);
   assert.throws(() => buildStrategicMapShell([], null), /StrategicMapShell options must be an object/);
+  assert.throws(() => buildStrategicMapShell([], { overlaySlots: null }), /overlaySlots must be an array/);
+  assert.throws(() => buildStrategicMapShell([], { factionMetaById: [] }), /factionMetaById must be an object/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,308 @@
+import { Province } from '../src/domain/war/Province.js';
+import { buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
+
+const paletteByFaction = {
+  aurora: { fill: '#2F6BFF', border: '#8FB3FF' },
+  ember: { fill: '#E8572A', border: '#FFB394' },
+  neutral: { fill: '#64748B', border: '#CBD5E1' },
+};
+
+const factionMetaById = {
+  aurora: { label: 'Alliance d’Aurora' },
+  ember: { label: 'Ligue d’Ember' },
+  neutral: { label: 'Marches neutres' },
+};
+
+const provinceLayouts = {
+  'north-watch': { x: 15, y: 18, w: 20, h: 18 },
+  'crown-heart': { x: 38, y: 18, w: 23, h: 20 },
+  'red-ridge': { x: 64, y: 16, w: 21, h: 22 },
+  'river-gate': { x: 22, y: 46, w: 24, h: 20 },
+  'iron-plain': { x: 50, y: 46, w: 26, h: 22 },
+  'southern-reach': { x: 33, y: 72, w: 28, h: 18 },
+};
+
+const provinces = [
+  new Province({
+    id: 'north-watch',
+    name: 'Veille du Nord',
+    ownerFactionId: 'aurora',
+    controllingFactionId: 'aurora',
+    supplyLevel: 'stable',
+    loyalty: 84,
+    strategicValue: 5,
+    neighborIds: ['crown-heart', 'river-gate'],
+  }),
+  new Province({
+    id: 'crown-heart',
+    name: 'Coeur de Couronne',
+    ownerFactionId: 'aurora',
+    controllingFactionId: 'aurora',
+    supplyLevel: 'stable',
+    loyalty: 78,
+    strategicValue: 8,
+    neighborIds: ['north-watch', 'red-ridge', 'river-gate', 'iron-plain'],
+  }),
+  new Province({
+    id: 'red-ridge',
+    name: 'Crête Rouge',
+    ownerFactionId: 'ember',
+    controllingFactionId: 'ember',
+    supplyLevel: 'strained',
+    loyalty: 58,
+    strategicValue: 6,
+    neighborIds: ['crown-heart', 'iron-plain'],
+  }),
+  new Province({
+    id: 'river-gate',
+    name: 'Porte du Fleuve',
+    ownerFactionId: 'aurora',
+    controllingFactionId: 'ember',
+    supplyLevel: 'disrupted',
+    loyalty: 39,
+    strategicValue: 7,
+    contested: true,
+    neighborIds: ['north-watch', 'crown-heart', 'iron-plain', 'southern-reach'],
+  }),
+  new Province({
+    id: 'iron-plain',
+    name: 'Plaine de Fer',
+    ownerFactionId: 'ember',
+    controllingFactionId: 'ember',
+    supplyLevel: 'strained',
+    loyalty: 61,
+    strategicValue: 4,
+    neighborIds: ['crown-heart', 'red-ridge', 'river-gate', 'southern-reach'],
+  }),
+  new Province({
+    id: 'southern-reach',
+    name: 'Basses Marches',
+    ownerFactionId: 'neutral',
+    controllingFactionId: 'aurora',
+    supplyLevel: 'collapsed',
+    loyalty: 44,
+    strategicValue: 3,
+    neighborIds: ['river-gate', 'iron-plain'],
+  }),
+];
+
+const overlayLabels = {
+  'climate-overlay': 'Climat',
+  'culture-overlay': 'Culture',
+  'economy-overlay': 'Économie',
+  'intrigue-overlay': 'Intrigue',
+};
+
+const state = {
+  focusedProvinceId: 'crown-heart',
+  selectedProvinceId: 'river-gate',
+  activeOverlaySlot: 'economy-overlay',
+};
+
+function getShell() {
+  return buildStrategicMapShell(provinces, {
+    title: 'Écran stratégique, théâtre continental',
+    subtitle: 'Prototype local Alpha prêt à accueillir les overlays inter-domaines',
+    paletteByFaction,
+    factionMetaById,
+    selectedProvinceId: state.selectedProvinceId,
+    focusedProvinceId: state.focusedProvinceId,
+  });
+}
+
+function getOverlayDescription(slotId) {
+  const copyBySlot = {
+    'climate-overlay': 'Ancrage réservé aux effets météo, saisons et catastrophes régionales.',
+    'culture-overlay': 'Ancrage réservé aux couches d’influence culturelle et aux découvertes.',
+    'economy-overlay': 'Ancrage réservé aux routes, flux, villes et tensions logistiques.',
+    'intrigue-overlay': 'Ancrage réservé aux cellules, alertes et opérations clandestines.',
+  };
+
+  return copyBySlot[slotId] ?? 'Ancrage overlay prêt à être enrichi.';
+}
+
+function renderStat(label, value, tone = 'neutral') {
+  return `<div class="stat-card stat-card--${tone}"><span>${label}</span><strong>${value}</strong></div>`;
+}
+
+function renderLegend(shell) {
+  const factions = shell.legend.factions.map((faction) => `
+    <li>
+      <span class="legend-swatch" style="--swatch-fill:${faction.color};--swatch-border:${faction.border}"></span>
+      <span>${faction.label}</span>
+    </li>
+  `).join('');
+
+  const statesMarkup = shell.legend.states.map((entry) => `<li><span class="legend-chip">${entry.code}</span>${entry.label}</li>`).join('');
+
+  return `
+    <section class="panel legend-panel">
+      <div class="panel-header">
+        <h3>Légende tactique</h3>
+        <p>Lecture par faction et état de contrôle</p>
+      </div>
+      <div class="legend-columns">
+        <div>
+          <h4>Factions</h4>
+          <ul class="legend-list">${factions}</ul>
+        </div>
+        <div>
+          <h4>États</h4>
+          <ul class="legend-list legend-list--states">${statesMarkup}</ul>
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderProvinceCard(province) {
+  const layout = provinceLayouts[province.provinceId];
+  const badges = province.badges.map((badge) => `<span class="province-badge">${badge}</span>`).join('');
+  const classes = [
+    'province-node',
+    province.selectionState.selected ? 'is-selected' : '',
+    province.selectionState.focused ? 'is-focused' : '',
+    province.contested ? 'is-contested' : '',
+    province.occupied ? 'is-occupied' : '',
+  ].filter(Boolean).join(' ');
+
+  return `
+    <button
+      class="${classes}"
+      type="button"
+      data-province-id="${province.provinceId}"
+      style="left:${layout.x}%;top:${layout.y}%;width:${layout.w}%;height:${layout.h}%;--province-fill:${province.style.fill};--province-border:${province.style.border};"
+      aria-pressed="${province.selectionState.selected}"
+    >
+      <span class="province-node__name">${province.label}</span>
+      <span class="province-node__meta">${province.supplyTone} · loyauté ${province.loyalty}</span>
+      <span class="province-node__badges">${badges}</span>
+    </button>
+  `;
+}
+
+function renderOverlaySlots(shell) {
+  return shell.overlays.slots.map((slot) => {
+    const active = slot.slotId === state.activeOverlaySlot;
+    return `
+      <button class="overlay-tab ${active ? 'is-active' : ''}" type="button" data-overlay-slot="${slot.slotId}">
+        <span>${overlayLabels[slot.slotId] ?? slot.label}</span>
+        <small>${active ? 'visible' : 'masqué'}</small>
+      </button>
+    `;
+  }).join('');
+}
+
+function renderActiveProvince(shell) {
+  const province = shell.activeProvince ?? shell.provinces[0] ?? null;
+
+  if (!province) {
+    return '<section class="panel province-details"><p>Aucune province chargée.</p></section>';
+  }
+
+  const controller = factionMetaById[province.controllingFactionId]?.label ?? province.controllingFactionId;
+  const owner = factionMetaById[province.ownerFactionId]?.label ?? province.ownerFactionId;
+
+  return `
+    <section class="panel province-details">
+      <div class="panel-header">
+        <h3>${province.label}</h3>
+        <p>${province.selectionState.selected ? 'Province sélectionnée' : 'Province focalisée'}</p>
+      </div>
+      <dl class="province-facts">
+        <div><dt>Contrôle</dt><dd>${controller}</dd></div>
+        <div><dt>Propriétaire</dt><dd>${owner}</dd></div>
+        <div><dt>Approvisionnement</dt><dd>${province.supplyLevel}</dd></div>
+        <div><dt>Valeur stratégique</dt><dd>${province.strategicValue}</dd></div>
+        <div><dt>Voisins</dt><dd>${province.neighborIds.join(', ')}</dd></div>
+      </dl>
+      <div class="province-summary-tags">${province.badges.map((badge) => `<span class="legend-chip">${badge}</span>`).join('')}</div>
+    </section>
+  `;
+}
+
+function renderOverlayPanel() {
+  return `
+    <section class="panel overlay-panel">
+      <div class="panel-header">
+        <h3>Overlay actif, ${overlayLabels[state.activeOverlaySlot]}</h3>
+        <p>${getOverlayDescription(state.activeOverlaySlot)}</p>
+      </div>
+      <div class="overlay-anchor-grid">
+        <div class="overlay-anchor"><span>HUD haut</span><strong>#top-hud</strong></div>
+        <div class="overlay-anchor"><span>Rail gauche</span><strong>#left-rail</strong></div>
+        <div class="overlay-anchor"><span>Rail droit</span><strong>#right-rail</strong></div>
+        <div class="overlay-anchor"><span>Barre basse</span><strong>#bottom-tray</strong></div>
+      </div>
+    </section>
+  `;
+}
+
+function render() {
+  const shell = getShell();
+
+  document.querySelector('#app').innerHTML = `
+    <main class="shell-root">
+      <section class="hero panel">
+        <div>
+          <p class="eyebrow">Alpha war room</p>
+          <h1>${shell.title}</h1>
+          <p class="hero-copy">${shell.subtitle}</p>
+        </div>
+        <div class="hero-stats">
+          ${renderStat('Provinces', shell.stats.provinceCount, 'neutral')}
+          ${renderStat('Fronts contestés', shell.stats.contestedCount, 'alert')}
+          ${renderStat('Occupations', shell.stats.occupiedCount, 'warning')}
+          ${renderStat('Loyauté moyenne', `${shell.stats.averageLoyalty}%`, 'success')}
+        </div>
+      </section>
+
+      <section class="layout-grid">
+        <section class="panel map-panel">
+          <div class="panel-header panel-header--spread">
+            <div>
+              <h2>Carte opérationnelle</h2>
+              <p>Cliquez pour sélectionner, survolez pour déplacer le focus</p>
+            </div>
+            <div class="overlay-tabs">${renderOverlaySlots(shell)}</div>
+          </div>
+          <div class="map-stage">
+            <div class="map-backdrop"></div>
+            <div id="top-hud" class="overlay-anchor-shell overlay-anchor-shell--top">Top HUD</div>
+            <div id="left-rail" class="overlay-anchor-shell overlay-anchor-shell--left">Left rail</div>
+            <div id="right-rail" class="overlay-anchor-shell overlay-anchor-shell--right">Right rail</div>
+            <div id="bottom-tray" class="overlay-anchor-shell overlay-anchor-shell--bottom">Bottom tray</div>
+            ${shell.provinces.map(renderProvinceCard).join('')}
+          </div>
+        </section>
+
+        <aside class="side-column">
+          ${renderLegend(shell)}
+          ${renderActiveProvince(shell)}
+          ${renderOverlayPanel()}
+        </aside>
+      </section>
+    </main>
+  `;
+
+  document.querySelectorAll('[data-province-id]').forEach((element) => {
+    element.addEventListener('mouseenter', () => {
+      state.focusedProvinceId = element.dataset.provinceId;
+      render();
+    });
+
+    element.addEventListener('click', () => {
+      state.selectedProvinceId = element.dataset.provinceId;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-overlay-slot]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.activeOverlaySlot = element.dataset.overlaySlot;
+      render();
+    });
+  });
+}
+
+render();

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,239 @@
+:root {
+  color-scheme: dark;
+  --bg: #08111f;
+  --panel: rgba(10, 20, 35, 0.86);
+  --panel-border: rgba(148, 163, 184, 0.18);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #7dd3fc;
+  --danger: #fb7185;
+  --warning: #f59e0b;
+  --success: #34d399;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  background:
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.18), transparent 30%),
+    linear-gradient(160deg, #030712 0%, #0f172a 55%, #111827 100%);
+}
+button { font: inherit; }
+.shell-root {
+  width: min(1400px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  box-shadow: 0 20px 60px rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(16px);
+}
+.hero {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 20px;
+  padding: 24px;
+  margin-bottom: 20px;
+}
+.eyebrow {
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  font-size: 12px;
+}
+.hero h1, .panel-header h2, .panel-header h3, .legend-panel h4 { margin: 0; }
+.hero-copy, .panel-header p { color: var(--muted); }
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+.stat-card {
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.6);
+}
+.stat-card span, .overlay-tab small { color: var(--muted); display: block; }
+.stat-card strong { display: block; margin-top: 4px; font-size: 28px; }
+.stat-card--alert strong { color: var(--danger); }
+.stat-card--warning strong { color: var(--warning); }
+.stat-card--success strong { color: var(--success); }
+.layout-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(320px, 0.9fr);
+  gap: 20px;
+}
+.map-panel { padding: 20px; }
+.panel-header { margin-bottom: 16px; }
+.panel-header--spread {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+.overlay-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  min-width: 280px;
+}
+.overlay-tab {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.72);
+  color: var(--text);
+  border-radius: 14px;
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+.overlay-tab.is-active {
+  border-color: rgba(125, 211, 252, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.3);
+}
+.map-stage {
+  position: relative;
+  min-height: 760px;
+  overflow: hidden;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: linear-gradient(180deg, rgba(14, 116, 144, 0.12), rgba(14, 165, 233, 0.04));
+}
+.map-backdrop {
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(circle at 20% 24%, rgba(59, 130, 246, 0.28), transparent 18%),
+    radial-gradient(circle at 74% 26%, rgba(239, 68, 68, 0.24), transparent 16%),
+    radial-gradient(circle at 48% 64%, rgba(34, 197, 94, 0.16), transparent 18%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.82), rgba(12, 74, 110, 0.48));
+}
+.map-backdrop::before,
+.map-backdrop::after {
+  content: '';
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+  background-size: 70px 70px;
+}
+.map-backdrop::after {
+  background: linear-gradient(transparent 0%, rgba(8, 15, 28, 0.46) 100%);
+}
+.overlay-anchor-shell {
+  position: absolute;
+  z-index: 1;
+  border: 1px dashed rgba(148, 163, 184, 0.28);
+  color: rgba(226, 232, 240, 0.65);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(15, 23, 42, 0.22);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.overlay-anchor-shell--top { left: 18%; top: 3%; width: 64%; height: 9%; }
+.overlay-anchor-shell--left { left: 3%; top: 18%; width: 12%; height: 58%; }
+.overlay-anchor-shell--right { right: 3%; top: 18%; width: 12%; height: 58%; }
+.overlay-anchor-shell--bottom { left: 20%; bottom: 4%; width: 60%; height: 11%; }
+.province-node {
+  position: absolute;
+  z-index: 2;
+  border-radius: 28px;
+  border: 2px solid var(--province-border);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--province-fill) 92%, white 8%), color-mix(in srgb, var(--province-fill) 72%, black 28%));
+  color: white;
+  padding: 14px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.3);
+  transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+}
+.province-node:hover, .province-node.is-focused {
+  transform: translateY(-3px) scale(1.01);
+  box-shadow: 0 16px 36px rgba(2, 6, 23, 0.42);
+}
+.province-node.is-selected {
+  outline: 3px solid rgba(125, 211, 252, 0.9);
+  outline-offset: 3px;
+}
+.province-node.is-contested { border-style: dashed; }
+.province-node.is-occupied::after {
+  content: '';
+  position: absolute; inset: 0;
+  border-radius: inherit;
+  background: repeating-linear-gradient(135deg, rgba(255,255,255,0.14), rgba(255,255,255,0.14) 10px, transparent 10px, transparent 20px);
+  pointer-events: none;
+}
+.province-node__name, .province-node__meta, .province-node__badges { position: relative; z-index: 1; }
+.province-node__name { font-weight: 700; font-size: 18px; }
+.province-node__meta { font-size: 13px; color: rgba(255,255,255,0.82); }
+.province-node__badges { display: flex; flex-wrap: wrap; gap: 6px; }
+.province-badge, .legend-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(226, 232, 240, 0.14);
+}
+.side-column { display: grid; gap: 16px; }
+.legend-panel, .province-details, .overlay-panel { padding: 18px; }
+.legend-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+.legend-list { list-style: none; padding: 0; margin: 10px 0 0; display: grid; gap: 10px; }
+.legend-list li { display: flex; align-items: center; gap: 10px; color: var(--text); }
+.legend-swatch {
+  width: 18px; height: 18px; border-radius: 999px;
+  background: var(--swatch-fill);
+  border: 2px solid var(--swatch-border);
+}
+.province-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+.province-facts div {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-facts dt { color: var(--muted); font-size: 12px; margin-bottom: 6px; }
+.province-facts dd { margin: 0; }
+.province-summary-tags, .overlay-anchor-grid { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.overlay-anchor {
+  flex: 1 1 140px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.overlay-anchor span { display: block; color: var(--muted); margin-bottom: 4px; }
+@media (max-width: 1100px) {
+  .hero, .layout-grid { grid-template-columns: 1fr; }
+  .panel-header--spread { flex-direction: column; }
+}
+@media (max-width: 720px) {
+  .shell-root { width: min(100vw - 16px, 100%); padding-top: 8px; }
+  .hero, .map-panel, .legend-panel, .province-details, .overlay-panel { padding: 14px; }
+  .hero-stats, .legend-columns, .province-facts, .overlay-tabs { grid-template-columns: 1fr; }
+  .map-stage { min-height: 680px; }
+}


### PR DESCRIPTION
## Summary\n- add a local strategic web shell with a game-like map presentation and selectable provinces\n- expose overlay anchor zones and reusable shell state for future Beta/Gamma/Delta/Epsilon layers\n- keep the local demo runnable through npm run dev and npm run play with a lightweight static server\n\n## Testing\n- npm test\n- PORT=4174 node scripts/dev-server.mjs