### PR TITLE
Alpha: Integrate procedural strategic map generator

### DIFF
--- a/ALPHA_GAMEPLAY_RULES.md
+++ b/ALPHA_GAMEPLAY_RULES.md
@@ -77,6 +77,16 @@ Ensuite:
 - l'adaptateur mémoire garde l'ordre d'insertion
 - l'adaptateur peut être initialisé avec un historique d'événements déjà normalisés
 
+## Génération de carte stratégique
+
+`GenerateStrategicMap` construit un socle procédural déterministe pour la carte stratégique.
+
+- le générateur produit des `Province` métier à partir de blueprints, factions et liens de voisinage
+- le voisinage est déduit depuis des liens non orientés et reste trié par province
+- les métadonnées UI (`provinceLayouts`, `provincePolygons`, `paletteByFaction`, `factionMetaById`) sont retournées avec les provinces pour brancher la démo web sans dupliquer les données métier
+- un `seed` stable garantit une sortie reproductible; les options de jitter permettent de varier loyauté et valeur stratégique de façon bornée
+- les liens invalides ou les factions et blueprints incomplets échouent explicitement avant de produire une carte incohérente
+
 ## Rendu UI Alpha
 
 Les helpers UI actuels restent déterministes et pilotés par le domaine.
@@ -103,6 +113,7 @@ Les helpers UI actuels restent déterministes et pilotés par le domaine.
 
 ## Références de code
 
+- `src/application/war/GenerateStrategicMap.js`
 - `src/application/war/DetectFronts.js`
 - `src/application/war/ExpandTerritory.js`
 - `src/application/war/ResolveBorderPressure.js`

--- a/src/application/war/GenerateStrategicMap.js
+++ b/src/application/war/GenerateStrategicMap.js
@@ -1,0 +1,281 @@
+import { Province } from '../../domain/war/Province.js';
+
+const DEFAULT_SEED = 'historia-alpha-strategic-map-v1';
+const DEFAULT_WIDTH = 100;
+const DEFAULT_HEIGHT = 100;
+
+const DEFAULT_FACTIONS = Object.freeze([
+  { id: 'aurora', label: 'Alliance d’Aurora', fill: '#2F6BFF', border: '#8FB3FF', homeColumn: 0 },
+  { id: 'ember', label: 'Ligue d’Ember', fill: '#E8572A', border: '#FFB394', homeColumn: 2 },
+  { id: 'neutral', label: 'Marches neutres', fill: '#64748B', border: '#CBD5E1', homeColumn: 1 },
+]);
+
+const DEFAULT_PROVINCE_BLUEPRINTS = Object.freeze([
+  {
+    id: 'north-watch',
+    name: 'Veille du Nord',
+    grid: { col: 0, row: 0 },
+    layout: { x: 15, y: 18, w: 20, h: 18 },
+    polygon: '8,24 24,12 39,10 47,18 46,36 34,42 18,40 8,32',
+    ownerFactionId: 'aurora',
+    controllingFactionId: 'aurora',
+    supplyLevel: 'stable',
+    loyalty: 84,
+    strategicValue: 5,
+  },
+  {
+    id: 'crown-heart',
+    name: 'Coeur de Couronne',
+    grid: { col: 1, row: 0 },
+    layout: { x: 38, y: 18, w: 23, h: 20 },
+    polygon: '24,18 40,12 58,14 64,24 58,40 40,46 26,38 22,28',
+    ownerFactionId: 'aurora',
+    controllingFactionId: 'aurora',
+    supplyLevel: 'stable',
+    loyalty: 78,
+    strategicValue: 8,
+  },
+  {
+    id: 'red-ridge',
+    name: 'Crête Rouge',
+    grid: { col: 2, row: 0 },
+    layout: { x: 64, y: 16, w: 21, h: 22 },
+    polygon: '58,16 73,10 88,18 90,34 80,44 64,42 54,32 52,22',
+    ownerFactionId: 'ember',
+    controllingFactionId: 'ember',
+    supplyLevel: 'strained',
+    loyalty: 58,
+    strategicValue: 6,
+  },
+  {
+    id: 'river-gate',
+    name: 'Porte du Fleuve',
+    grid: { col: 0, row: 1 },
+    layout: { x: 22, y: 46, w: 24, h: 20 },
+    polygon: '38,38 54,34 66,40 68,54 56,66 40,64 32,52 34,42',
+    ownerFactionId: 'aurora',
+    controllingFactionId: 'ember',
+    supplyLevel: 'disrupted',
+    loyalty: 39,
+    strategicValue: 7,
+    contested: true,
+  },
+  {
+    id: 'iron-plain',
+    name: 'Plaine de Fer',
+    grid: { col: 1, row: 1 },
+    layout: { x: 50, y: 46, w: 26, h: 22 },
+    polygon: '60,44 78,42 90,52 88,68 72,78 56,72 54,56',
+    ownerFactionId: 'ember',
+    controllingFactionId: 'ember',
+    supplyLevel: 'strained',
+    loyalty: 61,
+    strategicValue: 4,
+  },
+  {
+    id: 'southern-reach',
+    name: 'Basses Marches',
+    grid: { col: 0, row: 2 },
+    layout: { x: 33, y: 72, w: 28, h: 18 },
+    polygon: '24,58 42,54 58,58 64,74 48,88 28,86 16,72',
+    ownerFactionId: 'neutral',
+    controllingFactionId: 'aurora',
+    supplyLevel: 'collapsed',
+    loyalty: 44,
+    strategicValue: 3,
+  },
+]);
+
+const DEFAULT_LINKS = Object.freeze([
+  ['north-watch', 'crown-heart'],
+  ['north-watch', 'river-gate'],
+  ['crown-heart', 'red-ridge'],
+  ['crown-heart', 'river-gate'],
+  ['crown-heart', 'iron-plain'],
+  ['red-ridge', 'iron-plain'],
+  ['river-gate', 'iron-plain'],
+  ['river-gate', 'southern-reach'],
+  ['iron-plain', 'southern-reach'],
+]);
+
+function requireOptions(options) {
+  if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+    throw new TypeError('GenerateStrategicMap options must be an object.');
+  }
+
+  return options;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeCollection(value, fallback, label) {
+  if (value === undefined) {
+    return [...fallback];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function hashSeed(seed) {
+  let hash = 2166136261;
+  const text = requireText(seed, 'GenerateStrategicMap seed');
+
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+function createRandom(seed) {
+  let state = hashSeed(seed) || 1;
+
+  return () => {
+    state += 0x6D2B79F5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function jitterInteger(base, amplitude, random) {
+  if (amplitude <= 0) {
+    return base;
+  }
+
+  return base + Math.round((random() * (amplitude * 2)) - amplitude);
+}
+
+function clampInteger(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function normalizeFactions(factions) {
+  return factions.map((faction) => {
+    if (faction === null || typeof faction !== 'object' || Array.isArray(faction)) {
+      throw new TypeError('GenerateStrategicMap factions must contain objects.');
+    }
+
+    const id = requireText(faction.id, 'GenerateStrategicMap faction id');
+
+    return {
+      id,
+      label: String(faction.label ?? id).trim() || id,
+      fill: String(faction.fill ?? '#94A3B8').trim() || '#94A3B8',
+      border: String(faction.border ?? '#334155').trim() || '#334155',
+      homeColumn: Number.isInteger(faction.homeColumn) ? faction.homeColumn : null,
+    };
+  });
+}
+
+function normalizeBlueprints(blueprints) {
+  return blueprints.map((blueprint) => {
+    if (blueprint === null || typeof blueprint !== 'object' || Array.isArray(blueprint)) {
+      throw new TypeError('GenerateStrategicMap provinceBlueprints must contain objects.');
+    }
+
+    return {
+      ...blueprint,
+      id: requireText(blueprint.id, 'GenerateStrategicMap province id'),
+      name: requireText(blueprint.name, 'GenerateStrategicMap province name'),
+    };
+  });
+}
+
+function buildNeighborIds(blueprints, links) {
+  const blueprintIds = new Set(blueprints.map((blueprint) => blueprint.id));
+  const neighborIdsByProvinceId = new Map(blueprints.map((blueprint) => [blueprint.id, new Set()]));
+
+  for (const link of links) {
+    if (!Array.isArray(link) || link.length !== 2) {
+      throw new TypeError('GenerateStrategicMap links must be [leftProvinceId, rightProvinceId] pairs.');
+    }
+
+    const [leftId, rightId] = link.map((provinceId) => requireText(provinceId, 'GenerateStrategicMap link provinceId'));
+
+    if (!blueprintIds.has(leftId) || !blueprintIds.has(rightId)) {
+      throw new RangeError('GenerateStrategicMap links must reference generated provinces.');
+    }
+
+    if (leftId !== rightId) {
+      neighborIdsByProvinceId.get(leftId).add(rightId);
+      neighborIdsByProvinceId.get(rightId).add(leftId);
+    }
+  }
+
+  return neighborIdsByProvinceId;
+}
+
+function chooseFactionForBlueprint(blueprint, factions) {
+  if (blueprint.ownerFactionId) {
+    return requireText(blueprint.ownerFactionId, `GenerateStrategicMap ${blueprint.id} ownerFactionId`);
+  }
+
+  const column = blueprint.grid?.col;
+  const faction = factions.find((candidate) => candidate.homeColumn === column) ?? factions[0];
+  return faction.id;
+}
+
+export class GenerateStrategicMap {
+  execute(options = {}) {
+    const normalizedOptions = requireOptions(options);
+    const seed = String(normalizedOptions.seed ?? DEFAULT_SEED).trim() || DEFAULT_SEED;
+    const random = createRandom(seed);
+    const factions = normalizeFactions(normalizeCollection(normalizedOptions.factions, DEFAULT_FACTIONS, 'GenerateStrategicMap factions'));
+    const blueprints = normalizeBlueprints(
+      normalizeCollection(normalizedOptions.provinceBlueprints, DEFAULT_PROVINCE_BLUEPRINTS, 'GenerateStrategicMap provinceBlueprints'),
+    );
+    const links = normalizeCollection(normalizedOptions.links, DEFAULT_LINKS, 'GenerateStrategicMap links');
+    const neighborIdsByProvinceId = buildNeighborIds(blueprints, links);
+    const loyaltyJitter = Number.isInteger(normalizedOptions.loyaltyJitter) ? normalizedOptions.loyaltyJitter : 0;
+    const strategicValueJitter = Number.isInteger(normalizedOptions.strategicValueJitter) ? normalizedOptions.strategicValueJitter : 0;
+
+    const provinces = blueprints.map((blueprint) => {
+      const ownerFactionId = chooseFactionForBlueprint(blueprint, factions);
+      const controllingFactionId = String(blueprint.controllingFactionId ?? ownerFactionId).trim() || ownerFactionId;
+
+      return new Province({
+        id: blueprint.id,
+        name: blueprint.name,
+        ownerFactionId,
+        controllingFactionId,
+        supplyLevel: blueprint.supplyLevel ?? 'stable',
+        loyalty: clampInteger(jitterInteger(blueprint.loyalty ?? 60, loyaltyJitter, random), 0, 100),
+        strategicValue: clampInteger(jitterInteger(blueprint.strategicValue ?? 3, strategicValueJitter, random), 1, 10),
+        neighborIds: [...neighborIdsByProvinceId.get(blueprint.id)],
+        contested: Boolean(blueprint.contested),
+        capturedAt: blueprint.capturedAt ?? null,
+      });
+    }).sort((left, right) => left.id.localeCompare(right.id));
+
+    return {
+      seed,
+      width: normalizedOptions.width ?? DEFAULT_WIDTH,
+      height: normalizedOptions.height ?? DEFAULT_HEIGHT,
+      provinces,
+      provinceLayouts: Object.fromEntries(blueprints.map((blueprint) => [blueprint.id, { ...blueprint.layout }])),
+      provincePolygons: Object.fromEntries(blueprints.map((blueprint) => [blueprint.id, blueprint.polygon])),
+      paletteByFaction: Object.fromEntries(factions.map((faction) => [faction.id, {
+        fill: faction.fill,
+        border: faction.border,
+      }])),
+      factionMetaById: Object.fromEntries(factions.map((faction) => [faction.id, {
+        label: faction.label,
+      }])),
+    };
+  }
+}

--- a/test/application/war/GenerateStrategicMap.test.js
+++ b/test/application/war/GenerateStrategicMap.test.js
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { GenerateStrategicMap } from '../../../src/application/war/GenerateStrategicMap.js';
+import { Province } from '../../../src/domain/war/Province.js';
+
+test('GenerateStrategicMap returns deterministic strategic provinces and UI business metadata', () => {
+  const generator = new GenerateStrategicMap();
+  const map = generator.execute();
+  const repeated = generator.execute();
+
+  assert.equal(map.seed, 'historia-alpha-strategic-map-v1');
+  assert.equal(map.width, 100);
+  assert.equal(map.height, 100);
+  assert.deepEqual(map.provinces.map((province) => province.id), [
+    'crown-heart',
+    'iron-plain',
+    'north-watch',
+    'red-ridge',
+    'river-gate',
+    'southern-reach',
+  ]);
+  assert.ok(map.provinces.every((province) => province instanceof Province));
+  assert.deepEqual(map.provinces.map((province) => province.toJSON()), repeated.provinces.map((province) => province.toJSON()));
+
+  const riverGate = map.provinces.find((province) => province.id === 'river-gate');
+  assert.equal(riverGate.ownerFactionId, 'aurora');
+  assert.equal(riverGate.controllingFactionId, 'ember');
+  assert.equal(riverGate.contested, true);
+  assert.deepEqual(riverGate.neighborIds, ['crown-heart', 'iron-plain', 'north-watch', 'southern-reach']);
+
+  assert.deepEqual(map.factionMetaById.aurora, { label: 'Alliance d’Aurora' });
+  assert.deepEqual(map.paletteByFaction.ember, { fill: '#E8572A', border: '#FFB394' });
+  assert.deepEqual(map.provinceLayouts['crown-heart'], { x: 38, y: 18, w: 23, h: 20 });
+  assert.equal(map.provincePolygons['red-ridge'], '58,16 73,10 88,18 90,34 80,44 64,42 54,32 52,22');
+});
+
+test('GenerateStrategicMap can derive province ownership from faction home columns and seeded jitter', () => {
+  const generator = new GenerateStrategicMap();
+  const map = generator.execute({
+    seed: 'custom-front',
+    loyaltyJitter: 3,
+    strategicValueJitter: 1,
+    factions: [
+      { id: 'west', label: 'West', homeColumn: 0, fill: '#111111', border: '#222222' },
+      { id: 'east', label: 'East', homeColumn: 1, fill: '#333333', border: '#444444' },
+    ],
+    provinceBlueprints: [
+      { id: 'a', name: 'A', grid: { col: 0, row: 0 }, supplyLevel: 'stable', loyalty: 50, strategicValue: 4 },
+      { id: 'b', name: 'B', grid: { col: 1, row: 0 }, supplyLevel: 'strained', loyalty: 50, strategicValue: 4, contested: true },
+    ],
+    links: [['a', 'b']],
+  });
+
+  assert.deepEqual(map.provinces.map((province) => ({
+    id: province.id,
+    ownerFactionId: province.ownerFactionId,
+    neighborIds: province.neighborIds,
+    contested: province.contested,
+  })), [
+    { id: 'a', ownerFactionId: 'west', neighborIds: ['b'], contested: false },
+    { id: 'b', ownerFactionId: 'east', neighborIds: ['a'], contested: true },
+  ]);
+  assert.notDeepEqual(map.provinces.map((province) => province.loyalty), [50, 50]);
+});
+
+test('GenerateStrategicMap validates options, factions, blueprints and links', () => {
+  const generator = new GenerateStrategicMap();
+
+  assert.throws(() => generator.execute(null), /options must be an object/);
+  assert.throws(() => generator.execute({ factions: null }), /factions must be an array/);
+  assert.throws(() => generator.execute({ factions: [{}] }), /faction id is required/);
+  assert.throws(() => generator.execute({ provinceBlueprints: null }), /provinceBlueprints must be an array/);
+  assert.throws(() => generator.execute({ provinceBlueprints: [{}] }), /province id is required/);
+  assert.throws(() => generator.execute({ provinceBlueprints: [{ id: 'a', name: 'A' }], links: [['a', 'missing']] }), /links must reference generated provinces/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1,4 +1,5 @@
 import { Province } from '../src/domain/war/Province.js';
+import { GenerateStrategicMap } from '../src/application/war/GenerateStrategicMap.js';
 import { City } from '../src/domain/economy/City.js';
 import { TradeRoute } from '../src/domain/economy/TradeRoute.js';
 import { buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
@@ -9,90 +10,12 @@ import { Cellule } from '../src/domain/intrigue/Cellule.js';
 import { OperationClandestine } from '../src/domain/intrigue/OperationClandestine.js';
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
 
-const paletteByFaction = {
-  aurora: { fill: '#2F6BFF', border: '#8FB3FF' },
-  ember: { fill: '#E8572A', border: '#FFB394' },
-  neutral: { fill: '#64748B', border: '#CBD5E1' },
-};
-
-const factionMetaById = {
-  aurora: { label: 'Alliance d’Aurora' },
-  ember: { label: 'Ligue d’Ember' },
-  neutral: { label: 'Marches neutres' },
-};
-
-const provinceLayouts = {
-  'north-watch': { x: 15, y: 18, w: 20, h: 18 },
-  'crown-heart': { x: 38, y: 18, w: 23, h: 20 },
-  'red-ridge': { x: 64, y: 16, w: 21, h: 22 },
-  'river-gate': { x: 22, y: 46, w: 24, h: 20 },
-  'iron-plain': { x: 50, y: 46, w: 26, h: 22 },
-  'southern-reach': { x: 33, y: 72, w: 28, h: 18 },
-};
-
-const provinces = [
-  new Province({
-    id: 'north-watch',
-    name: 'Veille du Nord',
-    ownerFactionId: 'aurora',
-    controllingFactionId: 'aurora',
-    supplyLevel: 'stable',
-    loyalty: 84,
-    strategicValue: 5,
-    neighborIds: ['crown-heart', 'river-gate'],
-  }),
-  new Province({
-    id: 'crown-heart',
-    name: 'Coeur de Couronne',
-    ownerFactionId: 'aurora',
-    controllingFactionId: 'aurora',
-    supplyLevel: 'stable',
-    loyalty: 78,
-    strategicValue: 8,
-    neighborIds: ['north-watch', 'red-ridge', 'river-gate', 'iron-plain'],
-  }),
-  new Province({
-    id: 'red-ridge',
-    name: 'Crête Rouge',
-    ownerFactionId: 'ember',
-    controllingFactionId: 'ember',
-    supplyLevel: 'strained',
-    loyalty: 58,
-    strategicValue: 6,
-    neighborIds: ['crown-heart', 'iron-plain'],
-  }),
-  new Province({
-    id: 'river-gate',
-    name: 'Porte du Fleuve',
-    ownerFactionId: 'aurora',
-    controllingFactionId: 'ember',
-    supplyLevel: 'disrupted',
-    loyalty: 39,
-    strategicValue: 7,
-    contested: true,
-    neighborIds: ['north-watch', 'crown-heart', 'iron-plain', 'southern-reach'],
-  }),
-  new Province({
-    id: 'iron-plain',
-    name: 'Plaine de Fer',
-    ownerFactionId: 'ember',
-    controllingFactionId: 'ember',
-    supplyLevel: 'strained',
-    loyalty: 61,
-    strategicValue: 4,
-    neighborIds: ['crown-heart', 'red-ridge', 'river-gate', 'southern-reach'],
-  }),
-  new Province({
-    id: 'southern-reach',
-    name: 'Basses Marches',
-    ownerFactionId: 'neutral',
-    controllingFactionId: 'aurora',
-    supplyLevel: 'collapsed',
-    loyalty: 44,
-    strategicValue: 3,
-    neighborIds: ['river-gate', 'iron-plain'],
-  }),
-];
+const strategicMap = new GenerateStrategicMap().execute();
+const paletteByFaction = strategicMap.paletteByFaction;
+const factionMetaById = strategicMap.factionMetaById;
+const provinceLayouts = strategicMap.provinceLayouts;
+const provincePolygonById = strategicMap.provincePolygons;
+const provinces = strategicMap.provinces;
 
 const overlayLabels = {
   'climate-overlay': 'Climat',
@@ -492,15 +415,6 @@ function renderLegend(shell) {
     </section>
   `;
 }
-
-const provincePolygonById = {
-  'north-watch': '8,24 24,12 39,10 47,18 46,36 34,42 18,40 8,32',
-  'crown-heart': '24,18 40,12 58,14 64,24 58,40 40,46 26,38 22,28',
-  'red-ridge': '58,16 73,10 88,18 90,34 80,44 64,42 54,32 52,22',
-  'river-gate': '38,38 54,34 66,40 68,54 56,66 40,64 32,52 34,42',
-  'iron-plain': '60,44 78,42 90,52 88,68 72,78 56,72 54,56',
-  'southern-reach': '24,58 42,54 58,58 64,74 48,88 28,86 16,72',
-};
 
 function getProvinceShape(provinceId) {
   const polygon = provincePolygonById[provinceId] ?? '12,12 88,12 88,88 12,88';


### PR DESCRIPTION
Alpha: ## Summary\n- Add deterministic GenerateStrategicMap use case producing Province instances from factions, province blueprints and adjacency links\n- Return map UI metadata for layouts, polygons, palettes and faction labels so the web demo consumes generated strategic map data\n- Document the Alpha strategic map generator contract\n\n## Tests\n- node --test test/application/war/GenerateStrategicMap.test.js test/ui/war/StrategicMapShell.test.js\n- npm test\n\nCloses #357