### PR TITLE
Beta: [WEB-B8] ajouter une heatmap légère des zones de richesse ou tension

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -608,6 +608,24 @@ function renderEconomyMapOverlay(economyView) {
   }
 
   const tensionByCityId = Object.fromEntries(economyView.comparison.rows.map((row) => [row.cityId, row]));
+  const heatNodes = economyView.overlay.cities.map((city) => {
+    const position = city.marker.position;
+    const tension = tensionByCityId[city.cityId];
+
+    if (!position || !tension) {
+      return '';
+    }
+
+    const tensionRadius = tension.tensionLevel === 'high' ? 18 : tension.tensionLevel === 'medium' ? 13 : 9;
+    const prosperityRadius = city.prosperity >= 70 ? 14 : city.prosperity >= 55 ? 10 : 7;
+
+    return `
+      <g class="economy-heat-node is-${tension.tensionLevel}-tension ${city.prosperity >= 70 ? 'is-rich' : city.prosperity >= 55 ? 'is-balanced' : 'is-fragile'}">
+        <circle class="economy-heat-node__tension" cx="${position.x}%" cy="${position.y}%" r="${tensionRadius}" />
+        <circle class="economy-heat-node__prosperity" cx="${position.x}%" cy="${position.y}%" r="${prosperityRadius}" />
+      </g>
+    `;
+  }).join('');
 
   const routeLines = economyView.overlay.routes.map((route, index) => {
     const origin = cityLayoutsById[route.originCityId];
@@ -677,6 +695,9 @@ function renderEconomyMapOverlay(economyView) {
           <path d="M 0 1 L 10 5 L 0 9 z" fill="#c7d2fe" opacity="0.95" />
         </marker>
       </defs>
+      <g class="economy-heat-layer">
+        ${heatNodes}
+      </g>
       ${routeLines}
       ${cityNodes}
     </svg>
@@ -762,6 +783,8 @@ function renderEconomySidePanel(economyView) {
               <li><span class="tension-pill tension-pill--low">low</span>lecture stable</li>
               <li><span class="tension-pill tension-pill--medium">medium</span>stocks fragiles</li>
               <li><span class="tension-pill tension-pill--high">high</span>pénurie à traiter</li>
+              <li><span class="economy-legend-heat is-rich"></span>zone prospère</li>
+              <li><span class="economy-legend-heat is-fragile"></span>zone en tension</li>
             </ul>
           </article>
         </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -453,6 +453,27 @@ button { font: inherit; }
   z-index: 2;
   overflow: visible;
 }
+.economy-heat-layer {
+  pointer-events: none;
+  isolation: isolate;
+}
+.economy-heat-node__tension,
+.economy-heat-node__prosperity {
+  stroke: none;
+  opacity: 0.22;
+}
+.economy-heat-node__tension {
+  mix-blend-mode: screen;
+}
+.economy-heat-node__prosperity {
+  opacity: 0.18;
+}
+.economy-heat-node.is-low-tension .economy-heat-node__tension { fill: rgba(74, 222, 128, 0.26); }
+.economy-heat-node.is-medium-tension .economy-heat-node__tension { fill: rgba(245, 158, 11, 0.28); }
+.economy-heat-node.is-high-tension .economy-heat-node__tension { fill: rgba(251, 113, 133, 0.34); }
+.economy-heat-node.is-rich .economy-heat-node__prosperity { fill: rgba(56, 189, 248, 0.28); }
+.economy-heat-node.is-balanced .economy-heat-node__prosperity { fill: rgba(96, 165, 250, 0.18); }
+.economy-heat-node.is-fragile .economy-heat-node__prosperity { fill: rgba(148, 163, 184, 0.12); }
 .economy-route-group {
   isolation: isolate;
 }
@@ -1030,6 +1051,7 @@ button { font: inherit; }
 }
 .economy-legend-city,
 .economy-legend-ring,
+.economy-legend-heat,
 .economy-route-legend i {
   display: inline-block;
   flex: 0 0 auto;
@@ -1057,6 +1079,18 @@ button { font: inherit; }
   border-radius: 999px;
   border: 2px solid rgba(251, 113, 133, 0.95);
   box-shadow: 0 0 8px rgba(251, 113, 133, 0.35);
+}
+.economy-legend-heat {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  opacity: 0.8;
+}
+.economy-legend-heat.is-rich {
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.34) 0%, rgba(56, 189, 248, 0.1) 70%, transparent 100%);
+}
+.economy-legend-heat.is-fragile {
+  background: radial-gradient(circle, rgba(251, 113, 133, 0.4) 0%, rgba(251, 113, 133, 0.12) 72%, transparent 100%);
 }
 .economy-route-legend i {
   width: 20px;


### PR DESCRIPTION
## Résumé\n- ajoute une heatmap légère sous les routes et marqueurs pour lire les zones riches ou tendues\n- combine prospérité et niveau de tension sans masquer les autres couches Beta\n- étend la légende économique pour expliquer cette nouvelle lecture spatiale\n\n## Validation\n- npm test\n- PORT=4387 npm run dev