### PR TITLE
Epsilon: [WEB-E9] ajouter un mode de lecture des risques région par région

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -212,6 +212,25 @@ function buildCatastropheZones(catastropheEntries) {
     });
 }
 
+function buildRegionalRiskMode(regions) {
+  return regions.map((region) => ({
+    regionId: region.regionId,
+    riskLevel: region.strategicImpact,
+    anomaly: region.anomaly,
+    activeCatastropheIds: region.activeCatastropheIds,
+    signals: region.strategicSignals,
+    highlight: {
+      tone: region.strategicImpact === 'critical'
+        ? 'danger'
+        : region.strategicImpact === 'strained'
+          ? 'warning'
+          : 'calm',
+      emphasis: region.strategicImpact === 'critical' ? 'strong' : 'soft',
+    },
+    summary: `${region.seasonLabel}, ${region.strategicSignals.summary}`,
+  }));
+}
+
 function buildLegend(stateEntries, catastropheEntries, seasonLabels) {
   const seasonLegend = [...new Set(stateEntries
     .filter((entry) => entry.kind === 'season')
@@ -343,6 +362,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     regions,
     seasonalPanel: buildSeasonSummary(states, seasonLabels, seasonStyleByType),
     catastropheZones: buildCatastropheZones(catastropheEntries),
+    regionalRiskMode: buildRegionalRiskMode(regions),
     legend: buildLegend(stateEntries, catastropheEntries, seasonLabels),
     metrics: {
       regionCount: states.length,

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -211,6 +211,42 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         },
       },
     ],
+    regionalRiskMode: [
+      {
+        regionId: 'north-coast',
+        riskLevel: 'critical',
+        anomaly: null,
+        activeCatastropheIds: ['storm-1'],
+        signals: {
+          logisticsRisk: 'severe',
+          stabilityRisk: 'low',
+          harvestRisk: 'high',
+          summary: 'logistique severe, stabilité low, récoltes high',
+        },
+        highlight: {
+          tone: 'danger',
+          emphasis: 'strong',
+        },
+        summary: 'Printemps, logistique severe, stabilité low, récoltes high',
+      },
+      {
+        regionId: 'sunreach',
+        riskLevel: 'critical',
+        anomaly: 'heatwave',
+        activeCatastropheIds: ['storm-1'],
+        signals: {
+          logisticsRisk: 'severe',
+          stabilityRisk: 'moderate',
+          harvestRisk: 'high',
+          summary: 'logistique severe, stabilité moderate, récoltes high',
+        },
+        highlight: {
+          tone: 'danger',
+          emphasis: 'strong',
+        },
+        summary: 'Été, logistique severe, stabilité moderate, récoltes high',
+      },
+    ],
     legend: {
       title: 'Légende climat',
       compact: true,
@@ -290,6 +326,25 @@ test('buildClimateMapOverlay supports empty catastrophes and validated options',
   assert.equal(overlay.entries[0].overlayId, 'delta:season');
   assert.equal(overlay.seasonalPanel.summary, 'autumn: 1');
   assert.deepEqual(overlay.catastropheZones, []);
+  assert.deepEqual(overlay.regionalRiskMode, [
+    {
+      regionId: 'delta',
+      riskLevel: 'stable',
+      anomaly: null,
+      activeCatastropheIds: [],
+      signals: {
+        logisticsRisk: 'low',
+        stabilityRisk: 'low',
+        harvestRisk: 'low',
+        summary: 'logistique low, stabilité low, récoltes low',
+      },
+      highlight: {
+        tone: 'calm',
+        emphasis: 'soft',
+      },
+      summary: 'autumn, logistique low, stabilité low, récoltes low',
+    },
+  ]);
   assert.deepEqual(overlay.legend, {
     title: 'Légende climat',
     compact: true,


### PR DESCRIPTION
## Summary

- Epsilon: ajoute un mode de lecture régional des risques climatiques dans `buildClimateMapOverlay`
- Epsilon: met en avant les régions calmes, tendues ou critiques avec un résumé simple par région
- Epsilon: garde le changement limité à l'overlay et à ses tests

## Related issue

- One issue only: #316

## Changes

- Epsilon: ajoute `regionalRiskMode` pour exposer un focus région par région basé sur les signaux stratégiques existants
- Epsilon: ajoute un niveau de risque, un highlight et un résumé lisible pour chaque région
- Epsilon: étend les tests pour couvrir les cas critiques et stables

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [ ] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date

## Notes

- Epsilon: `npm test -- --test test/ui/climate/buildClimateMapOverlay.test.js`
- Epsilon: `npm test`
