### PR TITLE
Beta: [WEB-B3] ajouter des détails de ville au survol ou au clic

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -194,6 +194,8 @@ const state = {
   selectedProvinceId: 'river-gate',
   activeOverlaySlot: 'economy-overlay',
   popupProvinceId: 'river-gate',
+  hoveredCityId: 'river-gate-city',
+  selectedCityId: 'river-gate-city',
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
   lastTurnSummary: 'Le théâtre reste sous tension, sans bascule majeure.',
 };
@@ -506,6 +508,44 @@ function buildRouteVisual(route, origin, destination, index) {
   };
 }
 
+function renderCityQuickPanel(economyView) {
+  if (state.activeOverlaySlot !== 'economy-overlay') {
+    return '';
+  }
+
+  const cityId = state.hoveredCityId ?? state.selectedCityId;
+  const city = economyView.overlay.cities.find((candidate) => candidate.cityId === cityId);
+
+  if (!city || !city.marker.position) {
+    return '';
+  }
+
+  const stockPanel = economyView.stockPanels[city.cityId];
+  const topResources = stockPanel.rows.slice(0, 3);
+  const left = Math.min(76, Math.max(8, city.marker.position.x + 3));
+  const top = Math.min(66, Math.max(10, city.marker.position.y - 18));
+
+  return `
+    <aside class="city-quick-panel" style="left:${left}%;top:${top}%;" aria-live="polite">
+      <div class="city-quick-panel__header">
+        <div>
+          <strong>${city.cityName}</strong>
+          <p>${city.capital ? 'Capitale logistique' : 'Ville logistique'} · ${city.regionId}</p>
+        </div>
+        <span class="city-quick-panel__tone city-quick-panel__tone--${city.marker.tone}">${city.marker.tone}</span>
+      </div>
+      <div class="city-quick-panel__stats">
+        <span>Stock ${city.resources.totalStock}</span>
+        <span>Stabilité ${city.stability}</span>
+        <span>Prospérité ${city.prosperity}</span>
+      </div>
+      <ul class="city-quick-panel__stocks">
+        ${topResources.map((row) => `<li class="${row.status}"><span>${row.resourceId}</span><strong>${row.currentQuantity}</strong></li>`).join('')}
+      </ul>
+    </aside>
+  `;
+}
+
 function renderEconomyMapOverlay(economyView) {
   if (state.activeOverlaySlot !== 'economy-overlay') {
     return '';
@@ -543,8 +583,9 @@ function renderEconomyMapOverlay(economyView) {
     }
 
     return `
-      <g class="economy-city-group" data-city-id="${city.cityId}">
+      <g class="economy-city-group ${state.selectedCityId === city.cityId ? 'is-selected' : ''}" data-city-id="${city.cityId}">
         <circle class="economy-city economy-city--${city.marker.tone}" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 8}" />
+        <circle class="economy-city-hitbox" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 11}" />
         <text class="economy-city-label" x="${position.x}%" y="calc(${position.y}% - 14px)" text-anchor="middle">${city.cityName}</text>
         <text class="economy-city-resource" x="${position.x}%" y="calc(${position.y}% + 18px)" text-anchor="middle">${city.resources.primaryResourceId ?? 'stock vide'}</text>
       </g>
@@ -824,6 +865,7 @@ function render() {
             <div id="left-rail" class="overlay-anchor-shell overlay-anchor-shell--left">Left rail</div>
             <div id="right-rail" class="overlay-anchor-shell overlay-anchor-shell--right">Right rail</div>
             ${renderEconomyMapOverlay(economyView)}
+            ${renderCityQuickPanel(economyView)}
             ${renderBottomTray(economyView)}
             ${shell.provinces.map(renderProvinceCard).join('')}
             ${renderProvincePopup(shell)}
@@ -855,6 +897,19 @@ function render() {
   document.querySelectorAll('[data-overlay-slot]').forEach((element) => {
     element.addEventListener('click', () => {
       state.activeOverlaySlot = element.dataset.overlaySlot;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-city-id]').forEach((element) => {
+    element.addEventListener('mouseenter', () => {
+      state.hoveredCityId = element.dataset.cityId;
+      render();
+    });
+
+    element.addEventListener('click', () => {
+      state.selectedCityId = element.dataset.cityId;
+      state.hoveredCityId = element.dataset.cityId;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -336,6 +336,16 @@ button { font: inherit; }
   stroke: rgba(255, 255, 255, 0.88);
   stroke-width: 1.6;
 }
+.economy-city-hitbox {
+  fill: transparent;
+  pointer-events: auto;
+}
+.economy-city-group { cursor: pointer; }
+.economy-city-group.is-selected .economy-city {
+  stroke: #f8fafc;
+  stroke-width: 2.4;
+  filter: drop-shadow(0 0 8px rgba(255,255,255,0.35));
+}
 .economy-city--positive { fill: #22c55e; }
 .economy-city--warning { fill: #f97316; }
 .economy-city--neutral { fill: #38bdf8; }
@@ -426,6 +436,7 @@ button { font: inherit; }
   background: rgba(15, 23, 42, 0.58);
   border: 1px solid rgba(226, 232, 240, 0.14);
 }
+.city-quick-panel,
 .province-popup {
   position: absolute;
   z-index: 5;
@@ -437,6 +448,59 @@ button { font: inherit; }
   background: rgba(8, 15, 28, 0.94);
   box-shadow: 0 18px 40px rgba(2, 6, 23, 0.5);
   backdrop-filter: blur(10px);
+}
+.city-quick-panel {
+  z-index: 4;
+  min-width: 220px;
+  pointer-events: none;
+}
+.city-quick-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+.city-quick-panel__header strong { display: block; }
+.city-quick-panel__header p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+.city-quick-panel__tone {
+  align-self: flex-start;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  background: rgba(148, 163, 184, 0.16);
+}
+.city-quick-panel__tone--positive { color: #86efac; }
+.city-quick-panel__tone--warning { color: #fdba74; }
+.city-quick-panel__tone--neutral { color: #7dd3fc; }
+.city-quick-panel__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+.city-quick-panel__stats span,
+.city-quick-panel__stocks li {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  font-size: 12px;
+}
+.city-quick-panel__stocks {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.city-quick-panel__stocks li {
+  display: inline-flex;
+  gap: 8px;
 }
 .province-popup::before {
   content: '';
@@ -692,6 +756,7 @@ button { font: inherit; }
   .turn-toolbar { flex-direction: column; align-items: stretch; }
   .map-stage { min-height: 680px; }
   .province-node { padding: 14px 12px; }
+  .city-quick-panel,
   .province-popup {
     left: 8% !important;
     right: 8%;


### PR DESCRIPTION
## Résumé\n- ajoute une fiche rapide de ville au survol et au clic dans l'overlay économie\n- met en avant stock total, stabilité, prospérité et les ressources clés\n- renforce aussi la sélection visuelle des villes sur la carte\n\n## Validation\n- npm test\n- PORT=4382 npm run dev