### PR TITLE
Gamma: Define culture marker visual language

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1122,6 +1122,74 @@ function getCultureTone(entry) {
   return 'slate';
 }
 
+const cultureMarkerLanguage = {
+  innovation: {
+    code: 'INN',
+    label: 'Découverte active',
+    glyph: 'M 0 -1.15 L 0.34 -0.34 L 1.15 0 L 0.34 0.34 L 0 1.15 L -0.34 0.34 L -1.15 0 L -0.34 -0.34 Z',
+    ticks: 8,
+  },
+  balanced: {
+    code: 'BAL',
+    label: 'Synthèse culturelle',
+    glyph: 'M -0.82 -0.82 H 0.82 V 0.82 H -0.82 Z M -0.38 -0.38 H 0.38 V 0.38 H -0.38 Z',
+    ticks: 4,
+  },
+  traditional: {
+    code: 'TRD',
+    label: 'Tradition établie',
+    glyph: 'M 0 -1 L 0.86 -0.5 L 0.86 0.5 L 0 1 L -0.86 0.5 L -0.86 -0.5 Z M -0.5 0 H 0.5',
+    ticks: 6,
+  },
+  fragmented: {
+    code: 'FRG',
+    label: 'Mémoire fracturée',
+    glyph: 'M -0.95 -0.82 L 0.12 -0.28 L -0.5 0.05 L 0.82 0.78 M 0.62 -0.9 L 0.1 0.16 L 0.92 0.28 M -0.84 0.82 L -0.2 0.24',
+    ticks: 5,
+  },
+  default: {
+    code: 'CUL',
+    label: 'Présence culturelle',
+    glyph: 'M 0 -0.95 A 0.95 0.95 0 1 1 -0.01 -0.95 M -0.55 0 H 0.55',
+    ticks: 4,
+  },
+};
+
+function getCultureMarkerLanguage(entry) {
+  return cultureMarkerLanguage[entry.markerType] ?? cultureMarkerLanguage.default;
+}
+
+function renderCultureMarkerTicks(center, radius, markerLanguage) {
+  return Array.from({ length: markerLanguage.ticks }, (_, index) => {
+    const angle = ((Math.PI * 2) / markerLanguage.ticks) * index - (Math.PI / 2);
+    const innerRadius = radius + 1.05;
+    const outerRadius = radius + 2.05;
+    const x1 = center.x + Math.cos(angle) * innerRadius;
+    const y1 = center.y + Math.sin(angle) * innerRadius;
+    const x2 = center.x + Math.cos(angle) * outerRadius;
+    const y2 = center.y + Math.sin(angle) * outerRadius;
+
+    return `<line class="culture-marker__tick" x1="${x1}%" y1="${y1}%" x2="${x2}%" y2="${y2}%"></line>`;
+  }).join('');
+}
+
+function renderCultureLegendKey(cultureView) {
+  const entriesByType = [...new Map(cultureView.overlay.map((entry) => [entry.markerType, entry])).values()];
+
+  return `
+    <div class="culture-symbol-key" aria-label="Langage visuel culture et découvertes">
+      ${entriesByType.map((entry) => {
+        const language = getCultureMarkerLanguage(entry);
+        return `
+          <span class="culture-symbol-key__item culture-symbol-key__item--${getCultureTone(entry)}">
+            <i>${language.code}</i>${language.label}
+          </span>
+        `;
+      }).join('')}
+    </div>
+  `;
+}
+
 function renderCultureMapOverlay(cultureView) {
   if (state.activeOverlaySlot !== 'culture-overlay') {
     return '';
@@ -1138,15 +1206,20 @@ function renderCultureMapOverlay(cultureView) {
     const tone = getCultureTone(entry);
     const radius = Math.max(4.8, Math.min(13, entry.zoneContour.radius / 2.2));
     const eventBadgeY = center.y - radius - 2.8;
+    const language = getCultureMarkerLanguage(entry);
+    const glyphScale = Math.max(2.2, radius * 0.36);
+    const selectedClass = selected ? 'is-selected' : '';
 
     return `
-      <g class="culture-marker culture-marker--${tone} culture-marker--${entry.influenceTier} ${selected ? 'is-selected' : ''}" data-culture-region="${entry.regionId}">
+      <g class="culture-marker culture-marker--${tone} culture-marker--${entry.influenceTier} culture-marker--${entry.markerType} ${selectedClass}" data-culture-region="${entry.regionId}">
         <circle class="culture-marker__aura" cx="${center.x}%" cy="${center.y}%" r="${radius + 2.6}"></circle>
         <circle class="culture-marker__ring" cx="${center.x}%" cy="${center.y}%" r="${radius}"></circle>
+        ${renderCultureMarkerTicks(center, radius, language)}
         <path class="culture-marker__crosshair" d="M ${center.x - radius * 0.62} ${center.y} H ${center.x + radius * 0.62} M ${center.x} ${center.y - radius * 0.62} V ${center.y + radius * 0.62}"></path>
-        <text class="culture-marker__icon" x="${center.x}%" y="${center.y + 1.3}%" text-anchor="middle">${entry.style.markerIcon}</text>
+        <path class="culture-marker__sigil" d="${language.glyph}" transform="translate(${center.x} ${center.y}) scale(${glyphScale})"></path>
+        <text class="culture-marker__code" x="${center.x + radius + 2.6}%" y="${center.y - 1.2}%" text-anchor="start">${language.code}</text>
         <text class="culture-marker__label" x="${center.x}%" y="${center.y + radius + 4}%" text-anchor="middle">${entry.cultureName}</text>
-        ${entry.eventCount > 0 ? `<text class="culture-marker__event" x="${center.x}%" y="${eventBadgeY}%" text-anchor="middle">${entry.eventCount} repère${entry.eventCount > 1 ? 's' : ''}</text>` : ''}
+        ${entry.eventCount > 0 ? `<g class="culture-event-flag"><path d="M ${center.x - 3.8} ${eventBadgeY - 2.1} H ${center.x + 3.8} L ${center.x + 2.8} ${eventBadgeY + 1.4} H ${center.x - 3.8} Z"></path><text x="${center.x}%" y="${eventBadgeY + 0.15}%" text-anchor="middle">H-${entry.eventCount}</text></g>` : ''}
       </g>
     `;
   }).join('');
@@ -1161,10 +1234,14 @@ function renderCultureMapOverlay(cultureView) {
     const offset = (index - 0.5) * 5.4;
     const tone = getCultureTone(entry);
 
+    const x = center.x + offset;
+    const y = center.y - 8.4;
+
     return `
       <g class="culture-discovery-ping culture-discovery-ping--${tone}">
-        <circle cx="${center.x + offset}%" cy="${center.y - 8.4}%" r="1.15"></circle>
-        <text x="${center.x + offset}%" y="${center.y - 10.3}%" text-anchor="middle">${link.discoveryId}</text>
+        <line class="culture-discovery-ping__leader" x1="${center.x}%" y1="${center.y}%" x2="${x}%" y2="${y}%"></line>
+        <path class="culture-discovery-ping__glyph" d="M ${x} ${y - 1.45} L ${x + 1.45} ${y} L ${x} ${y + 1.45} L ${x - 1.45} ${y} Z M ${x - 0.55} ${y} H ${x + 0.55}"></path>
+        <text x="${x}%" y="${y - 2.15}%" text-anchor="middle">D:${link.discoveryId}</text>
       </g>
     `;
   })).join('');
@@ -1204,6 +1281,7 @@ function renderCultureSidePanel(cultureView) {
         <div class="overlay-anchor"><span>Découvertes</span><strong>${cultureView.metrics.discoveryCount}</strong></div>
         <div class="overlay-anchor"><span>Repères</span><strong>${cultureView.metrics.eventCount}</strong></div>
       </div>
+      ${renderCultureLegendKey(cultureView)}
       ${focus ? `
         <article class="culture-focus-card culture-focus-card--${getCultureTone(focus)}">
           <div class="culture-focus-card__header">

--- a/web/styles.css
+++ b/web/styles.css
@@ -2282,3 +2282,96 @@ button { font: inherit; }
     grid-template-columns: 1fr;
   }
 }
+
+/* Gamma UI-G2: technical culture marker language */
+.culture-marker__tick {
+  stroke: rgba(226, 232, 240, 0.56);
+  stroke-width: 0.22;
+  stroke-linecap: round;
+}
+.culture-marker__sigil {
+  fill: none;
+  stroke: #e0f2fe;
+  stroke-width: 0.28;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+.culture-marker__code {
+  fill: #bae6fd;
+  font-size: 1.65px;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.38px;
+}
+.culture-marker--traditional .culture-marker__sigil,
+.culture-marker--traditional .culture-marker__code { stroke: #fde68a; fill: #fde68a; }
+.culture-marker--fragmented .culture-marker__sigil,
+.culture-marker--fragmented .culture-marker__code { stroke: #fecdd3; fill: #fecdd3; }
+.culture-marker--balanced .culture-marker__sigil,
+.culture-marker--balanced .culture-marker__code { stroke: #a7f3d0; fill: #a7f3d0; }
+.culture-marker--innovation .culture-marker__sigil,
+.culture-marker--innovation .culture-marker__code { stroke: #bae6fd; fill: #bae6fd; }
+.culture-event-flag path {
+  fill: rgba(120, 53, 15, 0.82);
+  stroke: rgba(251, 191, 36, 0.86);
+  stroke-width: 0.28;
+}
+.culture-event-flag text {
+  fill: #fef3c7;
+  font-size: 1.55px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+.culture-discovery-ping__leader {
+  stroke: rgba(125, 211, 252, 0.28);
+  stroke-width: 0.18;
+  stroke-dasharray: 0.7 0.8;
+}
+.culture-discovery-ping__glyph {
+  fill: rgba(8, 47, 73, 0.72);
+  stroke: #67e8f9;
+  stroke-width: 0.26;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.culture-discovery-ping--amber .culture-discovery-ping__leader { stroke: rgba(251, 191, 36, 0.3); }
+.culture-discovery-ping--amber .culture-discovery-ping__glyph { stroke: #fcd34d; fill: rgba(120, 53, 15, 0.72); }
+.culture-discovery-ping--rose .culture-discovery-ping__leader { stroke: rgba(251, 113, 133, 0.3); }
+.culture-discovery-ping--rose .culture-discovery-ping__glyph { stroke: #fda4af; fill: rgba(136, 19, 55, 0.66); }
+.culture-symbol-key {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0 0 12px;
+}
+.culture-symbol-key__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(125, 211, 252, 0.16);
+  color: var(--muted);
+  font-size: 12px;
+}
+.culture-symbol-key__item i {
+  min-width: 34px;
+  padding: 3px 6px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.14);
+  color: #bae6fd;
+  font-style: normal;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-align: center;
+}
+.culture-symbol-key__item--amber i { background: rgba(120, 53, 15, 0.35); color: #fde68a; }
+.culture-symbol-key__item--rose i { background: rgba(136, 19, 55, 0.35); color: #fecdd3; }
+.culture-symbol-key__item--slate i { background: rgba(51, 65, 85, 0.42); color: #cbd5e1; }
+@media (max-width: 980px) {
+  .culture-symbol-key { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
Gamma: Implements #377.

Summary:
- adds a formal marker language for culture overlay types with compact HUD codes and vector sigils
- upgrades discovery pings with leader lines and technical diamond glyphs for readable dark-map annotations
- adds historical event flags and a side-panel symbol key so culture, discovery, and history markers are legible together

Validation:
- `node --check web/app.js`
- `npm test`
- `git diff --check`

Gamma: Ready for Zeta validation before merge.