### PR TITLE
Gamma: Compose culture seeds into generated map

### DIFF
--- a/src/application/war/GenerateStrategicMap.js
+++ b/src/application/war/GenerateStrategicMap.js
@@ -1,4 +1,6 @@
 import { Province } from '../../domain/war/Province.js';
+import { buildCultureLayerPanel } from '../../ui/culture/buildCultureLayerPanel.js';
+import { buildCultureMapOverlay } from '../../ui/culture/buildCultureMapOverlay.js';
 
 const DEFAULT_SEED = 'historia-alpha-strategic-map-v1';
 const DEFAULT_WIDTH = 100;
@@ -126,6 +128,142 @@ function normalizeCollection(value, fallback, label) {
   }
 
   return value;
+}
+
+
+function normalizeTextArray(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return [...new Set(values.map((value) => requireText(value, label)))].sort();
+}
+
+function normalizeCulturePayload(culturePayload = {}) {
+  const payload = requireOptions(culturePayload);
+
+  return {
+    cultures: normalizeCollection(payload.cultures, [], 'GenerateStrategicMap culturePayload.cultures'),
+    researchStates: normalizeCollection(payload.researchStates, [], 'GenerateStrategicMap culturePayload.researchStates'),
+    historicalEvents: normalizeCollection(payload.historicalEvents, [], 'GenerateStrategicMap culturePayload.historicalEvents'),
+  };
+}
+
+function normalizeRegionIdsByCulture(cultures, explicitRegionIdsByCulture) {
+  const regionIdsByCulture = {};
+  const rawRegionIdsByCulture = requireOptions(explicitRegionIdsByCulture ?? {});
+
+  for (const [cultureId, regionIds] of Object.entries(rawRegionIdsByCulture)) {
+    regionIdsByCulture[requireText(cultureId, 'GenerateStrategicMap regionIdsByCulture cultureId')] = normalizeTextArray(
+      regionIds,
+      `GenerateStrategicMap regionIdsByCulture.${cultureId}`,
+    );
+  }
+
+  for (const culture of cultures) {
+    const cultureId = requireText(culture.id, 'GenerateStrategicMap culture id');
+
+    if (regionIdsByCulture[cultureId]) {
+      continue;
+    }
+
+    const inferredRegionIds = culture.regionIds ?? culture.provinceIds ?? (culture.homeRegionId ? [culture.homeRegionId] : []);
+    regionIdsByCulture[cultureId] = normalizeTextArray(
+      inferredRegionIds,
+      `GenerateStrategicMap ${cultureId} regionIds`,
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(regionIdsByCulture)
+      .filter(([, regionIds]) => regionIds.length > 0)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function groupByCultureId(items, label) {
+  return items.reduce((groups, item) => {
+    const normalizedItem = requireOptions(item);
+    const affectedCultureIds = normalizedItem.affectedCultureIds;
+
+    if (affectedCultureIds !== undefined) {
+      for (const cultureId of normalizeTextArray(affectedCultureIds, `GenerateStrategicMap ${label}.affectedCultureIds`)) {
+        groups[cultureId] = [...(groups[cultureId] ?? []), normalizedItem];
+      }
+
+      return groups;
+    }
+
+    if (normalizedItem.cultureId !== undefined) {
+      const cultureId = requireText(normalizedItem.cultureId, `GenerateStrategicMap ${label}.cultureId`);
+      groups[cultureId] = [...(groups[cultureId] ?? []), normalizedItem];
+    }
+
+    return groups;
+  }, {});
+}
+
+function buildCultureSeeds(cultures, regionIdsByCulture, researchStatesByCulture, historicalEventsByCulture) {
+  return cultures
+    .map((culture) => {
+      const cultureId = requireText(culture.id, 'GenerateStrategicMap culture id');
+      const cultureResearchStates = researchStatesByCulture[cultureId] ?? [];
+      const cultureHistoricalEvents = historicalEventsByCulture[cultureId] ?? [];
+
+      return {
+        cultureId,
+        cultureName: String(culture.name ?? cultureId).trim() || cultureId,
+        regionIds: regionIdsByCulture[cultureId] ?? [],
+        discoveryIds: [...new Set([
+          ...cultureResearchStates.flatMap((researchState) => researchState.discoveredConceptIds ?? []),
+          ...cultureHistoricalEvents.flatMap((historicalEvent) => historicalEvent.discoveryIds ?? []),
+        ].map((discoveryId) => requireText(discoveryId, `GenerateStrategicMap ${cultureId} discoveryId`)))].sort(),
+        researchStateIds: cultureResearchStates.map((researchState) => requireText(
+          researchState.id,
+          `GenerateStrategicMap ${cultureId} researchState id`,
+        )).sort(),
+        historicalEventIds: cultureHistoricalEvents.map((historicalEvent) => requireText(
+          historicalEvent.id,
+          `GenerateStrategicMap ${cultureId} historicalEvent id`,
+        )).sort(),
+      };
+    })
+    .filter((seed) => seed.regionIds.length > 0)
+    .sort((left, right) => left.cultureId.localeCompare(right.cultureId));
+}
+
+function buildCultureMapBusinessData(culturePayload, options) {
+  const normalizedCulturePayload = normalizeCulturePayload(culturePayload);
+  const regionIdsByCulture = normalizeRegionIdsByCulture(
+    normalizedCulturePayload.cultures,
+    options.regionIdsByCulture,
+  );
+  const overlay = buildCultureMapOverlay(normalizedCulturePayload, {
+    ...(options.cultureOverlay ?? {}),
+    regionIdsByCulture,
+  });
+  const researchStatesByCulture = groupByCultureId(normalizedCulturePayload.researchStates, 'researchStates');
+  const historicalEventsByCulture = groupByCultureId(normalizedCulturePayload.historicalEvents, 'historicalEvents');
+  const panel = buildCultureLayerPanel(overlay, {
+    ...(options.cultureLayerPanel ?? {}),
+    selectedRegionId: options.selectedRegionId,
+    selectedCultureId: options.selectedCultureId,
+    activeFilter: options.activeFilter,
+    researchStatesByCulture,
+    historicalEventsByCulture,
+  });
+
+  return {
+    regionIdsByCulture,
+    overlay,
+    panel,
+    seeds: buildCultureSeeds(
+      normalizedCulturePayload.cultures,
+      regionIdsByCulture,
+      researchStatesByCulture,
+      historicalEventsByCulture,
+    ),
+  };
 }
 
 function hashSeed(seed) {
@@ -262,6 +400,8 @@ export class GenerateStrategicMap {
       });
     }).sort((left, right) => left.id.localeCompare(right.id));
 
+    const culture = buildCultureMapBusinessData(normalizedOptions.culturePayload, normalizedOptions);
+
     return {
       seed,
       width: normalizedOptions.width ?? DEFAULT_WIDTH,
@@ -276,6 +416,16 @@ export class GenerateStrategicMap {
       factionMetaById: Object.fromEntries(factions.map((faction) => [faction.id, {
         label: faction.label,
       }])),
+      overlays: {
+        culture: culture.overlay,
+      },
+      panels: {
+        culture: culture.panel,
+      },
+      businessData: {
+        regionIdsByCulture: culture.regionIdsByCulture,
+        cultureSeeds: culture.seeds,
+      },
     };
   }
 }

--- a/test/application/war/GenerateStrategicMap.test.js
+++ b/test/application/war/GenerateStrategicMap.test.js
@@ -33,6 +33,73 @@ test('GenerateStrategicMap returns deterministic strategic provinces and UI busi
   assert.deepEqual(map.paletteByFaction.ember, { fill: '#E8572A', border: '#FFB394' });
   assert.deepEqual(map.provinceLayouts['crown-heart'], { x: 38, y: 18, w: 23, h: 20 });
   assert.equal(map.provincePolygons['red-ridge'], '58,16 73,10 88,18 90,34 80,44 64,42 54,32 52,22');
+  assert.deepEqual(map.overlays.culture, []);
+  assert.equal(map.panels.culture.focus, null);
+  assert.deepEqual(map.businessData.cultureSeeds, []);
+});
+
+test('GenerateStrategicMap composes culture overlays and seed data from the generated map contract', () => {
+  const generator = new GenerateStrategicMap();
+  const map = generator.execute({
+    selectedRegionId: 'crown-heart',
+    culturePayload: {
+      cultures: [
+        {
+          id: 'culture-aurora',
+          name: 'Aurora Compact',
+          archetype: 'mercantile',
+          primaryLanguage: 'trade-speech',
+          valueIds: ['craft', 'navigation'],
+          traditionIds: ['harbor-moot'],
+          openness: 72,
+          cohesion: 61,
+          researchDrive: 77,
+          regionIds: ['crown-heart', 'north-watch'],
+        },
+      ],
+      researchStates: [
+        {
+          id: 'research-star-ledgers',
+          cultureId: 'culture-aurora',
+          topicId: 'star-ledgers',
+          status: 'active',
+          progress: 65,
+          discoveredConceptIds: ['tidal-ledgers'],
+        },
+      ],
+      historicalEvents: [
+        {
+          id: 'event-harbor-archives',
+          title: 'Harbor Archives',
+          category: 'knowledge',
+          summary: 'Dock scribes standardize voyage records.',
+          era: 'early-sails',
+          importance: 3,
+          triggeredAt: '2026-04-19T00:00:00.000Z',
+          affectedCultureIds: ['culture-aurora'],
+          discoveryIds: ['public-catalogue'],
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(map.businessData.regionIdsByCulture, {
+    'culture-aurora': ['crown-heart', 'north-watch'],
+  });
+  assert.deepEqual(map.businessData.cultureSeeds, [
+    {
+      cultureId: 'culture-aurora',
+      cultureName: 'Aurora Compact',
+      regionIds: ['crown-heart', 'north-watch'],
+      discoveryIds: ['public-catalogue', 'tidal-ledgers'],
+      researchStateIds: ['research-star-ledgers'],
+      historicalEventIds: ['event-harbor-archives'],
+    },
+  ]);
+  assert.deepEqual(map.overlays.culture.map((entry) => entry.regionId), ['crown-heart', 'north-watch']);
+  assert.deepEqual(map.overlays.culture[0].discoveries, ['public-catalogue', 'tidal-ledgers']);
+  assert.equal(map.panels.culture.focus.cultureId, 'culture-aurora');
+  assert.equal(map.panels.culture.focus.discoveriesPanel.summary, '2 concepts, 1 recherches, 1 événements');
 });
 
 test('GenerateStrategicMap can derive province ownership from faction home columns and seeded jitter', () => {


### PR DESCRIPTION
Gamma: Remplace #362 après merge de #363 et implémente #359.\n\nSummary:\n- Compose le contrat final de GenerateStrategicMap au lieu de redéfinir le module.\n- Ajoute les overlays/panels culture optionnels au résultat généré.\n- Expose les données métier seedées: regionIdsByCulture et cultureSeeds avec découvertes, recherches et événements historiques.\n\nTests:\n- node --test test/application/war/GenerateStrategicMap.test.js\n- npm test\n\nZeta: PR prête pour validation avant tout merge.