### PR TITLE
Gamma: [WEB-G5] ajouter des popups d’événements historiques sur la carte

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - côté UI, `buildDiscoveriesPanel` expose les concepts découverts, recherches débloquées, événements liés et une timeline chronologique compacte pour suivre l'ordre des découvertes
 - côté UI, `buildResearchProgressPanel` rend les recherches actives, bloquées et terminées lisibles d'un coup d'œil avec progression, ton visuel et métriques compactes
 - côté UI, `buildCultureLayerPanel` assemble un focus lisible par région et culture pour explorer les marqueurs, découvertes, progression des recherches et événements historiques depuis la carte
-- côté carte, `buildCultureMapOverlay` transforme cultures, recherches et événements historiques en marqueurs régionaux stables avec score d'influence, tier visuel, highlights et zoneStyle pour mieux distinguer les zones culturelles
+- côté carte, `buildCultureMapOverlay` transforme cultures, recherches et événements historiques en marqueurs régionaux stables avec score d'influence, tier visuel, highlights, `eventPopups` et zoneStyle pour mieux distinguer les zones culturelles et ouvrir les événements depuis la carte
 - les tests Gamma couvrent explicitement les use cases de recherche, dérive culturelle, divergence, déclenchement d’événements, ports, adaptateurs mémoire, chargeurs JSON et UI des découvertes, de la progression des recherches et de la couche culturelle
 
 ## Règles Delta, intrigue et opérations clandestines

--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -198,10 +198,13 @@ function summarizeSignals(culture, researchStates, historicalEvents) {
     }
   }
 
-  const eventIds = historicalEvents.map((historicalEvent) => historicalEvent.id).sort();
+  const orderedHistoricalEvents = historicalEvents
+    .slice()
+    .sort((left, right) => left.triggeredAt.getTime() - right.triggeredAt.getTime() || left.title.localeCompare(right.title));
+  const eventIds = orderedHistoricalEvents.map((historicalEvent) => historicalEvent.id);
   const highlightedDiscoveries = [...new Set([
     ...[...discoveredConceptIds],
-    ...historicalEvents.flatMap((historicalEvent) => historicalEvent.discoveryIds),
+    ...orderedHistoricalEvents.flatMap((historicalEvent) => historicalEvent.discoveryIds),
   ])].sort();
 
   return {
@@ -212,6 +215,7 @@ function summarizeSignals(culture, researchStates, historicalEvents) {
     eventIds,
     eventCount: eventIds.length,
     identityTags: [...new Set([...culture.valueIds, ...culture.traditionIds])].sort(),
+    orderedHistoricalEvents,
   };
 }
 
@@ -347,8 +351,20 @@ export function buildCultureMapOverlay(payload, options = {}) {
           unlockedResearchIds: cultureState.signals.unlockedResearchIds,
           activeResearchCount: cultureState.signals.activeResearchCount,
           eventIds: cultureState.signals.eventIds,
-          eventTitles: cultureState.cultureHistoricalEvents.map((historicalEvent) => historicalEvent.title).sort(),
+          eventTitles: cultureState.signals.orderedHistoricalEvents.map((historicalEvent) => historicalEvent.title),
           eventCount: cultureState.signals.eventCount,
+          eventPopups: cultureState.signals.orderedHistoricalEvents.map((historicalEvent, index) => ({
+            popupId: `${regionId}:${culture.id}:${historicalEvent.id}:popup`,
+            eventId: historicalEvent.id,
+            title: historicalEvent.title,
+            summary: historicalEvent.summary,
+            triggeredAt: historicalEvent.triggeredAt.toISOString(),
+            importance: historicalEvent.importance,
+            discoveries: [...historicalEvent.discoveryIds],
+            unlockedResearchIds: [...cultureState.signals.unlockedResearchIds],
+            label: `${historicalEvent.title} · ${historicalEvent.triggeredAt.toISOString().slice(0, 10)}`,
+            order: index + 1,
+          })),
           identityTags: cultureState.signals.identityTags,
           highlights: [
             ...cultureState.signals.highlightedDiscoveries.slice(0, 2),

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -93,6 +93,20 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
       eventIds: ['event-open-archives'],
       eventTitles: ['Open Archives'],
       eventCount: 1,
+      eventPopups: [
+        {
+          popupId: 'archipelago:culture-north:event-open-archives:popup',
+          eventId: 'event-open-archives',
+          title: 'Open Archives',
+          summary: 'Scholars share navigation routes.',
+          triggeredAt: '2026-04-19T00:00:00.000Z',
+          importance: 3,
+          discoveries: ['public-catalogue'],
+          unlockedResearchIds: ['astrolabe'],
+          label: 'Open Archives · 2026-04-19',
+          order: 1,
+        },
+      ],
       identityTags: ['assemblies', 'navigation', 'trade'],
       highlights: ['public-catalogue', 'star-maps', 'assemblies'],
       cultureMetrics: {
@@ -144,6 +158,7 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
       eventIds: [],
       eventTitles: [],
       eventCount: 0,
+      eventPopups: [],
       identityTags: ['clan-oaths', 'honor'],
       highlights: ['stirrup-drill', 'clan-oaths', 'honor'],
       cultureMetrics: {
@@ -195,6 +210,20 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
       eventIds: ['event-open-archives'],
       eventTitles: ['Open Archives'],
       eventCount: 1,
+      eventPopups: [
+        {
+          popupId: 'north-coast:culture-north:event-open-archives:popup',
+          eventId: 'event-open-archives',
+          title: 'Open Archives',
+          summary: 'Scholars share navigation routes.',
+          triggeredAt: '2026-04-19T00:00:00.000Z',
+          importance: 3,
+          discoveries: ['public-catalogue'],
+          unlockedResearchIds: ['astrolabe'],
+          label: 'Open Archives · 2026-04-19',
+          order: 1,
+        },
+      ],
       identityTags: ['assemblies', 'navigation', 'trade'],
       highlights: ['public-catalogue', 'star-maps', 'assemblies'],
       cultureMetrics: {
@@ -305,6 +334,7 @@ test('buildCultureMapOverlay distinguishes overlapping cultural influences in th
       eventIds: [],
       eventTitles: [],
       eventCount: 0,
+      eventPopups: [],
       identityTags: ['archives', 'memory'],
       highlights: ['ink-network', 'archives', 'memory'],
       cultureMetrics: {
@@ -356,6 +386,7 @@ test('buildCultureMapOverlay distinguishes overlapping cultural influences in th
       eventIds: [],
       eventTitles: [],
       eventCount: 0,
+      eventPopups: [],
       identityTags: ['assemblies', 'navigation', 'trade'],
       highlights: ['star-maps', 'tidal-ledgers', 'assemblies'],
       cultureMetrics: {


### PR DESCRIPTION
## Résumé
- ajout de `eventPopups` dans `buildCultureMapOverlay` pour ouvrir les événements historiques depuis les marqueurs Gamma
- exposition du titre, résumé, date, importance, découvertes liées et recherches associées dans un format stable pour l'UI
- mise à jour des tests et de la documentation Gamma

## Tests
- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Closes #296
