### PR TITLE
Gamma: [WEB-G4] mieux exposer la progression des recherches actives

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - `CultureRepositoryPort`, `ResearchRepositoryPort`, `InMemoryCultureRepository` et `InMemoryResearchRepository` fournissent une base hexagonale légère pour stocker cultures et recherches avec copies défensives et ordre stable
 - `loadHistoricalEventsFromJson` et `loadResearchStatesFromJson` chargent des contenus JSON normalisés avec valeurs par défaut utiles et erreurs explicites sur les payloads invalides
 - côté UI, `buildDiscoveriesPanel` expose les concepts découverts, recherches débloquées et événements liés dans une vue structurée réutilisable
-- côté UI, `buildCultureLayerPanel` assemble un focus lisible par région et culture pour explorer les marqueurs, découvertes et événements historiques depuis la carte
+- côté UI, `buildResearchProgressPanel` rend les recherches actives, bloquées et terminées lisibles d'un coup d'œil avec progression, ton visuel et métriques compactes
+- côté UI, `buildCultureLayerPanel` assemble un focus lisible par région et culture pour explorer les marqueurs, découvertes, progression des recherches et événements historiques depuis la carte
 - côté carte, `buildCultureMapOverlay` transforme cultures, recherches et événements historiques en marqueurs régionaux stables avec score d'influence, tier visuel, highlights et zoneStyle pour mieux distinguer les zones culturelles
-- les tests Gamma couvrent explicitement les use cases de recherche, dérive culturelle, divergence, déclenchement d’événements, ports, adaptateurs mémoire, chargeurs JSON et UI des découvertes et de la couche culturelle
+- les tests Gamma couvrent explicitement les use cases de recherche, dérive culturelle, divergence, déclenchement d’événements, ports, adaptateurs mémoire, chargeurs JSON et UI des découvertes, de la progression des recherches et de la couche culturelle
 
 ## Règles Delta, intrigue et opérations clandestines
 - `LancerOperation` vérifie la disponibilité de la cellule, des agents assignés et des assets requis avant tout lancement

--- a/src/ui/culture/buildCultureLayerPanel.js
+++ b/src/ui/culture/buildCultureLayerPanel.js
@@ -1,4 +1,5 @@
 import { buildDiscoveriesPanel } from './buildDiscoveriesPanel.js';
+import { buildResearchProgressPanel } from './buildResearchProgressPanel.js';
 
 function requireObject(value, label) {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
@@ -76,6 +77,10 @@ function buildFocus(entries, normalizedOptions) {
     normalizedOptions.historicalEventsByCulture ?? {},
     'CultureLayerPanel historicalEventsByCulture',
   );
+  const researchStatesByCulture = requireObject(
+    normalizedOptions.researchStatesByCulture ?? {},
+    'CultureLayerPanel researchStatesByCulture',
+  );
 
   const focusedEntry = entries.find((entry) => (
     (selectedRegionId === null || entry.regionId === selectedRegionId)
@@ -97,6 +102,13 @@ function buildFocus(entries, normalizedOptions) {
     influenceTier: focusedEntry.influenceTier,
     primaryLanguage: focusedEntry.primaryLanguage,
     highlights: focusedEntry.highlights,
+    researchProgressPanel: buildResearchProgressPanel(
+      researchStatesByCulture[focusedEntry.cultureId] ?? [],
+      {
+        cultureId: focusedEntry.cultureId,
+        title: 'Recherches actives',
+      },
+    ),
     discoveriesPanel: buildDiscoveriesPanel(
       {
         cultureId: focusedEntry.cultureId,

--- a/src/ui/culture/buildResearchProgressPanel.js
+++ b/src/ui/culture/buildResearchProgressPanel.js
@@ -1,0 +1,150 @@
+import { ResearchState } from '../../domain/culture/ResearchState.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeResearchState(researchState, index) {
+  if (researchState instanceof ResearchState) {
+    return researchState;
+  }
+
+  if (researchState === null || typeof researchState !== 'object' || Array.isArray(researchState)) {
+    throw new TypeError(`ResearchProgressPanel researchStates[${index}] must be a ResearchState instance or plain object.`);
+  }
+
+  return new ResearchState(researchState);
+}
+
+function normalizeResearchStates(researchStates) {
+  if (!Array.isArray(researchStates)) {
+    throw new TypeError('ResearchProgressPanel researchStates must be an array.');
+  }
+
+  return researchStates.map(normalizeResearchState);
+}
+
+function buildStatusTone(researchState) {
+  if (researchState.status === 'completed') {
+    return 'success';
+  }
+
+  if (researchState.status === 'blocked' || researchState.blockedByIds.length > 0) {
+    return 'warning';
+  }
+
+  if (researchState.status === 'active') {
+    return 'info';
+  }
+
+  return 'muted';
+}
+
+function buildStatusLabel(researchState) {
+  if (researchState.status === 'completed') {
+    return 'Terminée';
+  }
+
+  if (researchState.status === 'blocked' || researchState.blockedByIds.length > 0) {
+    return 'Bloquée';
+  }
+
+  if (researchState.status === 'active') {
+    return 'Active';
+  }
+
+  return 'Planifiée';
+}
+
+function buildProgressLabel(researchState) {
+  if (researchState.status === 'completed') {
+    return 'Terminée';
+  }
+
+  if (researchState.status === 'blocked' || researchState.blockedByIds.length > 0) {
+    return `${researchState.progress}% bloqué`;
+  }
+
+  if (researchState.status === 'planned') {
+    return `${researchState.progress}% planifié`;
+  }
+
+  return `${researchState.progress}% en cours`;
+}
+
+export function buildResearchProgressPanel(researchStates, options = {}) {
+  const normalizedResearchStates = normalizeResearchStates(researchStates);
+  const normalizedOptions = requireObject(options, 'ResearchProgressPanel options');
+  const cultureId = requireText(normalizedOptions.cultureId, 'ResearchProgressPanel options.cultureId');
+  const title = String(normalizedOptions.title ?? 'Recherches').trim() || 'Recherches';
+
+  const rows = normalizedResearchStates
+    .filter((researchState) => researchState.cultureId === cultureId)
+    .sort((left, right) => {
+      const statusRank = {
+        active: 0,
+        blocked: 1,
+        completed: 2,
+        planned: 3,
+      };
+      const rankComparison = (statusRank[left.status] ?? 9) - (statusRank[right.status] ?? 9);
+
+      if (rankComparison !== 0) {
+        return rankComparison;
+      }
+
+      const progressComparison = right.progress - left.progress;
+
+      if (progressComparison !== 0) {
+        return progressComparison;
+      }
+
+      return left.topicId.localeCompare(right.topicId);
+    })
+    .map((researchState) => ({
+      researchId: researchState.id,
+      topicId: researchState.topicId,
+      status: researchState.status,
+      statusLabel: buildStatusLabel(researchState),
+      tone: buildStatusTone(researchState),
+      progress: researchState.progress,
+      currentTier: researchState.currentTier,
+      progressLabel: buildProgressLabel(researchState),
+      blockedByIds: [...researchState.blockedByIds],
+      discoveredConceptCount: researchState.discoveredConceptIds.length,
+      lastAdvancedAt: researchState.lastAdvancedAt?.toISOString() ?? null,
+      completedAt: researchState.completedAt?.toISOString() ?? null,
+    }));
+
+  const activeCount = rows.filter((row) => row.status === 'active').length;
+  const blockedCount = rows.filter((row) => row.status === 'blocked' || row.blockedByIds.length > 0).length;
+  const completedCount = rows.filter((row) => row.status === 'completed').length;
+
+  return {
+    cultureId,
+    title,
+    summary: `${activeCount} actives, ${blockedCount} bloquées, ${completedCount} terminées`,
+    rows,
+    metrics: {
+      researchCount: rows.length,
+      activeCount,
+      blockedCount,
+      completedCount,
+      averageProgress: rows.length === 0 ? 0 : Math.round(rows.reduce((sum, row) => sum + row.progress, 0) / rows.length),
+    },
+  };
+}

--- a/test/ui/culture/buildCultureLayerPanel.test.js
+++ b/test/ui/culture/buildCultureLayerPanel.test.js
@@ -55,6 +55,28 @@ test('buildCultureLayerPanel summarizes regions and exposes a readable focus pan
           },
         ],
       },
+      researchStatesByCulture: {
+        'culture-north': [
+          {
+            id: 'research-astrolabe',
+            cultureId: 'culture-north',
+            topicId: 'astrolabe',
+            status: 'active',
+            progress: 65,
+            currentTier: 2,
+            discoveredConceptIds: ['star-maps', 'tidal-ledgers'],
+          },
+          {
+            id: 'research-navigation-codes',
+            cultureId: 'culture-north',
+            topicId: 'navigation-codes',
+            status: 'completed',
+            progress: 100,
+            currentTier: 3,
+            completedAt: '2026-04-18T08:00:00.000Z',
+          },
+        ],
+      },
     },
   );
 
@@ -84,6 +106,8 @@ test('buildCultureLayerPanel summarizes regions and exposes a readable focus pan
   ]);
   assert.equal(panel.focus.cultureId, 'culture-north');
   assert.equal(panel.focus.discoveriesPanel.summary, '3 concepts, 1 recherches, 1 événements');
+  assert.equal(panel.focus.researchProgressPanel.summary, '1 actives, 0 bloquées, 1 terminées');
+  assert.equal(panel.focus.researchProgressPanel.rows[0].progressLabel, '65% en cours');
   assert.deepEqual(panel.metrics, {
     markerCount: 2,
     regionCount: 2,
@@ -109,4 +133,5 @@ test('buildCultureLayerPanel falls back to the first marker and validates inputs
   assert.throws(() => buildCultureLayerPanel([null]), /entries\[0\] must be an object/);
   assert.throws(() => buildCultureLayerPanel([], null), /options must be an object/);
   assert.throws(() => buildCultureLayerPanel([], { historicalEventsByCulture: [] }), /historicalEventsByCulture must be an object/);
+  assert.throws(() => buildCultureLayerPanel([], { researchStatesByCulture: [] }), /researchStatesByCulture must be an object/);
 });

--- a/test/ui/culture/buildResearchProgressPanel.test.js
+++ b/test/ui/culture/buildResearchProgressPanel.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
+import { buildResearchProgressPanel } from '../../../src/ui/culture/buildResearchProgressPanel.js';
+
+test('buildResearchProgressPanel summarizes active, blocked, and completed research for one culture', () => {
+  const panel = buildResearchProgressPanel(
+    [
+      new ResearchState({
+        id: 'research-astrolabe',
+        cultureId: 'culture-north',
+        topicId: 'astrolabe',
+        status: 'active',
+        progress: 65,
+        currentTier: 2,
+        discoveredConceptIds: ['star-maps', 'tidal-ledgers'],
+        lastAdvancedAt: '2026-04-19T11:00:00.000Z',
+      }),
+      new ResearchState({
+        id: 'research-harbor-codes',
+        cultureId: 'culture-north',
+        topicId: 'harbor-codes',
+        status: 'blocked',
+        progress: 35,
+        currentTier: 1,
+        blockedByIds: ['dry-docks'],
+      }),
+      new ResearchState({
+        id: 'research-ledgers',
+        cultureId: 'culture-north',
+        topicId: 'paper-ledgers',
+        status: 'completed',
+        progress: 100,
+        currentTier: 3,
+        completedAt: '2026-04-18T08:00:00.000Z',
+      }),
+      new ResearchState({
+        id: 'research-foreign',
+        cultureId: 'culture-steppe',
+        topicId: 'horse-breeding',
+        status: 'active',
+        progress: 40,
+      }),
+    ],
+    { cultureId: 'culture-north' },
+  );
+
+  assert.equal(panel.summary, '1 actives, 1 bloquées, 1 terminées');
+  assert.deepEqual(panel.rows, [
+    {
+      researchId: 'research-astrolabe',
+      topicId: 'astrolabe',
+      status: 'active',
+      statusLabel: 'Active',
+      tone: 'info',
+      progress: 65,
+      currentTier: 2,
+      progressLabel: '65% en cours',
+      blockedByIds: [],
+      discoveredConceptCount: 2,
+      lastAdvancedAt: '2026-04-19T11:00:00.000Z',
+      completedAt: null,
+    },
+    {
+      researchId: 'research-harbor-codes',
+      topicId: 'harbor-codes',
+      status: 'blocked',
+      statusLabel: 'Bloquée',
+      tone: 'warning',
+      progress: 35,
+      currentTier: 1,
+      progressLabel: '35% bloqué',
+      blockedByIds: ['dry-docks'],
+      discoveredConceptCount: 0,
+      lastAdvancedAt: null,
+      completedAt: null,
+    },
+    {
+      researchId: 'research-ledgers',
+      topicId: 'paper-ledgers',
+      status: 'completed',
+      statusLabel: 'Terminée',
+      tone: 'success',
+      progress: 100,
+      currentTier: 3,
+      progressLabel: 'Terminée',
+      blockedByIds: [],
+      discoveredConceptCount: 0,
+      lastAdvancedAt: null,
+      completedAt: '2026-04-18T08:00:00.000Z',
+    },
+  ]);
+  assert.deepEqual(panel.metrics, {
+    researchCount: 3,
+    activeCount: 1,
+    blockedCount: 1,
+    completedCount: 1,
+    averageProgress: 67,
+  });
+});
+
+test('buildResearchProgressPanel validates inputs', () => {
+  assert.throws(() => buildResearchProgressPanel(null, { cultureId: 'culture-north' }), /researchStates must be an array/);
+  assert.throws(() => buildResearchProgressPanel([null], { cultureId: 'culture-north' }), /must be a ResearchState instance or plain object/);
+  assert.throws(() => buildResearchProgressPanel([], null), /options must be an object/);
+  assert.throws(() => buildResearchProgressPanel([], {}), /cultureId is required/);
+});


### PR DESCRIPTION
## Résumé
- ajout de `buildResearchProgressPanel` pour rendre les recherches actives, bloquées et terminées lisibles d'un coup d'œil
- intégration du panneau de progression dans le focus de `buildCultureLayerPanel`
- ajout de tests dédiés et mise à jour de la documentation Gamma

## Tests
- `node --test test/ui/culture/buildResearchProgressPanel.test.js test/ui/culture/buildCultureLayerPanel.test.js`
- `npm test`

Closes #295
