### PR TITLE
Delta: [WEB-D4] détailler le niveau d’alerte dans un panneau dédié

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - côté UI, le niveau d'alerte peut être transformé en badge lisible avec texte, ton, couleur, emphase, icône, progression et libellé accessible
 - côté UI, `buildIntrigueMapOverlay` agrège par lieu la présence de cellules et la menace de sabotage active dans une vue stable avec métriques, styles et niveaux de risque réutilisables pour la carte
 - côté UI, `buildIntrigueWebDemo` compose la couche intrigue pour la démo web avec badge d'alerte, hotspots triés, panneau simple des cellules et opérations actives, tout en réutilisant les composants intrigue existants
-- dans `web/app.js`, la démo web peut afficher un overlay intrigue dédié avec liens de réseau, foyers cliquables, heatmap de sabotage, synthèse latérale et rail bas pour rendre la présence clandestine plus lisible sans surcharger la carte
+- dans `web/app.js`, la démo web peut afficher un overlay intrigue dédié avec liens de réseau, foyers cliquables, heatmap de sabotage, panneau d’alerte dédié, synthèse latérale et rail bas pour rendre la présence clandestine plus lisible sans surcharger la carte
 - l'adaptateur `InMemoryIntrigueRepository` permet de stocker cellules et opérations clandestines en mémoire avec copies défensives et ordre de listing stable pour les tests et assemblages locaux
 - les tests Delta couvrent explicitement le risque de détection, l'exposition réseau, l'adaptateur mémoire intrigue et l'affichage du niveau d'alerte
 

--- a/src/ui/intrigue/buildIntrigueWebDemo.js
+++ b/src/ui/intrigue/buildIntrigueWebDemo.js
@@ -156,11 +156,42 @@ export function buildIntrigueWebDemo(payload, options = {}) {
   const sleeperCellCount = cellules.filter((cellule) => cellule.sleeper).length;
   const activeSabotageCount = operations.filter((operation) => operation.type === 'sabotage' && !operation.isResolved).length;
   const criticalHotspotCount = hotspots.filter((hotspot) => hotspot.severity === 'critical').length;
+  const topHotspots = hotspots.slice(0, 3);
+  const alertDrivers = [
+    criticalHotspotCount > 0 ? `${criticalHotspotCount} foyer${criticalHotspotCount > 1 ? 's' : ''} critique${criticalHotspotCount > 1 ? 's' : ''}` : null,
+    exposedCellCount > 0 ? `${exposedCellCount} cellule${exposedCellCount > 1 ? 's' : ''} exposée${exposedCellCount > 1 ? 's' : ''}` : null,
+    activeSabotageCount > 0 ? `${activeSabotageCount} sabotage${activeSabotageCount > 1 ? 's' : ''} actif${activeSabotageCount > 1 ? 's' : ''}` : null,
+  ].filter(Boolean);
+  const watchZones = topHotspots.map((hotspot) => ({
+    locationId: hotspot.locationId,
+    locationName: hotspot.locationName,
+    reason: hotspot.sabotageRiskLevel === 'high'
+      ? 'Risque critique de sabotage'
+      : hotspot.exposedCellCount > 0
+        ? 'Cellules exposées à surveiller'
+        : hotspot.operationCount > 0
+          ? 'Opérations actives à suivre'
+          : 'Présence clandestine à observer',
+    severity: hotspot.severity,
+  }));
 
   return {
     title: 'Couches intrigue',
     summary: `${criticalHotspotCount} foyers critiques, ${activeSabotageCount} sabotages actifs, alerte ${alertBadge.level.label.toLowerCase()}`,
     alertBadge,
+    alertPanel: {
+      title: `Niveau ${alertBadge.level.label}`,
+      tone: alertBadge.tone,
+      icon: alertBadge.icon,
+      summary: alertDrivers[0] ?? 'Aucun foyer critique détecté',
+      guidance: alertBadge.level.isCritical
+        ? 'Concentrez la lecture sur les foyers rouges, les cellules exposées et les sabotages en cours.'
+        : alertBadge.level.code === 'renforce'
+          ? 'Surveillez les provinces où le risque monte et anticipez les chaînes de sabotage.'
+          : 'Le réseau reste contenu, mais les foyers actifs doivent rester visibles.',
+      drivers: alertDrivers.length > 0 ? alertDrivers : ['aucun signal fort pour le moment'],
+      watchZones,
+    },
     map: {
       title: 'Couche intrigue',
       entries: mapOverlay,

--- a/web/app.js
+++ b/web/app.js
@@ -1015,6 +1015,24 @@ function renderIntrigueSidePanel(intrigueView) {
         <div class="overlay-anchor"><span>Sabotages actifs</span><strong>${intrigueView.metrics.activeSabotageCount}</strong></div>
         <div class="overlay-anchor"><span>Alerte</span><strong>${intrigueView.alertBadge.level.label}</strong></div>
       </div>
+      <section class="intrigue-alert-panel intrigue-alert-panel--${intrigueView.alertPanel.tone}" aria-label="Lecture du niveau d'alerte">
+        <div class="intrigue-alert-panel__header">
+          <strong>${intrigueView.alertPanel.icon} ${intrigueView.alertPanel.title}</strong>
+          <span>${intrigueView.alertPanel.summary}</span>
+        </div>
+        <p>${intrigueView.alertPanel.guidance}</p>
+        <ul class="intrigue-alert-panel__drivers">
+          ${intrigueView.alertPanel.drivers.map((driver) => `<li>${driver}</li>`).join('')}
+        </ul>
+        <div class="intrigue-alert-panel__zones">
+          ${intrigueView.alertPanel.watchZones.map((zone) => `
+            <article class="intrigue-alert-zone intrigue-alert-zone--${zone.severity}">
+              <strong>${zone.locationName}</strong>
+              <span>${zone.reason}</span>
+            </article>
+          `).join('')}
+        </div>
+      </section>
       <div class="intrigue-legend-strip" aria-label="Légende heatmap sabotage">
         <span>Heatmap sabotage</span>
         <div class="intrigue-legend-strip__scale">

--- a/web/styles.css
+++ b/web/styles.css
@@ -1129,6 +1129,67 @@ button { font: inherit; }
   gap: 10px;
   margin-top: 14px;
 }
+.intrigue-alert-panel {
+  margin-top: 14px;
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.intrigue-alert-panel--muted { border-color: rgba(148, 163, 184, 0.2); }
+.intrigue-alert-panel--watch { border-color: rgba(96, 165, 250, 0.3); }
+.intrigue-alert-panel--warning { border-color: rgba(250, 204, 21, 0.35); }
+.intrigue-alert-panel--danger,
+.intrigue-alert-panel--critical { border-color: rgba(251, 113, 133, 0.4); }
+.intrigue-alert-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+.intrigue-alert-panel__header strong,
+.intrigue-alert-zone strong {
+  display: block;
+}
+.intrigue-alert-panel__header span,
+.intrigue-alert-panel p,
+.intrigue-alert-zone span {
+  color: var(--muted);
+}
+.intrigue-alert-panel p {
+  margin: 10px 0 0;
+}
+.intrigue-alert-panel__drivers,
+.intrigue-alert-panel__zones {
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.intrigue-alert-panel__drivers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.intrigue-alert-panel__drivers li {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(8, 15, 28, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  color: var(--muted);
+  font-size: 12px;
+}
+.intrigue-alert-panel__zones {
+  display: grid;
+  gap: 8px;
+}
+.intrigue-alert-zone {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(8, 15, 28, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.intrigue-alert-zone--critical { border-color: rgba(251, 113, 133, 0.35); }
+.intrigue-alert-zone--warning { border-color: rgba(250, 204, 21, 0.28); }
 .intrigue-legend-strip {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Résumé\n- transforme le niveau d’alerte intrigue en panneau dédié, avec lecture, guidance et zones à surveiller\n- relie ce panneau aux foyers critiques, cellules exposées et sabotages actifs visibles sur la carte\n- documente cette lecture dans la démo web\n\n## Validation\n- npm test\n- node --check web/app.js