### PR TITLE
Delta: [WEB-D1] rendre la couche intrigue plus lisible dans la démo web

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - `NiveauAlerte` suit une échelle stable de `latent` à `verrouille`, avec une intensité de surveillance associée à chaque palier
 - côté UI, le niveau d'alerte peut être transformé en badge lisible avec texte, ton, couleur, emphase, icône, progression et libellé accessible
 - côté UI, `buildIntrigueMapOverlay` agrège par lieu la présence de cellules et la menace de sabotage active dans une vue stable avec métriques, styles et niveaux de risque réutilisables pour la carte
+- côté UI, `buildIntrigueWebDemo` compose la couche intrigue pour la démo web avec badge d'alerte, hotspots triés, panneau simple des cellules et opérations actives, tout en réutilisant les composants intrigue existants
 - l'adaptateur `InMemoryIntrigueRepository` permet de stocker cellules et opérations clandestines en mémoire avec copies défensives et ordre de listing stable pour les tests et assemblages locaux
 - les tests Delta couvrent explicitement le risque de détection, l'exposition réseau, l'adaptateur mémoire intrigue et l'affichage du niveau d'alerte
 

--- a/src/ui/intrigue/buildIntrigueWebDemo.js
+++ b/src/ui/intrigue/buildIntrigueWebDemo.js
@@ -1,0 +1,195 @@
+import { Cellule } from '../../domain/intrigue/Cellule.js';
+import { OperationClandestine } from '../../domain/intrigue/OperationClandestine.js';
+import { buildAlertLevelBadge } from './AlertLevelBadge.js';
+import { buildIntrigueMapOverlay } from './buildIntrigueMapOverlay.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function normalizeCellule(cellule) {
+  if (cellule instanceof Cellule) {
+    return cellule;
+  }
+
+  if (cellule === null || typeof cellule !== 'object' || Array.isArray(cellule)) {
+    throw new TypeError('IntrigueWebDemo cellules must be Cellule instances or plain objects.');
+  }
+
+  return new Cellule(cellule);
+}
+
+function normalizeOperation(operation) {
+  if (operation instanceof OperationClandestine) {
+    return operation;
+  }
+
+  if (operation === null || typeof operation !== 'object' || Array.isArray(operation)) {
+    throw new TypeError('IntrigueWebDemo operations must be OperationClandestine instances or plain objects.');
+  }
+
+  return new OperationClandestine(operation);
+}
+
+function compareHotspots(left, right) {
+  if (right.sabotageRiskScore !== left.sabotageRiskScore) {
+    return right.sabotageRiskScore - left.sabotageRiskScore;
+  }
+
+  if (right.metrics.exposedCellCount !== left.metrics.exposedCellCount) {
+    return right.metrics.exposedCellCount - left.metrics.exposedCellCount;
+  }
+
+  return left.locationId.localeCompare(right.locationId);
+}
+
+function buildHotspotEntry(entry) {
+  return {
+    locationId: entry.locationId,
+    locationName: entry.locationName,
+    label: entry.label,
+    severity: entry.sabotageRiskLevel === 'high' || entry.metrics.exposedCellCount > 0
+      ? 'critical'
+      : entry.sabotageRiskLevel === 'medium' || entry.presenceLevel === 'high'
+        ? 'warning'
+        : 'watch',
+    sabotageRiskScore: entry.sabotageRiskScore,
+    presenceLevel: entry.presenceLevel,
+    sabotageRiskLevel: entry.sabotageRiskLevel,
+    exposedCellCount: entry.metrics.exposedCellCount,
+    sleeperCellCount: entry.metrics.sleeperCellCount,
+    celluleCount: entry.metrics.celluleCount,
+    operationCount: entry.metrics.sabotageOperationCount,
+    visualCue: `${entry.style.presence.marker} ${entry.style.risk.emphasis}`,
+  };
+}
+
+function buildCellulesPanel(cellules, locationNames) {
+  return cellules
+    .slice()
+    .sort((left, right) => {
+      if (right.exposure !== left.exposure) {
+        return right.exposure - left.exposure;
+      }
+
+      return left.id.localeCompare(right.id);
+    })
+    .map((cellule) => ({
+      celluleId: cellule.id,
+      codename: cellule.codename,
+      locationId: cellule.locationId,
+      locationName: locationNames[cellule.locationId] ?? cellule.locationId,
+      status: cellule.status,
+      sleeper: cellule.sleeper,
+      exposure: cellule.exposure,
+      readiness: cellule.operationalReadiness,
+      tone: cellule.isExposed ? 'danger' : cellule.sleeper ? 'muted' : 'normal',
+      badges: [
+        cellule.isExposed ? 'exposed' : null,
+        cellule.sleeper ? 'sleeper' : null,
+        `loyalty:${cellule.loyalty}`,
+        `secrecy:${cellule.secrecy}`,
+      ].filter(Boolean),
+    }));
+}
+
+function buildOperationsPanel(operations, locationNames) {
+  return operations
+    .filter((operation) => !operation.isResolved)
+    .slice()
+    .sort((left, right) => {
+      if (right.heat !== left.heat) {
+        return right.heat - left.heat;
+      }
+
+      if (right.progress !== left.progress) {
+        return right.progress - left.progress;
+      }
+
+      return left.id.localeCompare(right.id);
+    })
+    .map((operation) => ({
+      operationId: operation.id,
+      type: operation.type,
+      objective: operation.objective,
+      locationId: operation.theaterId,
+      locationName: locationNames[operation.theaterId] ?? operation.theaterId,
+      phase: operation.phase,
+      progress: operation.progress,
+      heat: operation.heat,
+      detectionRisk: operation.detectionRisk,
+      successWindow: operation.successWindow,
+      tone: operation.type === 'sabotage' && operation.heat >= 50 ? 'danger' : 'warning',
+    }));
+}
+
+export function buildIntrigueWebDemo(payload, options = {}) {
+  const normalizedPayload = requireObject(payload, 'IntrigueWebDemo payload');
+  const normalizedOptions = requireObject(options, 'IntrigueWebDemo options');
+  const locationNames = requireObject(normalizedOptions.locationNames ?? {}, 'IntrigueWebDemo locationNames');
+  const rawCellules = normalizedPayload.cellules === undefined ? [] : normalizedPayload.cellules;
+  const rawOperations = normalizedPayload.operations === undefined ? [] : normalizedPayload.operations;
+  const cellules = requireArray(rawCellules, 'IntrigueWebDemo payload.cellules').map(normalizeCellule);
+  const operations = requireArray(rawOperations, 'IntrigueWebDemo payload.operations').map(normalizeOperation);
+  const mapOverlay = buildIntrigueMapOverlay(cellules, operations, {
+    locationNames,
+    styleByPresence: normalizedOptions.styleByPresence ?? {},
+    styleByRisk: normalizedOptions.styleByRisk ?? {},
+  });
+  const alertBadge = buildAlertLevelBadge(normalizedPayload.alertLevel ?? 0, {
+    prefix: normalizedOptions.alertPrefix ?? 'Alerte',
+  });
+  const hotspots = mapOverlay.map(buildHotspotEntry).sort(compareHotspots);
+  const exposedCellCount = cellules.filter((cellule) => cellule.isExposed).length;
+  const sleeperCellCount = cellules.filter((cellule) => cellule.sleeper).length;
+  const activeSabotageCount = operations.filter((operation) => operation.type === 'sabotage' && !operation.isResolved).length;
+  const criticalHotspotCount = hotspots.filter((hotspot) => hotspot.severity === 'critical').length;
+
+  return {
+    title: 'Couches intrigue',
+    summary: `${criticalHotspotCount} foyers critiques, ${activeSabotageCount} sabotages actifs, alerte ${alertBadge.level.label.toLowerCase()}`,
+    alertBadge,
+    map: {
+      title: 'Couche intrigue',
+      entries: mapOverlay,
+      legend: {
+        presenceLevels: [
+          { code: 'low', label: 'Présence faible', marker: '◔' },
+          { code: 'medium', label: 'Présence moyenne', marker: '◑' },
+          { code: 'high', label: 'Présence forte', marker: '●' },
+        ],
+        riskLevels: [
+          { code: 'low', label: 'Risque faible', emphasis: 'normal' },
+          { code: 'medium', label: 'Risque sensible', emphasis: 'elevated' },
+          { code: 'high', label: 'Risque critique', emphasis: 'high' },
+        ],
+      },
+    },
+    hotspots,
+    panels: {
+      cellules: buildCellulesPanel(cellules, locationNames),
+      operations: buildOperationsPanel(operations, locationNames),
+    },
+    metrics: {
+      locationCount: mapOverlay.length,
+      celluleCount: cellules.length,
+      exposedCellCount,
+      sleeperCellCount,
+      activeOperationCount: operations.filter((operation) => !operation.isResolved).length,
+      activeSabotageCount,
+      criticalHotspotCount,
+    },
+  };
+}

--- a/test/ui/intrigue/buildIntrigueWebDemo.test.js
+++ b/test/ui/intrigue/buildIntrigueWebDemo.test.js
@@ -1,0 +1,226 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Cellule } from '../../../src/domain/intrigue/Cellule.js';
+import { OperationClandestine } from '../../../src/domain/intrigue/OperationClandestine.js';
+import { buildIntrigueWebDemo } from '../../../src/ui/intrigue/buildIntrigueWebDemo.js';
+
+test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the web demo', () => {
+  const demo = buildIntrigueWebDemo({
+    alertLevel: 'critique',
+    cellules: [
+      new Cellule({
+        id: 'cell-ash-1',
+        factionId: 'shadow-league',
+        codename: 'Veil',
+        locationId: 'ashlands',
+        memberIds: ['ag-1'],
+        assetIds: ['asset-1'],
+        secrecy: 72,
+        loyalty: 66,
+        exposure: 21,
+      }),
+      new Cellule({
+        id: 'cell-ash-2',
+        factionId: 'shadow-league',
+        codename: 'Cinder',
+        locationId: 'ashlands',
+        memberIds: ['ag-2'],
+        assetIds: ['asset-2'],
+        secrecy: 49,
+        loyalty: 55,
+        exposure: 74,
+        sleeper: true,
+      }),
+      new Cellule({
+        id: 'cell-river-1',
+        factionId: 'shadow-league',
+        codename: 'Mist',
+        locationId: 'riverlands',
+        memberIds: ['ag-3'],
+        assetIds: ['asset-3'],
+        secrecy: 61,
+        loyalty: 62,
+        exposure: 15,
+      }),
+    ],
+    operations: [
+      new OperationClandestine({
+        id: 'op-ash-1',
+        celluleId: 'cell-ash-1',
+        targetFactionId: 'sun-empire',
+        type: 'sabotage',
+        objective: 'Cut the signal towers',
+        theaterId: 'ashlands',
+        assignedAgentIds: ['ag-1'],
+        requiredAssetIds: ['asset-1'],
+        detectionRisk: 20,
+        progress: 58,
+        heat: 44,
+        phase: 'execution',
+      }),
+      new OperationClandestine({
+        id: 'op-river-1',
+        celluleId: 'cell-river-1',
+        targetFactionId: 'sun-empire',
+        type: 'sabotage',
+        objective: 'Poison the ferries',
+        theaterId: 'riverlands',
+        assignedAgentIds: ['ag-3'],
+        requiredAssetIds: ['asset-3'],
+        detectionRisk: 70,
+        progress: 20,
+        heat: 10,
+        phase: 'infiltration',
+      }),
+      new OperationClandestine({
+        id: 'op-rumor',
+        celluleId: 'cell-river-1',
+        targetFactionId: 'sun-empire',
+        type: 'rumor',
+        objective: 'Spread false orders',
+        theaterId: 'riverlands',
+        assignedAgentIds: ['ag-3'],
+        requiredAssetIds: ['asset-3'],
+        phase: 'execution',
+      }),
+    ],
+  }, {
+    locationNames: {
+      ashlands: 'Ashlands',
+      riverlands: 'Riverlands',
+    },
+  });
+
+  assert.equal(demo.title, 'Couches intrigue');
+  assert.equal(demo.summary, '1 foyers critiques, 2 sabotages actifs, alerte critique');
+  assert.equal(demo.alertBadge.level.code, 'critique');
+  assert.equal(demo.map.entries.length, 2);
+  assert.deepEqual(demo.hotspots, [
+    {
+      locationId: 'ashlands',
+      locationName: 'Ashlands',
+      label: 'Ashlands, présence medium, risque sabotage medium',
+      severity: 'critical',
+      sabotageRiskScore: 61,
+      presenceLevel: 'medium',
+      sabotageRiskLevel: 'medium',
+      exposedCellCount: 1,
+      sleeperCellCount: 1,
+      celluleCount: 2,
+      operationCount: 1,
+      visualCue: '◑ elevated',
+    },
+    {
+      locationId: 'riverlands',
+      locationName: 'Riverlands',
+      label: 'Riverlands, présence low, risque sabotage low',
+      severity: 'watch',
+      sabotageRiskScore: 20,
+      presenceLevel: 'low',
+      sabotageRiskLevel: 'low',
+      exposedCellCount: 0,
+      sleeperCellCount: 0,
+      celluleCount: 1,
+      operationCount: 1,
+      visualCue: '◔ normal',
+    },
+  ]);
+  assert.deepEqual(demo.panels.cellules[0], {
+    celluleId: 'cell-ash-2',
+    codename: 'Cinder',
+    locationId: 'ashlands',
+    locationName: 'Ashlands',
+    status: 'active',
+    sleeper: true,
+    exposure: 74,
+    readiness: 43,
+    tone: 'danger',
+    badges: ['exposed', 'sleeper', 'loyalty:55', 'secrecy:49'],
+  });
+  assert.deepEqual(demo.panels.operations[0], {
+    operationId: 'op-ash-1',
+    type: 'sabotage',
+    objective: 'Cut the signal towers',
+    locationId: 'ashlands',
+    locationName: 'Ashlands',
+    phase: 'execution',
+    progress: 58,
+    heat: 44,
+    detectionRisk: 20,
+    successWindow: 88,
+    tone: 'warning',
+  });
+  assert.deepEqual(demo.metrics, {
+    locationCount: 2,
+    celluleCount: 3,
+    exposedCellCount: 1,
+    sleeperCellCount: 1,
+    activeOperationCount: 3,
+    activeSabotageCount: 2,
+    criticalHotspotCount: 1,
+  });
+});
+
+test('buildIntrigueWebDemo supports plain payloads and option overrides', () => {
+  const demo = buildIntrigueWebDemo({
+    alertLevel: 2,
+    cellules: [{
+      id: 'cell-delta-1',
+      factionId: 'shadow-league',
+      codename: 'Wake',
+      locationId: 'delta',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      secrecy: 60,
+      loyalty: 60,
+      exposure: 10,
+    }],
+    operations: [{
+      id: 'op-delta-1',
+      celluleId: 'cell-delta-1',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Disable the sluice gates',
+      theaterId: 'delta',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 5,
+      progress: 90,
+      heat: 30,
+      phase: 'execution',
+    }],
+  }, {
+    alertPrefix: 'Sécurité',
+    styleByPresence: {
+      low: { marker: '✦', color: '#10B981', opacity: 0.7 },
+    },
+    styleByRisk: {
+      high: { stroke: '#111827', fill: '#F59E0B', emphasis: 'critical' },
+    },
+  });
+
+  assert.equal(demo.alertBadge.text, 'Sécurité Renforcé');
+  assert.deepEqual(demo.map.entries[0].style, {
+    presence: {
+      marker: '✦',
+      color: '#10B981',
+      opacity: 0.7,
+    },
+    risk: {
+      stroke: '#111827',
+      fill: '#F59E0B',
+      emphasis: 'critical',
+    },
+  });
+});
+
+test('buildIntrigueWebDemo rejects invalid inputs', () => {
+  assert.throws(() => buildIntrigueWebDemo(null), /payload must be an object/);
+  assert.throws(() => buildIntrigueWebDemo({ cellules: null, operations: [] }), /payload.cellules must be an array/);
+  assert.throws(() => buildIntrigueWebDemo({ cellules: [], operations: null }), /payload.operations must be an array/);
+  assert.throws(() => buildIntrigueWebDemo({ cellules: [null], operations: [] }), /Cellule instances or plain objects/);
+  assert.throws(() => buildIntrigueWebDemo({ cellules: [], operations: [null] }), /OperationClandestine instances or plain objects/);
+  assert.throws(() => buildIntrigueWebDemo({ cellules: [], operations: [] }, null), /options must be an object/);
+  assert.throws(() => buildIntrigueWebDemo({ cellules: [], operations: [] }, { locationNames: [] }), /locationNames must be an object/);
+});


### PR DESCRIPTION
Closes #264

## Summary
- add `buildIntrigueWebDemo` to compose the Delta web demo layer from existing intrigue UI helpers
- expose an alert badge, sorted hotspots, and simple panels for cellules and active operations
- document the new helper and cover the web demo assembly with focused tests

## Testing
- npm test