### PR TITLE
Delta: [WEB-D3] ajouter une heatmap du risque de sabotage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - côté UI, le niveau d'alerte peut être transformé en badge lisible avec texte, ton, couleur, emphase, icône, progression et libellé accessible
 - côté UI, `buildIntrigueMapOverlay` agrège par lieu la présence de cellules et la menace de sabotage active dans une vue stable avec métriques, styles et niveaux de risque réutilisables pour la carte
 - côté UI, `buildIntrigueWebDemo` compose la couche intrigue pour la démo web avec badge d'alerte, hotspots triés, panneau simple des cellules et opérations actives, tout en réutilisant les composants intrigue existants
-- dans `web/app.js`, la démo web peut afficher un overlay intrigue dédié avec liens de réseau, foyers cliquables, synthèse latérale et rail bas pour rendre la présence clandestine plus lisible sans surcharger la carte
+- dans `web/app.js`, la démo web peut afficher un overlay intrigue dédié avec liens de réseau, foyers cliquables, heatmap de sabotage, synthèse latérale et rail bas pour rendre la présence clandestine plus lisible sans surcharger la carte
 - l'adaptateur `InMemoryIntrigueRepository` permet de stocker cellules et opérations clandestines en mémoire avec copies défensives et ordre de listing stable pour les tests et assemblages locaux
 - les tests Delta couvrent explicitement le risque de détection, l'exposition réseau, l'adaptateur mémoire intrigue et l'affichage du niveau d'alerte
 

--- a/web/app.js
+++ b/web/app.js
@@ -832,6 +832,14 @@ function getIntrigueViewModel() {
     isSelected: entry.locationId === state.selectedProvinceId,
     isFocused: entry.locationId === state.focusedProvinceId,
     celluleCount: entry.metrics.celluleCount,
+    heatRadius: entry.sabotageRiskLevel === 'high'
+      ? 22
+      : entry.sabotageRiskLevel === 'medium'
+        ? 16
+        : entry.sabotageRiskLevel === 'low'
+          ? 11
+          : 7,
+    heatIntensity: Math.max(0.14, entry.sabotageRiskScore / 100),
   })).filter((entry) => entry.center);
 
   return {
@@ -951,6 +959,13 @@ function renderIntrigueMapOverlay(intrigueView) {
     return '';
   }
 
+  const heatmapMarkup = intrigueView.map.entries.map((entry) => `
+    <g class="intrigue-heat-node intrigue-heat-node--${entry.sabotageRiskLevel} ${entry.isSelected ? 'is-selected' : ''}">
+      <circle class="intrigue-heat-node__outer" cx="${entry.center.x}%" cy="${entry.center.y}%" r="${entry.heatRadius}" style="opacity:${Math.min(0.72, entry.heatIntensity)}"></circle>
+      <circle class="intrigue-heat-node__inner" cx="${entry.center.x}%" cy="${entry.center.y}%" r="${Math.max(5, entry.heatRadius * 0.58)}" style="opacity:${Math.min(0.92, entry.heatIntensity + 0.12)}"></circle>
+    </g>
+  `).join('');
+
   const linkMarkup = intrigueView.map.links.map((link) => `
     <line
       class="intrigue-link intrigue-link--${link.riskLevel}"
@@ -973,7 +988,10 @@ function renderIntrigueMapOverlay(intrigueView) {
   `).join('');
 
   return `
-    <svg class="intrigue-map-layer" viewBox="0 0 100 100" aria-label="Overlay intrigue et réseau clandestin">
+    <svg class="intrigue-map-layer" viewBox="0 0 100 100" aria-label="Overlay intrigue et heatmap de sabotage">
+      <g class="intrigue-heat-layer">
+        ${heatmapMarkup}
+      </g>
       ${linkMarkup}
       ${hotspotMarkup}
     </svg>
@@ -996,6 +1014,15 @@ function renderIntrigueSidePanel(intrigueView) {
         <div class="overlay-anchor"><span>Cellules exposées</span><strong>${intrigueView.metrics.exposedCellCount}</strong></div>
         <div class="overlay-anchor"><span>Sabotages actifs</span><strong>${intrigueView.metrics.activeSabotageCount}</strong></div>
         <div class="overlay-anchor"><span>Alerte</span><strong>${intrigueView.alertBadge.level.label}</strong></div>
+      </div>
+      <div class="intrigue-legend-strip" aria-label="Légende heatmap sabotage">
+        <span>Heatmap sabotage</span>
+        <div class="intrigue-legend-strip__scale">
+          <i class="is-low"></i>
+          <i class="is-medium"></i>
+          <i class="is-high"></i>
+        </div>
+        <small>faible à critique</small>
       </div>
       <div class="intrigue-hotspot-list">
         ${intrigueView.hotspots.slice(0, 4).map((hotspot) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -695,6 +695,26 @@ button { font: inherit; }
   z-index: 2;
   overflow: visible;
 }
+.intrigue-heat-layer {
+  isolation: isolate;
+}
+.intrigue-heat-node {
+  mix-blend-mode: screen;
+}
+.intrigue-heat-node__outer,
+.intrigue-heat-node__inner {
+  stroke: none;
+}
+.intrigue-heat-node__outer { filter: blur(8px); }
+.intrigue-heat-node__inner { filter: blur(3px); }
+.intrigue-heat-node--none { opacity: 0.18; }
+.intrigue-heat-node--low .intrigue-heat-node__outer,
+.intrigue-heat-node--low .intrigue-heat-node__inner { fill: rgba(96, 165, 250, 0.45); }
+.intrigue-heat-node--medium .intrigue-heat-node__outer,
+.intrigue-heat-node--medium .intrigue-heat-node__inner { fill: rgba(250, 204, 21, 0.5); }
+.intrigue-heat-node--high .intrigue-heat-node__outer,
+.intrigue-heat-node--high .intrigue-heat-node__inner { fill: rgba(251, 113, 133, 0.58); }
+.intrigue-heat-node.is-selected .intrigue-heat-node__outer { filter: blur(10px); }
 .intrigue-link {
   fill: none;
   stroke-linecap: round;
@@ -1109,6 +1129,34 @@ button { font: inherit; }
   gap: 10px;
   margin-top: 14px;
 }
+.intrigue-legend-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  color: var(--muted);
+}
+.intrigue-legend-strip__scale {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  max-width: 180px;
+}
+.intrigue-legend-strip__scale i {
+  display: block;
+  flex: 1;
+  height: 10px;
+  border-radius: 999px;
+}
+.intrigue-legend-strip__scale .is-low { background: rgba(96, 165, 250, 0.72); }
+.intrigue-legend-strip__scale .is-medium { background: rgba(250, 204, 21, 0.78); }
+.intrigue-legend-strip__scale .is-high { background: rgba(251, 113, 133, 0.82); }
 .intrigue-hotspot-list {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
## Résumé\n- ajoute une heatmap légère du risque de sabotage sur l'overlay intrigue\n- garde les liens et hotspots interactifs lisibles au-dessus de la couche de chaleur\n- documente la lecture de cette nouvelle couche dans la démo web\n\n## Validation\n- npm test\n- node --check web/app.js