### PR TITLE
Beta: Seed economy from generated strategic maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Prototype de jeu de stratégie/simulation découpé entre Alpha, Beta, Gamma, De
 - `EconomyEventBusPort` publie des événements normalisés pour les pénuries et les surplus via `economy.shortage.detected` et `economy.surplus.detected`
 - `EmitShortageEvents` et `EmitSurplusEvents` transforment des cartes de ressources en événements unitaires stables, triés et validés, sans bruit quand une carte est vide
 - `CityRepositoryPort`, `RouteRepositoryPort` et `MarketRepository` fournissent une base hexagonale légère pour orchestrer villes, routes et prix, avec des adaptateurs mémoire déjà présents pour les villes et les routes
+- `seedEconomyFromStrategicMap` transforme une carte stratégique générée en villes, stocks, positions et routes logistiques déterministes, en tenant compte des voisins, terrains, ressources, niveaux d'approvisionnement, contestation et valeur stratégique des provinces
 - côté UI, `buildCityStockPanel` construit une vue lisible du stock d'une ville avec lignes triées, objectifs désirés, états `shortage` ou `balanced` ou `surplus`, et métriques de synthèse réutilisables
 - les tests Beta couvrent explicitement la production, la rareté, les transferts logistiques, l'émission d'événements économie, les adaptateurs mémoire et l'affichage UI du stock d'une ville
 

--- a/src/application/economy/SeedEconomyFromStrategicMap.js
+++ b/src/application/economy/SeedEconomyFromStrategicMap.js
@@ -1,0 +1,293 @@
+import { City } from '../../domain/economy/City.js';
+import { TradeRoute } from '../../domain/economy/TradeRoute.js';
+
+const SUPPLY_MODIFIERS = Object.freeze({
+  secure: { prosperity: 12, stability: 10, stock: 18, risk: -12 },
+  stable: { prosperity: 6, stability: 6, stock: 12, risk: -6 },
+  strained: { prosperity: -4, stability: -2, stock: 6, risk: 8 },
+  disrupted: { prosperity: -12, stability: -14, stock: 2, risk: 22 },
+  collapsed: { prosperity: -22, stability: -24, stock: 0, risk: 36 },
+});
+
+const TERRAIN_RESOURCE_HINTS = Object.freeze({
+  coastal: { fish: 10, salt: 6 },
+  coast: { fish: 10, salt: 6 },
+  forest: { timber: 12, game: 5 },
+  highland: { ore: 8, timber: 5 },
+  hills: { ore: 8, stone: 5 },
+  mountain: { ore: 12, stone: 8 },
+  mountains: { ore: 12, stone: 8 },
+  plain: { grain: 12, horses: 4 },
+  plains: { grain: 12, horses: 4 },
+  river: { grain: 8, fish: 7, clay: 4 },
+  wetland: { fish: 6, clay: 5 },
+  desert: { salt: 8, glass: 4 },
+});
+
+function clampInteger(value, min, max) {
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeProvince(rawProvince) {
+  const province = requireObject(rawProvince, 'SeedEconomyFromStrategicMap province');
+  const id = requireText(province.id, 'SeedEconomyFromStrategicMap province.id');
+  const strategicValue = Number.isInteger(province.strategicValue) ? clampInteger(province.strategicValue, 1, 10) : 1;
+
+  if (!Array.isArray(province.neighborIds)) {
+    throw new TypeError('SeedEconomyFromStrategicMap province.neighborIds must be an array.');
+  }
+
+  return {
+    ...province,
+    id,
+    name: requireText(province.name, 'SeedEconomyFromStrategicMap province.name'),
+    ownerFactionId: requireText(province.ownerFactionId, 'SeedEconomyFromStrategicMap province.ownerFactionId'),
+    controllingFactionId: requireText(province.controllingFactionId ?? province.ownerFactionId, 'SeedEconomyFromStrategicMap province.controllingFactionId'),
+    supplyLevel: requireText(province.supplyLevel, 'SeedEconomyFromStrategicMap province.supplyLevel'),
+    loyalty: Number.isInteger(province.loyalty) ? clampInteger(province.loyalty, 0, 100) : 50,
+    strategicValue,
+    neighborIds: [...new Set(province.neighborIds.map((neighborId) => requireText(neighborId, 'SeedEconomyFromStrategicMap province.neighborIds[]')))].sort(),
+    contested: Boolean(province.contested),
+  };
+}
+
+function normalizeResourceMap(value, label) {
+  const resourceMap = requireObject(value, label);
+
+  return Object.fromEntries(
+    Object.entries(resourceMap)
+      .map(([resourceId, quantity]) => {
+        const normalizedResourceId = requireText(resourceId, `${label} resource id`);
+
+        if (!Number.isInteger(quantity) || quantity < 0) {
+          throw new RangeError(`${label} quantities must be integers greater than or equal to 0.`);
+        }
+
+        return [normalizedResourceId, quantity];
+      })
+      .sort(([leftId], [rightId]) => leftId.localeCompare(rightId)),
+  );
+}
+
+function listTerrainKeys(province) {
+  return [province.biome, province.terrainType, province.terrain, ...(Array.isArray(province.tags) ? province.tags : [])]
+    .map((value) => String(value ?? '').trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function mergeResourceStock(target, source, multiplier = 1) {
+  for (const [resourceId, quantity] of Object.entries(source)) {
+    target[resourceId] = (target[resourceId] ?? 0) + Math.max(0, Math.round(quantity * multiplier));
+  }
+}
+
+function buildStockForProvince(province, resourceHintsByProvinceId) {
+  const stockByResource = {};
+  const supply = SUPPLY_MODIFIERS[province.supplyLevel] ?? SUPPLY_MODIFIERS.stable;
+  const baseMultiplier = 1 + (province.strategicValue - 1) * 0.12;
+
+  mergeResourceStock(stockByResource, { grain: 4 + supply.stock }, baseMultiplier);
+
+  for (const key of listTerrainKeys(province)) {
+    if (TERRAIN_RESOURCE_HINTS[key]) {
+      mergeResourceStock(stockByResource, TERRAIN_RESOURCE_HINTS[key], baseMultiplier);
+    }
+  }
+
+  if (Array.isArray(province.resourceIds)) {
+    mergeResourceStock(stockByResource, Object.fromEntries(province.resourceIds.map((resourceId) => [requireText(resourceId, 'SeedEconomyFromStrategicMap resourceIds[]'), 6])), baseMultiplier);
+  }
+
+  if (province.resourceDeposits !== undefined) {
+    mergeResourceStock(stockByResource, normalizeResourceMap(province.resourceDeposits, 'SeedEconomyFromStrategicMap resourceDeposits'));
+  }
+
+  const hintedResources = resourceHintsByProvinceId[province.id];
+  if (hintedResources !== undefined) {
+    mergeResourceStock(stockByResource, normalizeResourceMap(hintedResources, 'SeedEconomyFromStrategicMap resourceHintsByProvinceId'));
+  }
+
+  return normalizeResourceMap(stockByResource, 'SeedEconomyFromStrategicMap stockByResource');
+}
+
+function buildCityId(province, cityIdByProvinceId) {
+  return cityIdByProvinceId[province.id] ?? `city:${province.id}`;
+}
+
+function buildCityName(province, cityNameByProvinceId) {
+  return cityNameByProvinceId[province.id] ?? `Cité de ${province.name}`;
+}
+
+function resolveCityPosition(province, cityPositionByProvinceId, provincePositionById) {
+  return cityPositionByProvinceId[province.id]
+    ?? province.cityPosition
+    ?? province.center
+    ?? provincePositionById[province.id]
+    ?? null;
+}
+
+function deriveTransportMode(leftProvince, rightProvince) {
+  const keys = new Set([...listTerrainKeys(leftProvince), ...listTerrainKeys(rightProvince)]);
+
+  if (keys.has('river') || keys.has('wetland')) {
+    return 'river';
+  }
+
+  if ((keys.has('coastal') || keys.has('coast')) && (leftProvince.ownerFactionId === rightProvince.ownerFactionId || leftProvince.controllingFactionId === rightProvince.controllingFactionId)) {
+    return 'sea';
+  }
+
+  return 'land';
+}
+
+function deriveRouteCapacity(leftCity, rightCity) {
+  const capacityByResource = {};
+  const resourceIds = [...new Set([...Object.keys(leftCity.stockByResource), ...Object.keys(rightCity.stockByResource)])].sort();
+
+  for (const resourceId of resourceIds) {
+    const strongerStock = Math.max(leftCity.stockByResource[resourceId] ?? 0, rightCity.stockByResource[resourceId] ?? 0);
+    const weakerStock = Math.min(leftCity.stockByResource[resourceId] ?? 0, rightCity.stockByResource[resourceId] ?? 0);
+    const capacity = Math.floor((strongerStock - weakerStock) / 3);
+
+    if (capacity > 0) {
+      capacityByResource[resourceId] = clampInteger(capacity, 1, 18);
+    }
+  }
+
+  if (Object.keys(capacityByResource).length === 0) {
+    capacityByResource.grain = 1;
+  }
+
+  return capacityByResource;
+}
+
+function deriveRouteRisk(leftProvince, rightProvince) {
+  const leftSupply = SUPPLY_MODIFIERS[leftProvince.supplyLevel] ?? SUPPLY_MODIFIERS.stable;
+  const rightSupply = SUPPLY_MODIFIERS[rightProvince.supplyLevel] ?? SUPPLY_MODIFIERS.stable;
+  const contestedRisk = leftProvince.contested || rightProvince.contested ? 18 : 0;
+  const frontierRisk = leftProvince.controllingFactionId !== rightProvince.controllingFactionId ? 12 : 0;
+
+  return clampInteger(18 + leftSupply.risk + rightSupply.risk + contestedRisk + frontierRisk, 0, 100);
+}
+
+function buildRoute(leftProvince, rightProvince, leftCity, rightCity) {
+  const sortedCities = [leftCity, rightCity].sort((left, right) => left.id.localeCompare(right.id));
+  const sortedProvinceIds = [leftProvince.id, rightProvince.id].sort();
+  const routeId = `route:${sortedProvinceIds.join(':')}`;
+  const strategicDelta = Math.abs(leftProvince.strategicValue - rightProvince.strategicValue);
+
+  return new TradeRoute({
+    id: routeId,
+    name: `Route ${leftProvince.name} — ${rightProvince.name}`,
+    stopCityIds: sortedCities.map((city) => city.id),
+    distance: 4 + strategicDelta + Math.ceil((leftProvince.strategicValue + rightProvince.strategicValue) / 3),
+    capacityByResource: deriveRouteCapacity(leftCity, rightCity),
+    transportMode: deriveTransportMode(leftProvince, rightProvince),
+    riskLevel: deriveRouteRisk(leftProvince, rightProvince),
+    active: !leftProvince.contested && !rightProvince.contested,
+  });
+}
+
+export function seedEconomyFromStrategicMap(generatedMap, options = {}) {
+  const map = requireObject(generatedMap, 'SeedEconomyFromStrategicMap generatedMap');
+  const normalizedOptions = requireObject(options, 'SeedEconomyFromStrategicMap options');
+
+  if (!Array.isArray(map.provinces)) {
+    throw new TypeError('SeedEconomyFromStrategicMap generatedMap.provinces must be an array.');
+  }
+
+  const resourceHintsByProvinceId = requireObject(normalizedOptions.resourceHintsByProvinceId ?? {}, 'SeedEconomyFromStrategicMap resourceHintsByProvinceId');
+  const cityIdByProvinceId = requireObject(normalizedOptions.cityIdByProvinceId ?? {}, 'SeedEconomyFromStrategicMap cityIdByProvinceId');
+  const cityNameByProvinceId = requireObject(normalizedOptions.cityNameByProvinceId ?? {}, 'SeedEconomyFromStrategicMap cityNameByProvinceId');
+  const cityPositionByProvinceId = requireObject(normalizedOptions.cityPositionByProvinceId ?? {}, 'SeedEconomyFromStrategicMap cityPositionByProvinceId');
+  const provincePositionById = requireObject(map.provincePositionById ?? {}, 'SeedEconomyFromStrategicMap provincePositionById');
+  const provinces = map.provinces.map(normalizeProvince).sort((left, right) => left.id.localeCompare(right.id));
+  const provinceById = new Map(provinces.map((province) => [province.id, province]));
+
+  const cityByProvinceId = new Map();
+  const cityPositionById = {};
+
+  for (const province of provinces) {
+    const supply = SUPPLY_MODIFIERS[province.supplyLevel] ?? SUPPLY_MODIFIERS.stable;
+    const stockByResource = buildStockForProvince(province, resourceHintsByProvinceId);
+    const cityId = buildCityId(province, cityIdByProvinceId);
+    const capital = province.strategicValue >= 8 || Boolean(province.capital);
+    const city = new City({
+      id: cityId,
+      name: buildCityName(province, cityNameByProvinceId),
+      regionId: province.id,
+      population: clampInteger(60 + province.strategicValue * 18 + Object.keys(stockByResource).length * 7 + (capital ? 35 : 0), 1, Number.MAX_SAFE_INTEGER),
+      prosperity: clampInteger(50 + province.strategicValue * 3 + supply.prosperity, 0, 100),
+      stability: clampInteger(province.loyalty * 0.55 + 26 + supply.stability - (province.contested ? 12 : 0), 0, 100),
+      stockByResource,
+      productionRuleIds: Object.keys(stockByResource).map((resourceId) => `produce:${resourceId}`),
+      tags: [province.controllingFactionId, province.supplyLevel, capital ? 'capital' : 'regional-hub'],
+      capital,
+    });
+
+    const position = resolveCityPosition(province, cityPositionByProvinceId, provincePositionById);
+    cityByProvinceId.set(province.id, city);
+    if (position !== null) {
+      cityPositionById[city.id] = position;
+    }
+  }
+
+  const routeById = new Map();
+  for (const province of provinces) {
+    for (const neighborId of province.neighborIds) {
+      const neighbor = provinceById.get(neighborId);
+      if (!neighbor || province.id.localeCompare(neighbor.id) > 0) {
+        continue;
+      }
+
+      const route = buildRoute(province, neighbor, cityByProvinceId.get(province.id), cityByProvinceId.get(neighbor.id));
+      routeById.set(route.id, route);
+    }
+  }
+
+  const routes = [...routeById.values()].sort((left, right) => left.id.localeCompare(right.id));
+  const routeIdsByCityId = new Map();
+  for (const route of routes) {
+    for (const cityId of route.stopCityIds) {
+      routeIdsByCityId.set(cityId, [...(routeIdsByCityId.get(cityId) ?? []), route.id]);
+    }
+  }
+
+  const cities = [...cityByProvinceId.values()]
+    .map((city) => new City({
+      ...city.toJSON(),
+      tradeRouteIds: routeIdsByCityId.get(city.id) ?? [],
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  return {
+    cities,
+    routes,
+    cityPositionById,
+    metrics: {
+      provinceCount: provinces.length,
+      cityCount: cities.length,
+      routeCount: routes.length,
+      generatedRouteCapacity: routes.reduce((sum, route) => sum + route.totalCapacity, 0),
+      stockedResourceIds: [...new Set(cities.flatMap((city) => Object.keys(city.stockByResource)))].sort(),
+    },
+  };
+}

--- a/test/application/economy/SeedEconomyFromStrategicMap.test.js
+++ b/test/application/economy/SeedEconomyFromStrategicMap.test.js
@@ -1,0 +1,146 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { City } from '../../../src/domain/economy/City.js';
+import { TradeRoute } from '../../../src/domain/economy/TradeRoute.js';
+import { seedEconomyFromStrategicMap } from '../../../src/application/economy/SeedEconomyFromStrategicMap.js';
+
+function createGeneratedMap() {
+  return {
+    provincePositionById: {
+      'crown-heart': { x: 50, y: 28 },
+      'river-gate': { x: 35, y: 56 },
+      'iron-plain': { x: 62, y: 55 },
+    },
+    provinces: [
+      {
+        id: 'river-gate',
+        name: 'Porte du Fleuve',
+        ownerFactionId: 'aurora',
+        controllingFactionId: 'ember',
+        supplyLevel: 'disrupted',
+        loyalty: 39,
+        strategicValue: 7,
+        terrain: 'river',
+        resourceIds: ['clay'],
+        contested: true,
+        neighborIds: ['crown-heart', 'iron-plain'],
+      },
+      {
+        id: 'crown-heart',
+        name: 'Coeur de Couronne',
+        ownerFactionId: 'aurora',
+        supplyLevel: 'stable',
+        loyalty: 78,
+        strategicValue: 9,
+        terrain: 'coastal',
+        resourceDeposits: { timber: 3 },
+        capital: true,
+        neighborIds: ['river-gate'],
+      },
+      {
+        id: 'iron-plain',
+        name: 'Plaine de Fer',
+        ownerFactionId: 'ember',
+        supplyLevel: 'strained',
+        loyalty: 61,
+        strategicValue: 4,
+        terrain: 'plains',
+        resourceIds: ['ore'],
+        neighborIds: ['river-gate'],
+      },
+    ],
+  };
+}
+
+test('seedEconomyFromStrategicMap derives stable cities, stock and logistics from generated provinces', () => {
+  const result = seedEconomyFromStrategicMap(createGeneratedMap(), {
+    cityIdByProvinceId: {
+      'crown-heart': 'crown-port',
+      'river-gate': 'river-gate-city',
+      'iron-plain': 'iron-plain-city',
+    },
+    cityNameByProvinceId: {
+      'crown-heart': 'Port de Couronne',
+    },
+    resourceHintsByProvinceId: {
+      'iron-plain': { tools: 5 },
+    },
+  });
+
+  assert.equal(result.cities.length, 3);
+  assert.equal(result.routes.length, 2);
+  assert.equal(result.metrics.provinceCount, 3);
+  assert.deepEqual(result.metrics.stockedResourceIds, ['clay', 'fish', 'grain', 'horses', 'ore', 'salt', 'timber', 'tools']);
+
+  const crown = result.cities.find((city) => city.id === 'crown-port');
+  const river = result.cities.find((city) => city.id === 'river-gate-city');
+  const iron = result.cities.find((city) => city.id === 'iron-plain-city');
+
+  assert.equal(crown instanceof City, true);
+  assert.equal(crown.name, 'Port de Couronne');
+  assert.equal(crown.regionId, 'crown-heart');
+  assert.equal(crown.capital, true);
+  assert.equal(crown.prosperity, 83);
+  assert.equal(crown.stability, 75);
+  assert.equal(crown.stockByResource.fish > 0, true);
+  assert.equal(crown.stockByResource.salt > 0, true);
+  assert.equal(crown.stockByResource.timber, 3);
+
+  assert.equal(river.capital, false);
+  assert.equal(river.stability, 21);
+  assert.equal(river.stockByResource.clay > 0, true);
+  assert.equal(river.stockByResource.fish > 0, true);
+
+  assert.equal(iron.stockByResource.grain > river.stockByResource.grain, true);
+  assert.equal(iron.stockByResource.ore > 0, true);
+  assert.equal(iron.stockByResource.tools, 5);
+
+  assert.deepEqual(result.cityPositionById, {
+    'crown-port': { x: 50, y: 28 },
+    'iron-plain-city': { x: 62, y: 55 },
+    'river-gate-city': { x: 35, y: 56 },
+  });
+
+  const crownRoute = result.routes.find((route) => route.id === 'route:crown-heart:river-gate');
+  const ironRoute = result.routes.find((route) => route.id === 'route:iron-plain:river-gate');
+
+  assert.equal(crownRoute instanceof TradeRoute, true);
+  assert.deepEqual(crownRoute.stopCityIds, ['crown-port', 'river-gate-city']);
+  assert.equal(crownRoute.transportMode, 'river');
+  assert.equal(crownRoute.active, false);
+  assert.equal(crownRoute.riskLevel, 64);
+  assert.equal(crownRoute.capacityByResource.fish > 0, true);
+
+  assert.equal(ironRoute.transportMode, 'river');
+  assert.equal(ironRoute.active, false);
+  assert.equal(ironRoute.capacityByResource.ore > 0, true);
+  assert.deepEqual(river.tradeRouteIds, ['route:crown-heart:river-gate', 'route:iron-plain:river-gate']);
+});
+
+test('seedEconomyFromStrategicMap accepts explicit city positions and keeps generated route ids unique', () => {
+  const result = seedEconomyFromStrategicMap(createGeneratedMap(), {
+    cityPositionByProvinceId: {
+      'river-gate': { x: 34, y: 58, labelDx: -5 },
+    },
+  });
+
+  assert.equal(result.cities.every((city) => city instanceof City), true);
+  assert.equal(result.routes.every((route) => route instanceof TradeRoute), true);
+  assert.equal(new Set(result.routes.map((route) => route.id)).size, result.routes.length);
+  assert.deepEqual(result.cityPositionById['city:river-gate'], { x: 34, y: 58, labelDx: -5 });
+  assert.deepEqual(result.cities.map((city) => city.id), ['city:crown-heart', 'city:iron-plain', 'city:river-gate']);
+});
+
+test('seedEconomyFromStrategicMap rejects invalid generated map payloads', () => {
+  assert.throws(() => seedEconomyFromStrategicMap(null), /generatedMap must be an object/);
+  assert.throws(() => seedEconomyFromStrategicMap({ provinces: null }), /generatedMap.provinces must be an array/);
+  assert.throws(
+    () => seedEconomyFromStrategicMap({ provinces: [{ id: 'broken', name: 'Broken', ownerFactionId: 'aurora', supplyLevel: 'stable', neighborIds: null }] }),
+    /province.neighborIds must be an array/,
+  );
+  assert.throws(
+    () => seedEconomyFromStrategicMap({ provinces: [{ id: 'broken', name: 'Broken', ownerFactionId: 'aurora', supplyLevel: 'stable', neighborIds: [], resourceDeposits: { grain: -1 } }] }),
+    /resourceDeposits quantities must be integers/,
+  );
+});


### PR DESCRIPTION
Beta: ## Summary
- add seedEconomyFromStrategicMap to derive cities, resources, positions and logistics routes from generated provinces
- factor supply, terrain/resource hints, contestation, faction borders and strategic value into stocks, route capacity and risk
- document the new Beta generator bridge

## Tests
- npm test

Closes #358