### PR TITLE
Alpha: [WEB-A6] dessiner clairement les frontières et les lignes de front

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -224,22 +224,25 @@ function buildProvinceRelations(shell) {
         return;
       }
 
+      const neighbor = shell.provinces.find((candidate) => candidate.provinceId === neighborId);
       const origin = getProvinceCenter(province.provinceId);
       const destination = getProvinceCenter(neighborId);
 
-      if (!origin || !destination) {
+      if (!origin || !destination || !neighbor) {
         return;
       }
 
-      const contested = province.contested || shell.provinces.some(
-        (candidate) => candidate.provinceId === neighborId && candidate.contested,
-      );
+      const contested = province.contested || neighbor.contested;
+      const occupied = province.occupied || neighbor.occupied;
+      const stable = !contested && !occupied && province.controllingFactionId !== neighbor.controllingFactionId;
 
       uniqueRelations.set(relationId, {
         relationId,
         origin,
         destination,
         contested,
+        occupied,
+        stable,
       });
     });
   });
@@ -312,6 +315,16 @@ function renderLegend(shell) {
   `).join('');
 
   const statesMarkup = shell.legend.states.map((entry) => `<li><span class="legend-chip">${entry.code}</span>${entry.label}</li>`).join('');
+  const frontierMarkup = [
+    ['stable', 'Frontière stable'],
+    ['occupied', 'Limite sous occupation'],
+    ['contested', 'Front contesté'],
+  ].map(([tone, label]) => `
+    <li>
+      <span class="frontier-key frontier-key--${tone}"></span>
+      <span>${label}</span>
+    </li>
+  `).join('');
 
   return `
     <section class="panel legend-panel">
@@ -328,6 +341,10 @@ function renderLegend(shell) {
           <h4>États</h4>
           <ul class="legend-list legend-list--states">${statesMarkup}</ul>
         </div>
+      </div>
+      <div class="legend-frontiers">
+        <h4>Frontières</h4>
+        <ul class="legend-list">${frontierMarkup}</ul>
       </div>
     </section>
   `;
@@ -649,13 +666,29 @@ function renderProvincePopup(shell) {
 function renderStrategicRelations(shell) {
   const relationLines = buildProvinceRelations(shell).map((relation) => `
     <line
-      class="front-line ${relation.contested ? 'is-contested' : ''}"
+      class="front-line ${relation.contested ? 'is-contested' : relation.occupied ? 'is-occupied' : relation.stable ? 'is-stable' : ''}"
       x1="${relation.origin.x}%"
       y1="${relation.origin.y}%"
       x2="${relation.destination.x}%"
       y2="${relation.destination.y}%"
     />
   `).join('');
+
+  const frontierRings = shell.provinces.map((province) => {
+    const center = getProvinceCenter(province.provinceId);
+    if (!center) {
+      return '';
+    }
+
+    return `
+      <circle
+        class="province-ring ${province.contested ? 'is-contested' : province.occupied ? 'is-occupied' : 'is-stable'}"
+        cx="${center.x}%"
+        cy="${center.y}%"
+        r="6.4"
+      ></circle>
+    `;
+  }).join('');
 
   const hotspots = shell.provinces
     .filter((province) => province.contested || province.occupied)
@@ -676,6 +709,7 @@ function renderStrategicRelations(shell) {
   return `
     <svg class="strategic-relations-layer" viewBox="0 0 100 100" aria-label="Relations entre provinces et lignes de front">
       ${relationLines}
+      ${frontierRings}
       ${hotspots}
     </svg>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -197,10 +197,37 @@ button { font: inherit; }
   stroke: rgba(148, 163, 184, 0.28);
   stroke-width: 0.45;
 }
+.front-line.is-stable {
+  stroke: rgba(191, 219, 254, 0.7);
+  stroke-width: 0.55;
+}
+.front-line.is-occupied {
+  stroke: rgba(251, 191, 36, 0.95);
+  stroke-width: 0.6;
+  stroke-dasharray: 1.1 0.8;
+  filter: drop-shadow(0 0 6px rgba(251, 191, 36, 0.35));
+}
 .front-line.is-contested {
   stroke: rgba(251, 113, 133, 0.9);
+  stroke-width: 0.72;
   stroke-dasharray: 1.3 1;
   filter: drop-shadow(0 0 6px rgba(251, 113, 133, 0.55));
+}
+.province-ring {
+  fill: none;
+  stroke-width: 0.45;
+  opacity: 0.85;
+}
+.province-ring.is-stable {
+  stroke: rgba(226, 232, 240, 0.28);
+}
+.province-ring.is-occupied {
+  stroke: rgba(251, 191, 36, 0.9);
+  stroke-dasharray: 1.2 0.9;
+}
+.province-ring.is-contested {
+  stroke: rgba(251, 113, 133, 0.92);
+  stroke-dasharray: 0.8 0.7;
 }
 .front-hotspot circle {
   fill: rgba(15, 23, 42, 0.78);
@@ -414,10 +441,32 @@ button { font: inherit; }
 }
 .legend-list { list-style: none; padding: 0; margin: 10px 0 0; display: grid; gap: 10px; }
 .legend-list li { display: flex; align-items: center; gap: 10px; color: var(--text); }
+.legend-frontiers {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
 .legend-swatch {
   width: 18px; height: 18px; border-radius: 999px;
   background: var(--swatch-fill);
   border: 2px solid var(--swatch-border);
+}
+.frontier-key {
+  width: 26px;
+  height: 0;
+  border-top: 3px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+}
+.frontier-key--stable {
+  border-top-color: rgba(191, 219, 254, 0.75);
+}
+.frontier-key--occupied {
+  border-top-color: rgba(251, 191, 36, 0.92);
+  border-top-style: dashed;
+}
+.frontier-key--contested {
+  border-top-color: rgba(251, 113, 133, 0.92);
+  border-top-style: dashed;
 }
 .province-facts {
   display: grid;


### PR DESCRIPTION
## Résumé\n- distingue visuellement les frontières stables, occupées et contestées\n- ajoute des anneaux de lecture autour des provinces pour mieux repérer les états de contrôle\n- complète la légende pour rendre la carte lisible d'un coup d'œil\n\n## Tests\n- npm test\n- PORT=4178 node scripts/dev-server.mjs\n\nCloses #278