### PR TITLE
Gamma: [WEB-G9] ajouter des filtres dédiés aux événements et recherches

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - `loadHistoricalEventsFromJson` et `loadResearchStatesFromJson` chargent des contenus JSON normalisés avec valeurs par défaut utiles et erreurs explicites sur les payloads invalides
 - côté UI, `buildDiscoveriesPanel` expose les concepts découverts, recherches débloquées, événements liés et une timeline chronologique compacte pour suivre l'ordre des découvertes
 - côté UI, `buildResearchProgressPanel` rend les recherches actives, bloquées et terminées lisibles d'un coup d'œil avec progression, ton visuel et métriques compactes
-- côté UI, `buildCultureLayerPanel` assemble un focus lisible par région et culture pour explorer les marqueurs, découvertes, progression des recherches et événements historiques depuis la carte
+- côté UI, `buildCultureLayerPanel` assemble un focus lisible par région et culture pour explorer les marqueurs, découvertes, progression des recherches et événements historiques depuis la carte, avec des filtres internes simples pour isoler découvertes, recherches ou événements
 - côté carte, `buildCultureMapOverlay` transforme cultures, recherches et événements historiques en marqueurs régionaux stables avec score d'influence, tier visuel, highlights, `eventPopups` et zoneStyle pour mieux distinguer les zones culturelles et ouvrir les événements depuis la carte
 - les tests Gamma couvrent explicitement les use cases de recherche, dérive culturelle, divergence, déclenchement d’événements, ports, adaptateurs mémoire, chargeurs JSON et UI des découvertes, de la progression des recherches et de la couche culturelle
 

--- a/src/ui/culture/buildCultureLayerPanel.js
+++ b/src/ui/culture/buildCultureLayerPanel.js
@@ -73,6 +73,9 @@ function buildRegionRows(entries) {
 function buildFocus(entries, normalizedOptions) {
   const selectedRegionId = normalizedOptions.selectedRegionId ? requireText(normalizedOptions.selectedRegionId, 'CultureLayerPanel options.selectedRegionId') : null;
   const selectedCultureId = normalizedOptions.selectedCultureId ? requireText(normalizedOptions.selectedCultureId, 'CultureLayerPanel options.selectedCultureId') : null;
+  const activeFilter = normalizedOptions.activeFilter === undefined
+    ? 'all'
+    : requireText(normalizedOptions.activeFilter, 'CultureLayerPanel options.activeFilter');
   const historicalEventsByCulture = requireObject(
     normalizedOptions.historicalEventsByCulture ?? {},
     'CultureLayerPanel historicalEventsByCulture',
@@ -91,6 +94,29 @@ function buildFocus(entries, normalizedOptions) {
     return null;
   }
 
+  const allHistoricalEvents = historicalEventsByCulture[focusedEntry.cultureId] ?? focusedEntry.eventTitles.map((title, index) => ({
+    id: focusedEntry.eventIds[index] ?? `${focusedEntry.cultureId}:event:${index}`,
+    title,
+    discoveryIds: focusedEntry.discoveries,
+    unlockedResearchIds: focusedEntry.unlockedResearchIds,
+  }));
+  const filteredDiscoveries = activeFilter === 'research'
+    ? []
+    : focusedEntry.discoveries;
+  const filteredResearchIds = activeFilter === 'events'
+    ? []
+    : focusedEntry.unlockedResearchIds;
+  const filteredHistoricalEvents = activeFilter === 'research'
+    ? []
+    : activeFilter === 'discoveries'
+      ? allHistoricalEvents.filter((event) => Array.isArray(event.discoveryIds) && event.discoveryIds.length > 0)
+      : allHistoricalEvents;
+  const researchStatusFilter = activeFilter === 'events' || activeFilter === 'discoveries'
+    ? null
+    : activeFilter === 'research'
+      ? 'active'
+      : null;
+
   return {
     regionId: focusedEntry.regionId,
     cultureId: focusedEntry.cultureId,
@@ -102,26 +128,24 @@ function buildFocus(entries, normalizedOptions) {
     influenceTier: focusedEntry.influenceTier,
     primaryLanguage: focusedEntry.primaryLanguage,
     highlights: focusedEntry.highlights,
+    activeFilter,
+    availableFilters: ['all', 'discoveries', 'research', 'events'],
     researchProgressPanel: buildResearchProgressPanel(
       researchStatesByCulture[focusedEntry.cultureId] ?? [],
       {
         cultureId: focusedEntry.cultureId,
-        title: 'Recherches actives',
+        title: activeFilter === 'research' ? 'Recherches actives' : 'Recherches',
+        statusFilter: researchStatusFilter,
       },
     ),
     discoveriesPanel: buildDiscoveriesPanel(
       {
         cultureId: focusedEntry.cultureId,
-        discoveredConceptIds: focusedEntry.discoveries,
-        unlockedResearchIds: focusedEntry.unlockedResearchIds,
+        discoveredConceptIds: filteredDiscoveries,
+        unlockedResearchIds: filteredResearchIds,
       },
       {
-        historicalEvents: historicalEventsByCulture[focusedEntry.cultureId] ?? focusedEntry.eventTitles.map((title, index) => ({
-          id: focusedEntry.eventIds[index] ?? `${focusedEntry.cultureId}:event:${index}`,
-          title,
-          discoveryIds: focusedEntry.discoveries,
-          unlockedResearchIds: focusedEntry.unlockedResearchIds,
-        })),
+        historicalEvents: filteredHistoricalEvents,
       },
     ),
   };

--- a/src/ui/culture/buildResearchProgressPanel.js
+++ b/src/ui/culture/buildResearchProgressPanel.js
@@ -91,9 +91,13 @@ export function buildResearchProgressPanel(researchStates, options = {}) {
   const normalizedOptions = requireObject(options, 'ResearchProgressPanel options');
   const cultureId = requireText(normalizedOptions.cultureId, 'ResearchProgressPanel options.cultureId');
   const title = String(normalizedOptions.title ?? 'Recherches').trim() || 'Recherches';
+  const statusFilter = normalizedOptions.statusFilter === undefined || normalizedOptions.statusFilter === null
+    ? null
+    : requireText(normalizedOptions.statusFilter, 'ResearchProgressPanel options.statusFilter');
 
   const rows = normalizedResearchStates
     .filter((researchState) => researchState.cultureId === cultureId)
+    .filter((researchState) => statusFilter === null || researchState.status === statusFilter)
     .sort((left, right) => {
       const statusRank = {
         active: 0,
@@ -137,6 +141,7 @@ export function buildResearchProgressPanel(researchStates, options = {}) {
   return {
     cultureId,
     title,
+    statusFilter,
     summary: `${activeCount} actives, ${blockedCount} bloquées, ${completedCount} terminées`,
     rows,
     metrics: {

--- a/test/ui/culture/buildCultureLayerPanel.test.js
+++ b/test/ui/culture/buildCultureLayerPanel.test.js
@@ -105,6 +105,8 @@ test('buildCultureLayerPanel summarizes regions and exposes a readable focus pan
     },
   ]);
   assert.equal(panel.focus.cultureId, 'culture-north');
+  assert.equal(panel.focus.activeFilter, 'all');
+  assert.deepEqual(panel.focus.availableFilters, ['all', 'discoveries', 'research', 'events']);
   assert.equal(panel.focus.discoveriesPanel.summary, '3 concepts, 1 recherches, 1 événements');
   assert.equal(panel.focus.researchProgressPanel.summary, '1 actives, 0 bloquées, 1 terminées');
   assert.equal(panel.focus.researchProgressPanel.rows[0].progressLabel, '65% en cours');
@@ -114,6 +116,74 @@ test('buildCultureLayerPanel summarizes regions and exposes a readable focus pan
     strongInfluenceRegionCount: 1,
     cultureCount: 2,
   });
+});
+
+test('buildCultureLayerPanel can isolate discoveries, research, or events via activeFilter', () => {
+  const baseEntries = [
+    {
+      overlayId: 'archipelago:culture-north',
+      regionId: 'archipelago',
+      cultureId: 'culture-north',
+      cultureName: 'Northern League',
+      label: 'Northern League (3 découvertes)',
+      summary: '1 recherches actives, 1 événements, 3 repères culturels',
+      influenceScore: 70,
+      influenceTier: 'strong',
+      discoveries: ['public-catalogue', 'star-maps', 'tidal-ledgers'],
+      unlockedResearchIds: ['astrolabe'],
+      eventIds: ['event-open-archives'],
+      eventTitles: ['Open Archives'],
+      identityTags: ['assemblies', 'navigation', 'trade'],
+      highlights: ['assemblies', 'public-catalogue', 'star-maps'],
+      markerType: 'innovation',
+      primaryLanguage: 'north-tongue',
+    },
+  ];
+  const options = {
+    selectedRegionId: 'archipelago',
+    historicalEventsByCulture: {
+      'culture-north': [
+        {
+          id: 'event-open-archives',
+          title: 'Open Archives',
+          discoveryIds: ['public-catalogue'],
+          unlockedResearchIds: ['astrolabe'],
+        },
+      ],
+    },
+    researchStatesByCulture: {
+      'culture-north': [
+        {
+          id: 'research-astrolabe',
+          cultureId: 'culture-north',
+          topicId: 'astrolabe',
+          status: 'active',
+          progress: 65,
+          currentTier: 2,
+          discoveredConceptIds: ['star-maps', 'tidal-ledgers'],
+        },
+        {
+          id: 'research-navigation-codes',
+          cultureId: 'culture-north',
+          topicId: 'navigation-codes',
+          status: 'completed',
+          progress: 100,
+          currentTier: 3,
+          completedAt: '2026-04-18T08:00:00.000Z',
+        },
+      ],
+    },
+  };
+
+  const discoveriesPanel = buildCultureLayerPanel(baseEntries, { ...options, activeFilter: 'discoveries' });
+  const researchPanel = buildCultureLayerPanel(baseEntries, { ...options, activeFilter: 'research' });
+  const eventsPanel = buildCultureLayerPanel(baseEntries, { ...options, activeFilter: 'events' });
+
+  assert.equal(discoveriesPanel.focus.discoveriesPanel.summary, '3 concepts, 1 recherches, 1 événements');
+  assert.equal(researchPanel.focus.discoveriesPanel.summary, '0 concepts, 1 recherches, 0 événements');
+  assert.equal(researchPanel.focus.researchProgressPanel.statusFilter, 'active');
+  assert.equal(researchPanel.focus.researchProgressPanel.rows.length, 1);
+  assert.equal(eventsPanel.focus.discoveriesPanel.summary, '3 concepts, 0 recherches, 1 événements');
 });
 
 test('buildCultureLayerPanel falls back to the first marker and validates inputs', () => {
@@ -134,4 +204,5 @@ test('buildCultureLayerPanel falls back to the first marker and validates inputs
   assert.throws(() => buildCultureLayerPanel([], null), /options must be an object/);
   assert.throws(() => buildCultureLayerPanel([], { historicalEventsByCulture: [] }), /historicalEventsByCulture must be an object/);
   assert.throws(() => buildCultureLayerPanel([], { researchStatesByCulture: [] }), /researchStatesByCulture must be an object/);
+  assert.throws(() => buildCultureLayerPanel([], { activeFilter: [] }), /activeFilter is required/);
 });


### PR DESCRIPTION
## Résumé
- ajout d'un `activeFilter` simple dans `buildCultureLayerPanel` pour isoler découvertes, recherches ou événements
- ajout d'un `statusFilter` côté `buildResearchProgressPanel` pour concentrer la vue sur les recherches actives quand nécessaire
- mise à jour des tests et de la documentation Gamma

## Tests
- `node --test test/ui/culture/buildCultureLayerPanel.test.js test/ui/culture/buildResearchProgressPanel.test.js`
- `npm test`

Closes #300
