### PR TITLE
Alpha: [WEB-A4] ajouter un bouton Tour suivant pour la démo locale

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -188,12 +188,17 @@ const desiredStockByCityId = {
 };
 
 const state = {
+  turn: 1,
+  seasonIndex: 0,
   focusedProvinceId: 'crown-heart',
   selectedProvinceId: 'river-gate',
   activeOverlaySlot: 'economy-overlay',
   popupProvinceId: 'river-gate',
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
+  lastTurnSummary: 'Le théâtre reste sous tension, sans bascule majeure.',
 };
+
+const seasonLabels = ['Printemps', 'Été', 'Automne', 'Hiver'];
 
 function getProvinceCenter(provinceId) {
   const layout = provinceLayouts[provinceId];
@@ -242,8 +247,38 @@ function buildProvinceRelations(shell) {
   return [...uniqueRelations.values()];
 }
 
+function getProvinceStateByTurn(province) {
+  const seasonalShift = state.seasonIndex;
+  const turnShift = Math.max(0, state.turn - 1);
+  const loyaltyDelta = province.provinceId === 'river-gate'
+    ? Math.max(-18, -turnShift * 4)
+    : province.provinceId === 'southern-reach'
+      ? Math.min(10, turnShift * 2)
+      : province.provinceId === 'crown-heart'
+        ? Math.min(6, turnShift)
+        : province.provinceId === 'red-ridge'
+          ? Math.max(-8, -turnShift * 2)
+          : 0;
+
+  const supplyByProvinceId = {
+    'north-watch': ['stable', 'stable', 'strained', 'strained'],
+    'crown-heart': ['stable', 'stable', 'stable', 'strained'],
+    'red-ridge': ['strained', 'strained', 'disrupted', 'strained'],
+    'river-gate': ['disrupted', 'strained', 'disrupted', 'collapsed'],
+    'iron-plain': ['strained', 'stable', 'strained', 'disrupted'],
+    'southern-reach': ['collapsed', 'strained', 'strained', 'collapsed'],
+  };
+
+  return new Province({
+    ...province.toJSON(),
+    loyalty: Math.max(0, Math.min(100, province.loyalty + loyaltyDelta)),
+    supplyLevel: supplyByProvinceId[province.id]?.[seasonalShift] ?? province.supplyLevel,
+    contested: province.id === 'river-gate' ? state.turn % 2 === 1 : province.contested,
+  });
+}
+
 function getShell() {
-  return buildStrategicMapShell(provinces, {
+  return buildStrategicMapShell(provinces.map(getProvinceStateByTurn), {
     title: 'Écran stratégique, théâtre continental',
     subtitle: 'Prototype local Alpha prêt à accueillir les overlays inter-domaines',
     paletteByFaction,
@@ -380,14 +415,50 @@ function renderActiveProvince(shell) {
   `;
 }
 
+function getCityStateByTurn(city) {
+  const shift = Math.max(0, state.turn - 1);
+  const stockByResource = { ...city.stockByResource };
+
+  if (city.id === 'river-gate-city') {
+    stockByResource.grain = Math.max(0, stockByResource.grain - shift);
+    stockByResource.tools = Math.max(0, stockByResource.tools - Math.floor(shift / 2));
+  }
+
+  if (city.id === 'crown-port') {
+    stockByResource.grain += shift;
+    stockByResource.fish += Math.ceil(shift / 2);
+  }
+
+  if (city.id === 'southern-crossing') {
+    stockByResource.grain = Math.max(0, stockByResource.grain + (state.seasonIndex === 2 ? 2 : -1 + shift));
+  }
+
+  return new City({
+    ...city.toJSON(),
+    prosperity: Math.max(0, Math.min(100, city.prosperity + (city.id === 'crown-port' ? shift : city.id === 'river-gate-city' ? -shift : 0))),
+    stability: Math.max(0, Math.min(100, city.stability + (city.id === 'river-gate-city' ? -Math.ceil(shift / 2) : city.id === 'southern-crossing' ? 1 : 0))),
+    stockByResource,
+  });
+}
+
+function getRouteStateByTurn(route) {
+  return new TradeRoute({
+    ...route.toJSON(),
+    active: route.id === 'southern-grainway' ? state.seasonIndex !== 3 : route.active,
+    riskLevel: Math.max(0, Math.min(100, route.riskLevel + (route.id === 'ember-foundry-line' ? state.turn * 3 : state.seasonIndex === 3 ? 8 : -2))),
+  });
+}
+
 function getEconomyViewModel() {
-  const overlay = buildEconomyMapOverlay(cities, routes, { cityPositionById: cityLayoutsById });
-  const comparison = buildCityComparisonPanel(cities, { desiredStockByCityId });
+  const liveCities = cities.map(getCityStateByTurn);
+  const liveRoutes = routes.map(getRouteStateByTurn);
+  const overlay = buildEconomyMapOverlay(liveCities, liveRoutes, { cityPositionById: cityLayoutsById });
+  const comparison = buildCityComparisonPanel(liveCities, { desiredStockByCityId });
   const stockPanels = Object.fromEntries(
-    cities.map((city) => [city.id, buildCityStockPanel(city, { desiredStockByResource: desiredStockByCityId[city.id] ?? {} })]),
+    liveCities.map((city) => [city.id, buildCityStockPanel(city, { desiredStockByResource: desiredStockByCityId[city.id] ?? {} })]),
   );
 
-  return { overlay, comparison, stockPanels };
+  return { overlay, comparison, stockPanels, cities: liveCities, routes: liveRoutes };
 }
 
 function renderEconomyMapOverlay(economyView) {
@@ -621,6 +692,20 @@ function renderTerrainDecor() {
   `;
 }
 
+function advanceTurn() {
+  state.turn += 1;
+  state.seasonIndex = (state.seasonIndex + 1) % seasonLabels.length;
+
+  const summaries = [
+    'Les convois remontent depuis Couronne, mais la Porte du Fleuve reste fragile.',
+    'Les lignes se réorganisent, la logistique se tend autour du front central.',
+    'Les récoltes soulagent le sud, tandis que la pression remonte à la frontière est.',
+    'Le froid coupe certains flux, les provinces exposées repassent en posture défensive.',
+  ];
+
+  state.lastTurnSummary = summaries[(state.turn - 2) % summaries.length];
+}
+
 function render() {
   const shell = getShell();
   const economyView = getEconomyViewModel();
@@ -632,6 +717,14 @@ function render() {
           <p class="eyebrow">Alpha war room</p>
           <h1>${shell.title}</h1>
           <p class="hero-copy">${shell.subtitle}</p>
+          <div class="turn-toolbar">
+            <div class="turn-indicator">
+              <strong>Tour ${state.turn}</strong>
+              <span>${seasonLabels[state.seasonIndex]}</span>
+            </div>
+            <button type="button" class="turn-button" data-next-turn="true">Tour suivant</button>
+          </div>
+          <p class="turn-summary">${state.lastTurnSummary}</p>
         </div>
         <div class="hero-stats">
           ${renderStat('Provinces', shell.stats.provinceCount, 'neutral')}
@@ -689,6 +782,13 @@ function render() {
   document.querySelectorAll('[data-overlay-slot]').forEach((element) => {
     element.addEventListener('click', () => {
       state.activeOverlaySlot = element.dataset.overlaySlot;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-next-turn]').forEach((element) => {
+    element.addEventListener('click', () => {
+      advanceTurn();
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -50,6 +50,36 @@ button { font: inherit; }
 }
 .hero h1, .panel-header h2, .panel-header h3, .legend-panel h4 { margin: 0; }
 .hero-copy, .panel-header p { color: var(--muted); }
+.turn-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+.turn-indicator {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.turn-indicator span,
+.turn-summary { color: var(--muted); }
+.turn-button {
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  background: linear-gradient(180deg, rgba(14, 165, 233, 0.24), rgba(37, 99, 235, 0.3));
+  color: var(--text);
+  border-radius: 14px;
+  padding: 12px 16px;
+  cursor: pointer;
+  font-weight: 700;
+}
+.turn-summary {
+  margin: 12px 0 0;
+  max-width: 52ch;
+}
 .hero-stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -513,6 +543,7 @@ button { font: inherit; }
   .shell-root { width: min(100vw - 16px, 100%); padding-top: 8px; }
   .hero, .map-panel, .legend-panel, .province-details, .overlay-panel { padding: 14px; }
   .hero-stats, .legend-columns, .province-facts, .overlay-tabs, .economy-quick-stats, .bottom-tray-grid, .bottom-tray-stocks, .province-popup__actions { grid-template-columns: 1fr; }
+  .turn-toolbar { flex-direction: column; align-items: stretch; }
   .map-stage { min-height: 680px; }
   .province-node { padding: 14px 12px; }
   .province-popup {


### PR DESCRIPTION
## Résumé\n- ajoute un contrôle local Tour suivant dans la démo web\n- fait évoluer les provinces, stocks et routes selon le tour et la saison\n- rend les changements visibles dans l'UI avec indicateur de tour et résumé d'évolution\n\n## Tests\n- npm test\n- PORT=4177 node scripts/dev-server.mjs\n\nCloses #273