### PR TITLE
Gamma: Polish culture panels and timelines

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1178,6 +1178,49 @@ function renderCultureMarkerTicks(center, radius, markerLanguage) {
   }).join('');
 }
 
+function formatCultureDate(isoDate) {
+  const date = new Date(isoDate);
+
+  if (Number.isNaN(date.getTime())) {
+    return String(isoDate ?? '').slice(0, 10);
+  }
+
+  return new Intl.DateTimeFormat('fr-FR', { day: '2-digit', month: 'short' }).format(date).replace('.', '');
+}
+
+function getCultureEventTone(event) {
+  if (event.importance >= 4) {
+    return 'major';
+  }
+
+  if (event.discoveries.length > 0) {
+    return 'discovery';
+  }
+
+  return 'standard';
+}
+
+function renderCultureEventCard(event, cultureName) {
+  const tone = getCultureEventTone(event);
+  const discoveryCount = event.discoveries.length;
+
+  return `
+    <article class="culture-event-card culture-event-card--${tone}">
+      <div class="culture-event-card__rail"><span>${formatCultureDate(event.triggeredAt)}</span></div>
+      <div class="culture-event-card__body">
+        <div class="culture-event-card__meta">
+          <span>${cultureName}</span>
+          <b>IMP-${event.importance}</b>
+          ${discoveryCount > 0 ? `<b>D-${discoveryCount}</b>` : ''}
+        </div>
+        <h4>${event.title}</h4>
+        <p>${event.summary}</p>
+        ${discoveryCount > 0 ? `<div class="culture-event-card__chips">${event.discoveries.slice(0, 3).map((discoveryId) => `<i>${discoveryId}</i>`).join('')}</div>` : ''}
+      </div>
+    </article>
+  `;
+}
+
 function renderCultureLegendKey(cultureView) {
   const entriesByType = [...new Map(cultureView.overlay.map((entry) => [entry.markerType, entry])).values()];
 
@@ -1294,6 +1337,11 @@ function renderCultureSidePanel(cultureView) {
             <strong>${focus.cultureName}</strong>
           </div>
           <p>${focus.summary}</p>
+          <div class="culture-focus-card__microgrid">
+            <span><b>${focus.influenceTier}</b> influence</span>
+            <span><b>${focus.discoveries.length}</b> découvertes</span>
+            <span><b>${focus.eventCount}</b> repères</span>
+          </div>
           <div class="culture-focus-card__meter" style="--culture-score:${focus.influenceScore}%"><i></i></div>
           <ul class="culture-hud-tags">
             ${focus.highlights.slice(0, 5).map((tag) => `<li>${tag}</li>`).join('')}
@@ -1311,14 +1359,11 @@ function renderCultureSidePanel(cultureView) {
       </div>
       ${focusSeed ? `
         <div class="culture-event-stack">
-          <strong>Repères historiques</strong>
-          ${focus.eventPopups.slice(0, 3).map((event) => `
-            <article>
-              <span>${event.triggeredAt.slice(0, 10)}</span>
-              <h4>${event.title}</h4>
-              <p>${event.summary}</p>
-            </article>
-          `).join('')}
+          <div class="culture-event-stack__header">
+            <strong>Repères historiques</strong>
+            <span>${focus.eventPopups.length} entrées liées</span>
+          </div>
+          ${focus.eventPopups.slice(0, 3).map((event) => renderCultureEventCard(event, focus.cultureName)).join('')}
         </div>
       ` : ''}
     </section>
@@ -1337,11 +1382,11 @@ function renderCultureBottomTray(cultureView) {
           <h4>Timeline culturelle</h4>
           <p>Repères liés aux découvertes et aux zones d’influence visibles.</p>
           <div class="culture-timeline-items">
-            ${cultureView.overlay.flatMap((entry) => entry.eventPopups.map((event) => ({ ...event, cultureName: entry.cultureName }))).slice(0, 5).map((event) => `
-              <article>
-                <span>${event.triggeredAt.slice(5, 10)}</span>
+            ${cultureView.overlay.flatMap((entry) => entry.eventPopups.map((event) => ({ ...event, cultureName: entry.cultureName }))).slice(0, 5).map((event, index) => `
+              <article class="culture-timeline-node culture-timeline-node--${getCultureEventTone(event)}" style="--timeline-index:${index}">
+                <span>${formatCultureDate(event.triggeredAt)}</span>
                 <strong>${event.title}</strong>
-                <small>${event.cultureName}</small>
+                <small>${event.cultureName} · IMP-${event.importance}</small>
               </article>
             `).join('')}
           </div>
@@ -1349,7 +1394,10 @@ function renderCultureBottomTray(cultureView) {
         <div class="culture-discovery-stack">
           ${cultureView.seeds.map((seed) => `
             <article class="stock-mini-card culture-seed-card">
-              <h4>${seed.cultureName}</h4>
+              <div class="culture-seed-card__header">
+                <h4>${seed.cultureName}</h4>
+                <span>${seed.regionIds.length} zones</span>
+              </div>
               <p>${seed.regionIds.join(' · ')}</p>
               <ul>
                 ${seed.discoveryIds.slice(0, 3).map((discoveryId) => `<li><span>${discoveryId}</span><strong>catalogué</strong></li>`).join('')}

--- a/web/styles.css
+++ b/web/styles.css
@@ -2605,3 +2605,193 @@ button { font: inherit; }
 @media (max-width: 980px) {
   .culture-symbol-key { grid-template-columns: 1fr; }
 }
+
+/* Gamma UI-G3: polished culture panels, timelines, and event cards */
+.overlay-panel--culture,
+.overlay-anchor-shell--culture {
+  backdrop-filter: blur(18px) saturate(1.2);
+  box-shadow:
+    0 24px 60px rgba(2, 6, 23, 0.45),
+    inset 0 1px 0 rgba(226, 232, 240, 0.06),
+    inset 0 0 42px rgba(14, 165, 233, 0.05);
+}
+.overlay-panel--culture .panel-header {
+  position: relative;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(125, 211, 252, 0.12);
+}
+.overlay-panel--culture .panel-header::after,
+.overlay-anchor-shell--culture::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    linear-gradient(90deg, rgba(125, 211, 252, 0.08) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(125, 211, 252, 0.06) 1px, transparent 1px);
+  background-size: 18px 18px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.42), transparent 58%);
+}
+.overlay-anchor-shell--culture { position: relative; overflow: hidden; }
+.culture-focus-card {
+  background:
+    linear-gradient(145deg, rgba(8, 47, 73, 0.46), rgba(2, 6, 23, 0.5)),
+    rgba(15, 23, 42, 0.4);
+}
+.culture-focus-card__microgrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 10px 0;
+}
+.culture-focus-card__microgrid span {
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(8, 15, 28, 0.58);
+  border: 1px solid rgba(125, 211, 252, 0.12);
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.culture-focus-card__microgrid b {
+  display: block;
+  color: #e0f2fe;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+.culture-event-stack {
+  display: grid;
+  gap: 10px;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.62), rgba(2, 6, 23, 0.5));
+}
+.culture-event-stack__header,
+.culture-seed-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.culture-event-stack__header span,
+.culture-seed-card__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.culture-event-card {
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr);
+  overflow: hidden;
+  border-radius: 14px;
+  border: 1px solid rgba(125, 211, 252, 0.16);
+  background: rgba(8, 15, 28, 0.64);
+}
+.culture-event-card__rail {
+  display: grid;
+  place-items: center;
+  background:
+    linear-gradient(180deg, rgba(14, 165, 233, 0.18), rgba(15, 23, 42, 0.3));
+  border-right: 1px solid rgba(125, 211, 252, 0.14);
+}
+.culture-event-card__rail span {
+  color: #bae6fd;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  writing-mode: vertical-rl;
+  text-transform: uppercase;
+}
+.culture-event-card__body { padding: 10px 12px; }
+.culture-event-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+.culture-event-card__meta span,
+.culture-event-card__meta b {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.1);
+  color: #bae6fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-event-card__meta b {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fde68a;
+}
+.culture-event-card h4 { margin: 0 0 4px; }
+.culture-event-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+}
+.culture-event-card__chips i {
+  padding: 3px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(125, 211, 252, 0.14);
+  color: #c4b5fd;
+  font-size: 10px;
+  font-style: normal;
+}
+.culture-event-card--major { border-color: rgba(251, 191, 36, 0.34); }
+.culture-event-card--major .culture-event-card__rail { background: linear-gradient(180deg, rgba(120, 53, 15, 0.5), rgba(15, 23, 42, 0.34)); }
+.culture-event-card--discovery { border-color: rgba(167, 139, 250, 0.24); }
+.culture-timeline-strip {
+  position: relative;
+  z-index: 1;
+}
+.culture-timeline-items {
+  position: relative;
+  align-items: stretch;
+}
+.culture-timeline-items::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 18px;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(125, 211, 252, 0.08), rgba(125, 211, 252, 0.42), rgba(251, 191, 36, 0.26));
+}
+.culture-timeline-node {
+  position: relative;
+  min-height: 112px;
+  padding: 34px 10px 10px;
+  border: 1px solid rgba(125, 211, 252, 0.14);
+  border-radius: 14px;
+  background: rgba(8, 15, 28, 0.52);
+}
+.culture-timeline-node::before {
+  content: '';
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #22d3ee;
+  box-shadow: 0 0 18px rgba(34, 211, 238, 0.55);
+}
+.culture-timeline-node--major::before { background: #fbbf24; box-shadow: 0 0 18px rgba(251, 191, 36, 0.56); }
+.culture-timeline-node--discovery::before { background: #a78bfa; box-shadow: 0 0 18px rgba(167, 139, 250, 0.5); }
+.culture-timeline-node span { position: absolute; top: 8px; right: 10px; }
+.culture-timeline-node strong { margin-bottom: 5px; }
+.culture-seed-card {
+  background:
+    linear-gradient(180deg, rgba(8, 47, 73, 0.28), rgba(15, 23, 42, 0.62));
+}
+.culture-seed-card h4 { margin: 0; }
+@media (max-width: 720px) {
+  .culture-focus-card__microgrid,
+  .culture-event-card { grid-template-columns: 1fr; }
+  .culture-event-card__rail { min-height: 38px; border-right: 0; border-bottom: 1px solid rgba(125, 211, 252, 0.14); }
+  .culture-event-card__rail span { writing-mode: horizontal-tb; }
+}


### PR DESCRIPTION
Gamma: Implements #378.

Summary:
- polishes the culture side panel with frosted-glass HUD treatment and compact micro-metrics
- upgrades historical event cards with rails, importance/discovery badges, and minimal metadata chips
- refines the bottom culture timeline and discovery cards for dark Pax Historia readability

Validation:
- `node --check web/app.js`
- `npm test`
- `git diff --check`

Gamma: Ready for Zeta validation before merge.