### PR TITLE
Epsilon: [WEB-E5] ajouter un panneau météo et climat plus riche

### DIFF
--- a/src/ui/climate/buildClimateStatusPanel.js
+++ b/src/ui/climate/buildClimateStatusPanel.js
@@ -54,6 +54,29 @@ function buildAnomalySummary(anomaly, activeCatastropheIds) {
   return anomalies;
 }
 
+function buildRiskSummary(climateState) {
+  const logistics = climateState.activeCatastropheIds.length > 0
+    ? 'élevé'
+    : climateState.precipitationLevel < 20 || climateState.droughtIndex >= 55
+      ? 'surveillé'
+      : 'faible';
+
+  const harvest = climateState.precipitationLevel < 25 || climateState.droughtIndex >= 50
+    ? 'fragile'
+    : 'soutenu';
+
+  const vigilance = climateState.hasAnomaly() || climateState.activeCatastropheIds.length > 0
+    ? 'renforcée'
+    : 'normale';
+
+  return {
+    logistics,
+    harvest,
+    vigilance,
+    summary: `logistique ${logistics}, récoltes ${harvest}, vigilance ${vigilance}`,
+  };
+}
+
 export function buildClimateStatusPanel(climateState, options = {}) {
   const normalizedClimateState = normalizeClimateState(climateState);
   const normalizedOptions = requireObject(options, 'ClimateStatusPanel options');
@@ -72,12 +95,13 @@ export function buildClimateStatusPanel(climateState, options = {}) {
   const anomalySummary = anomalies.length === 0
     ? 'Aucune anomalie'
     : anomalies.map((entry) => entry.label).join(', ');
+  const riskSummary = buildRiskSummary(normalizedClimateState);
 
   return {
     regionId: normalizedClimateState.regionId,
     regionName,
     title: `Climat de ${regionName}`,
-    summary: `${seasonLabel}, ${anomalySummary}`,
+    summary: `${seasonLabel}, ${anomalySummary}, ${riskSummary.summary}`,
     season: {
       id: normalizedClimateState.season,
       label: seasonLabel,
@@ -88,11 +112,34 @@ export function buildClimateStatusPanel(climateState, options = {}) {
       droughtIndex: normalizedClimateState.droughtIndex,
       stability: normalizedClimateState.isStable() ? 'stable' : 'volatile',
     },
+    highlights: [
+      {
+        key: 'temperature',
+        label: 'Température',
+        value: `${normalizedClimateState.temperatureC}°C`,
+      },
+      {
+        key: 'precipitation',
+        label: 'Précipitations',
+        value: `${normalizedClimateState.precipitationLevel}/100`,
+      },
+      {
+        key: 'drought',
+        label: 'Sécheresse',
+        value: `${normalizedClimateState.droughtIndex}/100`,
+      },
+    ],
     anomalies,
+    risks: riskSummary,
     metrics: {
       anomalyCount: anomalies.length,
       activeCatastropheCount: normalizedClimateState.activeCatastropheIds.length,
       hasAnomaly: normalizedClimateState.hasAnomaly(),
+      riskLevel: normalizedClimateState.isStable() && !normalizedClimateState.hasAnomaly() && normalizedClimateState.activeCatastropheIds.length === 0
+        ? 'stable'
+        : normalizedClimateState.activeCatastropheIds.length > 0 || normalizedClimateState.droughtIndex >= 60
+          ? 'critical'
+          : 'watched',
     },
   };
 }

--- a/test/ui/climate/buildClimateStatusPanel.test.js
+++ b/test/ui/climate/buildClimateStatusPanel.test.js
@@ -24,7 +24,7 @@ test('buildClimateStatusPanel summarizes season, anomaly, and active catastrophe
     regionId: 'sunreach',
     regionName: 'Sunreach',
     title: 'Climat de Sunreach',
-    summary: 'Été, heatwave, locusts, wildfire',
+    summary: 'Été, heatwave, locusts, wildfire, logistique élevé, récoltes fragile, vigilance renforcée',
     season: {
       id: 'summer',
       label: 'Été',
@@ -35,6 +35,23 @@ test('buildClimateStatusPanel summarizes season, anomaly, and active catastrophe
       droughtIndex: 74,
       stability: 'volatile',
     },
+    highlights: [
+      {
+        key: 'temperature',
+        label: 'Température',
+        value: '33°C',
+      },
+      {
+        key: 'precipitation',
+        label: 'Précipitations',
+        value: '11/100',
+      },
+      {
+        key: 'drought',
+        label: 'Sécheresse',
+        value: '74/100',
+      },
+    ],
     anomalies: [
       {
         type: 'anomaly',
@@ -55,10 +72,17 @@ test('buildClimateStatusPanel summarizes season, anomaly, and active catastrophe
         tone: 'danger',
       },
     ],
+    risks: {
+      logistics: 'élevé',
+      harvest: 'fragile',
+      vigilance: 'renforcée',
+      summary: 'logistique élevé, récoltes fragile, vigilance renforcée',
+    },
     metrics: {
       anomalyCount: 3,
       activeCatastropheCount: 2,
       hasAnomaly: true,
+      riskLevel: 'critical',
     },
   });
 });
@@ -72,12 +96,36 @@ test('buildClimateStatusPanel supports plain payloads without anomalies', () => 
     droughtIndex: 18,
   });
 
-  assert.equal(panel.summary, 'spring, Aucune anomalie');
+  assert.equal(panel.summary, 'spring, Aucune anomalie, logistique faible, récoltes soutenu, vigilance normale');
+  assert.deepEqual(panel.highlights, [
+    {
+      key: 'temperature',
+      label: 'Température',
+      value: '12°C',
+    },
+    {
+      key: 'precipitation',
+      label: 'Précipitations',
+      value: '63/100',
+    },
+    {
+      key: 'drought',
+      label: 'Sécheresse',
+      value: '18/100',
+    },
+  ]);
   assert.deepEqual(panel.anomalies, []);
+  assert.deepEqual(panel.risks, {
+    logistics: 'faible',
+    harvest: 'soutenu',
+    vigilance: 'normale',
+    summary: 'logistique faible, récoltes soutenu, vigilance normale',
+  });
   assert.deepEqual(panel.metrics, {
     anomalyCount: 0,
     activeCatastropheCount: 0,
     hasAnomaly: false,
+    riskLevel: 'stable',
   });
   assert.equal(panel.readings.stability, 'stable');
 });


### PR DESCRIPTION
## Summary

- Epsilon: enrichit `buildClimateStatusPanel` avec une lecture plus synthétique du climat courant
- Epsilon: expose des points clés lisibles sur la température, les précipitations, la sécheresse et les risques
- Epsilon: garde la portée locale au panneau et à ses tests

## Related issue

- One issue only: #312

## Changes

- Epsilon: ajoute des `highlights` pour les indicateurs météo principaux
- Epsilon: ajoute un bloc `risks` et un résumé synthétique logistique, récoltes et vigilance
- Epsilon: complète les métriques avec un `riskLevel` lisible pour la démo

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [ ] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date

## Notes

- Epsilon: `npm test -- --test test/ui/climate/buildClimateStatusPanel.test.js`
- Epsilon: `npm test`
