### PR TITLE
Alpha: [WEB-A10] rendre les labels de provinces et points clés plus lisibles

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -99,10 +99,19 @@ const overlayLabels = {
 };
 
 const cityLayoutsById = {
-  'crown-port': { x: 49.5, y: 28 },
-  'river-gate-city': { x: 34, y: 56 },
-  'iron-plain-city': { x: 62, y: 55 },
-  'southern-crossing': { x: 47, y: 79 },
+  'crown-port': { x: 49.5, y: 28, labelDx: 0, labelDy: -6 },
+  'river-gate-city': { x: 34, y: 56, labelDx: -8, labelDy: 7 },
+  'iron-plain-city': { x: 62, y: 55, labelDx: 8, labelDy: -6 },
+  'southern-crossing': { x: 47, y: 79, labelDx: 0, labelDy: 8 },
+};
+
+const provinceLabelLayouts = {
+  'north-watch': { x: 26, y: 20, align: 'middle', tone: 'standard' },
+  'crown-heart': { x: 49.5, y: 18.5, align: 'middle', tone: 'capital' },
+  'red-ridge': { x: 75, y: 18.5, align: 'middle', tone: 'standard' },
+  'river-gate': { x: 21, y: 45, align: 'start', tone: 'frontier' },
+  'iron-plain': { x: 80, y: 48, align: 'end', tone: 'standard' },
+  'southern-reach': { x: 47, y: 91, align: 'middle', tone: 'frontier' },
 };
 
 const cities = [
@@ -621,8 +630,8 @@ function renderEconomyMapOverlay(economyView) {
       <g class="economy-city-group ${state.selectedCityId === city.cityId ? 'is-selected' : ''}" data-city-id="${city.cityId}">
         <circle class="economy-city economy-city--${city.marker.tone}" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 8}" />
         <circle class="economy-city-hitbox" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 11}" />
-        <text class="economy-city-label" x="${position.x}%" y="calc(${position.y}% - 14px)" text-anchor="middle">${city.cityName}</text>
-        <text class="economy-city-resource" x="${position.x}%" y="calc(${position.y}% + 18px)" text-anchor="middle">${city.resources.primaryResourceId ?? 'stock vide'}</text>
+        <text class="economy-city-label economy-city-label--sr" x="${position.x}%" y="calc(${position.y}% - 14px)" text-anchor="middle">${city.cityName}</text>
+        <text class="economy-city-resource economy-city-resource--sr" x="${position.x}%" y="calc(${position.y}% + 18px)" text-anchor="middle">${city.resources.primaryResourceId ?? 'stock vide'}</text>
       </g>
     `;
   }).join('');
@@ -737,6 +746,33 @@ function renderBottomTray(economyView) {
         </div>
       </div>
     </section>
+  `;
+}
+
+function renderProvinceLabels(shell) {
+  return `
+    <svg class="map-label-layer" viewBox="0 0 100 100" aria-label="Labels des provinces et points clés">
+      ${shell.provinces.map((province) => {
+        const label = provinceLabelLayouts[province.provinceId] ?? { ...getProvinceCenter(province.provinceId), align: 'middle', tone: 'standard' };
+        const city = cities.find((candidate) => candidate.regionId === province.provinceId) ?? null;
+        const cityLayout = city ? cityLayoutsById[city.id] : null;
+        const cityLabelX = cityLayout ? cityLayout.x + (cityLayout.labelDx ?? 0) : null;
+        const cityLabelY = cityLayout ? cityLayout.y + (cityLayout.labelDy ?? 0) : null;
+
+        return `
+          <g class="province-map-label province-map-label--${label.tone} ${province.selectionState.selected ? 'is-selected' : province.selectionState.focused ? 'is-focused' : ''}">
+            <text class="province-map-label__title" x="${label.x}%" y="${label.y}%" text-anchor="${label.align}">${province.label}</text>
+            <text class="province-map-label__subtitle" x="${label.x}%" y="${label.y + 3.4}%" text-anchor="${label.align}">${province.contested ? 'Front actif' : province.occupied ? 'Occupation' : `Valeur ${province.strategicValue}`}</text>
+            ${city && cityLayout ? `
+              <g class="city-map-label ${city.capital ? 'is-capital' : 'is-key'} ${state.selectedCityId === city.id ? 'is-selected' : ''}">
+                <line class="city-map-label__leader" x1="${cityLayout.x}%" y1="${cityLayout.y}%" x2="${cityLabelX}%" y2="${cityLabelY}%"></line>
+                <text class="city-map-label__title" x="${cityLabelX}%" y="${cityLabelY}%" text-anchor="middle">${city.name}</text>
+              </g>
+            ` : ''}
+          </g>
+        `;
+      }).join('')}
+    </svg>
   `;
 }
 
@@ -903,6 +939,7 @@ function render() {
             <div class="map-backdrop"></div>
             ${renderTerrainDecor()}
             ${renderStrategicRelations(shell)}
+            ${renderProvinceLabels(shell)}
             <div id="top-hud" class="overlay-anchor-shell overlay-anchor-shell--top">Top HUD</div>
             <div id="left-rail" class="overlay-anchor-shell overlay-anchor-shell--left">Left rail</div>
             <div id="right-rail" class="overlay-anchor-shell overlay-anchor-shell--right">Right rail</div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -193,6 +193,64 @@ button { font: inherit; }
   z-index: 1;
   overflow: visible;
 }
+.map-label-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  overflow: visible;
+  pointer-events: none;
+}
+.province-map-label__title,
+.province-map-label__subtitle,
+.city-map-label__title {
+  paint-order: stroke fill;
+  stroke-linejoin: round;
+}
+.province-map-label__title {
+  fill: #f8fafc;
+  stroke: rgba(8, 15, 28, 0.92);
+  stroke-width: 1.8;
+  font-size: 3.2px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-map-label__subtitle {
+  fill: rgba(226, 232, 240, 0.92);
+  stroke: rgba(8, 15, 28, 0.92);
+  stroke-width: 1.4;
+  font-size: 2px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.province-map-label--capital .province-map-label__title {
+  fill: #fde68a;
+}
+.province-map-label--frontier .province-map-label__subtitle {
+  fill: #fda4af;
+}
+.province-map-label.is-selected .province-map-label__title,
+.province-map-label.is-focused .province-map-label__title {
+  fill: #bae6fd;
+}
+.city-map-label__leader {
+  stroke: rgba(226, 232, 240, 0.38);
+  stroke-width: 0.3;
+  stroke-dasharray: 0.8 0.8;
+}
+.city-map-label__title {
+  fill: rgba(226, 232, 240, 0.96);
+  stroke: rgba(8, 15, 28, 0.95);
+  stroke-width: 1.2;
+  font-size: 1.95px;
+  font-weight: 700;
+}
+.city-map-label.is-capital .city-map-label__title {
+  fill: #fde68a;
+}
+.city-map-label.is-selected .city-map-label__title {
+  fill: #bfdbfe;
+}
 .front-line {
   stroke: rgba(148, 163, 184, 0.28);
   stroke-width: 0.45;
@@ -359,6 +417,10 @@ button { font: inherit; }
   font-size: 4px;
   letter-spacing: 0;
   text-transform: none;
+}
+.economy-city-label--sr,
+.economy-city-resource--sr {
+  opacity: 0;
 }
 .economy-city-resource { fill: #bfdbfe; }
 .overlay-anchor-shell--top { left: 18%; top: 3%; width: 64%; height: 9%; }
@@ -824,6 +886,9 @@ button { font: inherit; }
   .turn-toolbar { flex-direction: column; align-items: stretch; }
   .map-stage { min-height: 680px; }
   .province-node { padding: 14px 12px; }
+  .province-map-label__title { font-size: 3.6px; }
+  .province-map-label__subtitle,
+  .city-map-label__title { font-size: 2.4px; }
   .city-quick-panel,
   .province-popup {
     left: 8% !important;


### PR DESCRIPTION
## Résumé\n- ajoute une couche de labels dédiée pour les provinces et points clés\n- améliore la lisibilité avec halos, décalages anti-collision et leaders vers les villes\n- signale plus clairement les capitales et zones de frontière sans casser les overlays\n\n## Tests\n- npm test\n- PORT=4180 node scripts/dev-server.mjs\n\nCloses #282