### PR TITLE
Alpha: [WEB-A5] construire une carte type Google Maps avec provinces dessinées

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -380,6 +380,38 @@ function renderLegend(shell) {
   `;
 }
 
+const provincePolygonById = {
+  'north-watch': '8,24 24,12 39,10 47,18 46,36 34,42 18,40 8,32',
+  'crown-heart': '24,18 40,12 58,14 64,24 58,40 40,46 26,38 22,28',
+  'red-ridge': '58,16 73,10 88,18 90,34 80,44 64,42 54,32 52,22',
+  'river-gate': '38,38 54,34 66,40 68,54 56,66 40,64 32,52 34,42',
+  'iron-plain': '60,44 78,42 90,52 88,68 72,78 56,72 54,56',
+  'southern-reach': '24,58 42,54 58,58 64,74 48,88 28,86 16,72',
+};
+
+function getProvinceShape(provinceId) {
+  const polygon = provincePolygonById[provinceId] ?? '12,12 88,12 88,88 12,88';
+  return `polygon(${polygon.split(' ').map((point) => point.split(',').join('% ')).join('%, ') }%)`;
+}
+
+function renderProvinceSurface(shell, focusContext) {
+  return `
+    <svg class="province-surface-layer" viewBox="0 0 100 100" aria-label="Surface continue des provinces">
+      ${shell.provinces.map((province) => {
+        const isNeighbor = focusContext.neighborIds.has(province.provinceId);
+        const isSelected = province.selectionState.selected;
+        const isFocused = province.selectionState.focused;
+        const isMuted = !isSelected && !isFocused && !isNeighbor && (focusContext.selectedProvince || focusContext.focusedProvince);
+        return `
+          <g class="province-surface ${isSelected ? 'is-selected' : ''} ${isFocused ? 'is-focused' : ''} ${isNeighbor ? 'is-neighbor' : ''} ${isMuted ? 'is-muted' : ''} ${province.contested ? 'is-contested' : ''} ${province.occupied ? 'is-occupied' : ''}">
+            <polygon points="${provincePolygonById[province.provinceId]}" style="--province-fill:${province.style.fill};--province-border:${province.style.border};"></polygon>
+          </g>
+        `;
+      }).join('')}
+    </svg>
+  `;
+}
+
 function renderProvinceCard(province, focusContext) {
   const layout = provinceLayouts[province.provinceId];
   const badges = province.badges.map((badge) => `<span class="province-badge">${badge}</span>`).join('');
@@ -396,21 +428,13 @@ function renderProvinceCard(province, focusContext) {
     province.contested ? 'is-contested' : '',
     province.occupied ? 'is-occupied' : '',
   ].filter(Boolean).join(' ');
-  const silhouetteByProvinceId = {
-    'north-watch': 'polygon(10% 18%, 66% 6%, 92% 34%, 84% 88%, 28% 94%, 8% 58%)',
-    'crown-heart': 'polygon(8% 20%, 52% 4%, 90% 18%, 92% 74%, 54% 94%, 10% 78%)',
-    'red-ridge': 'polygon(16% 16%, 74% 8%, 94% 38%, 82% 92%, 22% 88%, 6% 44%)',
-    'river-gate': 'polygon(14% 10%, 86% 18%, 92% 54%, 74% 92%, 22% 86%, 6% 40%)',
-    'iron-plain': 'polygon(8% 24%, 48% 6%, 92% 28%, 88% 80%, 44% 96%, 6% 74%)',
-    'southern-reach': 'polygon(16% 14%, 78% 8%, 94% 46%, 74% 90%, 24% 92%, 6% 48%)',
-  };
 
   return `
     <button
       class="${classes}"
       type="button"
       data-province-id="${province.provinceId}"
-      style="left:${layout.x}%;top:${layout.y}%;width:${layout.w}%;height:${layout.h}%;--province-fill:${province.style.fill};--province-border:${province.style.border};--province-shape:${silhouetteByProvinceId[province.provinceId] ?? 'polygon(12% 12%, 88% 12%, 88% 88%, 12% 88%)'};"
+      style="left:${layout.x}%;top:${layout.y}%;width:${layout.w}%;height:${layout.h}%;--province-fill:${province.style.fill};--province-border:${province.style.border};--province-shape:${getProvinceShape(province.provinceId)};"
       aria-pressed="${province.selectionState.selected}"
     >
       <span class="province-node__terrain"></span>
@@ -1093,6 +1117,7 @@ function render() {
             <div class="map-viewport" style="transform:${getMapViewportTransform()};">
               <div class="map-backdrop"></div>
               ${renderTerrainDecor()}
+              ${renderProvinceSurface(shell, focusContext)}
               ${renderStrategicRelations(shell)}
               ${renderProvinceLabels(shell)}
               <div id="top-hud" class="overlay-anchor-shell overlay-anchor-shell--top">Top HUD</div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -311,11 +311,40 @@ button { font: inherit; }
   background-size: 26px 26px, 34px 34px;
   mix-blend-mode: soft-light;
 }
+.province-surface-layer,
 .strategic-relations-layer {
   position: absolute;
   inset: 0;
-  z-index: 1;
   overflow: visible;
+}
+.province-surface-layer {
+  z-index: 1;
+}
+.province-surface polygon {
+  fill: color-mix(in srgb, var(--province-fill) 88%, #0f172a 12%);
+  stroke: color-mix(in srgb, var(--province-border) 92%, white 8%);
+  stroke-width: 1.2;
+  filter: drop-shadow(0 10px 18px rgba(2, 6, 23, 0.22));
+}
+.province-surface.is-muted polygon {
+  opacity: 0.38;
+}
+.province-surface.is-neighbor polygon {
+  stroke-width: 1.5;
+}
+.province-surface.is-focused polygon,
+.province-surface.is-selected polygon {
+  stroke: #e0f2fe;
+  stroke-width: 2;
+}
+.province-surface.is-selected polygon {
+  filter: drop-shadow(0 0 0 rgba(0,0,0,0)) drop-shadow(0 0 12px rgba(125, 211, 252, 0.35));
+}
+.province-surface.is-occupied polygon {
+  stroke-dasharray: 3 2;
+}
+.province-surface.is-contested polygon {
+  stroke: rgba(251, 113, 133, 0.92);
 }
 .map-label-layer {
   position: absolute;
@@ -627,8 +656,7 @@ button { font: inherit; }
   z-index: 3;
   clip-path: var(--province-shape);
   border: 0;
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--province-fill) 92%, white 8%), color-mix(in srgb, var(--province-fill) 72%, black 28%));
+  background: transparent;
   color: white;
   padding: 18px 16px;
   text-align: left;
@@ -636,31 +664,27 @@ button { font: inherit; }
   flex-direction: column;
   justify-content: space-between;
   cursor: pointer;
-  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.3);
-  transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease, opacity 160ms ease;
+  box-shadow: none;
+  transition: transform 160ms ease, filter 160ms ease, opacity 160ms ease;
 }
 .province-node::before {
   content: '';
   position: absolute;
   inset: 0;
-  border: 2px solid var(--province-border);
+  border: 1px solid rgba(255,255,255,0.04);
   clip-path: var(--province-shape);
   pointer-events: none;
 }
 .province-node:hover, .province-node.is-focused {
-  transform: translateY(-3px) scale(1.01);
-  box-shadow: 0 16px 36px rgba(2, 6, 23, 0.42);
+  transform: translateY(-2px);
 }
 .province-node.is-selected {
   z-index: 6;
-  outline: 3px solid rgba(125, 211, 252, 0.9);
-  outline-offset: 3px;
-  box-shadow: 0 0 0 4px rgba(125, 211, 252, 0.18), 0 22px 42px rgba(2, 6, 23, 0.5);
+  outline: none;
 }
 .province-node.is-neighbor {
   z-index: 5;
   filter: saturate(1.06);
-  box-shadow: 0 0 0 2px rgba(191, 219, 254, 0.16), 0 14px 32px rgba(2, 6, 23, 0.38);
 }
 .province-node.is-muted {
   opacity: 0.45;


### PR DESCRIPTION
## Résumé\n- ajoute une surface cartographique continue en SVG sous les interactions des provinces\n- remplace l'effet de tuiles isolées par des provinces dessinées sur une même carte\n- conserve la sélection, le focus et les overlays existants dans la démo locale\n\n## Tests\n- npm test\n- PORT=4184 node scripts/dev-server.mjs\n\nCloses #277