### PR TITLE
Gamma: [WEB-G3] ajouter un panneau chronologique des découvertes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - `triggerHistoricalEvent`, `selectHistoricalEvent`, `RandomProviderPort` et `ClockPort` rendent le déclenchement d’événements testable, déterministe et injectable pour la sélection aléatoire comme pour l’horodatage
 - `CultureRepositoryPort`, `ResearchRepositoryPort`, `InMemoryCultureRepository` et `InMemoryResearchRepository` fournissent une base hexagonale légère pour stocker cultures et recherches avec copies défensives et ordre stable
 - `loadHistoricalEventsFromJson` et `loadResearchStatesFromJson` chargent des contenus JSON normalisés avec valeurs par défaut utiles et erreurs explicites sur les payloads invalides
-- côté UI, `buildDiscoveriesPanel` expose les concepts découverts, recherches débloquées et événements liés dans une vue structurée réutilisable
+- côté UI, `buildDiscoveriesPanel` expose les concepts découverts, recherches débloquées, événements liés et une timeline chronologique compacte pour suivre l'ordre des découvertes
 - côté UI, `buildResearchProgressPanel` rend les recherches actives, bloquées et terminées lisibles d'un coup d'œil avec progression, ton visuel et métriques compactes
 - côté UI, `buildCultureLayerPanel` assemble un focus lisible par région et culture pour explorer les marqueurs, découvertes, progression des recherches et événements historiques depuis la carte
 - côté carte, `buildCultureMapOverlay` transforme cultures, recherches et événements historiques en marqueurs régionaux stables avec score d'influence, tier visuel, highlights et zoneStyle pour mieux distinguer les zones culturelles

--- a/src/ui/culture/buildDiscoveriesPanel.js
+++ b/src/ui/culture/buildDiscoveriesPanel.js
@@ -24,6 +24,20 @@ function normalizeTextArray(values, label) {
   return [...new Set(values.map((value) => requireText(value, label)))].sort();
 }
 
+function normalizeDate(value, label) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const normalizedValue = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(normalizedValue.getTime())) {
+    throw new RangeError(`${label} must be a valid date.`);
+  }
+
+  return normalizedValue;
+}
+
 function normalizeHistoricalEvents(events) {
   if (!Array.isArray(events)) {
     throw new TypeError('DiscoveriesPanel historicalEvents must be an array.');
@@ -37,6 +51,11 @@ function normalizeHistoricalEvents(events) {
       title: requireText(
         normalizedEvent.title,
         `DiscoveriesPanel historicalEvents[${index}].title`,
+      ),
+      summary: String(normalizedEvent.summary ?? '').trim(),
+      triggeredAt: normalizeDate(
+        normalizedEvent.triggeredAt ?? null,
+        `DiscoveriesPanel historicalEvents[${index}].triggeredAt`,
       ),
       discoveryIds: normalizeTextArray(
         normalizedEvent.discoveryIds ?? [],
@@ -69,8 +88,31 @@ export function buildDiscoveriesPanel(researchState, options = {}) {
     discoveryCount: event.discoveryIds.length,
     discoveries: event.discoveryIds,
     unlockedResearchIds: event.unlockedResearchIds,
+    triggeredAt: event.triggeredAt?.toISOString() ?? null,
     label: `${event.title} (${event.discoveryIds.length} découverte${event.discoveryIds.length > 1 ? 's' : ''})`,
   }));
+
+  const timeline = historicalEvents
+    .slice()
+    .sort((left, right) => {
+      const leftTime = left.triggeredAt?.getTime() ?? Number.MAX_SAFE_INTEGER;
+      const rightTime = right.triggeredAt?.getTime() ?? Number.MAX_SAFE_INTEGER;
+
+      return leftTime - rightTime || left.title.localeCompare(right.title);
+    })
+    .map((event, index) => ({
+      id: `${event.id}:timeline`,
+      eventId: event.id,
+      title: event.title,
+      summary: event.summary || `${event.discoveryIds.length} découverte${event.discoveryIds.length > 1 ? 's' : ''}`,
+      triggeredAt: event.triggeredAt?.toISOString() ?? null,
+      order: index + 1,
+      discoveries: event.discoveryIds,
+      unlockedResearchIds: event.unlockedResearchIds,
+      label: event.triggeredAt
+        ? `${index + 1}. ${event.title} · ${event.triggeredAt.toISOString().slice(0, 10)}`
+        : `${index + 1}. ${event.title}`,
+    }));
 
   return {
     cultureId: requireText(normalizedResearchState.cultureId, 'DiscoveriesPanel researchState.cultureId'),
@@ -80,11 +122,13 @@ export function buildDiscoveriesPanel(researchState, options = {}) {
       concepts: discoveredConceptIds,
       research: unlockedResearchIds,
       events: eventRows,
+      timeline,
     },
     metrics: {
       conceptCount: discoveredConceptIds.length,
       unlockedResearchCount: unlockedResearchIds.length,
       eventCount: eventRows.length,
+      timelineEventCount: timeline.length,
     },
   };
 }

--- a/test/ui/culture/buildDiscoveriesPanel.test.js
+++ b/test/ui/culture/buildDiscoveriesPanel.test.js
@@ -13,8 +13,18 @@ test('buildDiscoveriesPanel summarizes research discoveries and event discoverie
     {
       historicalEvents: [
         {
+          id: 'event-navigators-guild',
+          title: 'Navigators Guild',
+          summary: 'Les premières cartes d\'étoiles circulent entre ports.',
+          triggeredAt: '2026-04-10T10:00:00.000Z',
+          discoveryIds: ['star-charts'],
+          unlockedResearchIds: ['observatory-maps'],
+        },
+        {
           id: 'event-open-archives',
           title: 'Open Archives',
+          summary: 'Les archives publiques rendent les découvertes traçables.',
+          triggeredAt: '2026-04-12T14:30:00.000Z',
           discoveryIds: ['public-catalogue', 'scholar-oath'],
           unlockedResearchIds: ['paper-ledgers'],
         },
@@ -25,25 +35,60 @@ test('buildDiscoveriesPanel summarizes research discoveries and event discoverie
   assert.deepEqual(panel, {
     cultureId: 'culture-north',
     title: 'Découvertes',
-    summary: '2 concepts, 2 recherches, 1 événements',
+    summary: '2 concepts, 2 recherches, 2 événements',
     sections: {
       concepts: ['bronze-smelting', 'star-maps'],
       research: ['observatory-maps', 'paper-ledgers'],
       events: [
+        {
+          eventId: 'event-navigators-guild',
+          eventTitle: 'Navigators Guild',
+          discoveryCount: 1,
+          discoveries: ['star-charts'],
+          unlockedResearchIds: ['observatory-maps'],
+          triggeredAt: '2026-04-10T10:00:00.000Z',
+          label: 'Navigators Guild (1 découverte)',
+        },
         {
           eventId: 'event-open-archives',
           eventTitle: 'Open Archives',
           discoveryCount: 2,
           discoveries: ['public-catalogue', 'scholar-oath'],
           unlockedResearchIds: ['paper-ledgers'],
+          triggeredAt: '2026-04-12T14:30:00.000Z',
           label: 'Open Archives (2 découvertes)',
+        },
+      ],
+      timeline: [
+        {
+          id: 'event-navigators-guild:timeline',
+          eventId: 'event-navigators-guild',
+          title: 'Navigators Guild',
+          summary: "Les premières cartes d'étoiles circulent entre ports.",
+          triggeredAt: '2026-04-10T10:00:00.000Z',
+          order: 1,
+          discoveries: ['star-charts'],
+          unlockedResearchIds: ['observatory-maps'],
+          label: '1. Navigators Guild · 2026-04-10',
+        },
+        {
+          id: 'event-open-archives:timeline',
+          eventId: 'event-open-archives',
+          title: 'Open Archives',
+          summary: 'Les archives publiques rendent les découvertes traçables.',
+          triggeredAt: '2026-04-12T14:30:00.000Z',
+          order: 2,
+          discoveries: ['public-catalogue', 'scholar-oath'],
+          unlockedResearchIds: ['paper-ledgers'],
+          label: '2. Open Archives · 2026-04-12',
         },
       ],
     },
     metrics: {
       conceptCount: 2,
       unlockedResearchCount: 2,
-      eventCount: 1,
+      eventCount: 2,
+      timelineEventCount: 2,
     },
   });
 });
@@ -62,6 +107,7 @@ test('buildDiscoveriesPanel supports empty discovery collections', () => {
 
   assert.equal(panel.summary, '0 concepts, 0 recherches, 0 événements');
   assert.deepEqual(panel.sections.events, []);
+  assert.deepEqual(panel.sections.timeline, []);
 });
 
 test('buildDiscoveriesPanel rejects invalid payloads', () => {
@@ -96,5 +142,20 @@ test('buildDiscoveriesPanel rejects invalid payloads', () => {
         },
       ),
     /DiscoveriesPanel historicalEvents\[0\]\.title is required/,
+  );
+
+  assert.throws(
+    () =>
+      buildDiscoveriesPanel(
+        {
+          cultureId: 'culture-north',
+          discoveredConceptIds: [],
+          unlockedResearchIds: [],
+        },
+        {
+          historicalEvents: [{ id: 'event-open-archives', title: 'Open Archives', triggeredAt: 'invalid-date', discoveryIds: [] }],
+        },
+      ),
+    /DiscoveriesPanel historicalEvents\[0\]\.triggeredAt must be a valid date/,
   );
 });


### PR DESCRIPTION
## Résumé
- ajout d'une timeline chronologique compacte dans `buildDiscoveriesPanel`
- liaison explicite entre événements, découvertes et recherches débloquées
- ajout des tests et mise à jour de la documentation Gamma

## Tests
- `node --test test/ui/culture/buildDiscoveriesPanel.test.js`
- `npm test`

Closes #294
