### PR TITLE
Alpha: Add tactical map depth and glowing borders

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -442,8 +442,10 @@ function renderProvinceSurface(shell, focusContext) {
         const isFocused = province.selectionState.focused;
         const isMuted = !isSelected && !isFocused && !isNeighbor && (focusContext.selectedProvince || focusContext.focusedProvince);
         return `
-          <g class="province-surface ${isSelected ? 'is-selected' : ''} ${isFocused ? 'is-focused' : ''} ${isNeighbor ? 'is-neighbor' : ''} ${isMuted ? 'is-muted' : ''} ${province.contested ? 'is-contested' : ''} ${province.occupied ? 'is-occupied' : ''}">
-            <polygon points="${provincePolygonById[province.provinceId]}" style="--province-fill:${province.style.fill};--province-border:${province.style.border};"></polygon>
+          <g class="province-surface ${isSelected ? 'is-selected' : ''} ${isFocused ? 'is-focused' : ''} ${isNeighbor ? 'is-neighbor' : ''} ${isMuted ? 'is-muted' : ''} ${province.contested ? 'is-contested' : ''} ${province.occupied ? 'is-occupied' : ''}" style="--province-fill:${province.style.fill};--province-border:${province.style.border};">
+            <polygon class="province-surface__glow" points="${provincePolygonById[province.provinceId]}"></polygon>
+            <polygon class="province-surface__core" points="${provincePolygonById[province.provinceId]}"></polygon>
+            <polygon class="province-surface__hairline" points="${provincePolygonById[province.provinceId]}"></polygon>
           </g>
         `;
       }).join('')}

--- a/web/styles.css
+++ b/web/styles.css
@@ -293,6 +293,19 @@ button { font: inherit; }
   border: 1px solid rgba(103, 232, 249, 0.08);
   box-shadow: inset 0 0 30px rgba(34, 211, 238, 0.035);
 }
+.tactical-coordinate-grid::before,
+.tactical-coordinate-grid::after {
+  content: '';
+  position: absolute;
+  inset: 9% 7%;
+  border: 1px solid rgba(103, 232, 249, 0.07);
+  clip-path: polygon(0 0, 34% 0, 34% 1px, 66% 1px, 66% 0, 100% 0, 100% 34%, calc(100% - 1px) 34%, calc(100% - 1px) 66%, 100% 66%, 100% 100%, 66% 100%, 66% calc(100% - 1px), 34% calc(100% - 1px), 34% 100%, 0 100%, 0 66%, 1px 66%, 1px 34%, 0 34%);
+}
+.tactical-coordinate-grid::after {
+  inset: 21% 18%;
+  border-color: rgba(251, 191, 36, 0.075);
+  transform: rotate(-1deg);
+}
 .coordinate-axis {
   position: absolute;
   display: flex;
@@ -433,33 +446,63 @@ button { font: inherit; }
   z-index: 1;
 }
 .province-surface polygon {
+  vector-effect: non-scaling-stroke;
+}
+.province-surface__core {
   fill: color-mix(in srgb, var(--province-fill) 70%, #08111f 30%);
   stroke: color-mix(in srgb, var(--province-border) 72%, #67e8f9 28%);
   stroke-width: 0.95;
-  vector-effect: non-scaling-stroke;
   filter: drop-shadow(0 10px 18px rgba(2, 6, 23, 0.28)) drop-shadow(0 0 5px rgba(103, 232, 249, 0.16));
+}
+.province-surface__glow {
+  fill: transparent;
+  stroke: color-mix(in srgb, var(--province-border) 50%, #67e8f9 50%);
+  stroke-width: 2.8;
+  opacity: 0.16;
+  filter: blur(0.7px) drop-shadow(0 0 10px rgba(103, 232, 249, 0.28));
+}
+.province-surface__hairline {
+  fill: transparent;
+  stroke: rgba(226, 232, 240, 0.28);
+  stroke-width: 0.28;
+  stroke-dasharray: 0.9 1.6;
+  opacity: 0.72;
 }
 .province-surface.is-muted polygon {
   opacity: 0.38;
 }
-.province-surface.is-neighbor polygon {
+.province-surface.is-neighbor .province-surface__core {
   stroke: rgba(251, 191, 36, 0.86);
   stroke-width: 1.25;
   filter: drop-shadow(0 0 9px rgba(251, 191, 36, 0.24));
 }
-.province-surface.is-focused polygon,
-.province-surface.is-selected polygon {
+.province-surface.is-neighbor .province-surface__glow {
+  stroke: rgba(251, 191, 36, 0.72);
+  opacity: 0.28;
+}
+.province-surface.is-focused .province-surface__core,
+.province-surface.is-selected .province-surface__core {
   stroke: #67e8f9;
   stroke-width: 1.65;
 }
-.province-surface.is-selected polygon {
+.province-surface.is-selected .province-surface__core {
   filter: drop-shadow(0 0 0 rgba(0,0,0,0)) drop-shadow(0 0 16px rgba(34, 211, 238, 0.48)) drop-shadow(0 0 28px rgba(251, 191, 36, 0.18));
 }
-.province-surface.is-occupied polygon {
+.province-surface.is-selected .province-surface__glow,
+.province-surface.is-focused .province-surface__glow {
+  stroke: #67e8f9;
+  stroke-width: 3.4;
+  opacity: 0.34;
+}
+.province-surface.is-occupied .province-surface__hairline {
   stroke-dasharray: 3 2;
 }
-.province-surface.is-contested polygon {
+.province-surface.is-contested .province-surface__core {
   stroke: rgba(251, 113, 133, 0.92);
+}
+.province-surface.is-contested .province-surface__glow {
+  stroke: rgba(251, 113, 133, 0.68);
+  opacity: 0.24;
 }
 .map-label-layer {
   position: absolute;


### PR DESCRIPTION
Alpha: ## Summary\n- Add layered province surface polygons for separate glow, core fill, and tactical hairline borders\n- Reinforce coordinate-grid hierarchy with nested blueprint frames and amber/cyan depth cues\n- Tune selected, focused, neighbor, occupied, and contested border states without changing map data contracts\n\n## Tests\n- node --check web/app.js\n- npm test\n\nCloses #373