### PR TITLE
Beta: [WEB-B2] mieux dessiner les routes logistiques sur la carte

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -461,12 +461,40 @@ function getEconomyViewModel() {
   return { overlay, comparison, stockPanels, cities: liveCities, routes: liveRoutes };
 }
 
+function buildRouteVisual(route, origin, destination, index) {
+  const deltaX = destination.x - origin.x;
+  const deltaY = destination.y - origin.y;
+  const length = Math.hypot(deltaX, deltaY) || 1;
+  const normalX = -deltaY / length;
+  const normalY = deltaX / length;
+  const critical = route.riskLevel >= 55 || route.totalCapacity >= 9;
+  const inactive = !route.active;
+  const modeClass = `is-${route.transportMode}`;
+  const emphasisClass = critical ? 'is-critical' : 'is-support';
+  const activeClass = inactive ? 'is-inactive' : 'is-active';
+  const amplitude = route.transportMode === 'river' ? 2.8 : route.transportMode === 'land' ? 1.6 : 2.2;
+  const curveLift = 4 + ((index % 2) * 1.8);
+  const controlX = ((origin.x + destination.x) / 2) + (normalX * curveLift);
+  const controlY = ((origin.y + destination.y) / 2) + (normalY * curveLift);
+  const pathD = `M ${origin.x} ${origin.y} Q ${controlX} ${controlY} ${destination.x} ${destination.y}`;
+  const markerId = `route-arrow-${route.transportMode}`;
+
+  return {
+    pathD,
+    classes: ['economy-route', modeClass, emphasisClass, activeClass].join(' '),
+    markerId,
+    critical,
+    inactive,
+    amplitude,
+  };
+}
+
 function renderEconomyMapOverlay(economyView) {
   if (state.activeOverlaySlot !== 'economy-overlay') {
     return '';
   }
 
-  const routeLines = economyView.overlay.routes.map((route) => {
+  const routeLines = economyView.overlay.routes.map((route, index) => {
     const origin = cityLayoutsById[route.originCityId];
     const destination = cityLayoutsById[route.destinationCityId];
 
@@ -474,24 +502,19 @@ function renderEconomyMapOverlay(economyView) {
       return '';
     }
 
-    const dashArray = route.style.pattern === 'dashed'
-      ? '10 7'
-      : route.style.pattern === 'wave'
-        ? '7 5'
-        : '0';
+    const visual = buildRouteVisual(route, origin, destination, index);
 
     return `
-      <line
-        class="economy-route"
-        x1="${origin.x}%"
-        y1="${origin.y}%"
-        x2="${destination.x}%"
-        y2="${destination.y}%"
-        stroke="${route.style.stroke}"
-        stroke-width="${route.style.width * 3}"
-        stroke-dasharray="${dashArray}"
-        opacity="${route.style.opacity}"
-      />
+      <g class="economy-route-group ${visual.classes}" data-route-id="${route.routeId}">
+        <path class="economy-route__halo" d="${visual.pathD}" pathLength="100" />
+        <path class="economy-route__casing" d="${visual.pathD}" pathLength="100" />
+        <path class="economy-route__line" d="${visual.pathD}" pathLength="100" marker-end="url(#${visual.markerId})" />
+        <path class="economy-route__flow" d="${visual.pathD}" pathLength="100" />
+        <text class="economy-route__label" text-anchor="middle">
+          <textPath href="#route-label-${route.routeId}" startOffset="50%">${route.routeName}</textPath>
+        </text>
+        <path id="route-label-${route.routeId}" d="${visual.pathD}" fill="none" stroke="none" />
+      </g>
     `;
   }).join('');
 
@@ -513,6 +536,17 @@ function renderEconomyMapOverlay(economyView) {
 
   return `
     <svg class="economy-map-layer" viewBox="0 0 100 100" aria-label="Overlay économie et logistique">
+      <defs>
+        <marker id="route-arrow-land" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+          <path d="M 0 1 L 10 5 L 0 9 z" fill="#f8fafc" opacity="0.9" />
+        </marker>
+        <marker id="route-arrow-river" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+          <path d="M 0 1 L 10 5 L 0 9 z" fill="#bae6fd" opacity="0.95" />
+        </marker>
+        <marker id="route-arrow-sea" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+          <path d="M 0 1 L 10 5 L 0 9 z" fill="#c7d2fe" opacity="0.95" />
+        </marker>
+      </defs>
       ${routeLines}
       ${cityNodes}
     </svg>
@@ -551,12 +585,17 @@ function renderEconomySidePanel(economyView) {
       </div>
       <div class="economy-route-list">
         ${economyView.overlay.routes.map((route) => `
-          <article class="economy-route-card ${route.active ? '' : 'is-inactive'}">
+          <article class="economy-route-card ${route.active ? '' : 'is-inactive'} ${route.transportMode === 'river' ? 'is-river' : route.transportMode === 'sea' ? 'is-sea' : 'is-land'} ${route.riskLevel >= 55 || route.totalCapacity >= 9 ? 'is-critical' : ''}">
             <strong>${route.routeName}</strong>
             <span>${route.transportMode}, risque ${route.riskLevel}</span>
             <span>capacité ${route.totalCapacity}</span>
           </article>
         `).join('')}
+      </div>
+      <div class="economy-route-legend">
+        <span><i class="is-land"></i>Terre</span>
+        <span><i class="is-river"></i>Fluvial</span>
+        <span><i class="is-critical"></i>Liaison critique</span>
       </div>
     </section>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -240,8 +240,70 @@ button { font: inherit; }
   z-index: 2;
   overflow: visible;
 }
-.economy-route {
-  filter: drop-shadow(0 0 8px rgba(125, 211, 252, 0.24));
+.economy-route-group {
+  isolation: isolate;
+}
+.economy-route__halo,
+.economy-route__casing,
+.economy-route__line,
+.economy-route__flow {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.economy-route__halo {
+  stroke: rgba(15, 23, 42, 0.78);
+  stroke-width: 4.6;
+  opacity: 0.95;
+}
+.economy-route__casing {
+  stroke: rgba(226, 232, 240, 0.22);
+  stroke-width: 3.4;
+}
+.economy-route__line {
+  stroke-width: 2.1;
+}
+.economy-route__flow {
+  stroke: rgba(255, 255, 255, 0.95);
+  stroke-width: 0.55;
+  stroke-dasharray: 7 12;
+  animation: economy-route-flow 10s linear infinite;
+}
+.economy-route__label {
+  fill: rgba(241, 245, 249, 0.92);
+  font-size: 2.6px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.economy-route.is-land .economy-route__line {
+  stroke: #f59e0b;
+}
+.economy-route.is-river .economy-route__line {
+  stroke: #38bdf8;
+}
+.economy-route.is-sea .economy-route__line {
+  stroke: #818cf8;
+}
+.economy-route.is-river .economy-route__flow {
+  stroke-dasharray: 2 9;
+  animation-duration: 7s;
+}
+.economy-route.is-inactive .economy-route__line,
+.economy-route.is-inactive .economy-route__flow,
+.economy-route.is-inactive .economy-route__label {
+  opacity: 0.4;
+}
+.economy-route.is-inactive .economy-route__line {
+  stroke-dasharray: 4 5;
+}
+.economy-route.is-critical .economy-route__halo {
+  stroke: rgba(127, 29, 29, 0.88);
+}
+.economy-route.is-critical .economy-route__casing {
+  stroke: rgba(251, 113, 133, 0.45);
+}
+.economy-route.is-critical .economy-route__line {
+  filter: drop-shadow(0 0 8px rgba(251, 113, 133, 0.4));
 }
 .economy-city {
   stroke: rgba(255, 255, 255, 0.88);
@@ -466,10 +528,40 @@ button { font: inherit; }
   border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.14);
   background: rgba(15, 23, 42, 0.55);
+  border-left-width: 4px;
+}
+.economy-route-card.is-land { border-left-color: #f59e0b; }
+.economy-route-card.is-river { border-left-color: #38bdf8; }
+.economy-route-card.is-sea { border-left-color: #818cf8; }
+.economy-route-card.is-critical {
+  box-shadow: inset 0 0 0 1px rgba(251, 113, 133, 0.16);
 }
 .economy-route-card.is-inactive {
   opacity: 0.68;
 }
+.economy-route-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 12px;
+}
+.economy-route-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.economy-route-legend i {
+  display: inline-block;
+  width: 20px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.5);
+}
+.economy-route-legend i.is-land { background: #f59e0b; }
+.economy-route-legend i.is-river { background: #38bdf8; }
+.economy-route-legend i.is-critical { background: #fb7185; }
 .bottom-tray-grid {
   display: grid;
   grid-template-columns: 1.2fr 1fr;
@@ -535,6 +627,11 @@ button { font: inherit; }
 .tension-pill--low { background: rgba(34, 197, 94, 0.14); color: #86efac; }
 .tension-pill--medium { background: rgba(245, 158, 11, 0.14); color: #fde68a; }
 .tension-pill--high { background: rgba(251, 113, 133, 0.14); color: #fda4af; }
+@keyframes economy-route-flow {
+  from { stroke-dashoffset: 0; }
+  to { stroke-dashoffset: -38; }
+}
+
 @media (max-width: 1100px) {
   .hero, .layout-grid { grid-template-columns: 1fr; }
   .panel-header--spread { flex-direction: column; }


### PR DESCRIPTION
## Résumé\n- renforce le tracé des routes logistiques sur la carte avec un halo, un casing et des courbes plus lisibles\n- distingue visuellement les modes terrestre et fluvial, avec des flèches et des flux animés\n- fait ressortir les liaisons critiques aussi dans le panneau latéral\n\n## Validation\n- npm test\n- PORT=4381 npm run dev