### PR TITLE
Gamma: Style culture overlays for technical dark HUD

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -10,7 +10,102 @@ import { Cellule } from '../src/domain/intrigue/Cellule.js';
 import { OperationClandestine } from '../src/domain/intrigue/OperationClandestine.js';
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
 
-const strategicMap = new GenerateStrategicMap().execute();
+const culturePayload = {
+  cultures: [
+    {
+      id: 'culture-aurora',
+      name: 'Compact d’Aurora',
+      archetype: 'maritime-savante',
+      primaryLanguage: 'haut-côtier',
+      valueIds: ['navigation', 'archives-publiques', 'artisanat'],
+      traditionIds: ['assemblées-portuaires', 'cartes-étoiles'],
+      openness: 74,
+      cohesion: 63,
+      researchDrive: 78,
+      regionIds: ['north-watch', 'crown-heart', 'river-gate'],
+    },
+    {
+      id: 'culture-ember',
+      name: 'Ligues des Forges',
+      archetype: 'industrielle-frontalière',
+      primaryLanguage: 'parler-des-hauts-fourneaux',
+      valueIds: ['discipline', 'maîtrise-du-feu'],
+      traditionIds: ['serments-de-fonderie', 'marques-de-lignée'],
+      openness: 42,
+      cohesion: 71,
+      researchDrive: 58,
+      regionIds: ['red-ridge', 'iron-plain', 'river-gate'],
+    },
+    {
+      id: 'culture-south',
+      name: 'Maisons des Basses Marches',
+      archetype: 'caravanière',
+      primaryLanguage: 'créole-des-pistes',
+      valueIds: ['hospitalité', 'mémoire-des-routes'],
+      traditionIds: ['foires-saisonnières', 'chants-des-bornes'],
+      openness: 61,
+      cohesion: 48,
+      researchDrive: 54,
+      regionIds: ['southern-reach', 'river-gate'],
+    },
+  ],
+  researchStates: [
+    {
+      id: 'research-aurora-celestial-ledgers',
+      cultureId: 'culture-aurora',
+      topicId: 'registres-célestes',
+      status: 'active',
+      progress: 68,
+      currentTier: 2,
+      discoveredConceptIds: ['astrolabes-portuaires', 'catalogues-publics'],
+    },
+    {
+      id: 'research-ember-blast-runes',
+      cultureId: 'culture-ember',
+      topicId: 'runes-de-haut-fourneau',
+      status: 'active',
+      progress: 52,
+      currentTier: 2,
+      discoveredConceptIds: ['alliages-de-siège'],
+    },
+    {
+      id: 'research-south-waystones',
+      cultureId: 'culture-south',
+      topicId: 'bornes-mémorielles',
+      status: 'completed',
+      progress: 100,
+      currentTier: 1,
+      completedAt: '2026-04-20T00:00:00.000Z',
+      discoveredConceptIds: ['cartes-orales', 'relais-de-caravane'],
+    },
+  ],
+  historicalEvents: [
+    {
+      id: 'event-aurora-open-archives',
+      title: 'Ouverture des archives de Couronne',
+      category: 'knowledge',
+      summary: 'Les maîtres-cartographes publient les routes célestes utilisées par la flotte.',
+      era: 'pax-historia-ui',
+      importance: 4,
+      triggeredAt: '2026-05-02T08:00:00.000Z',
+      affectedCultureIds: ['culture-aurora'],
+      discoveryIds: ['routes-célestes'],
+    },
+    {
+      id: 'event-river-gate-synod',
+      title: 'Synode de la Porte du Fleuve',
+      category: 'diplomacy',
+      summary: 'Marchands, forgerons et maisons caravanières fixent des signes communs pour les convois.',
+      era: 'pax-historia-ui',
+      importance: 3,
+      triggeredAt: '2026-05-02T12:00:00.000Z',
+      affectedCultureIds: ['culture-aurora', 'culture-ember', 'culture-south'],
+      discoveryIds: ['glyphes-de-convoi'],
+    },
+  ],
+};
+
+const strategicMap = new GenerateStrategicMap().execute({ culturePayload });
 const paletteByFaction = strategicMap.paletteByFaction;
 const factionMetaById = strategicMap.factionMetaById;
 const provinceLayouts = strategicMap.provinceLayouts;
@@ -243,7 +338,7 @@ const state = {
   seasonIndex: 0,
   focusedProvinceId: 'crown-heart',
   selectedProvinceId: 'river-gate',
-  activeOverlaySlot: 'economy-overlay',
+  activeOverlaySlot: 'culture-overlay',
   popupProvinceId: 'river-gate',
   hoveredCityId: 'river-gate-city',
   selectedCityId: 'river-gate-city',
@@ -932,6 +1027,205 @@ function getIntrigueViewModel() {
   };
 }
 
+
+function getCultureViewModel() {
+  const overlay = strategicMap.overlays.culture;
+  const panel = strategicMap.panels.culture;
+  const seeds = strategicMap.businessData.cultureSeeds;
+  const selectedRegionId = state.selectedProvinceId;
+  const selectedMarkers = overlay.filter((entry) => entry.regionId === selectedRegionId);
+  const selectedMarker = selectedMarkers[0] ?? overlay[0] ?? null;
+
+  return {
+    overlay,
+    panel,
+    seeds,
+    selectedRegionId,
+    selectedMarkers,
+    selectedMarker,
+    metrics: {
+      markerCount: overlay.length,
+      cultureCount: seeds.length,
+      discoveryCount: new Set(seeds.flatMap((seed) => seed.discoveryIds)).size,
+      eventCount: new Set(seeds.flatMap((seed) => seed.historicalEventIds)).size,
+      strongMarkerCount: overlay.filter((entry) => entry.influenceTier === 'dominant' || entry.influenceTier === 'strong').length,
+    },
+  };
+}
+
+function getCultureTone(entry) {
+  if (entry.markerType === 'innovation') {
+    return 'cyan';
+  }
+
+  if (entry.markerType === 'traditional') {
+    return 'amber';
+  }
+
+  if (entry.markerType === 'fragmented') {
+    return 'rose';
+  }
+
+  return 'slate';
+}
+
+function renderCultureMapOverlay(cultureView) {
+  if (state.activeOverlaySlot !== 'culture-overlay') {
+    return '';
+  }
+
+  const markerNodes = cultureView.overlay.map((entry) => {
+    const center = getProvinceCenter(entry.regionId);
+
+    if (!center) {
+      return '';
+    }
+
+    const selected = entry.regionId === state.selectedProvinceId;
+    const tone = getCultureTone(entry);
+    const radius = Math.max(4.8, Math.min(13, entry.zoneContour.radius / 2.2));
+    const eventBadgeY = center.y - radius - 2.8;
+
+    return `
+      <g class="culture-marker culture-marker--${tone} culture-marker--${entry.influenceTier} ${selected ? 'is-selected' : ''}" data-culture-region="${entry.regionId}">
+        <circle class="culture-marker__aura" cx="${center.x}%" cy="${center.y}%" r="${radius + 2.6}"></circle>
+        <circle class="culture-marker__ring" cx="${center.x}%" cy="${center.y}%" r="${radius}"></circle>
+        <path class="culture-marker__crosshair" d="M ${center.x - radius * 0.62} ${center.y} H ${center.x + radius * 0.62} M ${center.x} ${center.y - radius * 0.62} V ${center.y + radius * 0.62}"></path>
+        <text class="culture-marker__icon" x="${center.x}%" y="${center.y + 1.3}%" text-anchor="middle">${entry.style.markerIcon}</text>
+        <text class="culture-marker__label" x="${center.x}%" y="${center.y + radius + 4}%" text-anchor="middle">${entry.cultureName}</text>
+        ${entry.eventCount > 0 ? `<text class="culture-marker__event" x="${center.x}%" y="${eventBadgeY}%" text-anchor="middle">${entry.eventCount} repère${entry.eventCount > 1 ? 's' : ''}</text>` : ''}
+      </g>
+    `;
+  }).join('');
+
+  const discoveryLinks = cultureView.overlay.flatMap((entry) => entry.regionalDiscoveryLinks.slice(0, 2).map((link, index) => {
+    const center = getProvinceCenter(entry.regionId);
+
+    if (!center) {
+      return '';
+    }
+
+    const offset = (index - 0.5) * 5.4;
+    const tone = getCultureTone(entry);
+
+    return `
+      <g class="culture-discovery-ping culture-discovery-ping--${tone}">
+        <circle cx="${center.x + offset}%" cy="${center.y - 8.4}%" r="1.15"></circle>
+        <text x="${center.x + offset}%" y="${center.y - 10.3}%" text-anchor="middle">${link.discoveryId}</text>
+      </g>
+    `;
+  })).join('');
+
+  return `
+    <svg class="culture-overlay-map" viewBox="0 0 100 100" aria-label="Overlay culture et découvertes">
+      <defs>
+        <filter id="cultureHudGlow" x="-40%" y="-40%" width="180%" height="180%">
+          <feGaussianBlur stdDeviation="1.4" result="blur" />
+          <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+        </filter>
+      </defs>
+      ${markerNodes}
+      ${discoveryLinks}
+    </svg>
+  `;
+}
+
+function renderCultureSidePanel(cultureView) {
+  if (state.activeOverlaySlot !== 'culture-overlay') {
+    return null;
+  }
+
+  const focus = cultureView.selectedMarker ?? cultureView.panel.focus;
+  const focusSeed = focus ? cultureView.seeds.find((seed) => seed.cultureId === focus.cultureId) : null;
+
+  return `
+    <section class="panel overlay-panel overlay-panel--culture">
+      <div class="panel-header">
+        <p class="eyebrow">Culture HUD</p>
+        <h3>Overlay actif, Culture</h3>
+        <p>Découvertes, influences et repères historiques en lecture tactique sombre.</p>
+      </div>
+      <div class="culture-hud-stats">
+        <div class="overlay-anchor"><span>Marqueurs</span><strong>${cultureView.metrics.markerCount}</strong></div>
+        <div class="overlay-anchor"><span>Cultures</span><strong>${cultureView.metrics.cultureCount}</strong></div>
+        <div class="overlay-anchor"><span>Découvertes</span><strong>${cultureView.metrics.discoveryCount}</strong></div>
+        <div class="overlay-anchor"><span>Repères</span><strong>${cultureView.metrics.eventCount}</strong></div>
+      </div>
+      ${focus ? `
+        <article class="culture-focus-card culture-focus-card--${getCultureTone(focus)}">
+          <div class="culture-focus-card__header">
+            <span>${focus.markerType}</span>
+            <strong>${focus.cultureName}</strong>
+          </div>
+          <p>${focus.summary}</p>
+          <div class="culture-focus-card__meter" style="--culture-score:${focus.influenceScore}%"><i></i></div>
+          <ul class="culture-hud-tags">
+            ${focus.highlights.slice(0, 5).map((tag) => `<li>${tag}</li>`).join('')}
+          </ul>
+        </article>
+      ` : ''}
+      <div class="culture-marker-list">
+        ${cultureView.overlay.slice(0, 5).map((entry) => `
+          <article class="culture-marker-row culture-marker-row--${getCultureTone(entry)} ${entry.regionId === state.selectedProvinceId ? 'is-selected' : ''}">
+            <span>${entry.style.markerIcon}</span>
+            <div><strong>${entry.cultureName}</strong><small>${entry.regionId} · ${entry.influenceTier}</small></div>
+            <b>${entry.influenceScore}</b>
+          </article>
+        `).join('')}
+      </div>
+      ${focusSeed ? `
+        <div class="culture-event-stack">
+          <strong>Repères historiques</strong>
+          ${focus.eventPopups.slice(0, 3).map((event) => `
+            <article>
+              <span>${event.triggeredAt.slice(0, 10)}</span>
+              <h4>${event.title}</h4>
+              <p>${event.summary}</p>
+            </article>
+          `).join('')}
+        </div>
+      ` : ''}
+    </section>
+  `;
+}
+
+function renderCultureBottomTray(cultureView) {
+  if (state.activeOverlaySlot !== 'culture-overlay') {
+    return null;
+  }
+
+  return `
+    <section id="bottom-tray" class="overlay-anchor-shell overlay-anchor-shell--bottom overlay-anchor-shell--culture">
+      <div class="culture-bottom-grid">
+        <div class="culture-timeline-strip">
+          <h4>Timeline culturelle</h4>
+          <p>Repères liés aux découvertes et aux zones d’influence visibles.</p>
+          <div class="culture-timeline-items">
+            ${cultureView.overlay.flatMap((entry) => entry.eventPopups.map((event) => ({ ...event, cultureName: entry.cultureName }))).slice(0, 5).map((event) => `
+              <article>
+                <span>${event.triggeredAt.slice(5, 10)}</span>
+                <strong>${event.title}</strong>
+                <small>${event.cultureName}</small>
+              </article>
+            `).join('')}
+          </div>
+        </div>
+        <div class="culture-discovery-stack">
+          ${cultureView.seeds.map((seed) => `
+            <article class="stock-mini-card culture-seed-card">
+              <h4>${seed.cultureName}</h4>
+              <p>${seed.regionIds.join(' · ')}</p>
+              <ul>
+                ${seed.discoveryIds.slice(0, 3).map((discoveryId) => `<li><span>${discoveryId}</span><strong>catalogué</strong></li>`).join('')}
+              </ul>
+            </article>
+          `).join('')}
+        </div>
+      </div>
+    </section>
+  `;
+}
+
 function renderEconomyMapOverlay(economyView) {
   if (state.activeOverlaySlot !== 'economy-overlay') {
     return '';
@@ -1184,7 +1478,13 @@ function renderIntrigueSidePanel(intrigueView) {
   `;
 }
 
-function renderEconomySidePanel(economyView) {
+function renderEconomySidePanel(economyView, cultureView) {
+  const culturePanel = renderCultureSidePanel(cultureView);
+
+  if (culturePanel) {
+    return culturePanel;
+  }
+
   if (state.activeOverlaySlot !== 'economy-overlay') {
     return `
       <section class="panel overlay-panel">
@@ -1280,7 +1580,13 @@ function renderEconomySidePanel(economyView) {
   `;
 }
 
-function renderBottomTray(economyView, intrigueView) {
+function renderBottomTray(economyView, intrigueView, cultureView) {
+  const cultureTray = renderCultureBottomTray(cultureView);
+
+  if (cultureTray) {
+    return cultureTray;
+  }
+
   if (state.activeOverlaySlot === 'intrigue-overlay') {
     return `
       <section id="bottom-tray" class="overlay-anchor-shell overlay-anchor-shell--bottom overlay-anchor-shell--economy">
@@ -1622,7 +1928,7 @@ function renderTacticalCoordinateGrid() {
   `;
 }
 
-function getMapRenderLayers(shell, economyView, focusContext) {
+function getMapRenderLayers(shell, economyView, focusContext, cultureView) {
   return [
     { key: 'backdrop', className: 'map-layer map-layer--backdrop', content: `<div class="map-backdrop"></div>${renderTacticalCoordinateGrid()}` },
     { key: 'terrain', className: 'map-layer map-layer--terrain', content: renderTerrainDecor() },
@@ -1630,14 +1936,14 @@ function getMapRenderLayers(shell, economyView, focusContext) {
     { key: 'relations', className: 'map-layer map-layer--relations', content: renderStrategicRelations(shell) },
     { key: 'labels', className: 'map-layer map-layer--labels', content: renderProvinceLabels(shell) },
     { key: 'anchors', className: 'map-layer map-layer--anchors', content: renderMapAnchorShells() },
-    { key: 'economy', className: 'map-layer map-layer--economy', content: renderEconomyMapOverlay(economyView) },
-    { key: 'hud', className: 'map-layer map-layer--hud', content: `${renderCityQuickPanel(economyView)}${renderBottomTray(economyView)}<div class="focus-hint">${focusContext.selectedProvince ? `Sélection active, ${focusContext.selectedProvince.label}` : 'Survolez une province pour déplacer le focus'}</div>` },
+    { key: 'economy', className: 'map-layer map-layer--economy', content: `${renderEconomyMapOverlay(economyView)}${renderCultureMapOverlay(cultureView)}` },
+    { key: 'hud', className: 'map-layer map-layer--hud', content: `${renderCityQuickPanel(economyView)}<div class="focus-hint">${focusContext.selectedProvince ? `Sélection active, ${focusContext.selectedProvince.label}` : 'Survolez une province pour déplacer le focus'}</div>` },
     { key: 'interactions', className: 'map-layer map-layer--interactions', content: `${shell.provinces.map((province) => renderProvinceCard(province, focusContext)).join('')}${renderProvincePopup(shell)}` },
   ];
 }
 
-function renderMapLayerStack(shell, economyView, focusContext) {
-  return getMapRenderLayers(shell, economyView, focusContext)
+function renderMapLayerStack(shell, economyView, focusContext, cultureView) {
+  return getMapRenderLayers(shell, economyView, focusContext, cultureView)
     .map((layer) => `<div class="${layer.className}" data-map-layer="${layer.key}">${layer.content}</div>`)
     .join('');
 }
@@ -1697,6 +2003,7 @@ function render() {
   const economyView = getEconomyViewModel();
   const focusContext = getFocusContext(shell);
   const intrigueView = getIntrigueViewModel();
+  const cultureView = getCultureViewModel();
 
   document.querySelector('#app').innerHTML = `
     <main class="shell-root">
@@ -1741,10 +2048,10 @@ function render() {
           <div class="map-stage" data-map-stage="true">
             ${renderMapControls()}
             <div class="map-viewport" style="transform:${getMapViewportTransform()};">
-              ${renderMapLayerStack(shell, economyView, focusContext)}
+              ${renderMapLayerStack(shell, economyView, focusContext, cultureView)}
               ${renderIntrigueMapOverlay(intrigueView)}
             </div>
-            ${renderBottomTray(economyView, intrigueView)}
+            ${renderBottomTray(economyView, intrigueView, cultureView)}
           </div>
         </section>
 
@@ -1752,7 +2059,7 @@ function render() {
           <div class="mobile-panel-stack ${state.mobilePanelSection === 'legend' ? 'show-legend' : state.mobilePanelSection === 'overlay' ? 'show-overlay' : 'show-details'}">
             ${renderLegend(shell)}
             ${renderActiveProvince(shell)}
-            ${renderIntrigueSidePanel(intrigueView) ?? renderEconomySidePanel(economyView)}
+            ${renderIntrigueSidePanel(intrigueView) ?? renderEconomySidePanel(economyView, cultureView)}
             ${renderMapArchitecturePanel()}
           </div>
         </aside>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1969,3 +1969,238 @@ button { font: inherit; }
   }
   .province-popup::before { display: none; }
 }
+
+/* Gamma UI-G1: culture and discoveries dark HUD */
+.culture-overlay-map {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  filter: saturate(1.08);
+}
+.culture-marker {
+  filter: url(#cultureHudGlow);
+  opacity: 0.88;
+}
+.culture-marker__aura {
+  fill: rgba(8, 47, 73, 0.18);
+  stroke: rgba(125, 211, 252, 0.2);
+  stroke-width: 0.36;
+  stroke-dasharray: 1.2 1.1;
+}
+.culture-marker__ring {
+  fill: rgba(2, 6, 23, 0.34);
+  stroke: rgba(125, 211, 252, 0.82);
+  stroke-width: 0.52;
+}
+.culture-marker__crosshair {
+  fill: none;
+  stroke: rgba(226, 232, 240, 0.6);
+  stroke-width: 0.2;
+  stroke-linecap: round;
+}
+.culture-marker__icon {
+  fill: #e0f2fe;
+  font-size: 3.8px;
+  font-weight: 800;
+}
+.culture-marker__label,
+.culture-marker__event,
+.culture-discovery-ping text {
+  font-size: 2.1px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.42px;
+}
+.culture-marker__label { fill: #e2e8f0; }
+.culture-marker__event { fill: #fbbf24; }
+.culture-discovery-ping circle {
+  fill: #fbbf24;
+  stroke: rgba(2, 6, 23, 0.85);
+  stroke-width: 0.26;
+}
+.culture-discovery-ping text {
+  fill: #fde68a;
+  font-size: 1.6px;
+}
+.culture-marker--amber .culture-marker__ring,
+.culture-discovery-ping--amber circle { stroke: rgba(251, 191, 36, 0.88); }
+.culture-marker--amber .culture-marker__aura { fill: rgba(120, 53, 15, 0.22); }
+.culture-marker--amber .culture-marker__icon { fill: #fde68a; }
+.culture-marker--slate .culture-marker__ring,
+.culture-discovery-ping--slate circle { stroke: rgba(148, 163, 184, 0.88); }
+.culture-marker--slate .culture-marker__aura { fill: rgba(51, 65, 85, 0.24); }
+.culture-marker--rose .culture-marker__ring,
+.culture-discovery-ping--rose circle { stroke: rgba(251, 113, 133, 0.88); }
+.culture-marker--rose .culture-marker__aura { fill: rgba(136, 19, 55, 0.24); }
+.culture-marker.is-selected .culture-marker__ring {
+  stroke-width: 0.86;
+  stroke: #fbbf24;
+}
+.culture-marker.is-selected .culture-marker__aura {
+  stroke: rgba(251, 191, 36, 0.72);
+  stroke-dasharray: 0.8 0.7;
+}
+.overlay-panel--culture {
+  border-color: rgba(125, 211, 252, 0.26);
+  background:
+    linear-gradient(160deg, rgba(8, 47, 73, 0.42), rgba(15, 23, 42, 0.86)),
+    rgba(2, 6, 23, 0.72);
+}
+.culture-hud-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.culture-focus-card,
+.culture-marker-row,
+.culture-event-stack,
+.overlay-anchor-shell--culture {
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  background: rgba(2, 6, 23, 0.48);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+.culture-focus-card {
+  padding: 14px;
+  border-radius: 18px;
+  margin-bottom: 12px;
+}
+.culture-focus-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.culture-focus-card__header span {
+  color: var(--accent);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.culture-focus-card p,
+.culture-marker-row small,
+.culture-event-stack p,
+.culture-timeline-strip p,
+.culture-timeline-items small,
+.culture-seed-card p {
+  color: var(--muted);
+}
+.culture-focus-card__meter {
+  height: 7px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  margin: 10px 0;
+}
+.culture-focus-card__meter i {
+  display: block;
+  width: var(--culture-score);
+  height: 100%;
+  background: linear-gradient(90deg, #22d3ee, #fbbf24);
+  box-shadow: 0 0 18px rgba(34, 211, 238, 0.45);
+}
+.culture-hud-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.culture-hud-tags li,
+.culture-timeline-items span {
+  padding: 4px 7px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.12);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  color: #bae6fd;
+  font-size: 11px;
+}
+.culture-marker-list {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.culture-marker-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  border-radius: 14px;
+  padding: 10px;
+}
+.culture-marker-row > span {
+  width: 28px;
+  height: 28px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 10px;
+  background: rgba(14, 165, 233, 0.13);
+  color: #bae6fd;
+}
+.culture-marker-row b { color: #f8fafc; }
+.culture-marker-row.is-selected {
+  border-color: rgba(251, 191, 36, 0.48);
+  background: rgba(120, 53, 15, 0.2);
+}
+.culture-event-stack {
+  padding: 12px;
+  border-radius: 16px;
+}
+.culture-event-stack article + article { margin-top: 10px; }
+.culture-event-stack span {
+  color: #fbbf24;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-event-stack h4,
+.culture-timeline-strip h4 { margin: 4px 0; }
+.culture-event-stack p { margin: 0; font-size: 13px; }
+.overlay-anchor-shell--culture {
+  padding: 14px;
+  border-radius: 20px;
+  backdrop-filter: blur(14px);
+}
+.culture-bottom-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  gap: 14px;
+}
+.culture-timeline-items,
+.culture-discovery-stack {
+  display: grid;
+  gap: 8px;
+}
+.culture-timeline-items {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+.culture-timeline-items article {
+  border-top: 1px solid rgba(125, 211, 252, 0.24);
+  padding-top: 8px;
+}
+.culture-timeline-items strong,
+.culture-timeline-items small {
+  display: block;
+}
+.culture-discovery-stack {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.culture-seed-card {
+  border-color: rgba(125, 211, 252, 0.18);
+}
+@media (max-width: 980px) {
+  .culture-bottom-grid,
+  .culture-discovery-stack,
+  .culture-timeline-items {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Gamma: Implements #370.

Summary:
- seeds the web demo with culture, discovery, and historical event data from the generated map culture contract
- renders the culture overlay as dark technical HUD markers with cyan/amber/rose vector styling
- adds culture side-panel metrics, focus card, historical event stack, and bottom-tray discovery/timeline cards

Validation:
- `node --check web/app.js`
- `npm test`
- `git diff --check`

Gamma: Ready for Zeta validation before merge.