### PR TITLE
Gamma: Seed generated strategic culture map

### DIFF
--- a/src/application/war/GenerateStrategicMap.js
+++ b/src/application/war/GenerateStrategicMap.js
@@ -1,0 +1,186 @@
+import { buildCultureLayerPanel } from '../../ui/culture/buildCultureLayerPanel.js';
+import { buildCultureMapOverlay } from '../../ui/culture/buildCultureMapOverlay.js';
+import { buildStrategicMapShell } from '../../ui/war/StrategicMapShell.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeTextArray(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return [...new Set(values.map((value) => requireText(value, label)))].sort();
+}
+
+function normalizeCulturePayload(culturePayload = {}) {
+  const payload = requireObject(culturePayload, 'GenerateStrategicMap culturePayload');
+
+  return {
+    cultures: requireArray(payload.cultures ?? [], 'GenerateStrategicMap culturePayload.cultures'),
+    researchStates: requireArray(payload.researchStates ?? [], 'GenerateStrategicMap culturePayload.researchStates'),
+    historicalEvents: requireArray(payload.historicalEvents ?? [], 'GenerateStrategicMap culturePayload.historicalEvents'),
+  };
+}
+
+function normalizeRegionIdsByCulture(cultures, explicitRegionIdsByCulture) {
+  const normalizedRegionIdsByCulture = {};
+  const rawRegionIdsByCulture = requireObject(
+    explicitRegionIdsByCulture ?? {},
+    'GenerateStrategicMap regionIdsByCulture',
+  );
+
+  for (const [cultureId, regionIds] of Object.entries(rawRegionIdsByCulture)) {
+    normalizedRegionIdsByCulture[requireText(cultureId, 'GenerateStrategicMap regionIdsByCulture cultureId')] = normalizeTextArray(
+      regionIds,
+      `GenerateStrategicMap regionIdsByCulture.${cultureId}`,
+    );
+  }
+
+  for (const culture of cultures) {
+    const cultureId = requireText(culture.id, 'GenerateStrategicMap culture.id');
+
+    if (normalizedRegionIdsByCulture[cultureId]) {
+      continue;
+    }
+
+    const inferredRegionIds = culture.regionIds ?? culture.provinceIds ?? (
+      culture.homeRegionId ? [culture.homeRegionId] : []
+    );
+
+    normalizedRegionIdsByCulture[cultureId] = normalizeTextArray(
+      inferredRegionIds,
+      `GenerateStrategicMap culture ${cultureId} regionIds`,
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(normalizedRegionIdsByCulture)
+      .filter(([, regionIds]) => regionIds.length > 0)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function groupByCultureId(items, label) {
+  return items.reduce((groups, item) => {
+    const normalizedItem = requireObject(item, `GenerateStrategicMap ${label} item`);
+    const cultureId = normalizedItem.cultureId
+      ?? normalizedItem.affectedCultureIds?.[0]
+      ?? null;
+
+    if (normalizedItem.affectedCultureIds) {
+      for (const affectedCultureId of normalizeTextArray(normalizedItem.affectedCultureIds, `GenerateStrategicMap ${label}.affectedCultureIds`)) {
+        groups[affectedCultureId] = [...(groups[affectedCultureId] ?? []), normalizedItem];
+      }
+
+      return groups;
+    }
+
+    if (cultureId) {
+      const normalizedCultureId = requireText(cultureId, `GenerateStrategicMap ${label}.cultureId`);
+      groups[normalizedCultureId] = [...(groups[normalizedCultureId] ?? []), normalizedItem];
+    }
+
+    return groups;
+  }, {});
+}
+
+function buildCultureSeeds(cultures, regionIdsByCulture, researchStates, historicalEvents) {
+  const researchStatesByCulture = groupByCultureId(researchStates, 'researchStates');
+  const historicalEventsByCulture = groupByCultureId(historicalEvents, 'historicalEvents');
+
+  return cultures
+    .map((culture) => {
+      const cultureId = requireText(culture.id, 'GenerateStrategicMap culture.id');
+      const regionIds = regionIdsByCulture[cultureId] ?? [];
+      const cultureResearchStates = researchStatesByCulture[cultureId] ?? [];
+      const cultureHistoricalEvents = historicalEventsByCulture[cultureId] ?? [];
+
+      return {
+        cultureId,
+        cultureName: String(culture.name ?? cultureId).trim() || cultureId,
+        regionIds,
+        discoveryIds: [...new Set([
+          ...cultureResearchStates.flatMap((researchState) => researchState.discoveredConceptIds ?? []),
+          ...cultureHistoricalEvents.flatMap((historicalEvent) => historicalEvent.discoveryIds ?? []),
+        ].map((value) => requireText(value, `GenerateStrategicMap culture ${cultureId} discoveryId`)))].sort(),
+        historicalEventIds: cultureHistoricalEvents.map((historicalEvent) => requireText(
+          historicalEvent.id,
+          `GenerateStrategicMap culture ${cultureId} historicalEvent.id`,
+        )).sort(),
+        researchStateIds: cultureResearchStates.map((researchState) => requireText(
+          researchState.id,
+          `GenerateStrategicMap culture ${cultureId} researchState.id`,
+        )).sort(),
+      };
+    })
+    .filter((seed) => seed.regionIds.length > 0)
+    .sort((left, right) => left.cultureId.localeCompare(right.cultureId));
+}
+
+export function GenerateStrategicMap({ provinces, culturePayload = {}, options = {} } = {}) {
+  const normalizedOptions = requireObject(options, 'GenerateStrategicMap options');
+  const normalizedCulturePayload = normalizeCulturePayload(culturePayload);
+  const regionIdsByCulture = normalizeRegionIdsByCulture(
+    normalizedCulturePayload.cultures,
+    normalizedOptions.regionIdsByCulture,
+  );
+  const shell = buildStrategicMapShell(requireArray(provinces, 'GenerateStrategicMap provinces'), normalizedOptions.shell ?? normalizedOptions);
+  const cultureOverlay = buildCultureMapOverlay(normalizedCulturePayload, {
+    ...(normalizedOptions.cultureOverlay ?? {}),
+    regionIdsByCulture,
+  });
+  const researchStatesByCulture = groupByCultureId(normalizedCulturePayload.researchStates, 'researchStates');
+  const historicalEventsByCulture = groupByCultureId(normalizedCulturePayload.historicalEvents, 'historicalEvents');
+  const cultureLayerPanel = buildCultureLayerPanel(cultureOverlay, {
+    ...(normalizedOptions.cultureLayerPanel ?? {}),
+    selectedRegionId: normalizedOptions.selectedRegionId,
+    selectedCultureId: normalizedOptions.selectedCultureId,
+    activeFilter: normalizedOptions.activeFilter,
+    researchStatesByCulture,
+    historicalEventsByCulture,
+  });
+  const cultureSeeds = buildCultureSeeds(
+    normalizedCulturePayload.cultures,
+    regionIdsByCulture,
+    normalizedCulturePayload.researchStates,
+    normalizedCulturePayload.historicalEvents,
+  );
+
+  return {
+    shell,
+    overlays: {
+      culture: cultureOverlay,
+    },
+    panels: {
+      culture: cultureLayerPanel,
+    },
+    businessData: {
+      regionIdsByCulture,
+      cultureSeeds,
+    },
+  };
+}

--- a/test/application/war/GenerateStrategicMap.test.js
+++ b/test/application/war/GenerateStrategicMap.test.js
@@ -1,0 +1,142 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { GenerateStrategicMap } from '../../../src/application/war/GenerateStrategicMap.js';
+import { Province } from '../../../src/domain/war/Province.js';
+
+function createProvince(overrides = {}) {
+  return new Province({
+    id: 'north-coast',
+    name: 'North Coast',
+    ownerFactionId: 'aurora',
+    controllingFactionId: 'aurora',
+    supplyLevel: 'stable',
+    loyalty: 70,
+    strategicValue: 4,
+    neighborIds: [],
+    ...overrides,
+  });
+}
+
+test('GenerateStrategicMap wires strategic shell, culture overlay, and seeded business data', () => {
+  const generatedMap = GenerateStrategicMap({
+    provinces: [
+      createProvince({ id: 'north-coast', name: 'North Coast', neighborIds: ['delta-ford'] }),
+      createProvince({
+        id: 'delta-ford',
+        name: 'Delta Ford',
+        ownerFactionId: 'ember',
+        controllingFactionId: 'ember',
+        supplyLevel: 'strained',
+        loyalty: 52,
+        neighborIds: ['north-coast'],
+      }),
+    ],
+    culturePayload: {
+      cultures: [
+        {
+          id: 'culture-aurora',
+          name: 'Aurora Compact',
+          archetype: 'mercantile',
+          primaryLanguage: 'trade-speech',
+          valueIds: ['craft', 'navigation'],
+          traditionIds: ['harbor-moot'],
+          openness: 72,
+          cohesion: 61,
+          researchDrive: 77,
+          regionIds: ['north-coast'],
+        },
+      ],
+      researchStates: [
+        {
+          id: 'research-star-ledgers',
+          cultureId: 'culture-aurora',
+          topicId: 'star-ledgers',
+          status: 'active',
+          progress: 65,
+          discoveredConceptIds: ['tidal-ledgers'],
+        },
+      ],
+      historicalEvents: [
+        {
+          id: 'event-harbor-archives',
+          title: 'Harbor Archives',
+          category: 'knowledge',
+          summary: 'Dock scribes standardize voyage records.',
+          era: 'early-sails',
+          importance: 3,
+          triggeredAt: '2026-04-19T00:00:00.000Z',
+          affectedCultureIds: ['culture-aurora'],
+          discoveryIds: ['public-catalogue'],
+        },
+      ],
+    },
+    options: {
+      shell: {
+        title: 'Carte générée',
+        selectedProvinceId: 'north-coast',
+      },
+      selectedRegionId: 'north-coast',
+    },
+  });
+
+  assert.equal(generatedMap.shell.title, 'Carte générée');
+  assert.equal(generatedMap.shell.stats.provinceCount, 2);
+  assert.deepEqual(generatedMap.businessData.regionIdsByCulture, {
+    'culture-aurora': ['north-coast'],
+  });
+  assert.deepEqual(generatedMap.businessData.cultureSeeds, [
+    {
+      cultureId: 'culture-aurora',
+      cultureName: 'Aurora Compact',
+      regionIds: ['north-coast'],
+      discoveryIds: ['public-catalogue', 'tidal-ledgers'],
+      historicalEventIds: ['event-harbor-archives'],
+      researchStateIds: ['research-star-ledgers'],
+    },
+  ]);
+  assert.equal(generatedMap.overlays.culture.length, 1);
+  assert.equal(generatedMap.overlays.culture[0].regionId, 'north-coast');
+  assert.deepEqual(generatedMap.overlays.culture[0].discoveries, ['public-catalogue', 'tidal-ledgers']);
+  assert.equal(generatedMap.panels.culture.focus.cultureId, 'culture-aurora');
+  assert.equal(generatedMap.panels.culture.focus.discoveriesPanel.summary, '2 concepts, 1 recherches, 1 événements');
+});
+
+test('GenerateStrategicMap supports explicit culture-to-region mapping and validates inputs', () => {
+  const generatedMap = GenerateStrategicMap({
+    provinces: [createProvince()],
+    culturePayload: {
+      cultures: [
+        {
+          id: 'culture-steppe',
+          name: 'Steppe Houses',
+          archetype: 'nomadic',
+          primaryLanguage: 'horse-speech',
+          valueIds: ['honor'],
+          traditionIds: ['clan-oaths'],
+          openness: 35,
+          cohesion: 67,
+          researchDrive: 40,
+        },
+      ],
+    },
+    options: {
+      regionIdsByCulture: {
+        'culture-steppe': ['north-coast'],
+      },
+    },
+  });
+
+  assert.equal(generatedMap.overlays.culture[0].cultureId, 'culture-steppe');
+  assert.deepEqual(generatedMap.businessData.cultureSeeds[0].regionIds, ['north-coast']);
+
+  assert.throws(() => GenerateStrategicMap(), /GenerateStrategicMap provinces must be an array/);
+  assert.throws(
+    () => GenerateStrategicMap({ provinces: [createProvince()], culturePayload: null }),
+    /GenerateStrategicMap culturePayload must be an object/,
+  );
+  assert.throws(
+    () => GenerateStrategicMap({ provinces: [createProvince()], options: null }),
+    /GenerateStrategicMap options must be an object/,
+  );
+});


### PR DESCRIPTION
Gamma: Implements #359.\n\nSummary:\n- Adds GenerateStrategicMap orchestration for strategic shell + culture overlay + culture panel.\n- Seeds business data for culture-region mappings, discoveries, research states, and historical markers.\n- Covers generated map wiring and validation with node:test.\n\nTests:\n- node --test test/application/war/GenerateStrategicMap.test.js\n- npm test\n\nZeta: PR ready for validation before merge.