### PR TITLE
Gamma: Extract generated map culture data

### DIFF
--- a/src/application/culture/buildGeneratedMapCultureData.js
+++ b/src/application/culture/buildGeneratedMapCultureData.js
@@ -1,0 +1,179 @@
+import { buildCultureLayerPanel } from '../../ui/culture/buildCultureLayerPanel.js';
+import { buildCultureMapOverlay } from '../../ui/culture/buildCultureMapOverlay.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizeCollection(value, fallback, label) {
+  if (value === undefined) {
+    return [...fallback];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+function normalizeTextArray(values, label) {
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return [...new Set(values.map((value) => requireText(value, label)))].sort();
+}
+
+function normalizeCulturePayload(culturePayload = {}) {
+  const payload = requireObject(culturePayload, 'GeneratedMapCultureData culturePayload');
+
+  return {
+    cultures: normalizeCollection(payload.cultures, [], 'GeneratedMapCultureData culturePayload.cultures'),
+    researchStates: normalizeCollection(payload.researchStates, [], 'GeneratedMapCultureData culturePayload.researchStates'),
+    historicalEvents: normalizeCollection(payload.historicalEvents, [], 'GeneratedMapCultureData culturePayload.historicalEvents'),
+  };
+}
+
+function inferCultureRegionIds(culture) {
+  return culture.regionIds ?? culture.provinceIds ?? (culture.homeRegionId ? [culture.homeRegionId] : []);
+}
+
+export function buildRegionIdsByCulture(cultures, explicitRegionIdsByCulture = {}) {
+  if (!Array.isArray(cultures)) {
+    throw new TypeError('GeneratedMapCultureData cultures must be an array.');
+  }
+
+  const regionIdsByCulture = {};
+  const rawRegionIdsByCulture = requireObject(
+    explicitRegionIdsByCulture ?? {},
+    'GeneratedMapCultureData regionIdsByCulture',
+  );
+
+  for (const [cultureId, regionIds] of Object.entries(rawRegionIdsByCulture)) {
+    regionIdsByCulture[requireText(cultureId, 'GeneratedMapCultureData regionIdsByCulture cultureId')] = normalizeTextArray(
+      regionIds,
+      `GeneratedMapCultureData regionIdsByCulture.${cultureId}`,
+    );
+  }
+
+  for (const culture of cultures) {
+    const normalizedCulture = requireObject(culture, 'GeneratedMapCultureData culture');
+    const cultureId = requireText(normalizedCulture.id, 'GeneratedMapCultureData culture id');
+
+    if (regionIdsByCulture[cultureId]) {
+      continue;
+    }
+
+    regionIdsByCulture[cultureId] = normalizeTextArray(
+      inferCultureRegionIds(normalizedCulture),
+      `GeneratedMapCultureData ${cultureId} regionIds`,
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(regionIdsByCulture)
+      .filter(([, regionIds]) => regionIds.length > 0)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function groupByCultureId(items, label) {
+  return items.reduce((groups, item) => {
+    const normalizedItem = requireObject(item, `GeneratedMapCultureData ${label} item`);
+    const affectedCultureIds = normalizedItem.affectedCultureIds;
+
+    if (affectedCultureIds !== undefined) {
+      for (const cultureId of normalizeTextArray(affectedCultureIds, `GeneratedMapCultureData ${label}.affectedCultureIds`)) {
+        groups[cultureId] = [...(groups[cultureId] ?? []), normalizedItem];
+      }
+
+      return groups;
+    }
+
+    if (normalizedItem.cultureId !== undefined) {
+      const cultureId = requireText(normalizedItem.cultureId, `GeneratedMapCultureData ${label}.cultureId`);
+      groups[cultureId] = [...(groups[cultureId] ?? []), normalizedItem];
+    }
+
+    return groups;
+  }, {});
+}
+
+export function buildCultureMapSeeds(cultures, regionIdsByCulture, researchStatesByCulture, historicalEventsByCulture) {
+  return cultures
+    .map((culture) => {
+      const cultureId = requireText(culture.id, 'GeneratedMapCultureData culture id');
+      const cultureResearchStates = researchStatesByCulture[cultureId] ?? [];
+      const cultureHistoricalEvents = historicalEventsByCulture[cultureId] ?? [];
+
+      return {
+        cultureId,
+        cultureName: String(culture.name ?? cultureId).trim() || cultureId,
+        regionIds: regionIdsByCulture[cultureId] ?? [],
+        discoveryIds: [...new Set([
+          ...cultureResearchStates.flatMap((researchState) => researchState.discoveredConceptIds ?? []),
+          ...cultureHistoricalEvents.flatMap((historicalEvent) => historicalEvent.discoveryIds ?? []),
+        ].map((discoveryId) => requireText(discoveryId, `GeneratedMapCultureData ${cultureId} discoveryId`)))].sort(),
+        researchStateIds: cultureResearchStates.map((researchState) => requireText(
+          researchState.id,
+          `GeneratedMapCultureData ${cultureId} researchState id`,
+        )).sort(),
+        historicalEventIds: cultureHistoricalEvents.map((historicalEvent) => requireText(
+          historicalEvent.id,
+          `GeneratedMapCultureData ${cultureId} historicalEvent id`,
+        )).sort(),
+      };
+    })
+    .filter((seed) => seed.regionIds.length > 0)
+    .sort((left, right) => left.cultureId.localeCompare(right.cultureId));
+}
+
+export function buildGeneratedMapCultureData(culturePayload = {}, options = {}) {
+  const normalizedOptions = requireObject(options, 'GeneratedMapCultureData options');
+  const normalizedCulturePayload = normalizeCulturePayload(culturePayload);
+  const regionIdsByCulture = buildRegionIdsByCulture(
+    normalizedCulturePayload.cultures,
+    normalizedOptions.regionIdsByCulture,
+  );
+  const overlay = buildCultureMapOverlay(normalizedCulturePayload, {
+    ...(normalizedOptions.cultureOverlay ?? {}),
+    regionIdsByCulture,
+  });
+  const researchStatesByCulture = groupByCultureId(normalizedCulturePayload.researchStates, 'researchStates');
+  const historicalEventsByCulture = groupByCultureId(normalizedCulturePayload.historicalEvents, 'historicalEvents');
+  const panel = buildCultureLayerPanel(overlay, {
+    ...(normalizedOptions.cultureLayerPanel ?? {}),
+    selectedRegionId: normalizedOptions.selectedRegionId,
+    selectedCultureId: normalizedOptions.selectedCultureId,
+    activeFilter: normalizedOptions.activeFilter,
+    researchStatesByCulture,
+    historicalEventsByCulture,
+  });
+
+  return {
+    regionIdsByCulture,
+    overlay,
+    panel,
+    seeds: buildCultureMapSeeds(
+      normalizedCulturePayload.cultures,
+      regionIdsByCulture,
+      researchStatesByCulture,
+      historicalEventsByCulture,
+    ),
+  };
+}

--- a/src/application/war/GenerateStrategicMap.js
+++ b/src/application/war/GenerateStrategicMap.js
@@ -1,6 +1,5 @@
+import { buildGeneratedMapCultureData } from '../culture/buildGeneratedMapCultureData.js';
 import { Province } from '../../domain/war/Province.js';
-import { buildCultureLayerPanel } from '../../ui/culture/buildCultureLayerPanel.js';
-import { buildCultureMapOverlay } from '../../ui/culture/buildCultureMapOverlay.js';
 
 const DEFAULT_SEED = 'historia-alpha-strategic-map-v1';
 const DEFAULT_WIDTH = 100;
@@ -137,140 +136,6 @@ function normalizeCollection(value, fallback, label) {
 }
 
 
-function normalizeTextArray(values, label) {
-  if (!Array.isArray(values)) {
-    throw new TypeError(`${label} must be an array.`);
-  }
-
-  return [...new Set(values.map((value) => requireText(value, label)))].sort();
-}
-
-function normalizeCulturePayload(culturePayload = {}) {
-  const payload = requireOptions(culturePayload);
-
-  return {
-    cultures: normalizeCollection(payload.cultures, [], 'GenerateStrategicMap culturePayload.cultures'),
-    researchStates: normalizeCollection(payload.researchStates, [], 'GenerateStrategicMap culturePayload.researchStates'),
-    historicalEvents: normalizeCollection(payload.historicalEvents, [], 'GenerateStrategicMap culturePayload.historicalEvents'),
-  };
-}
-
-function normalizeRegionIdsByCulture(cultures, explicitRegionIdsByCulture) {
-  const regionIdsByCulture = {};
-  const rawRegionIdsByCulture = requireOptions(explicitRegionIdsByCulture ?? {});
-
-  for (const [cultureId, regionIds] of Object.entries(rawRegionIdsByCulture)) {
-    regionIdsByCulture[requireText(cultureId, 'GenerateStrategicMap regionIdsByCulture cultureId')] = normalizeTextArray(
-      regionIds,
-      `GenerateStrategicMap regionIdsByCulture.${cultureId}`,
-    );
-  }
-
-  for (const culture of cultures) {
-    const cultureId = requireText(culture.id, 'GenerateStrategicMap culture id');
-
-    if (regionIdsByCulture[cultureId]) {
-      continue;
-    }
-
-    const inferredRegionIds = culture.regionIds ?? culture.provinceIds ?? (culture.homeRegionId ? [culture.homeRegionId] : []);
-    regionIdsByCulture[cultureId] = normalizeTextArray(
-      inferredRegionIds,
-      `GenerateStrategicMap ${cultureId} regionIds`,
-    );
-  }
-
-  return Object.fromEntries(
-    Object.entries(regionIdsByCulture)
-      .filter(([, regionIds]) => regionIds.length > 0)
-      .sort(([left], [right]) => left.localeCompare(right)),
-  );
-}
-
-function groupByCultureId(items, label) {
-  return items.reduce((groups, item) => {
-    const normalizedItem = requireOptions(item);
-    const affectedCultureIds = normalizedItem.affectedCultureIds;
-
-    if (affectedCultureIds !== undefined) {
-      for (const cultureId of normalizeTextArray(affectedCultureIds, `GenerateStrategicMap ${label}.affectedCultureIds`)) {
-        groups[cultureId] = [...(groups[cultureId] ?? []), normalizedItem];
-      }
-
-      return groups;
-    }
-
-    if (normalizedItem.cultureId !== undefined) {
-      const cultureId = requireText(normalizedItem.cultureId, `GenerateStrategicMap ${label}.cultureId`);
-      groups[cultureId] = [...(groups[cultureId] ?? []), normalizedItem];
-    }
-
-    return groups;
-  }, {});
-}
-
-function buildCultureSeeds(cultures, regionIdsByCulture, researchStatesByCulture, historicalEventsByCulture) {
-  return cultures
-    .map((culture) => {
-      const cultureId = requireText(culture.id, 'GenerateStrategicMap culture id');
-      const cultureResearchStates = researchStatesByCulture[cultureId] ?? [];
-      const cultureHistoricalEvents = historicalEventsByCulture[cultureId] ?? [];
-
-      return {
-        cultureId,
-        cultureName: String(culture.name ?? cultureId).trim() || cultureId,
-        regionIds: regionIdsByCulture[cultureId] ?? [],
-        discoveryIds: [...new Set([
-          ...cultureResearchStates.flatMap((researchState) => researchState.discoveredConceptIds ?? []),
-          ...cultureHistoricalEvents.flatMap((historicalEvent) => historicalEvent.discoveryIds ?? []),
-        ].map((discoveryId) => requireText(discoveryId, `GenerateStrategicMap ${cultureId} discoveryId`)))].sort(),
-        researchStateIds: cultureResearchStates.map((researchState) => requireText(
-          researchState.id,
-          `GenerateStrategicMap ${cultureId} researchState id`,
-        )).sort(),
-        historicalEventIds: cultureHistoricalEvents.map((historicalEvent) => requireText(
-          historicalEvent.id,
-          `GenerateStrategicMap ${cultureId} historicalEvent id`,
-        )).sort(),
-      };
-    })
-    .filter((seed) => seed.regionIds.length > 0)
-    .sort((left, right) => left.cultureId.localeCompare(right.cultureId));
-}
-
-function buildCultureMapBusinessData(culturePayload, options) {
-  const normalizedCulturePayload = normalizeCulturePayload(culturePayload);
-  const regionIdsByCulture = normalizeRegionIdsByCulture(
-    normalizedCulturePayload.cultures,
-    options.regionIdsByCulture,
-  );
-  const overlay = buildCultureMapOverlay(normalizedCulturePayload, {
-    ...(options.cultureOverlay ?? {}),
-    regionIdsByCulture,
-  });
-  const researchStatesByCulture = groupByCultureId(normalizedCulturePayload.researchStates, 'researchStates');
-  const historicalEventsByCulture = groupByCultureId(normalizedCulturePayload.historicalEvents, 'historicalEvents');
-  const panel = buildCultureLayerPanel(overlay, {
-    ...(options.cultureLayerPanel ?? {}),
-    selectedRegionId: options.selectedRegionId,
-    selectedCultureId: options.selectedCultureId,
-    activeFilter: options.activeFilter,
-    researchStatesByCulture,
-    historicalEventsByCulture,
-  });
-
-  return {
-    regionIdsByCulture,
-    overlay,
-    panel,
-    seeds: buildCultureSeeds(
-      normalizedCulturePayload.cultures,
-      regionIdsByCulture,
-      researchStatesByCulture,
-      historicalEventsByCulture,
-    ),
-  };
-}
 
 function hashSeed(seed) {
   let hash = 2166136261;
@@ -502,7 +367,7 @@ export class GenerateStrategicMap {
       });
     }).sort((left, right) => left.id.localeCompare(right.id));
 
-    const culture = buildCultureMapBusinessData(normalizedOptions.culturePayload, normalizedOptions);
+    const culture = buildGeneratedMapCultureData(normalizedOptions.culturePayload, normalizedOptions);
 
     return {
       seed,

--- a/test/application/culture/buildGeneratedMapCultureData.test.js
+++ b/test/application/culture/buildGeneratedMapCultureData.test.js
@@ -1,0 +1,125 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildCultureMapSeeds,
+  buildGeneratedMapCultureData,
+  buildRegionIdsByCulture,
+} from '../../../src/application/culture/buildGeneratedMapCultureData.js';
+
+test('buildRegionIdsByCulture derives map regions from culture map hints', () => {
+  assert.deepEqual(buildRegionIdsByCulture([
+    { id: 'river-culture', regionIds: ['river-gate', 'crown-heart', 'river-gate'] },
+    { id: 'southern-culture', provinceIds: ['southern-reach'] },
+    { id: 'nomad-culture', homeRegionId: 'iron-plain' },
+  ]), {
+    'nomad-culture': ['iron-plain'],
+    'river-culture': ['crown-heart', 'river-gate'],
+    'southern-culture': ['southern-reach'],
+  });
+});
+
+test('buildGeneratedMapCultureData composes culture overlay, panel and seed metadata', () => {
+  const culturePayload = {
+    cultures: [
+      {
+        id: 'culture-aurora',
+        name: 'Aurora Compact',
+        archetype: 'mercantile',
+        primaryLanguage: 'trade-speech',
+        valueIds: ['craft'],
+        traditionIds: ['harbor-moot'],
+        openness: 72,
+        cohesion: 61,
+        researchDrive: 77,
+        regionIds: ['crown-heart', 'north-watch'],
+      },
+    ],
+    researchStates: [
+      {
+        id: 'research-star-ledgers',
+        cultureId: 'culture-aurora',
+        topicId: 'star-ledgers',
+        status: 'active',
+        progress: 65,
+        discoveredConceptIds: ['tidal-ledgers'],
+      },
+    ],
+    historicalEvents: [
+      {
+        id: 'event-harbor-archives',
+        title: 'Harbor Archives',
+        category: 'knowledge',
+        summary: 'Dock scribes standardize voyage records.',
+        era: 'early-sails',
+        importance: 3,
+        triggeredAt: '2026-04-19T00:00:00.000Z',
+        affectedCultureIds: ['culture-aurora'],
+        discoveryIds: ['public-catalogue'],
+      },
+    ],
+  };
+
+  const cultureData = buildGeneratedMapCultureData(culturePayload, { selectedRegionId: 'crown-heart' });
+
+  assert.deepEqual(cultureData.regionIdsByCulture, {
+    'culture-aurora': ['crown-heart', 'north-watch'],
+  });
+  assert.deepEqual(cultureData.seeds, [
+    {
+      cultureId: 'culture-aurora',
+      cultureName: 'Aurora Compact',
+      regionIds: ['crown-heart', 'north-watch'],
+      discoveryIds: ['public-catalogue', 'tidal-ledgers'],
+      researchStateIds: ['research-star-ledgers'],
+      historicalEventIds: ['event-harbor-archives'],
+    },
+  ]);
+  assert.deepEqual(cultureData.overlay.map((entry) => entry.regionId), ['crown-heart', 'north-watch']);
+  assert.deepEqual(cultureData.overlay[0].discoveries, ['public-catalogue', 'tidal-ledgers']);
+  assert.equal(cultureData.panel.focus.cultureId, 'culture-aurora');
+  assert.equal(cultureData.panel.focus.discoveriesPanel.summary, '2 concepts, 1 recherches, 1 événements');
+});
+
+test('buildCultureMapSeeds keeps only cultures attached to generated regions', () => {
+  const seeds = buildCultureMapSeeds(
+    [
+      { id: 'attached', name: 'Attached Culture' },
+      { id: 'floating', name: 'Floating Culture' },
+    ],
+    { attached: ['north-watch'] },
+    {
+      attached: [
+        { id: 'research-attached', discoveredConceptIds: ['surveying'] },
+      ],
+    },
+    {
+      attached: [
+        { id: 'event-attached', discoveryIds: ['marker-language'] },
+      ],
+    },
+  );
+
+  assert.deepEqual(seeds, [
+    {
+      cultureId: 'attached',
+      cultureName: 'Attached Culture',
+      regionIds: ['north-watch'],
+      discoveryIds: ['marker-language', 'surveying'],
+      researchStateIds: ['research-attached'],
+      historicalEventIds: ['event-attached'],
+    },
+  ]);
+});
+
+test('buildGeneratedMapCultureData validates map culture inputs', () => {
+  assert.throws(() => buildRegionIdsByCulture(null), /cultures must be an array/);
+  assert.throws(
+    () => buildGeneratedMapCultureData({ cultures: null }),
+    /culturePayload.cultures must be an array/,
+  );
+  assert.throws(
+    () => buildGeneratedMapCultureData({}, { regionIdsByCulture: [] }),
+    /regionIdsByCulture must be an object/,
+  );
+});


### PR DESCRIPTION
Gamma: ## Summary
- rebuilt the PR branch cleanly from the current `main` after Zeta's workflow feedback
- kept a single Gamma-scoped commit: `Gamma: extract generated map culture data`
- extracted generated-map culture composition into `src/application/culture/buildGeneratedMapCultureData.js`
- kept `GenerateStrategicMap` focused on strategic province generation while preserving the public generated-map culture contract: `overlays.culture`, `panels.culture`, and `businessData.cultureSeeds`

## Tests
- `npm test` — 353/353 passing
- `node --check web/app.js`
- `git diff --check origin/main...HEAD`

## Audit notes / out of Gamma scope
- `web/app.js` still concentrates demo fixtures, map state, rendering, economy, intrigue, and culture payloads; splitting it spans multiple agents.
- Generated-map consumers remain inconsistent across domains (`provinces`, `regions`, nested `map.provinces`); this should be coordinated with Alpha/Beta/Delta rather than owned only by Gamma.
- Supply vocabulary differs between war and intrigue/economy consumers; this needs cross-agent enum/mapping alignment.

## Validation
- Ready for Zeta validation before merge.