### PR TITLE
Epsilon: [WEB-E7] ajouter une légende climatique dédiée

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -89,6 +89,57 @@ function buildSeasonSummary(states, seasonLabels) {
   };
 }
 
+function buildLegend(stateEntries, catastropheEntries, seasonLabels) {
+  const seasonLegend = [...new Set(stateEntries
+    .filter((entry) => entry.kind === 'season')
+    .map((entry) => entry.season))]
+    .sort()
+    .map((season) => ({
+      key: `season:${season}`,
+      kind: 'season',
+      season,
+      label: seasonLabels[season] ?? season,
+      tone: 'info',
+      description: 'Saison dominante affichée pour une région.',
+    }));
+
+  const anomalyLegend = [...new Set(stateEntries
+    .filter((entry) => entry.kind === 'anomaly')
+    .map((entry) => entry.label))]
+    .sort((left, right) => left.localeCompare(right))
+    .map((anomaly) => ({
+      key: `anomaly:${anomaly}`,
+      kind: 'anomaly',
+      label: anomaly,
+      tone: 'warning',
+      description: 'Anomalie climatique active sur la région.',
+    }));
+
+  const catastropheLegend = [...new Map(catastropheEntries
+    .map((entry) => [entry.severity, {
+      key: `catastrophe:${entry.severity}`,
+      kind: 'catastrophe',
+      severity: entry.severity,
+      label: entry.severity,
+      icon: entry.style.icon,
+      color: entry.style.fill,
+      description: 'Catastrophe active ou imminente visible sur la carte.',
+    }]))
+    .entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, legendEntry]) => legendEntry);
+
+  return {
+    title: 'Légende climat',
+    compact: true,
+    items: [
+      ...seasonLegend,
+      ...anomalyLegend,
+      ...catastropheLegend,
+    ],
+  };
+}
+
 export function buildClimateMapOverlay(climateStates, options = {}) {
   const states = requireArray(climateStates, 'ClimateMapOverlay climateStates').map(normalizeClimateState);
   const normalizedOptions = requireObject(options, 'ClimateMapOverlay options');
@@ -148,6 +199,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     }),
     regions,
     seasonalPanel: buildSeasonSummary(states, seasonLabels),
+    legend: buildLegend(stateEntries, catastropheEntries, seasonLabels),
     metrics: {
       regionCount: states.length,
       seasonCount: states.length,

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -144,6 +144,44 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         },
       ],
     },
+    legend: {
+      title: 'Légende climat',
+      compact: true,
+      items: [
+        {
+          key: 'season:spring',
+          kind: 'season',
+          season: 'spring',
+          label: 'Printemps',
+          tone: 'info',
+          description: 'Saison dominante affichée pour une région.',
+        },
+        {
+          key: 'season:summer',
+          kind: 'season',
+          season: 'summer',
+          label: 'Été',
+          tone: 'info',
+          description: 'Saison dominante affichée pour une région.',
+        },
+        {
+          key: 'anomaly:heatwave',
+          kind: 'anomaly',
+          label: 'heatwave',
+          tone: 'warning',
+          description: 'Anomalie climatique active sur la région.',
+        },
+        {
+          key: 'catastrophe:major',
+          kind: 'catastrophe',
+          severity: 'major',
+          label: 'major',
+          icon: '▲',
+          color: 'orange',
+          description: 'Catastrophe active ou imminente visible sur la carte.',
+        },
+      ],
+    },
     metrics: {
       regionCount: 2,
       seasonCount: 2,
@@ -172,6 +210,20 @@ test('buildClimateMapOverlay supports empty catastrophes and validated options',
   assert.equal(overlay.metrics.criticalRegionCount, 0);
   assert.equal(overlay.entries[0].overlayId, 'delta:season');
   assert.equal(overlay.seasonalPanel.summary, 'autumn: 1');
+  assert.deepEqual(overlay.legend, {
+    title: 'Légende climat',
+    compact: true,
+    items: [
+      {
+        key: 'season:autumn',
+        kind: 'season',
+        season: 'autumn',
+        label: 'autumn',
+        tone: 'info',
+        description: 'Saison dominante affichée pour une région.',
+      },
+    ],
+  });
   assert.deepEqual(overlay.regions, [
     {
       regionId: 'delta',


### PR DESCRIPTION
## Summary

- Epsilon: ajoute une légende climat compacte directement dans `buildClimateMapOverlay`
- Epsilon: explique les saisons, anomalies et sévérités de catastrophes visibles sur la carte
- Epsilon: garde la sortie légère et dérivée des données déjà présentes dans l'overlay

## Related issue

- One issue only: #314

## Changes

- Epsilon: ajoute un bloc `legend` avec des items stables pour saisons, anomalies et catastrophes
- Epsilon: réutilise les labels de saison et les styles de catastrophe déjà calculés
- Epsilon: complète les tests pour couvrir la légende en mode riche et minimal

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [ ] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date

## Notes

- Epsilon: `npm test -- --test test/ui/climate/buildClimateMapOverlay.test.js`
- Epsilon: `npm test`
