### PR TITLE
Epsilon: Style climate disaster HUD

### DIFF
--- a/src/ui/climate/buildCatastropheMapOverlay.js
+++ b/src/ui/climate/buildCatastropheMapOverlay.js
@@ -38,6 +38,35 @@ function normalizeStyle(styleBySeverity, severity) {
   };
 }
 
+function buildTacticalHudStyle(catastrophe, style) {
+  const alertTone = catastrophe.severity === 'critical'
+    ? 'critical-red'
+    : catastrophe.severity === 'major'
+      ? 'amber-warning'
+      : 'cyan-watch';
+
+  return {
+    visualMode: 'tactical-dark',
+    panelClassName: `climate-disaster-card climate-disaster-card--${catastrophe.severity}`,
+    surface: {
+      background: 'rgba(3, 10, 22, 0.74)',
+      border: `1px solid ${style.stroke}`,
+      backdropFilter: 'blur(18px) saturate(1.18)',
+      gridOverlay: 'coordinate-grid',
+    },
+    alertTone,
+    glyph: {
+      icon: style.icon,
+      frame: catastrophe.status === 'active' ? 'pulsing-ring' : 'thin-warning-ring',
+      color: style.fill,
+    },
+    typography: {
+      family: 'technical-sans',
+      labelTransform: 'uppercase-tracked',
+    },
+  };
+}
+
 export function buildCatastropheMapOverlay(catastrophes, options = {}) {
   if (!Array.isArray(catastrophes)) {
     throw new TypeError('CatastropheMapOverlay catastrophes must be an array.');
@@ -48,6 +77,7 @@ export function buildCatastropheMapOverlay(catastrophes, options = {}) {
     ...DEFAULT_STYLE_BY_SEVERITY,
     ...requireObject(normalizedOptions.styleBySeverity ?? {}, 'CatastropheMapOverlay styleBySeverity'),
   };
+  const tacticalHud = Boolean(normalizedOptions.tacticalHud);
 
   return catastrophes
     .map(normalizeCatastrophe)
@@ -62,16 +92,21 @@ export function buildCatastropheMapOverlay(catastrophes, options = {}) {
 
       return left.catastrophe.id.localeCompare(right.catastrophe.id);
     })
-    .map(({ catastrophe, regionId }) => ({
-      overlayId: `${regionId}:${catastrophe.id}`,
-      regionId,
-      catastropheId: catastrophe.id,
-      type: catastrophe.type,
-      severity: catastrophe.severity,
-      status: catastrophe.status,
-      label: `${catastrophe.type} (${catastrophe.severity})`,
-      description: catastrophe.description,
-      impact: { ...catastrophe.impact },
-      style: normalizeStyle(styleBySeverity, catastrophe.severity),
-    }));
+    .map(({ catastrophe, regionId }) => {
+      const style = normalizeStyle(styleBySeverity, catastrophe.severity);
+
+      return {
+        overlayId: `${regionId}:${catastrophe.id}`,
+        regionId,
+        catastropheId: catastrophe.id,
+        type: catastrophe.type,
+        severity: catastrophe.severity,
+        status: catastrophe.status,
+        label: `${catastrophe.type} (${catastrophe.severity})`,
+        description: catastrophe.description,
+        impact: { ...catastrophe.impact },
+        style,
+        ...(tacticalHud ? { hudStyle: buildTacticalHudStyle(catastrophe, style) } : {}),
+      };
+    });
 }

--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -228,6 +228,34 @@ function buildTurnProgression(state, progressionByRegion) {
   };
 }
 
+function buildTacticalClimateTheme(regions, catastropheEntries) {
+  const criticalCount = regions.filter((region) => region.strategicImpact === 'critical').length;
+
+  return {
+    visualMode: 'tactical-dark',
+    className: 'climate-hud climate-hud--pax-dark',
+    palette: {
+      background: '#020817',
+      glass: 'rgba(3, 10, 22, 0.72)',
+      border: 'rgba(125, 211, 252, 0.24)',
+      accent: criticalCount > 0 ? '#f59e0b' : '#67e8f9',
+      danger: '#fb7185',
+      text: '#e2e8f0',
+    },
+    layers: {
+      regionFill: 'low-opacity-season-wash',
+      anomalyGlyphs: 'minimal-cyan-amber-markers',
+      catastropheRings: catastropheEntries.length > 0 ? 'thin-glowing-alert-rings' : 'standby-grid',
+      coordinateGrid: true,
+    },
+    panel: {
+      surface: 'frosted-glass',
+      density: 'compact',
+      typography: 'technical-sans',
+    },
+  };
+}
+
 function buildRegionalRiskMode(regions) {
   return regions.map((region) => ({
     regionId: region.regionId,
@@ -320,9 +348,10 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     ...requireObject(normalizedOptions.anomalyStyleByType ?? {}, 'ClimateMapOverlay anomalyStyleByType'),
   };
   const progressionByRegion = requireObject(normalizedOptions.progressionByRegion ?? {}, 'ClimateMapOverlay progressionByRegion');
+  const tacticalHud = Boolean(normalizedOptions.tacticalHud);
   const catastropheEntries = buildCatastropheMapOverlay(
     normalizedOptions.catastrophes ?? [],
-    { styleBySeverity: normalizedOptions.styleBySeverity ?? {} },
+    { styleBySeverity: normalizedOptions.styleBySeverity ?? {}, tacticalHud },
   ).map((entry) => ({
     ...entry,
     kind: 'catastrophe',
@@ -382,6 +411,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     catastropheZones: buildCatastropheZones(catastropheEntries),
     regionalRiskMode: buildRegionalRiskMode(regions),
     legend: buildLegend(stateEntries, catastropheEntries, seasonLabels),
+    ...(tacticalHud ? { tacticalTheme: buildTacticalClimateTheme(regions, catastropheEntries) } : {}),
     metrics: {
       regionCount: states.length,
       seasonCount: states.length,

--- a/src/ui/climate/buildClimateStatusPanel.js
+++ b/src/ui/climate/buildClimateStatusPanel.js
@@ -54,6 +54,28 @@ function buildAnomalySummary(anomaly, activeCatastropheIds) {
   return anomalies;
 }
 
+function buildTacticalPanelStyle(climateState, riskLevel) {
+  const accent = riskLevel === 'critical'
+    ? 'amber-danger'
+    : riskLevel === 'watched'
+      ? 'cyan-warning'
+      : 'cyan-calm';
+
+  return {
+    visualMode: 'tactical-dark',
+    className: `climate-status-panel climate-status-panel--${riskLevel}`,
+    surface: {
+      background: 'rgba(3, 10, 22, 0.72)',
+      border: riskLevel === 'critical' ? 'rgba(251, 191, 36, 0.42)' : 'rgba(125, 211, 252, 0.24)',
+      backdropFilter: 'blur(18px) saturate(1.18)',
+      coordinateGrid: true,
+    },
+    accent,
+    readoutMode: 'compact-hud',
+    glyphRail: climateState.activeCatastropheIds.length > 0 ? 'alert-stack' : climateState.hasAnomaly() ? 'anomaly-watch' : 'season-only',
+  };
+}
+
 function buildRiskSummary(climateState) {
   const logistics = climateState.activeCatastropheIds.length > 0
     ? 'élevé'
@@ -99,6 +121,12 @@ export function buildClimateStatusPanel(climateState, options = {}) {
     ? 'Aucune anomalie'
     : anomalies.map((entry) => entry.label).join(', ');
   const riskSummary = buildRiskSummary(normalizedClimateState);
+  const riskLevel = normalizedClimateState.isStable() && !normalizedClimateState.hasAnomaly() && normalizedClimateState.activeCatastropheIds.length === 0
+    ? 'stable'
+    : normalizedClimateState.activeCatastropheIds.length > 0 || normalizedClimateState.droughtIndex >= 60
+      ? 'critical'
+      : 'watched';
+  const tacticalHud = Boolean(normalizedOptions.tacticalHud);
 
   return {
     regionId: normalizedClimateState.regionId,
@@ -143,15 +171,12 @@ export function buildClimateStatusPanel(climateState, options = {}) {
       },
     anomalies,
     risks: riskSummary,
+    ...(tacticalHud ? { panelStyle: buildTacticalPanelStyle(normalizedClimateState, riskLevel) } : {}),
     metrics: {
       anomalyCount: anomalies.length,
       activeCatastropheCount: normalizedClimateState.activeCatastropheIds.length,
       hasAnomaly: normalizedClimateState.hasAnomaly(),
-      riskLevel: normalizedClimateState.isStable() && !normalizedClimateState.hasAnomaly() && normalizedClimateState.activeCatastropheIds.length === 0
-        ? 'stable'
-        : normalizedClimateState.activeCatastropheIds.length > 0 || normalizedClimateState.droughtIndex >= 60
-          ? 'critical'
-          : 'watched',
+      riskLevel,
     },
   };
 }

--- a/test/ui/climate/buildCatastropheMapOverlay.test.js
+++ b/test/ui/climate/buildCatastropheMapOverlay.test.js
@@ -122,3 +122,38 @@ test('buildCatastropheMapOverlay rejects invalid inputs', () => {
   assert.throws(() => buildCatastropheMapOverlay([], null), /options must be an object/);
   assert.throws(() => buildCatastropheMapOverlay([], { styleBySeverity: [] }), /styleBySeverity must be an object/);
 });
+
+test('buildCatastropheMapOverlay can expose tactical dark HUD styling for warning cards', () => {
+  const [overlay] = buildCatastropheMapOverlay([
+    {
+      id: 'drought-2',
+      type: 'drought',
+      severity: 'critical',
+      status: 'warning',
+      regionIds: ['ashlands'],
+      startedAt: '2026-04-19T00:00:00.000Z',
+      impact: { harvest: -40 },
+    },
+  ], { tacticalHud: true });
+
+  assert.deepEqual(overlay.hudStyle, {
+    visualMode: 'tactical-dark',
+    panelClassName: 'climate-disaster-card climate-disaster-card--critical',
+    surface: {
+      background: 'rgba(3, 10, 22, 0.74)',
+      border: '1px solid crimson',
+      backdropFilter: 'blur(18px) saturate(1.18)',
+      gridOverlay: 'coordinate-grid',
+    },
+    alertTone: 'critical-red',
+    glyph: {
+      icon: '⚠',
+      frame: 'thin-warning-ring',
+      color: 'crimson',
+    },
+    typography: {
+      family: 'technical-sans',
+      labelTransform: 'uppercase-tracked',
+    },
+  });
+});

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -521,3 +521,54 @@ test('buildClimateMapOverlay rejects invalid inputs', () => {
   assert.throws(() => buildClimateMapOverlay([], { seasonStyleByType: [] }), /seasonStyleByType must be an object/);
   assert.throws(() => buildClimateMapOverlay([], { anomalyStyleByType: [] }), /anomalyStyleByType must be an object/);
 });
+
+test('buildClimateMapOverlay can expose Pax Historia tactical dark styling tokens', () => {
+  const overlay = buildClimateMapOverlay([
+    {
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 33,
+      precipitationLevel: 11,
+      droughtIndex: 74,
+      anomaly: 'heatwave',
+    },
+  ], {
+    tacticalHud: true,
+    catastrophes: [
+      {
+        id: 'wildfire-1',
+        type: 'wildfire',
+        severity: 'major',
+        status: 'active',
+        regionIds: ['sunreach'],
+        startedAt: '2026-04-19T00:00:00.000Z',
+        impact: { harvest: -20 },
+      },
+    ],
+  });
+
+  assert.deepEqual(overlay.tacticalTheme, {
+    visualMode: 'tactical-dark',
+    className: 'climate-hud climate-hud--pax-dark',
+    palette: {
+      background: '#020817',
+      glass: 'rgba(3, 10, 22, 0.72)',
+      border: 'rgba(125, 211, 252, 0.24)',
+      accent: '#f59e0b',
+      danger: '#fb7185',
+      text: '#e2e8f0',
+    },
+    layers: {
+      regionFill: 'low-opacity-season-wash',
+      anomalyGlyphs: 'minimal-cyan-amber-markers',
+      catastropheRings: 'thin-glowing-alert-rings',
+      coordinateGrid: true,
+    },
+    panel: {
+      surface: 'frosted-glass',
+      density: 'compact',
+      typography: 'technical-sans',
+    },
+  });
+  assert.equal(overlay.entries.find((entry) => entry.kind === 'catastrophe').hudStyle.visualMode, 'tactical-dark');
+});

--- a/test/ui/climate/buildClimateStatusPanel.test.js
+++ b/test/ui/climate/buildClimateStatusPanel.test.js
@@ -188,3 +188,29 @@ test('buildClimateStatusPanel rejects invalid payloads', () => {
     /ClimateStatusPanel turnProgression must be an object/,
   );
 });
+
+test('buildClimateStatusPanel can expose frosted tactical HUD panel styling', () => {
+  const panel = buildClimateStatusPanel({
+    regionId: 'sunreach',
+    season: 'summer',
+    temperatureC: 33,
+    precipitationLevel: 11,
+    droughtIndex: 74,
+    anomaly: 'heatwave',
+    activeCatastropheIds: ['wildfire'],
+  }, { tacticalHud: true });
+
+  assert.deepEqual(panel.panelStyle, {
+    visualMode: 'tactical-dark',
+    className: 'climate-status-panel climate-status-panel--critical',
+    surface: {
+      background: 'rgba(3, 10, 22, 0.72)',
+      border: 'rgba(251, 191, 36, 0.42)',
+      backdropFilter: 'blur(18px) saturate(1.18)',
+      coordinateGrid: true,
+    },
+    accent: 'amber-danger',
+    readoutMode: 'compact-hud',
+    glyphRail: 'alert-stack',
+  });
+});


### PR DESCRIPTION
Epsilon: Implements #372.

## Summary
- Add optional tactical dark HUD styling tokens to climate map overlays, catastrophe warning cards, and regional climate status panels.
- Keep existing overlay payloads backward-compatible unless `tacticalHud` is enabled.
- Cover the Pax Historia dark tactical visual contract with focused UI tests.

## Tests
- node --test test/ui/climate/buildCatastropheMapOverlay.test.js test/ui/climate/buildClimateStatusPanel.test.js test/ui/climate/buildClimateMapOverlay.test.js
- npm test

Zeta, this PR is ready for validation before any merge.