### PR TITLE
Beta: [WEB-B5] mieux montrer les tensions d’approvisionnement

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -566,12 +566,14 @@ function renderCityQuickPanel(economyView) {
   }
 
   const stockPanel = economyView.stockPanels[city.cityId];
+  const comparisonRow = economyView.comparison.rows.find((candidate) => candidate.cityId === city.cityId);
   const topResources = stockPanel.rows.slice(0, 3);
+  const fragileResources = stockPanel.rows.filter((row) => row.status === 'shortage').length;
   const left = Math.min(76, Math.max(8, city.marker.position.x + 3));
   const top = Math.min(66, Math.max(10, city.marker.position.y - 18));
 
   return `
-    <aside class="city-quick-panel" style="left:${left}%;top:${top}%;" aria-live="polite">
+    <aside class="city-quick-panel city-quick-panel--${comparisonRow?.tensionLevel ?? 'low'}" style="left:${left}%;top:${top}%;" aria-live="polite">
       <div class="city-quick-panel__header">
         <div>
           <strong>${city.cityName}</strong>
@@ -583,6 +585,10 @@ function renderCityQuickPanel(economyView) {
         <span>Stock ${city.resources.totalStock}</span>
         <span>Stabilité ${city.stability}</span>
         <span>Prospérité ${city.prosperity}</span>
+      </div>
+      <div class="city-quick-panel__alert-row">
+        <span class="tension-pill tension-pill--${comparisonRow?.tensionLevel ?? 'low'}">${comparisonRow?.tensionLevel ?? 'low'}</span>
+        <span>${fragileResources} ressource${fragileResources > 1 ? 's' : ''} fragile${fragileResources > 1 ? 's' : ''}</span>
       </div>
       <ul class="city-quick-panel__stocks">
         ${topResources.map((row) => `<li class="${row.status}"><span>${row.resourceId}</span><strong>${row.currentQuantity}</strong></li>`).join('')}
@@ -596,6 +602,8 @@ function renderEconomyMapOverlay(economyView) {
     return '';
   }
 
+  const tensionByCityId = Object.fromEntries(economyView.comparison.rows.map((row) => [row.cityId, row]));
+
   const routeLines = economyView.overlay.routes.map((route, index) => {
     const origin = cityLayoutsById[route.originCityId];
     const destination = cityLayoutsById[route.destinationCityId];
@@ -605,9 +613,16 @@ function renderEconomyMapOverlay(economyView) {
     }
 
     const visual = buildRouteVisual(route, origin, destination, index);
+    const originTension = tensionByCityId[route.originCityId]?.tensionLevel ?? 'low';
+    const destinationTension = tensionByCityId[route.destinationCityId]?.tensionLevel ?? 'low';
+    const tensionClass = originTension === 'high' || destinationTension === 'high'
+      ? 'has-high-tension'
+      : originTension === 'medium' || destinationTension === 'medium'
+        ? 'has-medium-tension'
+        : 'has-low-tension';
 
     return `
-      <g class="economy-route-group ${visual.classes}" data-route-id="${route.routeId}">
+      <g class="economy-route-group ${visual.classes} ${tensionClass}" data-route-id="${route.routeId}">
         <path class="economy-route__halo" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__casing" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__line" d="${visual.pathD}" pathLength="100" marker-end="url(#${visual.markerId})" />
@@ -627,8 +642,11 @@ function renderEconomyMapOverlay(economyView) {
       return '';
     }
 
+    const tension = tensionByCityId[city.cityId]?.tensionLevel ?? 'low';
+
     return `
-      <g class="economy-city-group ${state.selectedCityId === city.cityId ? 'is-selected' : ''}" data-city-id="${city.cityId}">
+      <g class="economy-city-group ${state.selectedCityId === city.cityId ? 'is-selected' : ''} is-${tension}-tension" data-city-id="${city.cityId}">
+        <circle class="economy-city-tension-ring" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 10.5}" />
         <circle class="economy-city economy-city--${city.marker.tone}" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 8}" />
         <circle class="economy-city-hitbox" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 11}" />
         <text class="economy-city-label economy-city-label--sr" x="${position.x}%" y="calc(${position.y}% - 14px)" text-anchor="middle">${city.cityName}</text>
@@ -687,18 +705,29 @@ function renderEconomySidePanel(economyView) {
         <div class="overlay-anchor"><span>Capacité</span><strong>${economyView.overlay.metrics.totalRouteCapacity}</strong></div>
       </div>
       <div class="economy-route-list">
-        ${economyView.overlay.routes.map((route) => `
-          <article class="economy-route-card ${route.active ? '' : 'is-inactive'} ${route.transportMode === 'river' ? 'is-river' : route.transportMode === 'sea' ? 'is-sea' : 'is-land'} ${route.riskLevel >= 55 || route.totalCapacity >= 9 ? 'is-critical' : ''}">
-            <strong>${route.routeName}</strong>
-            <span>${route.transportMode}, risque ${route.riskLevel}</span>
-            <span>capacité ${route.totalCapacity}</span>
-          </article>
-        `).join('')}
+        ${economyView.overlay.routes.map((route) => {
+          const originTension = tensionByCityId[route.originCityId]?.tensionLevel ?? 'low';
+          const destinationTension = tensionByCityId[route.destinationCityId]?.tensionLevel ?? 'low';
+          const tensionClass = originTension === 'high' || destinationTension === 'high'
+            ? 'has-high-tension'
+            : originTension === 'medium' || destinationTension === 'medium'
+              ? 'has-medium-tension'
+              : 'has-low-tension';
+
+          return `
+            <article class="economy-route-card ${route.active ? '' : 'is-inactive'} ${route.transportMode === 'river' ? 'is-river' : route.transportMode === 'sea' ? 'is-sea' : 'is-land'} ${route.riskLevel >= 55 || route.totalCapacity >= 9 ? 'is-critical' : ''} ${tensionClass}">
+              <strong>${route.routeName}</strong>
+              <span>${route.transportMode}, risque ${route.riskLevel}</span>
+              <span>capacité ${route.totalCapacity}</span>
+            </article>
+          `;
+        }).join('')}
       </div>
       <div class="economy-route-legend">
         <span><i class="is-land"></i>Terre</span>
         <span><i class="is-river"></i>Fluvial</span>
         <span><i class="is-critical"></i>Liaison critique</span>
+        <span><i class="is-high-tension"></i>Tension forte</span>
       </div>
     </section>
   `;
@@ -758,8 +787,9 @@ function renderBottomTray(economyView) {
         <div class="bottom-tray-stocks">
           ${economyView.overlay.cities.map((city) => {
             const panel = economyView.stockPanels[city.cityId];
+            const comparisonRow = economyView.comparison.rows.find((candidate) => candidate.cityId === city.cityId);
             return `
-              <article class="stock-mini-card ${state.comparedCityIds.includes(city.cityId) ? 'is-compared' : ''}">
+              <article class="stock-mini-card ${state.comparedCityIds.includes(city.cityId) ? 'is-compared' : ''} ${comparisonRow?.tensionLevel === 'high' ? 'is-fragile' : ''}">
                 <h4>${panel.cityName}</h4>
                 <p>${panel.summary}</p>
                 <ul>

--- a/web/styles.css
+++ b/web/styles.css
@@ -394,6 +394,27 @@ button { font: inherit; }
 .economy-route.is-critical .economy-route__line {
   filter: drop-shadow(0 0 8px rgba(251, 113, 133, 0.4));
 }
+.economy-route.has-medium-tension .economy-route__halo {
+  stroke: rgba(245, 158, 11, 0.55);
+}
+.economy-route.has-high-tension .economy-route__halo {
+  stroke: rgba(251, 113, 133, 0.78);
+}
+.economy-city-tension-ring {
+  fill: none;
+  stroke-width: 1.6;
+  opacity: 0.9;
+}
+.economy-city-group.is-medium-tension .economy-city-tension-ring {
+  stroke: rgba(245, 158, 11, 0.85);
+}
+.economy-city-group.is-high-tension .economy-city-tension-ring {
+  stroke: rgba(251, 113, 133, 0.95);
+  filter: drop-shadow(0 0 7px rgba(251, 113, 133, 0.45));
+}
+.economy-city-group.is-low-tension .economy-city-tension-ring {
+  stroke: rgba(34, 197, 94, 0.35);
+}
 .economy-city {
   stroke: rgba(255, 255, 255, 0.88);
   stroke-width: 1.6;
@@ -567,6 +588,13 @@ button { font: inherit; }
   min-width: 220px;
   pointer-events: none;
 }
+.city-quick-panel--medium {
+  border-color: rgba(245, 158, 11, 0.28);
+}
+.city-quick-panel--high {
+  border-color: rgba(251, 113, 133, 0.34);
+  box-shadow: 0 18px 40px rgba(127, 29, 29, 0.28);
+}
 .city-quick-panel__header {
   display: flex;
   justify-content: space-between;
@@ -614,6 +642,14 @@ button { font: inherit; }
 .city-quick-panel__stocks li {
   display: inline-flex;
   gap: 8px;
+}
+.city-quick-panel__alert-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 12px;
 }
 .province-popup::before {
   content: '';
@@ -779,6 +815,12 @@ button { font: inherit; }
 .economy-route-card.is-critical {
   box-shadow: inset 0 0 0 1px rgba(251, 113, 133, 0.16);
 }
+.economy-route-card.has-medium-tension {
+  background: linear-gradient(90deg, rgba(245, 158, 11, 0.12), rgba(15, 23, 42, 0.55) 30%);
+}
+.economy-route-card.has-high-tension {
+  background: linear-gradient(90deg, rgba(251, 113, 133, 0.14), rgba(15, 23, 42, 0.55) 36%);
+}
 .economy-route-card.is-inactive {
   opacity: 0.68;
 }
@@ -805,6 +847,7 @@ button { font: inherit; }
 .economy-route-legend i.is-land { background: #f59e0b; }
 .economy-route-legend i.is-river { background: #38bdf8; }
 .economy-route-legend i.is-critical { background: #fb7185; }
+.economy-route-legend i.is-high-tension { background: linear-gradient(90deg, #fb7185, #fecdd3); }
 .bottom-tray-grid {
   display: grid;
   grid-template-columns: 1.2fr 1fr;
@@ -924,6 +967,10 @@ button { font: inherit; }
   border-radius: 16px;
   background: rgba(15, 23, 42, 0.58);
   border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.stock-mini-card.is-fragile {
+  border-color: rgba(251, 113, 133, 0.26);
+  background: linear-gradient(180deg, rgba(127, 29, 29, 0.14), rgba(15, 23, 42, 0.58));
 }
 .stock-mini-card ul {
   list-style: none;


### PR DESCRIPTION
## Résumé\n- fait ressortir les villes sous tension avec des anneaux et des cartes fragiles\n- relie les tensions d’approvisionnement aux routes concernées dans la carte et le panneau latéral\n- enrichit la fiche rapide de ville avec un niveau de tension et le nombre de ressources fragiles\n\n## Validation\n- npm test\n- PORT=4384 npm run dev