### PR TITLE
Beta: [WEB-B4] construire un panneau de comparaison de plusieurs villes

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -196,6 +196,7 @@ const state = {
   popupProvinceId: 'river-gate',
   hoveredCityId: 'river-gate-city',
   selectedCityId: 'river-gate-city',
+  comparedCityIds: ['river-gate-city', 'crown-port'],
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
   lastTurnSummary: 'Le théâtre reste sous tension, sans bascule majeure.',
 };
@@ -699,33 +700,57 @@ function renderBottomTray(economyView) {
     return '<div class="overlay-anchor-shell overlay-anchor-shell--bottom">Bottom tray</div>';
   }
 
+  const comparedIds = state.comparedCityIds.filter((cityId) => economyView.stockPanels[cityId]);
+  const comparedCities = (comparedIds.length > 0 ? comparedIds : economyView.overlay.cities.slice(0, 2).map((city) => city.cityId))
+    .map((cityId) => {
+      const city = economyView.overlay.cities.find((candidate) => candidate.cityId === cityId);
+      const panel = economyView.stockPanels[cityId];
+      const row = economyView.comparison.rows.find((candidate) => candidate.cityId === cityId);
+      return city && panel && row ? { city, panel, row } : null;
+    })
+    .filter(Boolean);
+
   return `
     <section id="bottom-tray" class="overlay-anchor-shell overlay-anchor-shell--bottom overlay-anchor-shell--economy">
       <div class="bottom-tray-grid">
-        <div class="bottom-tray-table">
-          <h4>${economyView.comparison.title}</h4>
-          <p>${economyView.comparison.summary}</p>
-          <table>
-            <thead>
-              <tr><th>Ville</th><th>Stock</th><th>Ratio</th><th>Tension</th></tr>
-            </thead>
-            <tbody>
-              ${economyView.comparison.rows.map((row) => `
-                <tr>
-                  <td>${row.cityName}</td>
-                  <td>${row.totalStock}</td>
-                  <td>${row.scarcityRatio}</td>
-                  <td><span class="tension-pill tension-pill--${row.tensionLevel}">${row.tensionLevel}</span></td>
-                </tr>
-              `).join('')}
-            </tbody>
-          </table>
+        <div class="bottom-tray-table bottom-tray-table--comparison">
+          <div class="comparison-toolbar">
+            <div>
+              <h4>Comparaison multi-villes</h4>
+              <p>Sélectionne jusqu’à 3 villes sur la carte pour comparer stock, stabilité et prospérité.</p>
+            </div>
+            <div class="comparison-chip-row">
+              ${economyView.overlay.cities.map((city) => `<button type="button" class="comparison-chip ${state.comparedCityIds.includes(city.cityId) ? 'is-active' : ''}" data-compare-city-id="${city.cityId}">${city.cityName}</button>`).join('')}
+            </div>
+          </div>
+          <div class="comparison-cards">
+            ${comparedCities.map(({ city, panel, row }) => `
+              <article class="comparison-card ${state.selectedCityId === city.cityId ? 'is-selected' : ''}">
+                <div class="comparison-card__header">
+                  <div>
+                    <h5>${city.cityName}</h5>
+                    <p>${panel.summary}</p>
+                  </div>
+                  <span class="tension-pill tension-pill--${row.tensionLevel}">${row.tensionLevel}</span>
+                </div>
+                <dl class="comparison-card__stats">
+                  <div><dt>Stock</dt><dd>${row.totalStock}</dd></div>
+                  <div><dt>Stabilité</dt><dd>${city.stability}</dd></div>
+                  <div><dt>Prospérité</dt><dd>${city.prosperity}</dd></div>
+                  <div><dt>Ratio</dt><dd>${row.scarcityRatio}</dd></div>
+                </dl>
+                <ul>
+                  ${panel.rows.slice(0, 3).map((resource) => `<li class="${resource.status}"><span>${resource.resourceId}</span><strong>${resource.detail}</strong></li>`).join('')}
+                </ul>
+              </article>
+            `).join('')}
+          </div>
         </div>
         <div class="bottom-tray-stocks">
           ${economyView.overlay.cities.map((city) => {
             const panel = economyView.stockPanels[city.cityId];
             return `
-              <article class="stock-mini-card">
+              <article class="stock-mini-card ${state.comparedCityIds.includes(city.cityId) ? 'is-compared' : ''}">
                 <h4>${panel.cityName}</h4>
                 <p>${panel.summary}</p>
                 <ul>
@@ -957,8 +982,33 @@ function render() {
     });
 
     element.addEventListener('click', () => {
-      state.selectedCityId = element.dataset.cityId;
-      state.hoveredCityId = element.dataset.cityId;
+      const cityId = element.dataset.cityId;
+      state.selectedCityId = cityId;
+      state.hoveredCityId = cityId;
+
+      if (state.comparedCityIds.includes(cityId)) {
+        state.comparedCityIds = [cityId, ...state.comparedCityIds.filter((candidate) => candidate !== cityId)].slice(0, 3);
+      } else {
+        state.comparedCityIds = [...state.comparedCityIds, cityId].slice(-3);
+      }
+
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-compare-city-id]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const cityId = element.dataset.compareCityId;
+      const exists = state.comparedCityIds.includes(cityId);
+
+      if (exists) {
+        state.comparedCityIds = state.comparedCityIds.filter((candidate) => candidate !== cityId);
+      } else {
+        state.comparedCityIds = [...state.comparedCityIds, cityId].slice(-3);
+      }
+
+      state.selectedCityId = cityId;
+      state.hoveredCityId = cityId;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -750,14 +750,95 @@ button { font: inherit; }
   width: 100%;
 }
 .bottom-tray-table h4,
-.stock-mini-card h4 {
+.stock-mini-card h4,
+.comparison-card h5 {
   margin: 0 0 4px;
 }
 .bottom-tray-table p,
 .stock-mini-card p,
+.comparison-card p,
 .economy-route-card span {
   margin: 0;
   color: var(--muted);
+}
+.comparison-toolbar {
+  display: grid;
+  gap: 12px;
+}
+.comparison-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.comparison-chip {
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.64);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.comparison-chip.is-active {
+  border-color: rgba(125, 211, 252, 0.4);
+  background: rgba(14, 116, 144, 0.28);
+}
+.comparison-cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+.comparison-card {
+  padding: 14px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  display: grid;
+  gap: 12px;
+}
+.comparison-card.is-selected,
+.stock-mini-card.is-compared {
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.32);
+}
+.comparison-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+.comparison-card__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+.comparison-card__stats div {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(8, 15, 28, 0.55);
+}
+.comparison-card__stats dt {
+  color: var(--muted);
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+.comparison-card__stats dd {
+  margin: 0;
+  font-weight: 600;
+}
+.comparison-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+.comparison-card li {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(8, 15, 28, 0.55);
 }
 .bottom-tray-table table {
   width: 100%;
@@ -820,7 +901,7 @@ button { font: inherit; }
 @media (max-width: 720px) {
   .shell-root { width: min(100vw - 16px, 100%); padding-top: 8px; }
   .hero, .map-panel, .legend-panel, .province-details, .overlay-panel { padding: 14px; }
-  .hero-stats, .legend-columns, .province-facts, .overlay-tabs, .economy-quick-stats, .bottom-tray-grid, .bottom-tray-stocks, .province-popup__actions, .focus-strip { grid-template-columns: 1fr; }
+  .hero-stats, .legend-columns, .province-facts, .overlay-tabs, .economy-quick-stats, .bottom-tray-grid, .bottom-tray-stocks, .province-popup__actions, .focus-strip, .comparison-cards { grid-template-columns: 1fr; }
   .turn-toolbar { flex-direction: column; align-items: stretch; }
   .map-stage { min-height: 680px; }
   .province-node { padding: 14px 12px; }


### PR DESCRIPTION
## Résumé\n- ajoute un panneau de comparaison multi-villes dans le bottom tray de l'overlay économie\n- permet de sélectionner jusqu'à 3 villes depuis la carte ou des chips rapides\n- expose stock, stabilité, prospérité et les ressources clés sans bruit visuel\n\n## Validation\n- npm test\n- PORT=4383 npm run dev