### PR TITLE
Delta: [WEB-D7] ajouter un historique léger des incidents de sécurité

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - côté UI, le niveau d'alerte peut être transformé en badge lisible avec texte, ton, couleur, emphase, icône, progression et libellé accessible
 - côté UI, `buildIntrigueMapOverlay` agrège par lieu la présence de cellules et la menace de sabotage active dans une vue stable avec métriques, styles et niveaux de risque réutilisables pour la carte
 - côté UI, `buildIntrigueWebDemo` compose la couche intrigue pour la démo web avec badge d'alerte, hotspots triés, panneau simple des cellules et opérations actives, tout en réutilisant les composants intrigue existants
-- dans `web/app.js`, la démo web peut afficher un overlay intrigue dédié avec liens de réseau, foyers cliquables, heatmap de sabotage, panneau d’alerte dédié, détails d’opérations actives au clic, et codes visuels distincts pour cellules dormantes, exposées et compromises, afin de rendre la présence clandestine plus lisible sans surcharger la carte
+- dans `web/app.js`, la démo web peut afficher un overlay intrigue dédié avec liens de réseau, foyers cliquables, heatmap de sabotage, panneau d’alerte dédié, détails d’opérations actives au clic, journal compact des incidents de sécurité, et codes visuels distincts pour cellules dormantes, exposées et compromises, afin de rendre la présence clandestine plus lisible sans surcharger la carte
 - l'adaptateur `InMemoryIntrigueRepository` permet de stocker cellules et opérations clandestines en mémoire avec copies défensives et ordre de listing stable pour les tests et assemblages locaux
 - les tests Delta couvrent explicitement le risque de détection, l'exposition réseau, l'adaptateur mémoire intrigue et l'affichage du niveau d'alerte
 

--- a/web/app.js
+++ b/web/app.js
@@ -847,10 +847,43 @@ function getIntrigueViewModel() {
     ?? demo.panels.operations.find((operation) => operation.locationId === state.selectedProvinceId)
     ?? demo.panels.operations[0]
     ?? null;
+  const incidents = [
+    {
+      id: 'incident-locks',
+      turnLabel: `T${state.turn}`,
+      severity: selectedOperation?.tone === 'danger' ? 'critical' : 'warning',
+      locationName: selectedOperation?.locationName ?? (entries[0]?.locationName ?? 'Frontieres'),
+      title: selectedOperation
+        ? `${selectedOperation.type} sous surveillance`
+        : 'Activite clandestine detectee',
+      detail: selectedOperation
+        ? `${selectedOperation.objective}, progression ${selectedOperation.progress}% et risque ${selectedOperation.detectionRisk}.`
+        : 'Les relais de terrain signalent un regain d activite a verifier.',
+    },
+    {
+      id: 'incident-cells',
+      turnLabel: `T${Math.max(1, state.turn - 1)}`,
+      severity: demo.metrics.exposedCellCount > 0 ? 'warning' : 'watch',
+      locationName: entries.find((entry) => entry.metrics.exposedCellCount > 0)?.locationName ?? (entries[1]?.locationName ?? 'Province secondaire'),
+      title: demo.metrics.exposedCellCount > 0 ? 'Cellules exposees remontees' : 'Reseau reste discret',
+      detail: demo.metrics.exposedCellCount > 0
+        ? `${demo.metrics.exposedCellCount} cellule${demo.metrics.exposedCellCount > 1 ? 's' : ''} exposee${demo.metrics.exposedCellCount > 1 ? 's' : ''} ont force un repli partiel.`
+        : 'Aucune cellule compromise supplementaire n a ete detectee sur le dernier tour.',
+    },
+    {
+      id: 'incident-summary',
+      turnLabel: `T${Math.max(1, state.turn - 2)}`,
+      severity: 'watch',
+      locationName: 'Synthese theatre',
+      title: 'Resume securite recent',
+      detail: state.lastTurnSummary,
+    },
+  ];
 
   return {
     ...demo,
     selectedOperation,
+    incidents,
     map: {
       ...demo.map,
       entries,
@@ -1049,6 +1082,22 @@ function renderIntrigueSidePanel(intrigueView) {
         </div>
         <small>faible à critique</small>
       </div>
+      <section class="intrigue-incident-log" aria-label="Historique leger des incidents de securite">
+        <div class="intrigue-incident-log__header">
+          <strong>Journal securite</strong>
+          <span>${intrigueView.incidents.length} entrees recentes</span>
+        </div>
+        ${intrigueView.incidents.map((incident) => `
+          <article class="intrigue-incident intrigue-incident--${incident.severity}">
+            <div class="intrigue-incident__meta">
+              <span>${incident.turnLabel}</span>
+              <strong>${incident.locationName}</strong>
+            </div>
+            <h4>${incident.title}</h4>
+            <p>${incident.detail}</p>
+          </article>
+        `).join('')}
+      </section>
       <div class="intrigue-hotspot-list">
         ${intrigueView.hotspots.slice(0, 4).map((hotspot) => {
           const statusPreview = intrigueView.panels.cellules

--- a/web/styles.css
+++ b/web/styles.css
@@ -1218,6 +1218,41 @@ button { font: inherit; }
 .intrigue-legend-strip__scale .is-low { background: rgba(96, 165, 250, 0.72); }
 .intrigue-legend-strip__scale .is-medium { background: rgba(250, 204, 21, 0.78); }
 .intrigue-legend-strip__scale .is-high { background: rgba(251, 113, 133, 0.82); }
+.intrigue-incident-log {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+.intrigue-incident-log__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+  color: var(--muted);
+}
+.intrigue-incident {
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.intrigue-incident__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 12px;
+}
+.intrigue-incident h4,
+.intrigue-incident p {
+  margin: 6px 0 0;
+}
+.intrigue-incident p {
+  color: var(--muted);
+}
+.intrigue-incident--watch { border-color: rgba(96, 165, 250, 0.24); }
+.intrigue-incident--warning { border-color: rgba(250, 204, 21, 0.28); }
+.intrigue-incident--critical { border-color: rgba(251, 113, 133, 0.34); }
 .intrigue-hotspot-list {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
## Résumé\n- ajoute un mini journal d incidents de securite dans l overlay intrigue\n- relie les entrees recentes a l operation suivie, aux cellules exposees et au resume du theatre\n- documente cette lecture compacte dans la demo web\n\n## Validation\n- npm test\n- node --check web/app.js