### PR TITLE
Delta: [WEB-D6] mieux distinguer cellules dormantes, exposées et compromises

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - côté UI, le niveau d'alerte peut être transformé en badge lisible avec texte, ton, couleur, emphase, icône, progression et libellé accessible
 - côté UI, `buildIntrigueMapOverlay` agrège par lieu la présence de cellules et la menace de sabotage active dans une vue stable avec métriques, styles et niveaux de risque réutilisables pour la carte
 - côté UI, `buildIntrigueWebDemo` compose la couche intrigue pour la démo web avec badge d'alerte, hotspots triés, panneau simple des cellules et opérations actives, tout en réutilisant les composants intrigue existants
-- dans `web/app.js`, la démo web peut afficher un overlay intrigue dédié avec liens de réseau, foyers cliquables, heatmap de sabotage, panneau d’alerte dédié, détails d’opérations actives au clic, synthèse latérale et rail bas pour rendre la présence clandestine plus lisible sans surcharger la carte
+- dans `web/app.js`, la démo web peut afficher un overlay intrigue dédié avec liens de réseau, foyers cliquables, heatmap de sabotage, panneau d’alerte dédié, détails d’opérations actives au clic, et codes visuels distincts pour cellules dormantes, exposées et compromises, afin de rendre la présence clandestine plus lisible sans surcharger la carte
 - l'adaptateur `InMemoryIntrigueRepository` permet de stocker cellules et opérations clandestines en mémoire avec copies défensives et ordre de listing stable pour les tests et assemblages locaux
 - les tests Delta couvrent explicitement le risque de détection, l'exposition réseau, l'adaptateur mémoire intrigue et l'affichage du niveau d'alerte
 

--- a/src/ui/intrigue/buildIntrigueWebDemo.js
+++ b/src/ui/intrigue/buildIntrigueWebDemo.js
@@ -86,23 +86,43 @@ function buildCellulesPanel(cellules, locationNames) {
 
       return left.id.localeCompare(right.id);
     })
-    .map((cellule) => ({
-      celluleId: cellule.id,
-      codename: cellule.codename,
-      locationId: cellule.locationId,
-      locationName: locationNames[cellule.locationId] ?? cellule.locationId,
-      status: cellule.status,
-      sleeper: cellule.sleeper,
-      exposure: cellule.exposure,
-      readiness: cellule.operationalReadiness,
-      tone: cellule.isExposed ? 'danger' : cellule.sleeper ? 'muted' : 'normal',
-      badges: [
-        cellule.isExposed ? 'exposed' : null,
-        cellule.sleeper ? 'sleeper' : null,
-        `loyalty:${cellule.loyalty}`,
-        `secrecy:${cellule.secrecy}`,
-      ].filter(Boolean),
-    }));
+    .map((cellule) => {
+      const compromised = cellule.status === 'compromised' || cellule.exposure >= 70;
+      const statusClass = compromised
+        ? 'compromised'
+        : cellule.sleeper || cellule.status === 'dormant'
+          ? 'sleeper'
+          : cellule.isExposed
+            ? 'exposed'
+            : 'active';
+      const statusLabel = compromised
+        ? 'Compromise'
+        : cellule.sleeper || cellule.status === 'dormant'
+          ? 'Dormante'
+          : cellule.isExposed
+            ? 'Exposee'
+            : 'Active';
+
+      return {
+        celluleId: cellule.id,
+        codename: cellule.codename,
+        locationId: cellule.locationId,
+        locationName: locationNames[cellule.locationId] ?? cellule.locationId,
+        status: cellule.status,
+        sleeper: cellule.sleeper,
+        exposure: cellule.exposure,
+        readiness: cellule.operationalReadiness,
+        tone: compromised ? 'danger' : cellule.sleeper ? 'muted' : cellule.isExposed ? 'warning' : 'normal',
+        statusClass,
+        statusLabel,
+        statusMarker: compromised ? '✕' : statusClass === 'sleeper' ? '◌' : statusClass === 'exposed' ? '◐' : '●',
+        badges: [
+          statusLabel.toLowerCase(),
+          `loyalty:${cellule.loyalty}`,
+          `secrecy:${cellule.secrecy}`,
+        ].filter(Boolean),
+      };
+    });
 }
 
 function buildOperationsPanel(operations, locationNames) {

--- a/test/ui/intrigue/buildIntrigueWebDemo.test.js
+++ b/test/ui/intrigue/buildIntrigueWebDemo.test.js
@@ -136,7 +136,10 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
     exposure: 74,
     readiness: 43,
     tone: 'danger',
-    badges: ['exposed', 'sleeper', 'loyalty:55', 'secrecy:49'],
+    statusClass: 'compromised',
+    statusLabel: 'Compromise',
+    statusMarker: '✕',
+    badges: ['compromise', 'loyalty:55', 'secrecy:49'],
   });
   assert.deepEqual(demo.panels.operations[0], {
     operationId: 'op-ash-1',

--- a/web/app.js
+++ b/web/app.js
@@ -1050,13 +1050,22 @@ function renderIntrigueSidePanel(intrigueView) {
         <small>faible à critique</small>
       </div>
       <div class="intrigue-hotspot-list">
-        ${intrigueView.hotspots.slice(0, 4).map((hotspot) => `
-          <article class="intrigue-hotspot-card intrigue-hotspot-card--${hotspot.severity}">
-            <strong>${hotspot.locationName}</strong>
-            <span>${hotspot.visualCue} · ${hotspot.celluleCount} cellules</span>
-            <span>${hotspot.operationCount} opérations, ${hotspot.exposedCellCount} exposées</span>
-          </article>
-        `).join('')}
+        ${intrigueView.hotspots.slice(0, 4).map((hotspot) => {
+          const statusPreview = intrigueView.panels.cellules
+            .filter((cellule) => cellule.locationId === hotspot.locationId)
+            .slice(0, 3)
+            .map((cellule) => `<span class="intrigue-status-pill intrigue-status-pill--${cellule.statusClass}">${cellule.statusMarker} ${cellule.statusLabel}</span>`)
+            .join('');
+
+          return `
+            <article class="intrigue-hotspot-card intrigue-hotspot-card--${hotspot.severity}">
+              <strong>${hotspot.locationName}</strong>
+              <span>${hotspot.visualCue} · ${hotspot.celluleCount} cellules</span>
+              <span>${hotspot.operationCount} opérations, ${hotspot.exposedCellCount} exposées</span>
+              <div class="intrigue-status-pill-row">${statusPreview}</div>
+            </article>
+          `;
+        }).join('')}
       </div>
     </section>
   `;
@@ -1165,11 +1174,11 @@ function renderBottomTray(economyView, intrigueView) {
               </thead>
               <tbody>
                 ${intrigueView.panels.cellules.slice(0, 4).map((cellule) => `
-                  <tr>
-                    <td>${cellule.codename}</td>
+                  <tr class="intrigue-cell-row intrigue-cell-row--${cellule.statusClass}">
+                    <td><span class="intrigue-cell-status-dot intrigue-cell-status-dot--${cellule.statusClass}"></span>${cellule.codename}</td>
                     <td>${cellule.locationName}</td>
                     <td>${cellule.exposure}</td>
-                    <td>${cellule.sleeper ? 'Dormante' : cellule.status}</td>
+                    <td><span class="intrigue-status-pill intrigue-status-pill--${cellule.statusClass}">${cellule.statusMarker} ${cellule.statusLabel}</span></td>
                   </tr>
                 `).join('')}
               </tbody>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1235,6 +1235,42 @@ button { font: inherit; }
   margin: 0;
   color: var(--muted);
 }
+.intrigue-status-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+.intrigue-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(8, 15, 28, 0.45);
+}
+.intrigue-status-pill--active { color: #bfdbfe; border-color: rgba(96, 165, 250, 0.26); }
+.intrigue-status-pill--exposed { color: #fde68a; border-color: rgba(250, 204, 21, 0.3); }
+.intrigue-status-pill--sleeper { color: #cbd5e1; border-color: rgba(148, 163, 184, 0.24); }
+.intrigue-status-pill--compromised { color: #fecdd3; border-color: rgba(251, 113, 133, 0.34); }
+.intrigue-cell-row--active td:first-child { color: #dbeafe; }
+.intrigue-cell-row--exposed td:first-child { color: #fef3c7; }
+.intrigue-cell-row--sleeper td:first-child { color: #e2e8f0; }
+.intrigue-cell-row--compromised td:first-child { color: #fecdd3; }
+.intrigue-cell-status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+.intrigue-cell-status-dot--active { background: #60a5fa; }
+.intrigue-cell-status-dot--exposed { background: #facc15; }
+.intrigue-cell-status-dot--sleeper { background: #94a3b8; }
+.intrigue-cell-status-dot--compromised { background: #fb7185; box-shadow: 0 0 8px rgba(251, 113, 133, 0.45); }
 .intrigue-hotspot-card--critical { border-color: rgba(251, 113, 133, 0.4); }
 .intrigue-hotspot-card--warning { border-color: rgba(250, 204, 21, 0.35); }
 .intrigue-operation-card {


### PR DESCRIPTION
## Résumé\n- clarifie les états de cellules avec des marqueurs dédiés dans les cartes, listes et tableaux intrigue\n- distingue explicitement les cellules dormantes, exposées et compromises dans la lecture web\n- met à jour la documentation et les tests de la démo intrigue\n\n## Validation\n- npm test\n- node --check web/app.js