### PR TITLE
Alpha: [WEB-A8] améliorer la sélection de province et le focus stratégique

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -200,6 +200,19 @@ const state = {
 
 const seasonLabels = ['Printemps', 'Été', 'Automne', 'Hiver'];
 
+function getFocusContext(shell) {
+  const selectedProvince = shell.provinces.find((province) => province.provinceId === state.selectedProvinceId) ?? null;
+  const focusedProvince = shell.provinces.find((province) => province.provinceId === state.focusedProvinceId) ?? selectedProvince ?? null;
+  const anchorProvince = selectedProvince ?? focusedProvince;
+  const neighborIds = new Set(anchorProvince?.neighborIds ?? []);
+
+  return {
+    selectedProvince,
+    focusedProvince,
+    neighborIds,
+  };
+}
+
 function getProvinceCenter(provinceId) {
   const layout = provinceLayouts[provinceId];
 
@@ -350,13 +363,19 @@ function renderLegend(shell) {
   `;
 }
 
-function renderProvinceCard(province) {
+function renderProvinceCard(province, focusContext) {
   const layout = provinceLayouts[province.provinceId];
   const badges = province.badges.map((badge) => `<span class="province-badge">${badge}</span>`).join('');
+  const isNeighbor = focusContext.neighborIds.has(province.provinceId);
+  const isSelected = province.selectionState.selected;
+  const isFocused = province.selectionState.focused;
+  const isMuted = !isSelected && !isFocused && !isNeighbor && (focusContext.selectedProvince || focusContext.focusedProvince);
   const classes = [
     'province-node',
-    province.selectionState.selected ? 'is-selected' : '',
-    province.selectionState.focused ? 'is-focused' : '',
+    isSelected ? 'is-selected' : '',
+    isFocused ? 'is-focused' : '',
+    isNeighbor ? 'is-neighbor' : '',
+    isMuted ? 'is-muted' : '',
     province.contested ? 'is-contested' : '',
     province.occupied ? 'is-occupied' : '',
   ].filter(Boolean).join(' ');
@@ -378,9 +397,11 @@ function renderProvinceCard(province) {
       aria-pressed="${province.selectionState.selected}"
     >
       <span class="province-node__terrain"></span>
+      <span class="province-node__focus-rail"></span>
       <span class="province-node__name">${province.label}</span>
       <span class="province-node__meta">${province.supplyTone} · loyauté ${province.loyalty}</span>
       <span class="province-node__badges">${badges}</span>
+      ${isNeighbor ? '<span class="province-node__link">Voisine directe</span>' : ''}
     </button>
   `;
 }
@@ -398,6 +419,7 @@ function renderOverlaySlots(shell) {
 }
 
 function renderActiveProvince(shell) {
+  const focusContext = getFocusContext(shell);
   const province = shell.activeProvince ?? shell.provinces[0] ?? null;
 
   if (!province) {
@@ -407,6 +429,9 @@ function renderActiveProvince(shell) {
   const controller = factionMetaById[province.controllingFactionId]?.label ?? province.controllingFactionId;
   const owner = factionMetaById[province.ownerFactionId]?.label ?? province.ownerFactionId;
   const comparedProvinceNames = state.comparisonProvinceIds
+    .map((provinceId) => shell.provinces.find((candidate) => candidate.provinceId === provinceId)?.label)
+    .filter(Boolean);
+  const neighborNames = [...focusContext.neighborIds]
     .map((provinceId) => shell.provinces.find((candidate) => candidate.provinceId === provinceId)?.label)
     .filter(Boolean);
 
@@ -424,6 +449,16 @@ function renderActiveProvince(shell) {
         <div><dt>Voisins</dt><dd>${province.neighborIds.join(', ')}</dd></div>
       </dl>
       <div class="province-summary-tags">${province.badges.map((badge) => `<span class="legend-chip">${badge}</span>`).join('')}</div>
+      <div class="focus-strip">
+        <div class="focus-strip__item">
+          <span>Voisines mises en avant</span>
+          <strong>${neighborNames.length > 0 ? neighborNames.join(', ') : 'Aucune'}</strong>
+        </div>
+        <div class="focus-strip__item">
+          <span>Transition de focus</span>
+          <strong>${focusContext.focusedProvince?.label ?? province.label}</strong>
+        </div>
+      </div>
       <div class="context-summary">
         <strong>Comparaison rapide</strong>
         <p>${comparedProvinceNames.length > 0 ? comparedProvinceNames.join(' vs ') : 'Aucune province comparée pour le moment.'}</p>
@@ -703,15 +738,21 @@ function renderProvincePopup(shell) {
 }
 
 function renderStrategicRelations(shell) {
-  const relationLines = buildProvinceRelations(shell).map((relation) => `
+  const focusContext = getFocusContext(shell);
+  const relationLines = buildProvinceRelations(shell).map((relation) => {
+    const linkedToSelection = focusContext.selectedProvince
+      && (relation.relationId.includes(focusContext.selectedProvince.provinceId));
+
+    return `
     <line
-      class="front-line ${relation.contested ? 'is-contested' : relation.occupied ? 'is-occupied' : relation.stable ? 'is-stable' : ''}"
+      class="front-line ${relation.contested ? 'is-contested' : relation.occupied ? 'is-occupied' : relation.stable ? 'is-stable' : ''} ${linkedToSelection ? 'is-emphasized' : ''}"
       x1="${relation.origin.x}%"
       y1="${relation.origin.y}%"
       x2="${relation.destination.x}%"
       y2="${relation.destination.y}%"
     />
-  `).join('');
+  `;
+  }).join('');
 
   const frontierRings = shell.provinces.map((province) => {
     const center = getProvinceCenter(province.provinceId);
@@ -782,6 +823,7 @@ function advanceTurn() {
 function render() {
   const shell = getShell();
   const economyView = getEconomyViewModel();
+  const focusContext = getFocusContext(shell);
 
   document.querySelector('#app').innerHTML = `
     <main class="shell-root">
@@ -825,7 +867,8 @@ function render() {
             <div id="right-rail" class="overlay-anchor-shell overlay-anchor-shell--right">Right rail</div>
             ${renderEconomyMapOverlay(economyView)}
             ${renderBottomTray(economyView)}
-            ${shell.provinces.map(renderProvinceCard).join('')}
+            <div class="focus-hint">${focusContext.selectedProvince ? `Sélection active, ${focusContext.selectedProvince.label}` : 'Survolez une province pour déplacer le focus'}</div>
+            ${shell.provinces.map((province) => renderProvinceCard(province, focusContext)).join('')}
             ${renderProvincePopup(shell)}
           </div>
         </section>
@@ -845,7 +888,13 @@ function render() {
       render();
     });
 
+    element.addEventListener('mouseleave', () => {
+      state.focusedProvinceId = state.selectedProvinceId;
+      render();
+    });
+
     element.addEventListener('click', () => {
+      state.focusedProvinceId = element.dataset.provinceId;
       state.selectedProvinceId = element.dataset.provinceId;
       state.popupProvinceId = element.dataset.provinceId;
       render();

--- a/web/styles.css
+++ b/web/styles.css
@@ -213,6 +213,10 @@ button { font: inherit; }
   stroke-dasharray: 1.3 1;
   filter: drop-shadow(0 0 6px rgba(251, 113, 133, 0.55));
 }
+.front-line.is-emphasized {
+  stroke-width: 1;
+  opacity: 1;
+}
 .province-ring {
   fill: none;
   stroke-width: 0.45;
@@ -360,6 +364,19 @@ button { font: inherit; }
   letter-spacing: 0;
   background: rgba(8, 15, 28, 0.72);
 }
+.focus-hint {
+  position: absolute;
+  left: 50%;
+  top: 18px;
+  z-index: 4;
+  transform: translateX(-50%);
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(8, 15, 28, 0.76);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: var(--text);
+  font-size: 12px;
+}
 .province-node {
   position: absolute;
   z-index: 3;
@@ -375,7 +392,7 @@ button { font: inherit; }
   justify-content: space-between;
   cursor: pointer;
   box-shadow: 0 12px 30px rgba(2, 6, 23, 0.3);
-  transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+  transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease, opacity 160ms ease;
 }
 .province-node::before {
   content: '';
@@ -390,8 +407,19 @@ button { font: inherit; }
   box-shadow: 0 16px 36px rgba(2, 6, 23, 0.42);
 }
 .province-node.is-selected {
+  z-index: 6;
   outline: 3px solid rgba(125, 211, 252, 0.9);
   outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgba(125, 211, 252, 0.18), 0 22px 42px rgba(2, 6, 23, 0.5);
+}
+.province-node.is-neighbor {
+  z-index: 5;
+  filter: saturate(1.06);
+  box-shadow: 0 0 0 2px rgba(191, 219, 254, 0.16), 0 14px 32px rgba(2, 6, 23, 0.38);
+}
+.province-node.is-muted {
+  opacity: 0.45;
+  filter: saturate(0.76) brightness(0.82);
 }
 .province-node.is-contested { border-style: dashed; }
 .province-node.is-occupied::after {
@@ -412,10 +440,33 @@ button { font: inherit; }
     linear-gradient(135deg, rgba(255,255,255,0.12), transparent 38%, rgba(15,23,42,0.32) 70%);
   mix-blend-mode: screen;
 }
-.province-node__name, .province-node__meta, .province-node__badges { position: relative; z-index: 1; }
+.province-node__focus-rail {
+  position: absolute;
+  left: 0;
+  top: 10%;
+  bottom: 10%;
+  width: 5px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255,255,255,0), rgba(255,255,255,0.9), rgba(255,255,255,0));
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+.province-node.is-selected .province-node__focus-rail,
+.province-node.is-neighbor .province-node__focus-rail,
+.province-node.is-focused .province-node__focus-rail {
+  opacity: 1;
+}
+.province-node__name, .province-node__meta, .province-node__badges, .province-node__link { position: relative; z-index: 1; }
 .province-node__name { font-weight: 700; font-size: 18px; }
 .province-node__meta { font-size: 13px; color: rgba(255,255,255,0.82); }
 .province-node__badges { display: flex; flex-wrap: wrap; gap: 6px; }
+.province-node__link {
+  margin-top: 8px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.95);
+}
 .province-badge, .legend-chip {
   display: inline-flex;
   align-items: center;
@@ -545,6 +596,23 @@ button { font: inherit; }
 .province-facts dt { color: var(--muted); font-size: 12px; margin-bottom: 6px; }
 .province-facts dd { margin: 0; }
 .province-summary-tags, .overlay-anchor-grid { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.focus-strip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+.focus-strip__item {
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.focus-strip__item span {
+  display: block;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
 .context-summary {
   margin-top: 14px;
   padding: 12px;
@@ -688,7 +756,7 @@ button { font: inherit; }
 @media (max-width: 720px) {
   .shell-root { width: min(100vw - 16px, 100%); padding-top: 8px; }
   .hero, .map-panel, .legend-panel, .province-details, .overlay-panel { padding: 14px; }
-  .hero-stats, .legend-columns, .province-facts, .overlay-tabs, .economy-quick-stats, .bottom-tray-grid, .bottom-tray-stocks, .province-popup__actions { grid-template-columns: 1fr; }
+  .hero-stats, .legend-columns, .province-facts, .overlay-tabs, .economy-quick-stats, .bottom-tray-grid, .bottom-tray-stocks, .province-popup__actions, .focus-strip { grid-template-columns: 1fr; }
   .turn-toolbar { flex-direction: column; align-items: stretch; }
   .map-stage { min-height: 680px; }
   .province-node { padding: 14px 12px; }


### PR DESCRIPTION
## Résumé\n- renforce la province sélectionnée avec un état de focus plus clair\n- met en avant les provinces voisines et atténue le reste de la carte\n- rend les transitions de focus plus lisibles dans la carte et le panneau latéral\n\n## Tests\n- npm test\n- PORT=4179 node scripts/dev-server.mjs\n\nCloses #280