### PR TITLE
Epsilon: [WEB-E2] mieux afficher les saisons sur l’ensemble de la carte

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -29,14 +29,36 @@ function normalizeClimateState(climateState) {
   return new ClimateState(climateState);
 }
 
-function buildSeasonEntry(state, seasonLabels) {
+const DEFAULT_SEASON_STYLE_BY_TYPE = Object.freeze({
+  spring: { icon: '✿', tone: 'renewal', accent: 'green' },
+  summer: { icon: '☀', tone: 'bright', accent: 'gold' },
+  autumn: { icon: '❋', tone: 'harvest', accent: 'amber' },
+  winter: { icon: '❄', tone: 'cold', accent: 'cyan' },
+  default: { icon: '◐', tone: 'info', accent: 'slate' },
+});
+
+function normalizeSeasonStyle(styleByType, season) {
+  const seasonType = String(season ?? '').trim().toLowerCase();
+  const style = styleByType[seasonType] ?? styleByType.default ?? DEFAULT_SEASON_STYLE_BY_TYPE.default;
+
+  return {
+    icon: String(style.icon ?? DEFAULT_SEASON_STYLE_BY_TYPE[seasonType]?.icon ?? '◐').trim() || '◐',
+    tone: String(style.tone ?? DEFAULT_SEASON_STYLE_BY_TYPE[seasonType]?.tone ?? 'info').trim() || 'info',
+    accent: String(style.accent ?? DEFAULT_SEASON_STYLE_BY_TYPE[seasonType]?.accent ?? 'slate').trim() || 'slate',
+  };
+}
+
+function buildSeasonEntry(state, seasonLabels, seasonStyleByType) {
+  const badge = normalizeSeasonStyle(seasonStyleByType, state.season);
+
   return {
     overlayId: `${state.regionId}:season`,
     regionId: state.regionId,
     kind: 'season',
     label: seasonLabels[state.season] ?? state.season,
     season: state.season,
-    tone: 'info',
+    tone: badge.tone,
+    badge,
   };
 }
 
@@ -97,7 +119,7 @@ function buildStrategicImpact(state, catastropheEntries) {
   return 'stable';
 }
 
-function buildSeasonSummary(states, seasonLabels) {
+function buildSeasonSummary(states, seasonLabels, seasonStyleByType) {
   const countsBySeason = Object.create(null);
 
   for (const state of states) {
@@ -110,11 +132,23 @@ function buildSeasonSummary(states, seasonLabels) {
       season,
       label: seasonLabels[season] ?? season,
       regionCount,
+      badge: normalizeSeasonStyle(seasonStyleByType, season),
     }));
+
+  const dominantSeason = seasons
+    .slice()
+    .sort((left, right) => {
+      if (right.regionCount !== left.regionCount) {
+        return right.regionCount - left.regionCount;
+      }
+
+      return left.season.localeCompare(right.season);
+    })[0] ?? null;
 
   return {
     title: 'Situation saisonnière',
     summary: seasons.map((entry) => `${entry.label}: ${entry.regionCount}`).join(', '),
+    dominantSeason,
     seasons,
   };
 }
@@ -124,14 +158,20 @@ function buildLegend(stateEntries, catastropheEntries, seasonLabels) {
     .filter((entry) => entry.kind === 'season')
     .map((entry) => entry.season))]
     .sort()
-    .map((season) => ({
-      key: `season:${season}`,
-      kind: 'season',
-      season,
-      label: seasonLabels[season] ?? season,
-      tone: 'info',
-      description: 'Saison dominante affichée pour une région.',
-    }));
+    .map((season) => {
+      const seasonEntry = stateEntries.find((entry) => entry.kind === 'season' && entry.season === season);
+
+      return {
+        key: `season:${season}`,
+        kind: 'season',
+        season,
+        label: seasonLabels[season] ?? season,
+        tone: seasonEntry?.tone ?? 'info',
+        icon: seasonEntry?.badge?.icon ?? '◐',
+        accent: seasonEntry?.badge?.accent ?? 'slate',
+        description: 'Saison dominante affichée pour une région.',
+      };
+    });
 
   const anomalyLegend = [...new Map(stateEntries
     .filter((entry) => entry.kind === 'anomaly')
@@ -177,6 +217,10 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
   const states = requireArray(climateStates, 'ClimateMapOverlay climateStates').map(normalizeClimateState);
   const normalizedOptions = requireObject(options, 'ClimateMapOverlay options');
   const seasonLabels = requireObject(normalizedOptions.seasonLabels ?? {}, 'ClimateMapOverlay seasonLabels');
+  const seasonStyleByType = {
+    ...DEFAULT_SEASON_STYLE_BY_TYPE,
+    ...requireObject(normalizedOptions.seasonStyleByType ?? {}, 'ClimateMapOverlay seasonStyleByType'),
+  };
   const anomalyStyleByType = {
     ...DEFAULT_ANOMALY_STYLE_BY_TYPE,
     ...requireObject(normalizedOptions.anomalyStyleByType ?? {}, 'ClimateMapOverlay anomalyStyleByType'),
@@ -193,7 +237,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     .slice()
     .sort((left, right) => left.regionId.localeCompare(right.regionId))
     .flatMap((state) => {
-      const entries = [buildSeasonEntry(state, seasonLabels)];
+      const entries = [buildSeasonEntry(state, seasonLabels, seasonStyleByType)];
       const anomalyEntry = buildAnomalyEntry(state, anomalyStyleByType);
 
       if (anomalyEntry) {
@@ -235,7 +279,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
       return left.overlayId.localeCompare(right.overlayId);
     }),
     regions,
-    seasonalPanel: buildSeasonSummary(states, seasonLabels),
+    seasonalPanel: buildSeasonSummary(states, seasonLabels, seasonStyleByType),
     legend: buildLegend(stateEntries, catastropheEntries, seasonLabels),
     metrics: {
       regionCount: states.length,

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -49,7 +49,12 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         kind: 'season',
         label: 'Printemps',
         season: 'spring',
-        tone: 'info',
+        tone: 'renewal',
+        badge: {
+          icon: '✿',
+          tone: 'renewal',
+          accent: 'green',
+        },
       },
       {
         overlayId: 'north-coast:storm-1',
@@ -88,7 +93,12 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         kind: 'season',
         label: 'Été',
         season: 'summer',
-        tone: 'info',
+        tone: 'bright',
+        badge: {
+          icon: '☀',
+          tone: 'bright',
+          accent: 'gold',
+        },
       },
       {
         overlayId: 'sunreach:storm-1',
@@ -136,16 +146,36 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
     seasonalPanel: {
       title: 'Situation saisonnière',
       summary: 'Printemps: 1, Été: 1',
+      dominantSeason: {
+        season: 'spring',
+        label: 'Printemps',
+        regionCount: 1,
+        badge: {
+          icon: '✿',
+          tone: 'renewal',
+          accent: 'green',
+        },
+      },
       seasons: [
         {
           season: 'spring',
           label: 'Printemps',
           regionCount: 1,
+          badge: {
+            icon: '✿',
+            tone: 'renewal',
+            accent: 'green',
+          },
         },
         {
           season: 'summer',
           label: 'Été',
           regionCount: 1,
+          badge: {
+            icon: '☀',
+            tone: 'bright',
+            accent: 'gold',
+          },
         },
       ],
     },
@@ -158,7 +188,9 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
           kind: 'season',
           season: 'spring',
           label: 'Printemps',
-          tone: 'info',
+          tone: 'renewal',
+          icon: '✿',
+          accent: 'green',
           description: 'Saison dominante affichée pour une région.',
         },
         {
@@ -166,7 +198,9 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
           kind: 'season',
           season: 'summer',
           label: 'Été',
-          tone: 'info',
+          tone: 'bright',
+          icon: '☀',
+          accent: 'gold',
           description: 'Saison dominante affichée pour une région.',
         },
         {
@@ -226,10 +260,22 @@ test('buildClimateMapOverlay supports empty catastrophes and validated options',
         kind: 'season',
         season: 'autumn',
         label: 'autumn',
-        tone: 'info',
+        tone: 'harvest',
+        icon: '❋',
+        accent: 'amber',
         description: 'Saison dominante affichée pour une région.',
       },
     ],
+  });
+  assert.deepEqual(overlay.seasonalPanel.dominantSeason, {
+    season: 'autumn',
+    label: 'autumn',
+    regionCount: 1,
+    badge: {
+      icon: '❋',
+      tone: 'harvest',
+      accent: 'amber',
+    },
   });
   assert.deepEqual(overlay.regions, [
     {
@@ -244,6 +290,56 @@ test('buildClimateMapOverlay supports empty catastrophes and validated options',
       droughtIndex: 29,
     },
   ]);
+});
+
+test('buildClimateMapOverlay supports season badge overrides', () => {
+  const overlay = buildClimateMapOverlay([
+    {
+      regionId: 'delta',
+      season: 'winter',
+      temperatureC: 2,
+      precipitationLevel: 40,
+      droughtIndex: 9,
+    },
+  ], {
+    seasonStyleByType: {
+      winter: { icon: '*', tone: 'still', accent: 'ice' },
+    },
+  });
+
+  assert.deepEqual(overlay.entries[0], {
+    overlayId: 'delta:season',
+    regionId: 'delta',
+    kind: 'season',
+    label: 'winter',
+    season: 'winter',
+    tone: 'still',
+    badge: {
+      icon: '*',
+      tone: 'still',
+      accent: 'ice',
+    },
+  });
+  assert.deepEqual(overlay.legend.items[0], {
+    key: 'season:winter',
+    kind: 'season',
+    season: 'winter',
+    label: 'winter',
+    tone: 'still',
+    icon: '*',
+    accent: 'ice',
+    description: 'Saison dominante affichée pour une région.',
+  });
+  assert.deepEqual(overlay.seasonalPanel.dominantSeason, {
+    season: 'winter',
+    label: 'winter',
+    regionCount: 1,
+    badge: {
+      icon: '*',
+      tone: 'still',
+      accent: 'ice',
+    },
+  });
 });
 
 test('buildClimateMapOverlay supports anomaly marker overrides', () => {
@@ -291,5 +387,6 @@ test('buildClimateMapOverlay rejects invalid inputs', () => {
   assert.throws(() => buildClimateMapOverlay([null]), /ClimateState instances or plain objects/);
   assert.throws(() => buildClimateMapOverlay([], null), /options must be an object/);
   assert.throws(() => buildClimateMapOverlay([], { seasonLabels: [] }), /seasonLabels must be an object/);
+  assert.throws(() => buildClimateMapOverlay([], { seasonStyleByType: [] }), /seasonStyleByType must be an object/);
   assert.throws(() => buildClimateMapOverlay([], { anomalyStyleByType: [] }), /anomalyStyleByType must be an object/);
 });


### PR DESCRIPTION
## Summary

- Epsilon: rend la lecture des saisons plus visuelle dans `buildClimateMapOverlay`
- Epsilon: ajoute des badges saisonniers cohérents par région, dans le panneau saisonnier et dans la légende
- Epsilon: garde la couche légère avec des styles configurables via les options d'overlay

## Related issue

- One issue only: #309

## Changes

- Epsilon: ajoute des styles saisonniers par défaut avec icône, ton et accent
- Epsilon: enrichit chaque entrée de saison avec un `badge` explicite pour la carte
- Epsilon: complète `seasonalPanel` avec une `dominantSeason` plus lisible
- Epsilon: fait remonter les repères saisonniers dans la légende climat
- Epsilon: ajoute des tests pour les styles par défaut, les overrides et la validation

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [ ] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date

## Notes

- Epsilon: `npm test -- --test test/ui/climate/buildClimateMapOverlay.test.js`
- Epsilon: `npm test`
