### PR TITLE
Gamma: [WEB-G1] renforcer la couche culture, découvertes et événements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - `CultureRepositoryPort`, `ResearchRepositoryPort`, `InMemoryCultureRepository` et `InMemoryResearchRepository` fournissent une base hexagonale légère pour stocker cultures et recherches avec copies défensives et ordre stable
 - `loadHistoricalEventsFromJson` et `loadResearchStatesFromJson` chargent des contenus JSON normalisés avec valeurs par défaut utiles et erreurs explicites sur les payloads invalides
 - côté UI, `buildDiscoveriesPanel` expose les concepts découverts, recherches débloquées et événements liés dans une vue structurée réutilisable
-- côté carte, `buildCultureMapOverlay` transforme cultures, recherches et événements historiques en marqueurs régionaux stables pour afficher découvertes et repères culturels sur la carte
-- les tests Gamma couvrent explicitement les use cases de recherche, dérive culturelle, divergence, déclenchement d’événements, ports, adaptateurs mémoire, chargeurs JSON et UI des découvertes
+- côté UI, `buildCultureLayerPanel` assemble un focus lisible par région et culture pour explorer les marqueurs, découvertes et événements historiques depuis la carte
+- côté carte, `buildCultureMapOverlay` transforme cultures, recherches et événements historiques en marqueurs régionaux stables avec score d'influence, tier visuel, highlights et zoneStyle pour mieux distinguer les zones culturelles
+- les tests Gamma couvrent explicitement les use cases de recherche, dérive culturelle, divergence, déclenchement d’événements, ports, adaptateurs mémoire, chargeurs JSON et UI des découvertes et de la couche culturelle
 
 ## Règles Delta, intrigue et opérations clandestines
 - `LancerOperation` vérifie la disponibilité de la cellule, des agents assignés et des assets requis avant tout lancement

--- a/src/ui/culture/buildCultureLayerPanel.js
+++ b/src/ui/culture/buildCultureLayerPanel.js
@@ -1,0 +1,140 @@
+import { buildDiscoveriesPanel } from './buildDiscoveriesPanel.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeEntries(entries) {
+  if (!Array.isArray(entries)) {
+    throw new TypeError('CultureLayerPanel entries must be an array.');
+  }
+
+  return entries.map((entry, index) => {
+    const normalizedEntry = requireObject(entry, `CultureLayerPanel entries[${index}]`);
+
+    return {
+      overlayId: requireText(normalizedEntry.overlayId, `CultureLayerPanel entries[${index}].overlayId`),
+      regionId: requireText(normalizedEntry.regionId, `CultureLayerPanel entries[${index}].regionId`),
+      cultureId: requireText(normalizedEntry.cultureId, `CultureLayerPanel entries[${index}].cultureId`),
+      cultureName: requireText(normalizedEntry.cultureName, `CultureLayerPanel entries[${index}].cultureName`),
+      label: requireText(normalizedEntry.label, `CultureLayerPanel entries[${index}].label`),
+      summary: String(normalizedEntry.summary ?? '').trim(),
+      influenceScore: Number.isFinite(normalizedEntry.influenceScore) ? normalizedEntry.influenceScore : 0,
+      influenceTier: String(normalizedEntry.influenceTier ?? 'faint').trim() || 'faint',
+      discoveries: Array.isArray(normalizedEntry.discoveries) ? [...normalizedEntry.discoveries].sort() : [],
+      unlockedResearchIds: Array.isArray(normalizedEntry.unlockedResearchIds) ? [...normalizedEntry.unlockedResearchIds].sort() : [],
+      eventIds: Array.isArray(normalizedEntry.eventIds) ? [...normalizedEntry.eventIds].sort() : [],
+      eventTitles: Array.isArray(normalizedEntry.eventTitles) ? [...normalizedEntry.eventTitles].sort() : [],
+      identityTags: Array.isArray(normalizedEntry.identityTags) ? [...normalizedEntry.identityTags].sort() : [],
+      highlights: Array.isArray(normalizedEntry.highlights) ? [...normalizedEntry.highlights].sort() : [],
+      markerType: String(normalizedEntry.markerType ?? 'balanced').trim() || 'balanced',
+      primaryLanguage: String(normalizedEntry.primaryLanguage ?? '').trim() || null,
+    };
+  });
+}
+
+function buildRegionRows(entries) {
+  return [...new Set(entries.map((entry) => entry.regionId))]
+    .sort()
+    .map((regionId) => {
+      const regionEntries = entries
+        .filter((entry) => entry.regionId === regionId)
+        .sort((left, right) => right.influenceScore - left.influenceScore || left.cultureName.localeCompare(right.cultureName));
+      const dominantEntry = regionEntries[0] ?? null;
+
+      return {
+        regionId,
+        markerCount: regionEntries.length,
+        dominantCultureId: dominantEntry?.cultureId ?? null,
+        dominantCultureName: dominantEntry?.cultureName ?? null,
+        influenceTier: dominantEntry?.influenceTier ?? 'faint',
+        influenceScore: dominantEntry?.influenceScore ?? 0,
+        highlights: [...new Set(regionEntries.flatMap((entry) => entry.highlights))].slice(0, 4),
+        markerIds: regionEntries.map((entry) => entry.overlayId),
+      };
+    });
+}
+
+function buildFocus(entries, normalizedOptions) {
+  const selectedRegionId = normalizedOptions.selectedRegionId ? requireText(normalizedOptions.selectedRegionId, 'CultureLayerPanel options.selectedRegionId') : null;
+  const selectedCultureId = normalizedOptions.selectedCultureId ? requireText(normalizedOptions.selectedCultureId, 'CultureLayerPanel options.selectedCultureId') : null;
+  const historicalEventsByCulture = requireObject(
+    normalizedOptions.historicalEventsByCulture ?? {},
+    'CultureLayerPanel historicalEventsByCulture',
+  );
+
+  const focusedEntry = entries.find((entry) => (
+    (selectedRegionId === null || entry.regionId === selectedRegionId)
+      && (selectedCultureId === null || entry.cultureId === selectedCultureId)
+  )) ?? entries[0] ?? null;
+
+  if (!focusedEntry) {
+    return null;
+  }
+
+  return {
+    regionId: focusedEntry.regionId,
+    cultureId: focusedEntry.cultureId,
+    cultureName: focusedEntry.cultureName,
+    label: focusedEntry.label,
+    summary: focusedEntry.summary,
+    markerType: focusedEntry.markerType,
+    influenceScore: focusedEntry.influenceScore,
+    influenceTier: focusedEntry.influenceTier,
+    primaryLanguage: focusedEntry.primaryLanguage,
+    highlights: focusedEntry.highlights,
+    discoveriesPanel: buildDiscoveriesPanel(
+      {
+        cultureId: focusedEntry.cultureId,
+        discoveredConceptIds: focusedEntry.discoveries,
+        unlockedResearchIds: focusedEntry.unlockedResearchIds,
+      },
+      {
+        historicalEvents: historicalEventsByCulture[focusedEntry.cultureId] ?? focusedEntry.eventTitles.map((title, index) => ({
+          id: focusedEntry.eventIds[index] ?? `${focusedEntry.cultureId}:event:${index}`,
+          title,
+          discoveryIds: focusedEntry.discoveries,
+          unlockedResearchIds: focusedEntry.unlockedResearchIds,
+        })),
+      },
+    ),
+  };
+}
+
+export function buildCultureLayerPanel(entries, options = {}) {
+  const normalizedEntries = normalizeEntries(entries);
+  const normalizedOptions = requireObject(options, 'CultureLayerPanel options');
+  const title = String(normalizedOptions.title ?? 'Couche culturelle').trim() || 'Couche culturelle';
+  const regionRows = buildRegionRows(normalizedEntries);
+  const focus = buildFocus(normalizedEntries, normalizedOptions);
+
+  return {
+    title,
+    summary: `${normalizedEntries.length} marqueurs, ${regionRows.length} régions, ${regionRows.filter((row) => row.influenceTier === 'dominant' || row.influenceTier === 'strong').length} zones d'influence fortes`,
+    markers: normalizedEntries
+      .slice()
+      .sort((left, right) => left.regionId.localeCompare(right.regionId) || right.influenceScore - left.influenceScore),
+    regions: regionRows,
+    focus,
+    metrics: {
+      markerCount: normalizedEntries.length,
+      regionCount: regionRows.length,
+      strongInfluenceRegionCount: regionRows.filter((row) => row.influenceTier === 'dominant' || row.influenceTier === 'strong').length,
+      cultureCount: new Set(normalizedEntries.map((entry) => entry.cultureId)).size,
+    },
+  };
+}

--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -114,6 +114,64 @@ function buildMarkerType(culture) {
   return 'balanced';
 }
 
+function clampScore(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function buildInfluenceScore(culture, signals) {
+  return clampScore(
+    (culture.openness * 0.2)
+    + (culture.cohesion * 0.3)
+    + (culture.researchDrive * 0.3)
+    + (signals.highlightedDiscoveries.length * 6)
+    + (signals.eventCount * 5)
+  );
+}
+
+function buildInfluenceTier(influenceScore) {
+  if (influenceScore >= 85) {
+    return 'dominant';
+  }
+
+  if (influenceScore >= 65) {
+    return 'strong';
+  }
+
+  if (influenceScore >= 40) {
+    return 'emerging';
+  }
+
+  return 'faint';
+}
+
+function buildZoneStyle(markerType, influenceTier, style) {
+  const opacityByTier = {
+    dominant: 0.85,
+    strong: 0.7,
+    emerging: 0.55,
+    faint: 0.35,
+  };
+
+  return {
+    fill: style.color,
+    outline: style.color,
+    markerIcon: style.icon,
+    emphasis: style.emphasis,
+    opacity: opacityByTier[influenceTier] ?? 0.35,
+    pattern: markerType === 'traditional'
+      ? 'woven'
+      : markerType === 'fragmented'
+        ? 'fractured'
+        : markerType === 'innovation'
+          ? 'radiant'
+          : 'solid',
+  };
+}
+
 function summarizeSignals(culture, researchStates, historicalEvents) {
   const discoveredConceptIds = new Set();
   const unlockedResearchIds = new Set();
@@ -185,7 +243,10 @@ export function buildCultureMapOverlay(payload, options = {}) {
       const cultureHistoricalEvents = historicalEvents.filter((historicalEvent) => historicalEvent.affectsCulture(culture.id));
       const signals = summarizeSignals(culture, cultureResearchStates, cultureHistoricalEvents);
       const markerType = buildMarkerType(culture);
+      const influenceScore = buildInfluenceScore(culture, signals);
+      const influenceTier = buildInfluenceTier(influenceScore);
       const regionIds = regionIdsByCulture[culture.id] ?? [];
+      const style = normalizeStyle(styleByMarkerType, markerType);
 
       return regionIds.map((regionId) => ({
         overlayId: `${regionId}:${culture.id}`,
@@ -195,20 +256,28 @@ export function buildCultureMapOverlay(payload, options = {}) {
         archetype: culture.archetype,
         primaryLanguage: culture.primaryLanguage,
         markerType,
+        influenceScore,
+        influenceTier,
         label: `${culture.name} (${signals.highlightedDiscoveries.length} découvertes)`,
         summary: `${signals.activeResearchCount} recherches actives, ${signals.eventCount} événements, ${signals.identityTags.length} repères culturels`,
         discoveries: signals.highlightedDiscoveries,
         unlockedResearchIds: signals.unlockedResearchIds,
         activeResearchCount: signals.activeResearchCount,
         eventIds: signals.eventIds,
+        eventTitles: cultureHistoricalEvents.map((historicalEvent) => historicalEvent.title).sort(),
         eventCount: signals.eventCount,
         identityTags: signals.identityTags,
+        highlights: [
+          ...signals.highlightedDiscoveries.slice(0, 2),
+          ...signals.identityTags.slice(0, Math.max(0, 3 - Math.min(2, signals.highlightedDiscoveries.length))),
+        ],
         cultureMetrics: {
           openness: culture.openness,
           cohesion: culture.cohesion,
           researchDrive: culture.researchDrive,
         },
-        style: normalizeStyle(styleByMarkerType, markerType),
+        style,
+        zoneStyle: buildZoneStyle(markerType, influenceTier, style),
       }));
     })
     .sort((left, right) => {

--- a/test/ui/culture/buildCultureLayerPanel.test.js
+++ b/test/ui/culture/buildCultureLayerPanel.test.js
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCultureLayerPanel } from '../../../src/ui/culture/buildCultureLayerPanel.js';
+
+test('buildCultureLayerPanel summarizes regions and exposes a readable focus panel', () => {
+  const panel = buildCultureLayerPanel(
+    [
+      {
+        overlayId: 'archipelago:culture-north',
+        regionId: 'archipelago',
+        cultureId: 'culture-north',
+        cultureName: 'Northern League',
+        label: 'Northern League (3 découvertes)',
+        summary: '1 recherches actives, 1 événements, 3 repères culturels',
+        influenceScore: 70,
+        influenceTier: 'strong',
+        discoveries: ['public-catalogue', 'star-maps', 'tidal-ledgers'],
+        unlockedResearchIds: ['astrolabe'],
+        eventIds: ['event-open-archives'],
+        eventTitles: ['Open Archives'],
+        identityTags: ['assemblies', 'navigation', 'trade'],
+        highlights: ['assemblies', 'public-catalogue', 'star-maps'],
+        markerType: 'innovation',
+        primaryLanguage: 'north-tongue',
+      },
+      {
+        overlayId: 'high-steppe:culture-steppe',
+        regionId: 'high-steppe',
+        cultureId: 'culture-steppe',
+        cultureName: 'Steppe Houses',
+        label: 'Steppe Houses (1 découvertes)',
+        summary: '0 recherches actives, 0 événements, 2 repères culturels',
+        influenceScore: 46,
+        influenceTier: 'emerging',
+        discoveries: ['stirrup-drill'],
+        unlockedResearchIds: ['composite-saddles'],
+        eventIds: [],
+        eventTitles: [],
+        identityTags: ['clan-oaths', 'honor'],
+        highlights: ['honor', 'stirrup-drill'],
+        markerType: 'traditional',
+        primaryLanguage: 'horse-speech',
+      },
+    ],
+    {
+      selectedRegionId: 'archipelago',
+      historicalEventsByCulture: {
+        'culture-north': [
+          {
+            id: 'event-open-archives',
+            title: 'Open Archives',
+            discoveryIds: ['public-catalogue'],
+            unlockedResearchIds: ['astrolabe'],
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(panel.title, 'Couche culturelle');
+  assert.equal(panel.summary, "2 marqueurs, 2 régions, 1 zones d'influence fortes");
+  assert.deepEqual(panel.regions, [
+    {
+      regionId: 'archipelago',
+      markerCount: 1,
+      dominantCultureId: 'culture-north',
+      dominantCultureName: 'Northern League',
+      influenceTier: 'strong',
+      influenceScore: 70,
+      highlights: ['assemblies', 'public-catalogue', 'star-maps'],
+      markerIds: ['archipelago:culture-north'],
+    },
+    {
+      regionId: 'high-steppe',
+      markerCount: 1,
+      dominantCultureId: 'culture-steppe',
+      dominantCultureName: 'Steppe Houses',
+      influenceTier: 'emerging',
+      influenceScore: 46,
+      highlights: ['honor', 'stirrup-drill'],
+      markerIds: ['high-steppe:culture-steppe'],
+    },
+  ]);
+  assert.equal(panel.focus.cultureId, 'culture-north');
+  assert.equal(panel.focus.discoveriesPanel.summary, '3 concepts, 1 recherches, 1 événements');
+  assert.deepEqual(panel.metrics, {
+    markerCount: 2,
+    regionCount: 2,
+    strongInfluenceRegionCount: 1,
+    cultureCount: 2,
+  });
+});
+
+test('buildCultureLayerPanel falls back to the first marker and validates inputs', () => {
+  const panel = buildCultureLayerPanel([
+    {
+      overlayId: 'delta:culture-delta',
+      regionId: 'delta',
+      cultureId: 'culture-delta',
+      cultureName: 'Delta Scribes',
+      label: 'Delta Scribes (0 découvertes)',
+      summary: '0 recherches actives, 0 événements, 1 repères culturels',
+    },
+  ]);
+
+  assert.equal(panel.focus.cultureId, 'culture-delta');
+  assert.throws(() => buildCultureLayerPanel(null), /entries must be an array/);
+  assert.throws(() => buildCultureLayerPanel([null]), /entries\[0\] must be an object/);
+  assert.throws(() => buildCultureLayerPanel([], null), /options must be an object/);
+  assert.throws(() => buildCultureLayerPanel([], { historicalEventsByCulture: [] }), /historicalEventsByCulture must be an object/);
+});

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -83,14 +83,18 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
       archetype: 'maritime',
       primaryLanguage: 'north-tongue',
       markerType: 'innovation',
+      influenceScore: 79,
+      influenceTier: 'strong',
       label: 'Northern League (3 découvertes)',
       summary: '1 recherches actives, 1 événements, 3 repères culturels',
       discoveries: ['public-catalogue', 'star-maps', 'tidal-ledgers'],
       unlockedResearchIds: ['astrolabe'],
       activeResearchCount: 1,
       eventIds: ['event-open-archives'],
+      eventTitles: ['Open Archives'],
       eventCount: 1,
       identityTags: ['assemblies', 'navigation', 'trade'],
+      highlights: ['public-catalogue', 'star-maps', 'assemblies'],
       cultureMetrics: {
         openness: 72,
         cohesion: 61,
@@ -100,6 +104,14 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
         color: 'violet',
         icon: '✦',
         emphasis: 'high',
+      },
+      zoneStyle: {
+        fill: 'violet',
+        outline: 'violet',
+        markerIcon: '✦',
+        emphasis: 'high',
+        opacity: 0.7,
+        pattern: 'radiant',
       },
     },
     {
@@ -110,14 +122,18 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
       archetype: 'nomadic',
       primaryLanguage: 'horse-speech',
       markerType: 'traditional',
+      influenceScore: 45,
+      influenceTier: 'emerging',
       label: 'Steppe Houses (1 découvertes)',
       summary: '0 recherches actives, 0 événements, 2 repères culturels',
       discoveries: ['stirrup-drill'],
       unlockedResearchIds: ['composite-saddles'],
       activeResearchCount: 0,
       eventIds: [],
+      eventTitles: [],
       eventCount: 0,
       identityTags: ['clan-oaths', 'honor'],
+      highlights: ['stirrup-drill', 'clan-oaths', 'honor'],
       cultureMetrics: {
         openness: 35,
         cohesion: 67,
@@ -128,6 +144,14 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
         icon: '⬢',
         emphasis: 'normal',
       },
+      zoneStyle: {
+        fill: 'amber',
+        outline: 'amber',
+        markerIcon: '⬢',
+        emphasis: 'normal',
+        opacity: 0.55,
+        pattern: 'woven',
+      },
     },
     {
       overlayId: 'north-coast:culture-north',
@@ -137,14 +161,18 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
       archetype: 'maritime',
       primaryLanguage: 'north-tongue',
       markerType: 'innovation',
+      influenceScore: 79,
+      influenceTier: 'strong',
       label: 'Northern League (3 découvertes)',
       summary: '1 recherches actives, 1 événements, 3 repères culturels',
       discoveries: ['public-catalogue', 'star-maps', 'tidal-ledgers'],
       unlockedResearchIds: ['astrolabe'],
       activeResearchCount: 1,
       eventIds: ['event-open-archives'],
+      eventTitles: ['Open Archives'],
       eventCount: 1,
       identityTags: ['assemblies', 'navigation', 'trade'],
+      highlights: ['public-catalogue', 'star-maps', 'assemblies'],
       cultureMetrics: {
         openness: 72,
         cohesion: 61,
@@ -154,6 +182,14 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
         color: 'violet',
         icon: '✦',
         emphasis: 'high',
+      },
+      zoneStyle: {
+        fill: 'violet',
+        outline: 'violet',
+        markerIcon: '✦',
+        emphasis: 'high',
+        opacity: 0.7,
+        pattern: 'radiant',
       },
     },
   ]);
@@ -192,6 +228,8 @@ test('buildCultureMapOverlay supports plain payloads and style overrides', () =>
     emphasis: 'critical',
   });
   assert.equal(overlay[0].markerType, 'fragmented');
+  assert.equal(overlay[0].influenceTier, 'faint');
+  assert.equal(overlay[0].zoneStyle.pattern, 'fractured');
 });
 
 test('buildCultureMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
## Résumé
- enrichit `buildCultureMapOverlay` avec score d'influence, tier visuel, highlights et `zoneStyle` pour mieux distinguer les zones culturelles sur la carte
- ajoute `buildCultureLayerPanel` pour exposer un focus lisible par région/culture avec découvertes, recherches et événements historiques
- étend les tests UI Gamma et la documentation README pour couvrir cette couche culturelle plus lisible

## Tests
- `node --test test/ui/culture/buildCultureMapOverlay.test.js test/ui/culture/buildCultureLayerPanel.test.js test/ui/culture/buildDiscoveriesPanel.test.js`
- `npm test`

## Notes
- le repo ne contient pas aujourd'hui de script `npm run dev`; la validation locale disponible ici passe par les builders UI et leur suite de tests
- clôt #263
