### PR TITLE
Epsilon: [WEB-E4] dessiner les zones touchées par une catastrophe

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -153,6 +153,38 @@ function buildSeasonSummary(states, seasonLabels, seasonStyleByType) {
   };
 }
 
+function buildCatastropheZones(catastropheEntries) {
+  return [...new Map(catastropheEntries
+    .map((entry) => [entry.catastropheId, entry]))
+    .values()]
+    .sort((left, right) => left.catastropheId.localeCompare(right.catastropheId))
+    .map((entry) => {
+      const regionIds = catastropheEntries
+        .filter((candidate) => candidate.catastropheId === entry.catastropheId)
+        .map((candidate) => candidate.regionId)
+        .sort((left, right) => left.localeCompare(right));
+
+      return {
+        zoneId: `zone:${entry.catastropheId}`,
+        catastropheId: entry.catastropheId,
+        type: entry.type,
+        severity: entry.severity,
+        status: entry.status,
+        label: entry.label,
+        regionIds,
+        outline: {
+          stroke: entry.style.stroke,
+          pattern: 'ring',
+          opacity: Math.min(1, entry.style.opacity + 0.2),
+        },
+        fill: {
+          color: entry.style.fill,
+          opacity: Math.max(0.12, entry.style.opacity - 0.1),
+        },
+      };
+    });
+}
+
 function buildLegend(stateEntries, catastropheEntries, seasonLabels) {
   const seasonLegend = [...new Set(stateEntries
     .filter((entry) => entry.kind === 'season')
@@ -280,6 +312,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     }),
     regions,
     seasonalPanel: buildSeasonSummary(states, seasonLabels, seasonStyleByType),
+    catastropheZones: buildCatastropheZones(catastropheEntries),
     legend: buildLegend(stateEntries, catastropheEntries, seasonLabels),
     metrics: {
       regionCount: states.length,

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -179,6 +179,26 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         },
       ],
     },
+    catastropheZones: [
+      {
+        zoneId: 'zone:storm-1',
+        catastropheId: 'storm-1',
+        type: 'great-storm',
+        severity: 'major',
+        status: 'active',
+        label: 'great-storm (major)',
+        regionIds: ['north-coast', 'sunreach'],
+        outline: {
+          stroke: 'orange',
+          pattern: 'ring',
+          opacity: 0.6000000000000001,
+        },
+        fill: {
+          color: 'orange',
+          opacity: 0.30000000000000004,
+        },
+      },
+    ],
     legend: {
       title: 'Légende climat',
       compact: true,
@@ -251,6 +271,7 @@ test('buildClimateMapOverlay supports empty catastrophes and validated options',
   assert.equal(overlay.metrics.criticalRegionCount, 0);
   assert.equal(overlay.entries[0].overlayId, 'delta:season');
   assert.equal(overlay.seasonalPanel.summary, 'autumn: 1');
+  assert.deepEqual(overlay.catastropheZones, []);
   assert.deepEqual(overlay.legend, {
     title: 'Légende climat',
     compact: true,


### PR DESCRIPTION
## Summary

- Epsilon: ajoute des zones de catastrophe dédiées dans `buildClimateMapOverlay`
- Epsilon: relie explicitement chaque catastrophe active à son emprise régionale
- Epsilon: garde la lecture légère avec des styles de contour et de remplissage dérivés de l'overlay existant

## Related issue

- One issue only: #311

## Changes

- Epsilon: ajoute un tableau `catastropheZones` groupé par catastrophe active
- Epsilon: expose les régions touchées, un contour et un remplissage lisibles pour chaque zone
- Epsilon: complète les tests pour couvrir les zones de catastrophe et le cas sans catastrophe

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [ ] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date

## Notes

- Epsilon: `npm test -- --test test/ui/climate/buildClimateMapOverlay.test.js`
- Epsilon: `npm test`
