### PR TITLE
Epsilon: [WEB-E8] mieux relier climat et impact stratégique

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -119,6 +119,33 @@ function buildStrategicImpact(state, catastropheEntries) {
   return 'stable';
 }
 
+function buildStrategicSignals(state, catastropheEntries) {
+  const logisticsRisk = catastropheEntries.length > 0
+    ? 'severe'
+    : state.precipitationLevel < 20 || state.droughtIndex >= 55
+      ? 'elevated'
+      : 'low';
+
+  const stabilityRisk = catastropheEntries.some((entry) => entry.impact.unrest > 0)
+    ? 'high'
+    : state.hasAnomaly() || state.droughtIndex >= 45
+      ? 'moderate'
+      : 'low';
+
+  const harvestRisk = catastropheEntries.some((entry) => entry.impact.harvest < 0)
+    ? 'high'
+    : state.precipitationLevel < 25 || state.droughtIndex >= 50
+      ? 'moderate'
+      : 'low';
+
+  return {
+    logisticsRisk,
+    stabilityRisk,
+    harvestRisk,
+    summary: `logistique ${logisticsRisk}, stabilité ${stabilityRisk}, récoltes ${harvestRisk}`,
+  };
+}
+
 function buildSeasonSummary(states, seasonLabels, seasonStyleByType) {
   const countsBySeason = Object.create(null);
 
@@ -285,6 +312,8 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     .map((state) => {
       const regionalCatastrophes = catastropheEntries.filter((entry) => entry.regionId === state.regionId);
 
+      const strategicSignals = buildStrategicSignals(state, regionalCatastrophes);
+
       return {
         regionId: state.regionId,
         season: state.season,
@@ -292,6 +321,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
         anomaly: state.anomaly,
         activeCatastropheIds: regionalCatastrophes.map((entry) => entry.catastropheId),
         strategicImpact: buildStrategicImpact(state, regionalCatastrophes),
+        strategicSignals,
         temperatureC: state.temperatureC,
         precipitationLevel: state.precipitationLevel,
         droughtIndex: state.droughtIndex,
@@ -320,6 +350,9 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
       anomalyCount: stateEntries.filter((entry) => entry.kind === 'anomaly').length,
       catastropheCount: catastropheEntries.length,
       criticalRegionCount: regions.filter((region) => region.strategicImpact === 'critical').length,
+      logisticsRiskRegionCount: regions.filter((region) => region.strategicSignals.logisticsRisk !== 'low').length,
+      stabilityRiskRegionCount: regions.filter((region) => region.strategicSignals.stabilityRisk !== 'low').length,
+      harvestRiskRegionCount: regions.filter((region) => region.strategicSignals.harvestRisk !== 'low').length,
     },
   };
 }

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -127,6 +127,12 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         anomaly: null,
         activeCatastropheIds: ['storm-1'],
         strategicImpact: 'critical',
+        strategicSignals: {
+          logisticsRisk: 'severe',
+          stabilityRisk: 'low',
+          harvestRisk: 'high',
+          summary: 'logistique severe, stabilité low, récoltes high',
+        },
         temperatureC: 12,
         precipitationLevel: 63,
         droughtIndex: 18,
@@ -138,6 +144,12 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         anomaly: 'heatwave',
         activeCatastropheIds: ['storm-1'],
         strategicImpact: 'critical',
+        strategicSignals: {
+          logisticsRisk: 'severe',
+          stabilityRisk: 'moderate',
+          harvestRisk: 'high',
+          summary: 'logistique severe, stabilité moderate, récoltes high',
+        },
         temperatureC: 33,
         precipitationLevel: 11,
         droughtIndex: 74,
@@ -249,6 +261,9 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
       anomalyCount: 1,
       catastropheCount: 2,
       criticalRegionCount: 2,
+      logisticsRiskRegionCount: 2,
+      stabilityRiskRegionCount: 1,
+      harvestRiskRegionCount: 2,
     },
   });
 });
@@ -269,6 +284,9 @@ test('buildClimateMapOverlay supports empty catastrophes and validated options',
   assert.equal(overlay.entries.length, 1);
   assert.equal(overlay.metrics.catastropheCount, 0);
   assert.equal(overlay.metrics.criticalRegionCount, 0);
+  assert.equal(overlay.metrics.logisticsRiskRegionCount, 0);
+  assert.equal(overlay.metrics.stabilityRiskRegionCount, 0);
+  assert.equal(overlay.metrics.harvestRiskRegionCount, 0);
   assert.equal(overlay.entries[0].overlayId, 'delta:season');
   assert.equal(overlay.seasonalPanel.summary, 'autumn: 1');
   assert.deepEqual(overlay.catastropheZones, []);
@@ -306,6 +324,12 @@ test('buildClimateMapOverlay supports empty catastrophes and validated options',
       anomaly: null,
       activeCatastropheIds: [],
       strategicImpact: 'stable',
+      strategicSignals: {
+        logisticsRisk: 'low',
+        stabilityRisk: 'low',
+        harvestRisk: 'low',
+        summary: 'logistique low, stabilité low, récoltes low',
+      },
       temperatureC: 18,
       precipitationLevel: 48,
       droughtIndex: 29,


### PR DESCRIPTION
## Summary

- Epsilon: relie plus explicitement le climat aux effets stratégiques dans `buildClimateMapOverlay`
- Epsilon: expose des signaux simples sur la logistique, la stabilité et les récoltes pour chaque région
- Epsilon: ajoute des métriques agrégées pour rendre ces impacts lisibles dans la démo

## Related issue

- One issue only: #315

## Changes

- Epsilon: ajoute `strategicSignals` par région avec un résumé court et trois axes de risque
- Epsilon: complète les métriques d'overlay avec les compteurs de risque logistique, stabilité et récoltes
- Epsilon: met à jour les tests pour couvrir les impacts critiques, modérés et stables

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [ ] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date

## Notes

- Epsilon: `npm test -- --test test/ui/climate/buildClimateMapOverlay.test.js`
- Epsilon: `npm test`
