### PR TITLE
Alpha: [WEB-A9] ajouter un fond cartographique et un relief léger

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -931,12 +931,24 @@ function renderStrategicRelations(shell) {
 
 function renderTerrainDecor() {
   return `
+    <div class="map-sea map-sea--west"></div>
+    <div class="map-sea map-sea--south"></div>
+    <div class="terrain-shadow terrain-shadow--north"></div>
+    <div class="terrain-shadow terrain-shadow--central"></div>
+    <div class="terrain-shadow terrain-shadow--south"></div>
     <div class="terrain-mass terrain-mass--north"></div>
     <div class="terrain-mass terrain-mass--east"></div>
     <div class="terrain-mass terrain-mass--south"></div>
+    <div class="terrain-ridge terrain-ridge--north"></div>
+    <div class="terrain-ridge terrain-ridge--central"></div>
+    <div class="terrain-ridge terrain-ridge--south"></div>
+    <div class="terrain-forest terrain-forest--west"></div>
+    <div class="terrain-forest terrain-forest--east"></div>
     <div class="terrain-river"></div>
     <div class="terrain-contours terrain-contours--a"></div>
     <div class="terrain-contours terrain-contours--b"></div>
+    <div class="terrain-contours terrain-contours--c"></div>
+    <div class="terrain-grain"></div>
   `;
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -158,10 +158,11 @@ button { font: inherit; }
 .map-backdrop {
   position: absolute; inset: 0;
   background:
-    radial-gradient(circle at 20% 24%, rgba(59, 130, 246, 0.18), transparent 18%),
-    radial-gradient(circle at 74% 26%, rgba(239, 68, 68, 0.16), transparent 16%),
-    radial-gradient(circle at 48% 64%, rgba(34, 197, 94, 0.12), transparent 18%),
-    linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(12, 74, 110, 0.56));
+    radial-gradient(circle at 18% 22%, rgba(125, 211, 252, 0.16), transparent 14%),
+    radial-gradient(circle at 74% 24%, rgba(248, 113, 113, 0.14), transparent 18%),
+    radial-gradient(circle at 46% 66%, rgba(74, 222, 128, 0.1), transparent 18%),
+    linear-gradient(180deg, rgba(8, 47, 73, 0.4), rgba(15, 23, 42, 0.2) 24%, rgba(11, 15, 25, 0.14) 60%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.94), rgba(12, 74, 110, 0.62));
 }
 .map-backdrop::before,
 .map-backdrop::after {
@@ -175,21 +176,73 @@ button { font: inherit; }
 .map-backdrop::after {
   background: linear-gradient(transparent 0%, rgba(8, 15, 28, 0.46) 100%);
 }
+.map-sea,
+.terrain-shadow,
 .terrain-mass,
+.terrain-ridge,
+.terrain-forest,
 .terrain-river,
-.terrain-contours {
+.terrain-contours,
+.terrain-grain {
   position: absolute;
   pointer-events: none;
 }
+.map-sea {
+  z-index: 0;
+  opacity: 0.95;
+  filter: blur(1px);
+}
+.map-sea--west {
+  left: -6%;
+  top: 6%;
+  width: 24%;
+  height: 84%;
+  background: linear-gradient(180deg, rgba(8, 145, 178, 0.3), rgba(14, 165, 233, 0.16));
+  clip-path: polygon(0 0, 88% 6%, 74% 18%, 96% 31%, 70% 46%, 84% 64%, 58% 80%, 72% 100%, 0 100%);
+}
+.map-sea--south {
+  left: 18%;
+  right: 8%;
+  bottom: -6%;
+  height: 18%;
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.08), rgba(8, 145, 178, 0.22));
+  clip-path: ellipse(50% 72% at 50% 100%);
+}
+.terrain-shadow {
+  z-index: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(2, 6, 23, 0.28), transparent 70%);
+}
+.terrain-shadow--north { left: 14%; top: 12%; width: 28%; height: 18%; }
+.terrain-shadow--central { left: 46%; top: 18%; width: 34%; height: 28%; }
+.terrain-shadow--south { left: 30%; bottom: 14%; width: 30%; height: 16%; }
 .terrain-mass {
   z-index: 0;
   border-radius: 42% 58% 50% 50% / 36% 44% 56% 64%;
-  background: linear-gradient(145deg, rgba(30, 41, 59, 0.78), rgba(22, 78, 99, 0.32));
+  background: linear-gradient(145deg, rgba(51, 65, 85, 0.78), rgba(34, 197, 94, 0.12) 42%, rgba(22, 78, 99, 0.32));
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08), 0 20px 30px rgba(2, 6, 23, 0.18);
 }
 .terrain-mass--north { left: 10%; top: 10%; width: 34%; height: 22%; transform: rotate(-8deg); }
 .terrain-mass--east { right: 10%; top: 12%; width: 28%; height: 30%; transform: rotate(16deg); }
 .terrain-mass--south { left: 26%; bottom: 12%; width: 40%; height: 22%; transform: rotate(5deg); }
+.terrain-ridge {
+  z-index: 0;
+  border-radius: 999px;
+  border: 1px solid rgba(226, 232, 240, 0.08);
+  background: linear-gradient(180deg, rgba(226, 232, 240, 0.1), rgba(148, 163, 184, 0.04));
+  opacity: 0.6;
+}
+.terrain-ridge--north { left: 24%; top: 18%; width: 22%; height: 3%; transform: rotate(-18deg); }
+.terrain-ridge--central { left: 54%; top: 32%; width: 18%; height: 3%; transform: rotate(22deg); }
+.terrain-ridge--south { left: 38%; bottom: 22%; width: 24%; height: 3%; transform: rotate(10deg); }
+.terrain-forest {
+  z-index: 0;
+  opacity: 0.34;
+  background-image: radial-gradient(circle, rgba(22, 163, 74, 0.42) 0 18%, transparent 20%);
+  background-size: 18px 18px;
+}
+.terrain-forest--west { left: 16%; top: 34%; width: 18%; height: 18%; }
+.terrain-forest--east { left: 64%; top: 42%; width: 16%; height: 16%; }
 .terrain-river {
   z-index: 0;
   left: 44%; top: 12%; width: 8%; height: 66%;
@@ -205,6 +258,15 @@ button { font: inherit; }
 }
 .terrain-contours--a { transform: rotate(-8deg); }
 .terrain-contours--b { inset: 20% 18% 24% 22%; transform: rotate(10deg); }
+.terrain-contours--c { inset: 28% 24% 30% 28%; transform: rotate(-4deg); opacity: 0.55; }
+.terrain-grain {
+  z-index: 0;
+  inset: 0;
+  opacity: 0.08;
+  background-image: radial-gradient(circle at 20% 24%, rgba(255,255,255,0.45) 0 1px, transparent 1.4px), radial-gradient(circle at 70% 64%, rgba(255,255,255,0.28) 0 1px, transparent 1.4px);
+  background-size: 26px 26px, 34px 34px;
+  mix-blend-mode: soft-light;
+}
 .strategic-relations-layer {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Résumé\n- enrichit le fond de carte avec mer stylisée, masses de terrain, ombres et lignes de relief\n- ajoute des motifs de forêt, de grain et des crêtes discrètes pour renforcer la profondeur visuelle\n- conserve la lisibilité des overlays métier au-dessus du fond\n\n## Tests\n- npm test\n- PORT=4182 node scripts/dev-server.mjs\n\nCloses #281