### PR TITLE
Epsilon: [WEB-E6] faire évoluer les effets climatiques après Tour suivant

### DIFF
--- a/src/application/climate/UpdateRegionalClimate.js
+++ b/src/application/climate/UpdateRegionalClimate.js
@@ -26,6 +26,22 @@ function normalizeShift(shift = {}) {
   };
 }
 
+function buildProgression(previousState, nextState) {
+  return {
+    regionId: nextState.regionId,
+    seasonChanged: previousState.season !== nextState.season,
+    temperatureDelta: nextState.temperatureC - previousState.temperatureC,
+    precipitationDelta: nextState.precipitationLevel - previousState.precipitationLevel,
+    droughtDelta: nextState.droughtIndex - previousState.droughtIndex,
+    summary: [
+      previousState.season !== nextState.season ? `${previousState.season} → ${nextState.season}` : null,
+      `temp ${nextState.temperatureC - previousState.temperatureC >= 0 ? '+' : ''}${nextState.temperatureC - previousState.temperatureC}°C`,
+      `précip ${nextState.precipitationLevel - previousState.precipitationLevel >= 0 ? '+' : ''}${nextState.precipitationLevel - previousState.precipitationLevel}`,
+      `sécheresse ${nextState.droughtIndex - previousState.droughtIndex >= 0 ? '+' : ''}${nextState.droughtIndex - previousState.droughtIndex}`,
+    ].filter(Boolean).join(', '),
+  };
+}
+
 export class UpdateRegionalClimate {
   execute({ regionalStates, shiftsByRegionId = {}, defaultShift = {}, nextSeason } = {}) {
     const states = normalizeRegionalStates(regionalStates);
@@ -49,6 +65,10 @@ export class UpdateRegionalClimate {
     return {
       updatedRegionalStates,
       appliedShiftCount: updatedRegionalStates.length,
+      progressionByRegion: Object.fromEntries(updatedRegionalStates.map((state, index) => [
+        state.regionId,
+        buildProgression(states[index], state),
+      ])),
     };
   }
 }

--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -212,6 +212,22 @@ function buildCatastropheZones(catastropheEntries) {
     });
 }
 
+function buildTurnProgression(state, progressionByRegion) {
+  const progression = progressionByRegion[state.regionId] ?? null;
+
+  if (!progression) {
+    return null;
+  }
+
+  return {
+    seasonChanged: progression.seasonChanged,
+    temperatureDelta: progression.temperatureDelta,
+    precipitationDelta: progression.precipitationDelta,
+    droughtDelta: progression.droughtDelta,
+    summary: progression.summary,
+  };
+}
+
 function buildRegionalRiskMode(regions) {
   return regions.map((region) => ({
     regionId: region.regionId,
@@ -303,6 +319,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     ...DEFAULT_ANOMALY_STYLE_BY_TYPE,
     ...requireObject(normalizedOptions.anomalyStyleByType ?? {}, 'ClimateMapOverlay anomalyStyleByType'),
   };
+  const progressionByRegion = requireObject(normalizedOptions.progressionByRegion ?? {}, 'ClimateMapOverlay progressionByRegion');
   const catastropheEntries = buildCatastropheMapOverlay(
     normalizedOptions.catastrophes ?? [],
     { styleBySeverity: normalizedOptions.styleBySeverity ?? {} },
@@ -341,6 +358,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
         activeCatastropheIds: regionalCatastrophes.map((entry) => entry.catastropheId),
         strategicImpact: buildStrategicImpact(state, regionalCatastrophes),
         strategicSignals,
+        turnProgression: buildTurnProgression(state, progressionByRegion),
         temperatureC: state.temperatureC,
         precipitationLevel: state.precipitationLevel,
         droughtIndex: state.droughtIndex,

--- a/src/ui/climate/buildClimateStatusPanel.js
+++ b/src/ui/climate/buildClimateStatusPanel.js
@@ -80,6 +80,9 @@ function buildRiskSummary(climateState) {
 export function buildClimateStatusPanel(climateState, options = {}) {
   const normalizedClimateState = normalizeClimateState(climateState);
   const normalizedOptions = requireObject(options, 'ClimateStatusPanel options');
+  const turnProgression = normalizedOptions.turnProgression === undefined
+    ? null
+    : requireObject(normalizedOptions.turnProgression, 'ClimateStatusPanel turnProgression');
   const regionName = requireText(
     normalizedOptions.regionName ?? normalizedClimateState.regionId,
     'ClimateStatusPanel regionName',
@@ -129,6 +132,15 @@ export function buildClimateStatusPanel(climateState, options = {}) {
         value: `${normalizedClimateState.droughtIndex}/100`,
       },
     ],
+    turnProgression: turnProgression === null
+      ? null
+      : {
+        seasonChanged: Boolean(turnProgression.seasonChanged),
+        temperatureDelta: Number(turnProgression.temperatureDelta ?? 0),
+        precipitationDelta: Number(turnProgression.precipitationDelta ?? 0),
+        droughtDelta: Number(turnProgression.droughtDelta ?? 0),
+        summary: requireText(turnProgression.summary ?? '', 'ClimateStatusPanel turnProgression summary'),
+      },
     anomalies,
     risks: riskSummary,
     metrics: {

--- a/test/application/climate/UpdateRegionalClimate.test.js
+++ b/test/application/climate/UpdateRegionalClimate.test.js
@@ -45,6 +45,24 @@ test('UpdateRegionalClimate applies default and regional drift immutably', () =>
   });
 
   assert.equal(result.appliedShiftCount, 2);
+  assert.deepEqual(result.progressionByRegion, {
+    'north-coast': {
+      regionId: 'north-coast',
+      seasonChanged: true,
+      temperatureDelta: 1,
+      precipitationDelta: 2,
+      droughtDelta: 6,
+      summary: 'spring → summer, temp +1°C, précip +2, sécheresse +6',
+    },
+    sunreach: {
+      regionId: 'sunreach',
+      seasonChanged: true,
+      temperatureDelta: 5,
+      precipitationDelta: -4,
+      droughtDelta: 14,
+      summary: 'spring → summer, temp +5°C, précip -4, sécheresse +14',
+    },
+  });
   assert.deepEqual(
     result.updatedRegionalStates.map((state) => state.toJSON()),
     [
@@ -97,6 +115,14 @@ test('UpdateRegionalClimate clamps precipitation and drought indicators', () => 
   assert.equal(result.updatedRegionalStates[0].precipitationLevel, 0);
   assert.equal(result.updatedRegionalStates[0].droughtIndex, 100);
   assert.equal(result.updatedRegionalStates[0].season, 'winter');
+  assert.deepEqual(result.progressionByRegion.frostmarch, {
+    regionId: 'frostmarch',
+    seasonChanged: false,
+    temperatureDelta: 0,
+    precipitationDelta: -2,
+    droughtDelta: 1,
+    summary: 'temp +0°C, précip -2, sécheresse +1',
+  });
 });
 
 test('UpdateRegionalClimate supports season rollover while preserving active climate events', () => {

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -37,6 +37,22 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         impact: { harvest: -12 },
       },
     ],
+    progressionByRegion: {
+      'north-coast': {
+        seasonChanged: true,
+        temperatureDelta: 1,
+        precipitationDelta: 2,
+        droughtDelta: 6,
+        summary: 'spring → summer, temp +1°C, précip +2, sécheresse +6',
+      },
+      sunreach: {
+        seasonChanged: true,
+        temperatureDelta: 5,
+        precipitationDelta: -4,
+        droughtDelta: 14,
+        summary: 'spring → summer, temp +5°C, précip -4, sécheresse +14',
+      },
+    },
   });
 
   assert.deepEqual(overlay, {
@@ -133,6 +149,13 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
           harvestRisk: 'high',
           summary: 'logistique severe, stabilité low, récoltes high',
         },
+        turnProgression: {
+          seasonChanged: true,
+          temperatureDelta: 1,
+          precipitationDelta: 2,
+          droughtDelta: 6,
+          summary: 'spring → summer, temp +1°C, précip +2, sécheresse +6',
+        },
         temperatureC: 12,
         precipitationLevel: 63,
         droughtIndex: 18,
@@ -149,6 +172,13 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
           stabilityRisk: 'moderate',
           harvestRisk: 'high',
           summary: 'logistique severe, stabilité moderate, récoltes high',
+        },
+        turnProgression: {
+          seasonChanged: true,
+          temperatureDelta: 5,
+          precipitationDelta: -4,
+          droughtDelta: 14,
+          summary: 'spring → summer, temp +5°C, précip -4, sécheresse +14',
         },
         temperatureC: 33,
         precipitationLevel: 11,
@@ -385,6 +415,7 @@ test('buildClimateMapOverlay supports empty catastrophes and validated options',
         harvestRisk: 'low',
         summary: 'logistique low, stabilité low, récoltes low',
       },
+      turnProgression: null,
       temperatureC: 18,
       precipitationLevel: 48,
       droughtIndex: 29,

--- a/test/ui/climate/buildClimateStatusPanel.test.js
+++ b/test/ui/climate/buildClimateStatusPanel.test.js
@@ -18,6 +18,13 @@ test('buildClimateStatusPanel summarizes season, anomaly, and active catastrophe
     seasonLabels: {
       summer: 'Été',
     },
+    turnProgression: {
+      seasonChanged: true,
+      temperatureDelta: 5,
+      precipitationDelta: -4,
+      droughtDelta: 14,
+      summary: 'spring → summer, temp +5°C, précip -4, sécheresse +14',
+    },
   });
 
   assert.deepEqual(panel, {
@@ -52,6 +59,13 @@ test('buildClimateStatusPanel summarizes season, anomaly, and active catastrophe
         value: '74/100',
       },
     ],
+    turnProgression: {
+      seasonChanged: true,
+      temperatureDelta: 5,
+      precipitationDelta: -4,
+      droughtDelta: 14,
+      summary: 'spring → summer, temp +5°C, précip -4, sécheresse +14',
+    },
     anomalies: [
       {
         type: 'anomaly',
@@ -114,6 +128,7 @@ test('buildClimateStatusPanel supports plain payloads without anomalies', () => 
       value: '18/100',
     },
   ]);
+  assert.equal(panel.turnProgression, null);
   assert.deepEqual(panel.anomalies, []);
   assert.deepEqual(panel.risks, {
     logistics: 'faible',
@@ -158,5 +173,18 @@ test('buildClimateStatusPanel rejects invalid payloads', () => {
       regionName: ' ',
     }),
     /ClimateStatusPanel regionName is required/,
+  );
+
+  assert.throws(
+    () => buildClimateStatusPanel({
+      regionId: 'north-coast',
+      season: 'spring',
+      temperatureC: 12,
+      precipitationLevel: 63,
+      droughtIndex: 18,
+    }, {
+      turnProgression: [],
+    }),
+    /ClimateStatusPanel turnProgression must be an object/,
   );
 });


### PR DESCRIPTION
## Summary

- Epsilon: relie la progression du climat au passage de tour avec des deltas lisibles par région
- Epsilon: rend ces évolutions visibles sur la carte et dans le panneau climat
- Epsilon: garde la portée locale sur les helpers climat et leurs tests

## Related issue

- One issue only: #313

## Changes

- Epsilon: enrichit `UpdateRegionalClimate` avec `progressionByRegion` pour résumer les effets du tour suivant
- Epsilon: expose `turnProgression` dans `buildClimateMapOverlay` pour chaque région
- Epsilon: expose `turnProgression` dans `buildClimateStatusPanel` pour rendre les changements lisibles dans le focus local

## Testing

- [x] Local checks run
- [x] Relevant tests added or updated
- [ ] Manual check if relevant

## Branch routine

- [x] Before branching, I ran `git fetch origin main && git checkout main && git reset --hard origin/main`
- [x] This PR covers one issue or one narrowly-scoped fix only

## Rules check

- [x] This work comes through a pull request
- [x] This PR is mandatory to avoid bugs and validation problems with Zeta
- [x] This PR targets `main` directly
- [x] This PR is not stacked on another feature branch
- [x] I do not already have another open feature PR, unless this PR explicitly replaces a broken one
- [x] The team is not exceeding the three-open-feature-PR limit, unless this PR explicitly replaces a broken one or addresses requested rework
- [x] GitHub text starts with the agent name followed by `:`
- [x] The work stays inside the author's domain
- [ ] A message was sent to Zeta to signal that this work is finished and ready for validation
- [ ] Zeta has been asked for validation before merge
- [ ] If this PR is merged, the associated issue will be closed immediately to keep the backlog up to date

## Notes

- Epsilon: `npm test -- --test test/application/climate/UpdateRegionalClimate.test.js --test test/ui/climate/buildClimateMapOverlay.test.js --test test/ui/climate/buildClimateStatusPanel.test.js`
- Epsilon: `npm test`
