### PR TITLE
Delta: Seed intrigue from generated maps

### DIFF
--- a/src/application/intrigue/SeedIntrigueFromGeneratedMap.js
+++ b/src/application/intrigue/SeedIntrigueFromGeneratedMap.js
@@ -1,0 +1,271 @@
+import { Cellule } from '../../domain/intrigue/Cellule.js';
+import { OperationClandestine } from '../../domain/intrigue/OperationClandestine.js';
+import { NiveauAlerte } from '../../domain/intrigue/NiveauAlerte.js';
+
+const DEFAULT_NETWORK_FACTION_ID = 'shadow-network';
+const DEFAULT_OPERATION_TYPE = 'sabotage';
+const PRESENCE_THRESHOLD = 45;
+const SABOTAGE_THRESHOLD = 65;
+
+const SUPPLY_RISK_BY_LEVEL = Object.freeze({
+  abundant: 0,
+  stable: 0,
+  strained: 8,
+  low: 12,
+  critical: 18,
+  depleted: 18,
+});
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeInteger(value, label, { min, max, fallback }) {
+  const normalizedValue = value === undefined || value === null ? fallback : value;
+
+  if (!Number.isInteger(normalizedValue) || normalizedValue < min || normalizedValue > max) {
+    throw new RangeError(`${label} must be an integer between ${min} and ${max}.`);
+  }
+
+  return normalizedValue;
+}
+
+function clampInteger(value, min, max) {
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+function slugify(value) {
+  return requireText(value, 'SeedIntrigueFromGeneratedMap slug value')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'province';
+}
+
+function extractProvinces(generatedMap) {
+  if (Array.isArray(generatedMap.provinces)) {
+    return generatedMap.provinces;
+  }
+
+  if (Array.isArray(generatedMap.regions)) {
+    return generatedMap.regions;
+  }
+
+  if (generatedMap.map && Array.isArray(generatedMap.map.provinces)) {
+    return generatedMap.map.provinces;
+  }
+
+  throw new TypeError('SeedIntrigueFromGeneratedMap generatedMap.provinces must be an array.');
+}
+
+function normalizeProvince(province) {
+  const normalizedProvince = requireObject(province, 'SeedIntrigueFromGeneratedMap province');
+  const id = requireText(normalizedProvince.id, 'SeedIntrigueFromGeneratedMap province id');
+  const ownerFactionId = requireText(
+    normalizedProvince.ownerFactionId ?? normalizedProvince.factionId,
+    'SeedIntrigueFromGeneratedMap province ownerFactionId',
+  );
+  const controllingFactionId = requireText(
+    normalizedProvince.controllingFactionId ?? ownerFactionId,
+    'SeedIntrigueFromGeneratedMap province controllingFactionId',
+  );
+
+  return {
+    id,
+    name: String(normalizedProvince.name ?? id).trim() || id,
+    ownerFactionId,
+    controllingFactionId,
+    loyalty: normalizeInteger(normalizedProvince.loyalty, 'SeedIntrigueFromGeneratedMap province loyalty', {
+      min: 0,
+      max: 100,
+      fallback: 50,
+    }),
+    strategicValue: normalizeInteger(
+      normalizedProvince.strategicValue ?? normalizedProvince.value,
+      'SeedIntrigueFromGeneratedMap province strategicValue',
+      { min: 1, max: 10, fallback: 1 },
+    ),
+    supplyLevel: String(normalizedProvince.supplyLevel ?? 'stable').trim().toLowerCase(),
+    contested: Boolean(normalizedProvince.contested),
+  };
+}
+
+function computeSabotageRiskScore(province) {
+  const strategicPressure = province.strategicValue * 6;
+  const loyaltyPressure = (100 - province.loyalty) * 0.35;
+  const contestPressure = province.contested ? 22 : 0;
+  const occupationPressure = province.ownerFactionId !== province.controllingFactionId ? 15 : 0;
+  const supplyPressure = SUPPLY_RISK_BY_LEVEL[province.supplyLevel] ?? 6;
+
+  return clampInteger(strategicPressure + loyaltyPressure + contestPressure + occupationPressure + supplyPressure, 0, 100);
+}
+
+function buildRiskLevel(score) {
+  if (score >= 80) {
+    return 'critical';
+  }
+
+  if (score >= SABOTAGE_THRESHOLD) {
+    return 'high';
+  }
+
+  if (score >= PRESENCE_THRESHOLD) {
+    return 'watch';
+  }
+
+  return 'latent';
+}
+
+function buildAlertLevel(maxRiskScore) {
+  if (maxRiskScore >= 85) {
+    return new NiveauAlerte(4);
+  }
+
+  if (maxRiskScore >= 70) {
+    return new NiveauAlerte(3);
+  }
+
+  if (maxRiskScore >= 50) {
+    return new NiveauAlerte(2);
+  }
+
+  if (maxRiskScore > 0) {
+    return new NiveauAlerte(1);
+  }
+
+  return NiveauAlerte.minimum();
+}
+
+function buildCellule({ province, riskScore, networkFactionId }) {
+  const slug = slugify(province.id);
+  const sleeper = riskScore < SABOTAGE_THRESHOLD;
+
+  return new Cellule({
+    id: `cell-${slug}`,
+    factionId: networkFactionId,
+    codename: `Réseau ${province.name}`,
+    locationId: province.id,
+    memberIds: [`agent-${slug}`],
+    assetIds: [`asset-${slug}`],
+    secrecy: clampInteger(82 - riskScore / 3, 25, 90),
+    loyalty: clampInteger(42 + province.strategicValue * 4, 35, 88),
+    exposure: clampInteger(riskScore - 25, 0, 85),
+    status: sleeper ? 'dormant' : 'active',
+    sleeper,
+  });
+}
+
+function buildSabotageOperation({ province, riskScore, celluleId }) {
+  const slug = slugify(province.id);
+
+  return new OperationClandestine({
+    id: `op-sabotage-${slug}`,
+    celluleId,
+    targetFactionId: province.controllingFactionId,
+    type: DEFAULT_OPERATION_TYPE,
+    objective: `Déstabiliser ${province.name}`,
+    theaterId: province.id,
+    assignedAgentIds: [`agent-${slug}`],
+    requiredAssetIds: [`asset-${slug}`],
+    difficulty: clampInteger(30 + province.strategicValue * 4 + (province.contested ? 10 : 0), 0, 100),
+    detectionRisk: clampInteger(20 + riskScore / 2 + (province.contested ? 8 : 0), 0, 100),
+    progress: clampInteger(riskScore - 30, 0, 85),
+    phase: province.contested || riskScore >= 80 ? 'infiltration' : 'planning',
+    heat: clampInteger(riskScore - 20, 0, 90),
+  });
+}
+
+export function seedIntrigueFromGeneratedMap(generatedMap, options = {}) {
+  const normalizedMap = requireObject(generatedMap, 'SeedIntrigueFromGeneratedMap generatedMap');
+  const normalizedOptions = requireObject(options, 'SeedIntrigueFromGeneratedMap options');
+  const provinces = requireArray(extractProvinces(normalizedMap), 'SeedIntrigueFromGeneratedMap generatedMap.provinces')
+    .map(normalizeProvince)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const networkFactionId = requireText(
+    normalizedOptions.networkFactionId ?? DEFAULT_NETWORK_FACTION_ID,
+    'SeedIntrigueFromGeneratedMap networkFactionId',
+  );
+
+  const riskProfiles = provinces.map((province) => {
+    const sabotageRiskScore = computeSabotageRiskScore(province);
+
+    return {
+      provinceId: province.id,
+      provinceName: province.name,
+      controllingFactionId: province.controllingFactionId,
+      sabotageRiskScore,
+      riskLevel: buildRiskLevel(sabotageRiskScore),
+      drivers: [
+        province.strategicValue >= 7 ? 'strategic-value' : null,
+        province.loyalty <= 45 ? 'low-loyalty' : null,
+        province.contested ? 'contested' : null,
+        province.ownerFactionId !== province.controllingFactionId ? 'occupied' : null,
+        (SUPPLY_RISK_BY_LEVEL[province.supplyLevel] ?? 0) >= 12 ? 'supply-stress' : null,
+      ].filter(Boolean),
+    };
+  });
+
+  const cellules = [];
+  const operations = [];
+
+  for (const riskProfile of riskProfiles) {
+    if (riskProfile.sabotageRiskScore < PRESENCE_THRESHOLD) {
+      continue;
+    }
+
+    const province = provinces.find((candidate) => candidate.id === riskProfile.provinceId);
+    const cellule = buildCellule({ province, riskScore: riskProfile.sabotageRiskScore, networkFactionId });
+    cellules.push(cellule);
+
+    if (riskProfile.sabotageRiskScore >= SABOTAGE_THRESHOLD) {
+      operations.push(buildSabotageOperation({
+        province,
+        riskScore: riskProfile.sabotageRiskScore,
+        celluleId: cellule.id,
+      }));
+    }
+  }
+
+  const maxRiskScore = riskProfiles.reduce(
+    (maximum, profile) => Math.max(maximum, profile.sabotageRiskScore),
+    0,
+  );
+  const alertLevel = buildAlertLevel(maxRiskScore);
+
+  return {
+    cellules,
+    operations,
+    alertLevel,
+    riskProfiles,
+    summary: {
+      provinceCount: provinces.length,
+      seededCelluleCount: cellules.length,
+      seededSabotageOperationCount: operations.length,
+      maxSabotageRiskScore: maxRiskScore,
+      alertCode: alertLevel.code,
+    },
+  };
+}

--- a/test/application/intrigue/SeedIntrigueFromGeneratedMap.test.js
+++ b/test/application/intrigue/SeedIntrigueFromGeneratedMap.test.js
@@ -1,0 +1,157 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Cellule } from '../../../src/domain/intrigue/Cellule.js';
+import { OperationClandestine } from '../../../src/domain/intrigue/OperationClandestine.js';
+import { NiveauAlerte } from '../../../src/domain/intrigue/NiveauAlerte.js';
+import { seedIntrigueFromGeneratedMap } from '../../../src/application/intrigue/SeedIntrigueFromGeneratedMap.js';
+
+test('seedIntrigueFromGeneratedMap derives cells, sabotage operations, risk profiles and alert level', () => {
+  const result = seedIntrigueFromGeneratedMap({
+    provinces: [
+      {
+        id: 'ash-front',
+        name: 'Front des Cendres',
+        ownerFactionId: 'sun-empire',
+        controllingFactionId: 'moon-league',
+        loyalty: 28,
+        strategicValue: 9,
+        supplyLevel: 'critical',
+        contested: true,
+      },
+      {
+        id: 'delta-port',
+        name: 'Port du Delta',
+        ownerFactionId: 'sun-empire',
+        loyalty: 62,
+        strategicValue: 6,
+        supplyLevel: 'low',
+      },
+      {
+        id: 'quiet-hills',
+        name: 'Collines Calmes',
+        ownerFactionId: 'sun-empire',
+        loyalty: 82,
+        strategicValue: 2,
+        supplyLevel: 'stable',
+      },
+    ],
+  }, { networkFactionId: 'delta-web' });
+
+  assert.equal(result.cellules.length, 2);
+  assert.ok(result.cellules.every((cellule) => cellule instanceof Cellule));
+  assert.equal(result.operations.length, 1);
+  assert.ok(result.operations[0] instanceof OperationClandestine);
+  assert.ok(result.alertLevel instanceof NiveauAlerte);
+
+  assert.deepEqual(result.riskProfiles, [
+    {
+      provinceId: 'ash-front',
+      provinceName: 'Front des Cendres',
+      controllingFactionId: 'moon-league',
+      sabotageRiskScore: 100,
+      riskLevel: 'critical',
+      drivers: ['strategic-value', 'low-loyalty', 'contested', 'occupied', 'supply-stress'],
+    },
+    {
+      provinceId: 'delta-port',
+      provinceName: 'Port du Delta',
+      controllingFactionId: 'sun-empire',
+      sabotageRiskScore: 61,
+      riskLevel: 'watch',
+      drivers: ['supply-stress'],
+    },
+    {
+      provinceId: 'quiet-hills',
+      provinceName: 'Collines Calmes',
+      controllingFactionId: 'sun-empire',
+      sabotageRiskScore: 18,
+      riskLevel: 'latent',
+      drivers: [],
+    },
+  ]);
+
+  assert.deepEqual(result.cellules.map((cellule) => cellule.toJSON()), [
+    {
+      id: 'cell-ash-front',
+      factionId: 'delta-web',
+      codename: 'Réseau Front des Cendres',
+      locationId: 'ash-front',
+      memberIds: ['agent-ash-front'],
+      assetIds: ['asset-ash-front'],
+      operationIds: [],
+      secrecy: 49,
+      loyalty: 78,
+      exposure: 75,
+      status: 'active',
+      sleeper: false,
+    },
+    {
+      id: 'cell-delta-port',
+      factionId: 'delta-web',
+      codename: 'Réseau Port du Delta',
+      locationId: 'delta-port',
+      memberIds: ['agent-delta-port'],
+      assetIds: ['asset-delta-port'],
+      operationIds: [],
+      secrecy: 62,
+      loyalty: 66,
+      exposure: 36,
+      status: 'dormant',
+      sleeper: true,
+    },
+  ]);
+
+  assert.deepEqual(result.operations[0].toJSON(), {
+    id: 'op-sabotage-ash-front',
+    celluleId: 'cell-ash-front',
+    targetFactionId: 'moon-league',
+    type: 'sabotage',
+    objective: 'Déstabiliser Front des Cendres',
+    theaterId: 'ash-front',
+    assignedAgentIds: ['agent-ash-front'],
+    requiredAssetIds: ['asset-ash-front'],
+    difficulty: 76,
+    detectionRisk: 78,
+    progress: 70,
+    phase: 'infiltration',
+    heat: 80,
+  });
+
+  assert.deepEqual(result.alertLevel.toJSON(), {
+    value: 4,
+    code: 'verrouille',
+    label: 'Verrouillé',
+    surveillanceIntensity: 100,
+  });
+  assert.deepEqual(result.summary, {
+    provinceCount: 3,
+    seededCelluleCount: 2,
+    seededSabotageOperationCount: 1,
+    maxSabotageRiskScore: 100,
+    alertCode: 'verrouille',
+  });
+});
+
+test('seedIntrigueFromGeneratedMap supports generated regions and nested map payloads', () => {
+  assert.equal(seedIntrigueFromGeneratedMap({
+    regions: [{ id: 'border-march', ownerFactionId: 'north', loyalty: 40, strategicValue: 5 }],
+  }).summary.seededCelluleCount, 1);
+
+  assert.equal(seedIntrigueFromGeneratedMap({
+    map: { provinces: [{ id: 'safe-core', ownerFactionId: 'north', loyalty: 90, strategicValue: 1 }] },
+  }).summary.seededCelluleCount, 0);
+});
+
+test('seedIntrigueFromGeneratedMap validates payloads', () => {
+  assert.throws(() => seedIntrigueFromGeneratedMap(null), /generatedMap must be an object/);
+  assert.throws(() => seedIntrigueFromGeneratedMap({ provinces: null }), /generatedMap.provinces must be an array/);
+  assert.throws(
+    () => seedIntrigueFromGeneratedMap({ provinces: [{ id: 'x', ownerFactionId: 'north', loyalty: 101 }] }),
+    /province loyalty must be an integer between 0 and 100/,
+  );
+  assert.throws(
+    () => seedIntrigueFromGeneratedMap({ provinces: [] }, { networkFactionId: ' ' }),
+    /networkFactionId is required/,
+  );
+});


### PR DESCRIPTION
Delta: Implements #360.

Summary:
- adds `seedIntrigueFromGeneratedMap` to derive clandestine cells, sabotage operations, risk profiles, and alert levels from generated strategic map provinces/regions
- scores sabotage risk from strategic value, loyalty, contested/occupied state, and supply stress
- covers generated `provinces`, `regions`, and nested `map.provinces` payloads with validation tests

Tests:
- `npm test`

Zeta: PR ready for review. Please validate before any merge.