### PR TITLE
Alpha: [WEB-A2] rendre la carte plus visuelle qu'une simple grille

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -193,6 +193,53 @@ const state = {
   activeOverlaySlot: 'economy-overlay',
 };
 
+function getProvinceCenter(provinceId) {
+  const layout = provinceLayouts[provinceId];
+
+  if (!layout) {
+    return null;
+  }
+
+  return {
+    x: layout.x + (layout.w / 2),
+    y: layout.y + (layout.h / 2),
+  };
+}
+
+function buildProvinceRelations(shell) {
+  const uniqueRelations = new Map();
+
+  shell.provinces.forEach((province) => {
+    province.neighborIds.forEach((neighborId) => {
+      const relationId = [province.provinceId, neighborId].sort().join('::');
+
+      if (uniqueRelations.has(relationId)) {
+        return;
+      }
+
+      const origin = getProvinceCenter(province.provinceId);
+      const destination = getProvinceCenter(neighborId);
+
+      if (!origin || !destination) {
+        return;
+      }
+
+      const contested = province.contested || shell.provinces.some(
+        (candidate) => candidate.provinceId === neighborId && candidate.contested,
+      );
+
+      uniqueRelations.set(relationId, {
+        relationId,
+        origin,
+        destination,
+        contested,
+      });
+    });
+  });
+
+  return [...uniqueRelations.values()];
+}
+
 function getShell() {
   return buildStrategicMapShell(provinces, {
     title: 'Écran stratégique, théâtre continental',
@@ -259,15 +306,24 @@ function renderProvinceCard(province) {
     province.contested ? 'is-contested' : '',
     province.occupied ? 'is-occupied' : '',
   ].filter(Boolean).join(' ');
+  const silhouetteByProvinceId = {
+    'north-watch': 'polygon(10% 18%, 66% 6%, 92% 34%, 84% 88%, 28% 94%, 8% 58%)',
+    'crown-heart': 'polygon(8% 20%, 52% 4%, 90% 18%, 92% 74%, 54% 94%, 10% 78%)',
+    'red-ridge': 'polygon(16% 16%, 74% 8%, 94% 38%, 82% 92%, 22% 88%, 6% 44%)',
+    'river-gate': 'polygon(14% 10%, 86% 18%, 92% 54%, 74% 92%, 22% 86%, 6% 40%)',
+    'iron-plain': 'polygon(8% 24%, 48% 6%, 92% 28%, 88% 80%, 44% 96%, 6% 74%)',
+    'southern-reach': 'polygon(16% 14%, 78% 8%, 94% 46%, 74% 90%, 24% 92%, 6% 48%)',
+  };
 
   return `
     <button
       class="${classes}"
       type="button"
       data-province-id="${province.provinceId}"
-      style="left:${layout.x}%;top:${layout.y}%;width:${layout.w}%;height:${layout.h}%;--province-fill:${province.style.fill};--province-border:${province.style.border};"
+      style="left:${layout.x}%;top:${layout.y}%;width:${layout.w}%;height:${layout.h}%;--province-fill:${province.style.fill};--province-border:${province.style.border};--province-shape:${silhouetteByProvinceId[province.provinceId] ?? 'polygon(12% 12%, 88% 12%, 88% 88%, 12% 88%)'};"
       aria-pressed="${province.selectionState.selected}"
     >
+      <span class="province-node__terrain"></span>
       <span class="province-node__name">${province.label}</span>
       <span class="province-node__meta">${province.supplyTone} · loyauté ${province.loyalty}</span>
       <span class="province-node__badges">${badges}</span>
@@ -472,6 +528,52 @@ function renderBottomTray(economyView) {
   `;
 }
 
+function renderStrategicRelations(shell) {
+  const relationLines = buildProvinceRelations(shell).map((relation) => `
+    <line
+      class="front-line ${relation.contested ? 'is-contested' : ''}"
+      x1="${relation.origin.x}%"
+      y1="${relation.origin.y}%"
+      x2="${relation.destination.x}%"
+      y2="${relation.destination.y}%"
+    />
+  `).join('');
+
+  const hotspots = shell.provinces
+    .filter((province) => province.contested || province.occupied)
+    .map((province) => {
+      const center = getProvinceCenter(province.provinceId);
+      if (!center) {
+        return '';
+      }
+
+      return `
+        <g class="front-hotspot ${province.contested ? 'is-contested' : 'is-occupied'}">
+          <circle cx="${center.x}%" cy="${center.y}%" r="2.3"></circle>
+          <text x="${center.x}%" y="${center.y - 4}%" text-anchor="middle">${province.contested ? 'Front' : 'Occupation'}</text>
+        </g>
+      `;
+    }).join('');
+
+  return `
+    <svg class="strategic-relations-layer" viewBox="0 0 100 100" aria-label="Relations entre provinces et lignes de front">
+      ${relationLines}
+      ${hotspots}
+    </svg>
+  `;
+}
+
+function renderTerrainDecor() {
+  return `
+    <div class="terrain-mass terrain-mass--north"></div>
+    <div class="terrain-mass terrain-mass--east"></div>
+    <div class="terrain-mass terrain-mass--south"></div>
+    <div class="terrain-river"></div>
+    <div class="terrain-contours terrain-contours--a"></div>
+    <div class="terrain-contours terrain-contours--b"></div>
+  `;
+}
+
 function render() {
   const shell = getShell();
   const economyView = getEconomyViewModel();
@@ -503,6 +605,8 @@ function render() {
           </div>
           <div class="map-stage">
             <div class="map-backdrop"></div>
+            ${renderTerrainDecor()}
+            ${renderStrategicRelations(shell)}
             <div id="top-hud" class="overlay-anchor-shell overlay-anchor-shell--top">Top HUD</div>
             <div id="left-rail" class="overlay-anchor-shell overlay-anchor-shell--left">Left rail</div>
             <div id="right-rail" class="overlay-anchor-shell overlay-anchor-shell--right">Right rail</div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -105,14 +105,15 @@ button { font: inherit; }
   border-radius: 24px;
   border: 1px solid rgba(148, 163, 184, 0.16);
   background: linear-gradient(180deg, rgba(14, 116, 144, 0.12), rgba(14, 165, 233, 0.04));
+  isolation: isolate;
 }
 .map-backdrop {
   position: absolute; inset: 0;
   background:
-    radial-gradient(circle at 20% 24%, rgba(59, 130, 246, 0.28), transparent 18%),
-    radial-gradient(circle at 74% 26%, rgba(239, 68, 68, 0.24), transparent 16%),
-    radial-gradient(circle at 48% 64%, rgba(34, 197, 94, 0.16), transparent 18%),
-    linear-gradient(135deg, rgba(15, 23, 42, 0.82), rgba(12, 74, 110, 0.48));
+    radial-gradient(circle at 20% 24%, rgba(59, 130, 246, 0.18), transparent 18%),
+    radial-gradient(circle at 74% 26%, rgba(239, 68, 68, 0.16), transparent 16%),
+    radial-gradient(circle at 48% 64%, rgba(34, 197, 94, 0.12), transparent 18%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(12, 74, 110, 0.56));
 }
 .map-backdrop::before,
 .map-backdrop::after {
@@ -125,6 +126,70 @@ button { font: inherit; }
 }
 .map-backdrop::after {
   background: linear-gradient(transparent 0%, rgba(8, 15, 28, 0.46) 100%);
+}
+.terrain-mass,
+.terrain-river,
+.terrain-contours {
+  position: absolute;
+  pointer-events: none;
+}
+.terrain-mass {
+  z-index: 0;
+  border-radius: 42% 58% 50% 50% / 36% 44% 56% 64%;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.78), rgba(22, 78, 99, 0.32));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08), 0 20px 30px rgba(2, 6, 23, 0.18);
+}
+.terrain-mass--north { left: 10%; top: 10%; width: 34%; height: 22%; transform: rotate(-8deg); }
+.terrain-mass--east { right: 10%; top: 12%; width: 28%; height: 30%; transform: rotate(16deg); }
+.terrain-mass--south { left: 26%; bottom: 12%; width: 40%; height: 22%; transform: rotate(5deg); }
+.terrain-river {
+  z-index: 0;
+  left: 44%; top: 12%; width: 8%; height: 66%;
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.2), rgba(125, 211, 252, 0.55), rgba(14, 165, 233, 0.2));
+  filter: blur(2px);
+  clip-path: polygon(39% 0, 62% 7%, 55% 17%, 68% 29%, 44% 38%, 58% 49%, 35% 65%, 49% 79%, 31% 100%, 16% 100%, 28% 79%, 14% 63%, 34% 49%, 18% 37%, 41% 28%, 30% 15%, 43% 0);
+}
+.terrain-contours {
+  z-index: 0;
+  inset: 14% 10% 18% 12%;
+  border: 1px dashed rgba(148, 163, 184, 0.14);
+  border-radius: 44% 56% 60% 40% / 38% 45% 55% 62%;
+}
+.terrain-contours--a { transform: rotate(-8deg); }
+.terrain-contours--b { inset: 20% 18% 24% 22%; transform: rotate(10deg); }
+.strategic-relations-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: visible;
+}
+.front-line {
+  stroke: rgba(148, 163, 184, 0.28);
+  stroke-width: 0.45;
+}
+.front-line.is-contested {
+  stroke: rgba(251, 113, 133, 0.9);
+  stroke-dasharray: 1.3 1;
+  filter: drop-shadow(0 0 6px rgba(251, 113, 133, 0.55));
+}
+.front-hotspot circle {
+  fill: rgba(15, 23, 42, 0.78);
+  stroke: rgba(226, 232, 240, 0.82);
+  stroke-width: 0.35;
+}
+.front-hotspot.is-contested circle {
+  fill: rgba(127, 29, 29, 0.85);
+  stroke: rgba(251, 113, 133, 0.95);
+}
+.front-hotspot.is-occupied circle {
+  fill: rgba(120, 53, 15, 0.8);
+  stroke: rgba(251, 191, 36, 0.95);
+}
+.front-hotspot text {
+  fill: rgba(241, 245, 249, 0.9);
+  font-size: 3px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 .overlay-anchor-shell {
   position: absolute;
@@ -142,7 +207,7 @@ button { font: inherit; }
 .economy-map-layer {
   position: absolute;
   inset: 0;
-  z-index: 1;
+  z-index: 2;
   overflow: visible;
 }
 .economy-route {
@@ -178,13 +243,13 @@ button { font: inherit; }
 }
 .province-node {
   position: absolute;
-  z-index: 2;
-  border-radius: 28px;
-  border: 2px solid var(--province-border);
+  z-index: 3;
+  clip-path: var(--province-shape);
+  border: 0;
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--province-fill) 92%, white 8%), color-mix(in srgb, var(--province-fill) 72%, black 28%));
   color: white;
-  padding: 14px;
+  padding: 18px 16px;
   text-align: left;
   display: flex;
   flex-direction: column;
@@ -192,6 +257,14 @@ button { font: inherit; }
   cursor: pointer;
   box-shadow: 0 12px 30px rgba(2, 6, 23, 0.3);
   transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+}
+.province-node::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 2px solid var(--province-border);
+  clip-path: var(--province-shape);
+  pointer-events: none;
 }
 .province-node:hover, .province-node.is-focused {
   transform: translateY(-3px) scale(1.01);
@@ -205,9 +278,20 @@ button { font: inherit; }
 .province-node.is-occupied::after {
   content: '';
   position: absolute; inset: 0;
-  border-radius: inherit;
   background: repeating-linear-gradient(135deg, rgba(255,255,255,0.14), rgba(255,255,255,0.14) 10px, transparent 10px, transparent 20px);
+  clip-path: var(--province-shape);
   pointer-events: none;
+}
+.province-node__terrain {
+  position: absolute;
+  inset: 10% 12%;
+  z-index: 0;
+  opacity: 0.22;
+  background:
+    radial-gradient(circle at 22% 30%, rgba(255,255,255,0.42), transparent 18%),
+    radial-gradient(circle at 72% 62%, rgba(15,23,42,0.55), transparent 24%),
+    linear-gradient(135deg, rgba(255,255,255,0.12), transparent 38%, rgba(15,23,42,0.32) 70%);
+  mix-blend-mode: screen;
 }
 .province-node__name, .province-node__meta, .province-node__badges { position: relative; z-index: 1; }
 .province-node__name { font-weight: 700; font-size: 18px; }
@@ -355,4 +439,5 @@ button { font: inherit; }
   .hero, .map-panel, .legend-panel, .province-details, .overlay-panel { padding: 14px; }
   .hero-stats, .legend-columns, .province-facts, .overlay-tabs, .economy-quick-stats, .bottom-tray-grid, .bottom-tray-stocks { grid-template-columns: 1fr; }
   .map-stage { min-height: 680px; }
+  .province-node { padding: 14px 12px; }
 }


### PR DESCRIPTION
## Summary\n- turn the demo map into a more visual strategic composition with terrain masses, river shapes, front links and hotspots\n- reshape province cards into map-like silhouettes with stronger territorial hierarchy and clearer contested borders\n- keep the local demo working with the existing web shell and economy overlay\n\n## Testing\n- npm test\n- PORT=4175 node scripts/dev-server.mjs