### PR TITLE
Alpha: [WEB-A11] améliorer la navigation carte sur petit écran

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -207,6 +207,8 @@ const state = {
   selectedCityId: 'river-gate-city',
   comparedCityIds: ['river-gate-city', 'crown-port'],
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
+  mobilePanelSection: 'details',
+  mobileMapExpanded: true,
   lastTurnSummary: 'Le théâtre reste sous tension, sans bascule majeure.',
 };
 
@@ -922,6 +924,17 @@ function advanceTurn() {
   state.lastTurnSummary = summaries[(state.turn - 2) % summaries.length];
 }
 
+function renderMobileToolbar() {
+  return `
+    <div class="mobile-toolbar" aria-label="Navigation mobile de la carte">
+      <button type="button" class="mobile-toolbar__button ${state.mobilePanelSection === 'details' ? 'is-active' : ''}" data-mobile-panel="details">Détails</button>
+      <button type="button" class="mobile-toolbar__button ${state.mobilePanelSection === 'legend' ? 'is-active' : ''}" data-mobile-panel="legend">Légende</button>
+      <button type="button" class="mobile-toolbar__button ${state.mobilePanelSection === 'overlay' ? 'is-active' : ''}" data-mobile-panel="overlay">Overlay</button>
+      <button type="button" class="mobile-toolbar__button ${state.mobileMapExpanded ? 'is-active' : ''}" data-mobile-map-toggle="true">${state.mobileMapExpanded ? 'Réduire carte' : 'Ouvrir carte'}</button>
+    </div>
+  `;
+}
+
 function render() {
   const shell = getShell();
   const economyView = getEconomyViewModel();
@@ -951,7 +964,8 @@ function render() {
         </div>
       </section>
 
-      <section class="layout-grid">
+      ${renderMobileToolbar()}
+      <section class="layout-grid ${state.mobileMapExpanded ? 'is-map-expanded' : 'is-map-collapsed'}">
         <section class="panel map-panel">
           <div class="panel-header panel-header--spread">
             <div>
@@ -978,9 +992,11 @@ function render() {
         </section>
 
         <aside class="side-column">
-          ${renderLegend(shell)}
-          ${renderActiveProvince(shell)}
-          ${renderEconomySidePanel(economyView)}
+          <div class="mobile-panel-stack ${state.mobilePanelSection === 'legend' ? 'show-legend' : state.mobilePanelSection === 'overlay' ? 'show-overlay' : 'show-details'}">
+            ${renderLegend(shell)}
+            ${renderActiveProvince(shell)}
+            ${renderEconomySidePanel(economyView)}
+          </div>
         </aside>
       </section>
     </main>
@@ -1053,6 +1069,20 @@ function render() {
   document.querySelectorAll('[data-next-turn]').forEach((element) => {
     element.addEventListener('click', () => {
       advanceTurn();
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-mobile-panel]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.mobilePanelSection = element.dataset.mobilePanel;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-mobile-map-toggle]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.mobileMapExpanded = !state.mobileMapExpanded;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -101,6 +101,24 @@ button { font: inherit; }
   grid-template-columns: minmax(0, 2fr) minmax(320px, 0.9fr);
   gap: 20px;
 }
+.mobile-toolbar {
+  display: none;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.mobile-toolbar__button {
+  flex: 1 1 0;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.72);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+.mobile-toolbar__button.is-active {
+  border-color: rgba(125, 211, 252, 0.42);
+  background: rgba(14, 116, 144, 0.3);
+}
 .map-panel { padding: 20px; }
 .panel-header { margin-bottom: 16px; }
 .panel-header--spread {
@@ -672,6 +690,9 @@ button { font: inherit; }
   cursor: pointer;
 }
 .side-column { display: grid; gap: 16px; }
+.mobile-panel-stack {
+  display: contents;
+}
 .legend-panel, .province-details, .overlay-panel { padding: 18px; }
 .legend-columns {
   display: grid;
@@ -962,14 +983,36 @@ button { font: inherit; }
 }
 @media (max-width: 720px) {
   .shell-root { width: min(100vw - 16px, 100%); padding-top: 8px; }
+  .mobile-toolbar { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .hero, .map-panel, .legend-panel, .province-details, .overlay-panel { padding: 14px; }
   .hero-stats, .legend-columns, .province-facts, .overlay-tabs, .economy-quick-stats, .bottom-tray-grid, .bottom-tray-stocks, .province-popup__actions, .focus-strip, .comparison-cards { grid-template-columns: 1fr; }
   .turn-toolbar { flex-direction: column; align-items: stretch; }
-  .map-stage { min-height: 680px; }
+  .layout-grid { gap: 12px; }
+  .layout-grid.is-map-collapsed .map-panel { display: none; }
+  .layout-grid.is-map-expanded .side-column { order: 2; }
+  .layout-grid.is-map-expanded .map-panel { order: 1; }
+  .map-panel { padding: 12px; }
+  .panel-header--spread { gap: 10px; }
+  .overlay-tabs { min-width: 0; grid-template-columns: 1fr 1fr; }
+  .map-stage { min-height: 560px; }
+  .overlay-anchor-shell--top,
+  .overlay-anchor-shell--left,
+  .overlay-anchor-shell--right,
+  .overlay-anchor-shell--bottom { display: none; }
+  .focus-hint { left: 12px; right: 12px; transform: none; text-align: center; }
   .province-node { padding: 14px 12px; }
-  .province-map-label__title { font-size: 3.6px; }
+  .province-node__meta,
+  .province-node__badges,
+  .province-node__link,
   .province-map-label__subtitle,
-  .city-map-label__title { font-size: 2.4px; }
+  .city-map-label { display: none; }
+  .province-map-label__title { font-size: 3.6px; }
+  .mobile-panel-stack > .legend-panel,
+  .mobile-panel-stack > .province-details,
+  .mobile-panel-stack > .overlay-panel { display: none; }
+  .mobile-panel-stack.show-legend > .legend-panel,
+  .mobile-panel-stack.show-details > .province-details,
+  .mobile-panel-stack.show-overlay > .overlay-panel { display: block; }
   .city-quick-panel,
   .province-popup {
     left: 8% !important;


### PR DESCRIPTION
## Résumé\n- ajoute une barre de navigation mobile pour alterner entre détails, légende et overlay\n- permet de réduire la carte pour libérer l'espace sur petit écran\n- simplifie l'affichage mobile pour limiter les collisions visuelles entre carte, labels et panneaux\n\n## Tests\n- npm test\n- PORT=4181 node scripts/dev-server.mjs\n\nCloses #283