### PR TITLE
Alpha: Build startup launcher menu before game entry

### DIFF
--- a/src/ui/launcher/buildLauncherMapSelection.js
+++ b/src/ui/launcher/buildLauncherMapSelection.js
@@ -1,0 +1,72 @@
+function requireMapOptions(mapOptions) {
+  if (!Array.isArray(mapOptions)) {
+    throw new TypeError('Launcher map options must be an array.');
+  }
+
+  return mapOptions;
+}
+
+function normalizeText(value, fallback) {
+  const normalized = String(value ?? '').trim();
+
+  return normalized || fallback;
+}
+
+function normalizeStats(stats) {
+  if (stats === undefined) {
+    return {};
+  }
+
+  if (stats === null || typeof stats !== 'object' || Array.isArray(stats)) {
+    throw new TypeError('Launcher map stats must be an object.');
+  }
+
+  return Object.fromEntries(
+    Object.entries(stats)
+      .map(([key, value]) => [String(key).trim(), Number(value)])
+      .filter(([key, value]) => key && Number.isFinite(value)),
+  );
+}
+
+function normalizeMapOption(option, index) {
+  if (option === null || typeof option !== 'object' || Array.isArray(option)) {
+    throw new TypeError('Launcher map options must contain objects.');
+  }
+
+  const id = normalizeText(option.id, `map-${index + 1}`);
+  const playable = option.playable !== false;
+
+  return {
+    id,
+    title: normalizeText(option.title, id),
+    subtitle: normalizeText(option.subtitle, 'Carte jouable'),
+    description: normalizeText(option.description, 'Prototype prêt à lancer.'),
+    tag: normalizeText(option.tag, playable ? 'Jouable' : 'Bientôt'),
+    status: normalizeText(option.status, playable ? 'ready' : 'locked'),
+    recommended: Boolean(option.recommended),
+    playable,
+    previewTone: normalizeText(option.previewTone, 'cyan'),
+    stats: normalizeStats(option.stats),
+  };
+}
+
+export function buildLauncherMapSelection(mapOptions, selectedMapId) {
+  const maps = requireMapOptions(mapOptions).map(normalizeMapOption);
+  const playableMaps = maps.filter((map) => map.playable);
+  const selectedMap = maps.find((map) => map.id === selectedMapId && map.playable)
+    ?? playableMaps.find((map) => map.recommended)
+    ?? playableMaps[0]
+    ?? null;
+
+  return {
+    maps: maps.map((map) => ({
+      ...map,
+      selected: selectedMap?.id === map.id,
+    })),
+    selectedMap,
+    canLaunch: Boolean(selectedMap),
+    headline: selectedMap
+      ? `Carte sélectionnée: ${selectedMap.title}`
+      : 'Aucune carte jouable disponible',
+  };
+}

--- a/test/ui/launcher/buildLauncherMapSelection.test.js
+++ b/test/ui/launcher/buildLauncherMapSelection.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildLauncherMapSelection } from '../../../src/ui/launcher/buildLauncherMapSelection.js';
+
+test('buildLauncherMapSelection selects the requested playable map', () => {
+  const selection = buildLauncherMapSelection([
+    {
+      id: 'continental-prototype',
+      title: 'Pax Historia prototype',
+      subtitle: 'Théâtre continental',
+      stats: { provinces: 6, routes: 3 },
+      recommended: true,
+    },
+    {
+      id: 'river-crisis',
+      title: 'Crise de la Porte du Fleuve',
+      playable: true,
+      stats: { provinces: '6', disabled: Number.NaN },
+    },
+  ], 'river-crisis');
+
+  assert.equal(selection.canLaunch, true);
+  assert.equal(selection.selectedMap.id, 'river-crisis');
+  assert.equal(selection.headline, 'Carte sélectionnée: Crise de la Porte du Fleuve');
+  assert.deepEqual(selection.maps.map((map) => [map.id, map.selected]), [
+    ['continental-prototype', false],
+    ['river-crisis', true],
+  ]);
+  assert.deepEqual(selection.selectedMap.stats, { provinces: 6 });
+});
+
+test('buildLauncherMapSelection falls back to the recommended playable map', () => {
+  const selection = buildLauncherMapSelection([
+    { id: 'future-map', title: 'Carte future', playable: false },
+    { id: 'prototype', title: 'Prototype', recommended: true },
+  ], 'future-map');
+
+  assert.equal(selection.selectedMap.id, 'prototype');
+  assert.equal(selection.maps[0].selected, false);
+  assert.equal(selection.maps[1].selected, true);
+});
+
+test('buildLauncherMapSelection reports no launch when no playable map exists', () => {
+  const selection = buildLauncherMapSelection([
+    { id: 'locked', title: 'Verrouillée', playable: false },
+  ], 'locked');
+
+  assert.equal(selection.canLaunch, false);
+  assert.equal(selection.selectedMap, null);
+  assert.equal(selection.headline, 'Aucune carte jouable disponible');
+});
+
+test('buildLauncherMapSelection validates inputs', () => {
+  assert.throws(() => buildLauncherMapSelection(null), /must be an array/);
+  assert.throws(() => buildLauncherMapSelection([null]), /must contain objects/);
+  assert.throws(() => buildLauncherMapSelection([{ stats: [] }]), /stats must be an object/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3,6 +3,7 @@ import { GenerateStrategicMap } from '../src/application/war/GenerateStrategicMa
 import { City } from '../src/domain/economy/City.js';
 import { TradeRoute } from '../src/domain/economy/TradeRoute.js';
 import { buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
+import { buildLauncherMapSelection } from '../src/ui/launcher/buildLauncherMapSelection.js';
 import { buildEconomyMapOverlay } from '../src/ui/economy/buildEconomyMapOverlay.js';
 import { buildCityStockPanel } from '../src/ui/economy/buildCityStockPanel.js';
 import { buildCityComparisonPanel } from '../src/ui/economy/buildCityComparisonPanel.js';
@@ -341,7 +342,86 @@ const routeHudByMode = {
 
 const defaultRouteHud = { glyph: '—', label: 'Route logistique', tone: 'slate' };
 
+const mapScenarios = [
+  {
+    id: 'continental-prototype',
+    title: 'Pax Historia — théâtre continental',
+    subtitle: 'Carte prototype jouable',
+    description: 'Le prototype complet avec provinces visibles, fronts, villes, routes et overlays prêts pour test rapide.',
+    tag: 'Recommandée',
+    status: 'ready',
+    previewTone: 'cyan',
+    recommended: true,
+    stats: {
+      Provinces: provinces.length,
+      Villes: cities.length,
+      Routes: routes.length,
+      Fronts: provinces.filter((province) => province.contested).length,
+    },
+    gameTitle: 'Écran stratégique, théâtre continental',
+    gameSubtitle: 'Prototype local Alpha prêt à accueillir les overlays inter-domaines',
+    initialState: {
+      focusedProvinceId: 'crown-heart',
+      selectedProvinceId: 'river-gate',
+      activeOverlaySlot: 'culture-overlay',
+      popupProvinceId: 'river-gate',
+      hoveredCityId: 'river-gate-city',
+      selectedCityId: 'river-gate-city',
+      comparedCityIds: ['river-gate-city', 'crown-port'],
+      comparisonProvinceIds: ['river-gate', 'crown-heart'],
+      selectedIntrigueOperationId: 'op-river-locks',
+      lastTurnSummary: 'Le théâtre continental est chargé: carte visible, overlays prêts, crise du fleuve sélectionnée.',
+    },
+  },
+  {
+    id: 'river-crisis',
+    title: 'Crise de la Porte du Fleuve',
+    subtitle: 'Scénario court de validation UI',
+    description: 'Démarre directement sur la province contestée, avec économie et intrigue autour des convois du fleuve.',
+    tag: 'Test rapide',
+    status: 'ready',
+    previewTone: 'amber',
+    playable: true,
+    stats: {
+      Provinces: provinces.length,
+      Villes: 2,
+      Routes: 2,
+      Alertes: intrigueOperations.length,
+    },
+    gameTitle: 'Crise de la Porte du Fleuve',
+    gameSubtitle: 'Carte prototype centrée sur le verrou fluvial et ses opérations clandestines',
+    initialState: {
+      focusedProvinceId: 'river-gate',
+      selectedProvinceId: 'river-gate',
+      activeOverlaySlot: 'intrigue-overlay',
+      popupProvinceId: 'river-gate',
+      hoveredCityId: 'river-gate-city',
+      selectedCityId: 'river-gate-city',
+      comparedCityIds: ['river-gate-city', 'iron-plain-city'],
+      comparisonProvinceIds: ['river-gate', 'iron-plain'],
+      selectedIntrigueOperationId: 'op-river-locks',
+      lastTurnSummary: 'La Porte du Fleuve est sélectionnée pour vérifier immédiatement carte, panels et signaux d’alerte.',
+    },
+  },
+  {
+    id: 'archipelago-coming-soon',
+    title: 'Archipels marchands',
+    subtitle: 'Carte future',
+    description: 'Emplacement réservé pour une carte maritime; visible dans le launcher mais non lançable.',
+    tag: 'Bientôt',
+    status: 'locked',
+    previewTone: 'slate',
+    playable: false,
+    stats: {
+      Îles: 0,
+      Routes: 0,
+    },
+  },
+];
+
 const state = {
+  screen: 'launcher',
+  selectedMapId: 'continental-prototype',
   turn: 1,
   seasonIndex: 0,
   focusedProvinceId: 'crown-heart',
@@ -365,6 +445,35 @@ const state = {
     sabotage: true,
   },
 };
+
+function getSelectedMapScenario() {
+  return mapScenarios.find((scenario) => scenario.id === state.selectedMapId && scenario.playable !== false)
+    ?? mapScenarios.find((scenario) => scenario.recommended && scenario.playable !== false)
+    ?? mapScenarios.find((scenario) => scenario.playable !== false)
+    ?? null;
+}
+
+function applyMapScenario(scenario) {
+  if (!scenario) {
+    return;
+  }
+
+  state.screen = 'game';
+  state.selectedMapId = scenario.id;
+  state.turn = 1;
+  state.seasonIndex = 0;
+  state.mapZoom = 1;
+  state.mapPanX = 0;
+  state.mapPanY = 0;
+  state.mobilePanelSection = 'details';
+  state.mobileMapExpanded = true;
+  state.intrigueFilters = {
+    presence: true,
+    alerts: true,
+    sabotage: true,
+  };
+  Object.assign(state, scenario.initialState ?? {});
+}
 
 const seasonLabels = ['Printemps', 'Été', 'Automne', 'Hiver'];
 
@@ -462,9 +571,11 @@ function getProvinceStateByTurn(province) {
 }
 
 function getShell() {
+  const scenario = getSelectedMapScenario();
+
   return buildStrategicMapShell(provinces.map(getProvinceStateByTurn), {
-    title: 'Écran stratégique, théâtre continental',
-    subtitle: 'Prototype local Alpha prêt à accueillir les overlays inter-domaines',
+    title: scenario?.gameTitle ?? 'Écran stratégique, théâtre continental',
+    subtitle: scenario?.gameSubtitle ?? 'Prototype local Alpha prêt à accueillir les overlays inter-domaines',
     paletteByFaction,
     factionMetaById,
     selectedProvinceId: state.selectedProvinceId,
@@ -2356,7 +2467,152 @@ function renderMobileToolbar() {
   `;
 }
 
+function renderLauncherMapStats(stats) {
+  return Object.entries(stats).map(([label, value]) => `
+    <span class="launcher-map-card__stat"><strong>${value}</strong>${label}</span>
+  `).join('');
+}
+
+function renderLauncher() {
+  return `
+    <main class="launcher-root">
+      <section class="launcher-hero panel launcher-hero--startup">
+        <div class="launcher-hero__copy">
+          <p class="eyebrow">Historia launcher</p>
+          <h1>Bienvenue dans Historia</h1>
+          <p>Un démarrage clair avant le jeu: choisissez une carte prototype, puis entrez dans une carte visible sans écran vide.</p>
+          <div class="launcher-actions">
+            <button type="button" class="turn-button launcher-primary" data-open-map-select="true">Choisir une carte</button>
+          </div>
+        </div>
+        <div class="launcher-hero__screen" aria-label="Aperçu du menu de démarrage">
+          <div class="launcher-screen-frame launcher-screen-frame--cyan">
+            <div class="launcher-screen-map">
+              <span class="launcher-screen-map__province launcher-screen-map__province--a"></span>
+              <span class="launcher-screen-map__province launcher-screen-map__province--b"></span>
+              <span class="launcher-screen-map__province launcher-screen-map__province--c"></span>
+              <span class="launcher-screen-map__route launcher-screen-map__route--a"></span>
+              <span class="launcher-screen-map__route launcher-screen-map__route--b"></span>
+            </div>
+            <strong>Launcher → sélection → carte</strong>
+            <small>Flux court et testable pour vérifier immédiatement que la carte apparaît.</small>
+          </div>
+        </div>
+      </section>
+    </main>
+  `;
+}
+
+function renderMapSelection() {
+  const selection = buildLauncherMapSelection(mapScenarios, state.selectedMapId);
+  const selectedMap = selection.selectedMap;
+  const mapCards = selection.maps.map((map) => `
+    <button
+      type="button"
+      class="launcher-map-card launcher-map-card--${map.previewTone} ${map.selected ? 'is-selected' : ''} ${map.playable ? '' : 'is-locked'}"
+      data-map-option="${map.id}"
+      ${map.playable ? '' : 'disabled'}
+      aria-pressed="${map.selected ? 'true' : 'false'}"
+    >
+      <span class="launcher-map-card__tag">${map.tag}</span>
+      <span class="launcher-map-card__preview" aria-hidden="true">
+        <span></span><span></span><span></span><span></span>
+      </span>
+      <span class="launcher-map-card__title">${map.title}</span>
+      <span class="launcher-map-card__subtitle">${map.subtitle}</span>
+      <span class="launcher-map-card__description">${map.description}</span>
+      <span class="launcher-map-card__stats">${renderLauncherMapStats(map.stats)}</span>
+    </button>
+  `).join('');
+
+  return `
+    <main class="launcher-root">
+      <section class="launcher-hero panel">
+        <div class="launcher-hero__copy">
+          <p class="eyebrow">Historia launcher</p>
+          <h1>Choisissez une carte</h1>
+          <p>Une carte prototype est disponible maintenant; les autres emplacements restent visibles mais ne se superposent pas au jeu.</p>
+          <div class="launcher-actions">
+            <button type="button" class="turn-button turn-button--secondary" data-open-startup="true">Retour au menu</button>
+            <button type="button" class="turn-button launcher-primary" data-launch-selected="true" ${selection.canLaunch ? '' : 'disabled'}>
+              Lancer la carte sélectionnée
+            </button>
+            <span>${selection.headline}</span>
+          </div>
+        </div>
+        <div class="launcher-hero__screen" aria-label="Aperçu de la carte sélectionnée">
+          <div class="launcher-screen-frame launcher-screen-frame--${selectedMap?.previewTone ?? 'cyan'}">
+            <div class="launcher-screen-map">
+              <span class="launcher-screen-map__province launcher-screen-map__province--a"></span>
+              <span class="launcher-screen-map__province launcher-screen-map__province--b"></span>
+              <span class="launcher-screen-map__province launcher-screen-map__province--c"></span>
+              <span class="launcher-screen-map__route launcher-screen-map__route--a"></span>
+              <span class="launcher-screen-map__route launcher-screen-map__route--b"></span>
+            </div>
+            <strong>${selectedMap?.title ?? 'Aucune carte'}</strong>
+            <small>${selectedMap?.description ?? 'Ajoutez une carte jouable pour lancer Historia.'}</small>
+          </div>
+        </div>
+      </section>
+
+      <section class="launcher-map-select panel">
+        <div class="panel-header panel-header--spread">
+          <div>
+            <h2>Sélection de carte</h2>
+            <p>Le premier choix est prêt pour validation produit; les cartes futures restent visibles sans bloquer le test.</p>
+          </div>
+        </div>
+        <div class="launcher-map-grid">${mapCards}</div>
+      </section>
+    </main>
+  `;
+}
+
+function bindLauncherEvents() {
+  document.querySelectorAll('[data-open-map-select]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.screen = 'map-select';
+      render();
+    });
+  });
+}
+
+function bindMapSelectionEvents() {
+  document.querySelectorAll('[data-open-startup]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.screen = 'launcher';
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-map-option]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.selectedMapId = element.dataset.mapOption;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-launch-selected]').forEach((element) => {
+    element.addEventListener('click', () => {
+      applyMapScenario(getSelectedMapScenario());
+      render();
+    });
+  });
+}
+
 function render() {
+  if (state.screen === 'launcher') {
+    document.querySelector('#app').innerHTML = renderLauncher();
+    bindLauncherEvents();
+    return;
+  }
+
+  if (state.screen === 'map-select') {
+    document.querySelector('#app').innerHTML = renderMapSelection();
+    bindMapSelectionEvents();
+    return;
+  }
+
   const shell = getShell();
   const economyView = getEconomyViewModel();
   const focusContext = getFocusContext(shell);
@@ -2376,6 +2632,7 @@ function render() {
               <span>${seasonLabels[state.seasonIndex]}</span>
             </div>
             <button type="button" class="turn-button" data-next-turn="true">Tour suivant</button>
+            <button type="button" class="turn-button turn-button--secondary" data-open-launcher="true">Changer de carte</button>
           </div>
           <p class="turn-summary">${state.lastTurnSummary}</p>
           ${economyView.pulse ? `
@@ -2492,6 +2749,13 @@ function render() {
   document.querySelectorAll('[data-next-turn]').forEach((element) => {
     element.addEventListener('click', () => {
       advanceTurn();
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-open-launcher]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.screen = 'launcher';
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -2974,3 +2974,306 @@ button { font: inherit; }
   stroke-width: 0.54;
   filter: drop-shadow(0 0 14px rgba(103, 232, 249, 0.38));
 }
+
+.turn-button--secondary {
+  background: rgba(15, 23, 42, 0.58);
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+.launcher-root {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 28px 0 44px;
+}
+
+.launcher-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+  gap: 24px;
+  padding: 28px;
+  margin-bottom: 20px;
+  overflow: hidden;
+}
+
+.launcher-hero h1 {
+  max-width: 720px;
+  margin: 0;
+  font-size: clamp(34px, 5vw, 64px);
+  line-height: 0.96;
+  letter-spacing: -0.05em;
+}
+
+.launcher-hero__copy p:not(.eyebrow) {
+  max-width: 66ch;
+  color: var(--muted);
+  font-size: 17px;
+}
+
+.launcher-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.launcher-actions span {
+  color: #bae6fd;
+  font-size: 14px;
+}
+
+.launcher-primary:disabled,
+.launcher-map-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.launcher-hero__screen {
+  display: flex;
+  align-items: stretch;
+  min-height: 340px;
+}
+
+.launcher-screen-frame {
+  position: relative;
+  width: 100%;
+  min-height: 100%;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  overflow: hidden;
+  border-radius: 28px;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(103, 232, 249, 0.18), transparent 28%),
+    radial-gradient(circle at 80% 62%, rgba(251, 191, 36, 0.12), transparent 26%),
+    linear-gradient(145deg, rgba(2, 6, 23, 0.98), rgba(12, 74, 110, 0.4));
+  box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.05), 0 24px 70px rgba(2, 6, 23, 0.44);
+}
+
+.launcher-screen-frame--amber {
+  border-color: rgba(251, 191, 36, 0.34);
+}
+
+.launcher-screen-frame--slate {
+  border-color: rgba(148, 163, 184, 0.24);
+  filter: saturate(0.72);
+}
+
+.launcher-screen-frame strong,
+.launcher-screen-frame small {
+  position: relative;
+  z-index: 2;
+}
+
+.launcher-screen-frame strong {
+  font-size: 24px;
+}
+
+.launcher-screen-frame small {
+  max-width: 44ch;
+  margin-top: 6px;
+  color: var(--muted);
+}
+
+.launcher-screen-map {
+  position: absolute;
+  inset: 18px;
+  border-radius: 22px;
+  overflow: hidden;
+  background:
+    linear-gradient(rgba(125, 211, 252, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(125, 211, 252, 0.08) 1px, transparent 1px);
+  background-size: 42px 42px;
+}
+
+.launcher-screen-map::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 42%, rgba(2, 6, 23, 0.72));
+}
+
+.launcher-screen-map__province,
+.launcher-screen-map__route {
+  position: absolute;
+  display: block;
+}
+
+.launcher-screen-map__province {
+  border: 1px solid rgba(103, 232, 249, 0.58);
+  background: rgba(14, 165, 233, 0.16);
+  box-shadow: 0 0 24px rgba(34, 211, 238, 0.18);
+}
+
+.launcher-screen-map__province--a {
+  left: 13%;
+  top: 18%;
+  width: 34%;
+  height: 28%;
+  clip-path: polygon(12% 14%, 78% 0, 100% 42%, 70% 100%, 8% 78%, 0 34%);
+}
+
+.launcher-screen-map__province--b {
+  right: 12%;
+  top: 22%;
+  width: 35%;
+  height: 34%;
+  border-color: rgba(251, 191, 36, 0.66);
+  background: rgba(251, 191, 36, 0.12);
+  clip-path: polygon(22% 0, 88% 16%, 100% 68%, 48% 100%, 0 74%, 6% 22%);
+}
+
+.launcher-screen-map__province--c {
+  left: 28%;
+  bottom: 14%;
+  width: 43%;
+  height: 26%;
+  clip-path: polygon(7% 22%, 46% 0, 92% 12%, 100% 72%, 54% 100%, 0 78%);
+}
+
+.launcher-screen-map__route {
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(226, 232, 240, 0.68), transparent);
+  transform-origin: left center;
+}
+
+.launcher-screen-map__route--a {
+  left: 36%;
+  top: 44%;
+  width: 34%;
+  transform: rotate(12deg);
+}
+
+.launcher-screen-map__route--b {
+  left: 48%;
+  top: 58%;
+  width: 24%;
+  transform: rotate(68deg);
+}
+
+.launcher-map-select {
+  padding: 22px;
+}
+
+.launcher-map-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.launcher-map-card {
+  position: relative;
+  display: flex;
+  min-height: 320px;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  overflow: hidden;
+  text-align: left;
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 22px;
+  background: rgba(15, 23, 42, 0.58);
+  cursor: pointer;
+}
+
+.launcher-map-card.is-selected {
+  border-color: rgba(103, 232, 249, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(103, 232, 249, 0.22), 0 18px 44px rgba(8, 145, 178, 0.16);
+}
+
+.launcher-map-card--amber.is-selected {
+  border-color: rgba(251, 191, 36, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.2), 0 18px 44px rgba(180, 83, 9, 0.14);
+}
+
+.launcher-map-card__tag {
+  align-self: flex-start;
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: #bae6fd;
+  background: rgba(8, 47, 73, 0.58);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.launcher-map-card__preview {
+  position: relative;
+  height: 92px;
+  margin: 2px 0 4px;
+  border-radius: 16px;
+  overflow: hidden;
+  background:
+    linear-gradient(rgba(125, 211, 252, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(125, 211, 252, 0.08) 1px, transparent 1px),
+    rgba(2, 6, 23, 0.42);
+  background-size: 24px 24px;
+}
+
+.launcher-map-card__preview span {
+  position: absolute;
+  border: 1px solid rgba(103, 232, 249, 0.48);
+  background: rgba(34, 211, 238, 0.11);
+}
+
+.launcher-map-card--amber .launcher-map-card__preview span {
+  border-color: rgba(251, 191, 36, 0.52);
+  background: rgba(251, 191, 36, 0.1);
+}
+
+.launcher-map-card__preview span:nth-child(1) { left: 9%; top: 18%; width: 32%; height: 42%; clip-path: polygon(0 24%, 64% 0, 100% 42%, 76% 100%, 12% 78%); }
+.launcher-map-card__preview span:nth-child(2) { right: 10%; top: 20%; width: 34%; height: 48%; clip-path: polygon(12% 0, 100% 20%, 84% 100%, 0 78%); }
+.launcher-map-card__preview span:nth-child(3) { left: 28%; bottom: 10%; width: 42%; height: 34%; clip-path: polygon(10% 14%, 78% 0, 100% 72%, 48% 100%, 0 70%); }
+.launcher-map-card__preview span:nth-child(4) { left: 42%; top: 48%; width: 32%; height: 2px; border: 0; background: rgba(226, 232, 240, 0.56); transform: rotate(20deg); }
+
+.launcher-map-card__title {
+  font-size: 20px;
+  font-weight: 800;
+}
+
+.launcher-map-card__subtitle,
+.launcher-map-card__description {
+  color: var(--muted);
+}
+
+.launcher-map-card__description {
+  line-height: 1.45;
+}
+
+.launcher-map-card__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: auto;
+}
+
+.launcher-map-card__stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  padding: 7px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.36);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.launcher-map-card__stat strong {
+  color: var(--text);
+}
+
+@media (max-width: 900px) {
+  .launcher-hero,
+  .launcher-map-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .launcher-hero__screen {
+    min-height: 260px;
+  }
+}


### PR DESCRIPTION
Alpha: ## Summary
- add a startup launcher screen so Historia no longer opens directly into a confusing/empty-feeling game shell
- add a simple continuation path from the launcher to a map-choice screen, matching the #398 acceptance path
- keep one prototype map available as the minimal playable target needed to verify the launcher flow end-to-end
- wire launch into the existing visible strategic map and reset scenario focus/zoom so provinces and HUD elements are immediately readable
- add a tested launcher selection view model with safe fallback when no selected map is playable

## Product scope
- This PR is scoped as the Alpha implementation for #398: startup launcher first, then continuation toward map choice.
- The prototype map handoff is kept deliberately minimal because #398 requires the user to continue from the launcher toward map choice; #399 remains open for any follow-up expansion or dedicated validation of the first playable map selection experience.
- Avoids a blank screen by rendering a launcher immediately on app load.
- Avoids overlaid UI by separating startup, map selection, and game screens instead of stacking selection cards over the map.

## Tests
- `node --check web/app.js`
- `node --test test/ui/launcher/buildLauncherMapSelection.test.js`
- `npm test` (348 passing)
- `git diff --check`

Fixes #398

Zeta: prête pour validation avant tout merge.
