### PR TITLE
Alpha: Centralize strategic map geometry for playable map

### DIFF
--- a/src/application/war/GenerateStrategicMap.js
+++ b/src/application/war/GenerateStrategicMap.js
@@ -18,6 +18,7 @@ const DEFAULT_PROVINCE_BLUEPRINTS = Object.freeze([
     name: 'Veille du Nord',
     grid: { col: 0, row: 0 },
     layout: { x: 15, y: 18, w: 20, h: 18 },
+    labelLayout: { x: 26, y: 20, align: 'middle', tone: 'standard' },
     polygon: '8,24 24,12 39,10 47,18 46,36 34,42 18,40 8,32',
     ownerFactionId: 'aurora',
     controllingFactionId: 'aurora',
@@ -30,6 +31,7 @@ const DEFAULT_PROVINCE_BLUEPRINTS = Object.freeze([
     name: 'Coeur de Couronne',
     grid: { col: 1, row: 0 },
     layout: { x: 38, y: 18, w: 23, h: 20 },
+    labelLayout: { x: 49.5, y: 18.5, align: 'middle', tone: 'capital' },
     polygon: '24,18 40,12 58,14 64,24 58,40 40,46 26,38 22,28',
     ownerFactionId: 'aurora',
     controllingFactionId: 'aurora',
@@ -42,6 +44,7 @@ const DEFAULT_PROVINCE_BLUEPRINTS = Object.freeze([
     name: 'Crête Rouge',
     grid: { col: 2, row: 0 },
     layout: { x: 64, y: 16, w: 21, h: 22 },
+    labelLayout: { x: 75, y: 18.5, align: 'middle', tone: 'standard' },
     polygon: '58,16 73,10 88,18 90,34 80,44 64,42 54,32 52,22',
     ownerFactionId: 'ember',
     controllingFactionId: 'ember',
@@ -54,6 +57,7 @@ const DEFAULT_PROVINCE_BLUEPRINTS = Object.freeze([
     name: 'Porte du Fleuve',
     grid: { col: 0, row: 1 },
     layout: { x: 22, y: 46, w: 24, h: 20 },
+    labelLayout: { x: 21, y: 45, align: 'start', tone: 'frontier' },
     polygon: '38,38 54,34 66,40 68,54 56,66 40,64 32,52 34,42',
     ownerFactionId: 'aurora',
     controllingFactionId: 'ember',
@@ -67,6 +71,7 @@ const DEFAULT_PROVINCE_BLUEPRINTS = Object.freeze([
     name: 'Plaine de Fer',
     grid: { col: 1, row: 1 },
     layout: { x: 50, y: 46, w: 26, h: 22 },
+    labelLayout: { x: 80, y: 48, align: 'end', tone: 'standard' },
     polygon: '60,44 78,42 90,52 88,68 72,78 56,72 54,56',
     ownerFactionId: 'ember',
     controllingFactionId: 'ember',
@@ -79,6 +84,7 @@ const DEFAULT_PROVINCE_BLUEPRINTS = Object.freeze([
     name: 'Basses Marches',
     grid: { col: 0, row: 2 },
     layout: { x: 33, y: 72, w: 28, h: 18 },
+    labelLayout: { x: 47, y: 91, align: 'middle', tone: 'frontier' },
     polygon: '24,58 42,54 58,58 64,74 48,88 28,86 16,72',
     ownerFactionId: 'neutral',
     controllingFactionId: 'aurora',
@@ -368,6 +374,97 @@ function chooseFactionForBlueprint(blueprint, factions) {
   return faction.id;
 }
 
+
+function requireNumber(value, label) {
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`${label} must be a finite number.`);
+  }
+
+  return value;
+}
+
+function normalizeLayout(layout, blueprint) {
+  if (layout === undefined) {
+    const col = Number.isInteger(blueprint.grid?.col) ? blueprint.grid.col : 0;
+    const row = Number.isInteger(blueprint.grid?.row) ? blueprint.grid.row : 0;
+
+    return {
+      x: 10 + col * 28,
+      y: 12 + row * 24,
+      w: 22,
+      h: 18,
+    };
+  }
+
+  const normalizedLayout = requireOptions(layout);
+
+  return {
+    x: requireNumber(normalizedLayout.x, `GenerateStrategicMap ${blueprint.id} layout.x`),
+    y: requireNumber(normalizedLayout.y, `GenerateStrategicMap ${blueprint.id} layout.y`),
+    w: requireNumber(normalizedLayout.w, `GenerateStrategicMap ${blueprint.id} layout.w`),
+    h: requireNumber(normalizedLayout.h, `GenerateStrategicMap ${blueprint.id} layout.h`),
+  };
+}
+
+function buildRectanglePolygon(layout) {
+  return `${layout.x},${layout.y} ${layout.x + layout.w},${layout.y} ${layout.x + layout.w},${layout.y + layout.h} ${layout.x},${layout.y + layout.h}`;
+}
+
+function normalizePolygon(polygon, layout, blueprint) {
+  if (polygon === undefined) {
+    return buildRectanglePolygon(layout);
+  }
+
+  const normalizedPolygon = requireText(polygon, `GenerateStrategicMap ${blueprint.id} polygon`);
+  const points = normalizedPolygon.split(/\s+/);
+
+  if (points.some((point) => !/^[-]?\d+(?:\.\d+)?,[-]?\d+(?:\.\d+)?$/.test(point))) {
+    throw new RangeError(`GenerateStrategicMap ${blueprint.id} polygon must contain x,y point pairs.`);
+  }
+
+  return normalizedPolygon;
+}
+
+function polygonToCssClipPath(polygon) {
+  return `polygon(${polygon.split(' ').map((point) => point.split(',').join('% ')).join('%, ') }%)`;
+}
+
+function normalizeLabelLayout(labelLayout, layout, blueprint) {
+  if (labelLayout === undefined) {
+    return {
+      x: layout.x + (layout.w / 2),
+      y: layout.y + (layout.h / 2),
+      align: 'middle',
+      tone: 'standard',
+    };
+  }
+
+  const normalizedLabelLayout = requireOptions(labelLayout);
+
+  return {
+    x: requireNumber(normalizedLabelLayout.x, `GenerateStrategicMap ${blueprint.id} labelLayout.x`),
+    y: requireNumber(normalizedLabelLayout.y, `GenerateStrategicMap ${blueprint.id} labelLayout.y`),
+    align: String(normalizedLabelLayout.align ?? 'middle').trim() || 'middle',
+    tone: String(normalizedLabelLayout.tone ?? 'standard').trim() || 'standard',
+  };
+}
+
+function buildProvinceGeometry(blueprint) {
+  const layout = normalizeLayout(blueprint.layout, blueprint);
+  const polygon = normalizePolygon(blueprint.polygon, layout, blueprint);
+
+  return {
+    layout,
+    center: {
+      x: layout.x + (layout.w / 2),
+      y: layout.y + (layout.h / 2),
+    },
+    polygon,
+    shape: polygonToCssClipPath(polygon),
+    labelLayout: normalizeLabelLayout(blueprint.labelLayout, layout, blueprint),
+  };
+}
+
 export class GenerateStrategicMap {
   execute(options = {}) {
     const normalizedOptions = requireOptions(options);
@@ -379,6 +476,7 @@ export class GenerateStrategicMap {
     );
     const links = normalizeCollection(normalizedOptions.links, DEFAULT_LINKS, 'GenerateStrategicMap links');
     const neighborIdsByProvinceId = buildNeighborIds(blueprints, links);
+    const provinceGeometryById = Object.fromEntries(blueprints.map((blueprint) => [blueprint.id, buildProvinceGeometry(blueprint)]));
     const loyaltyJitter = Number.isInteger(normalizedOptions.loyaltyJitter) ? normalizedOptions.loyaltyJitter : 0;
     const strategicValueJitter = Number.isInteger(normalizedOptions.strategicValueJitter) ? normalizedOptions.strategicValueJitter : 0;
 
@@ -407,8 +505,10 @@ export class GenerateStrategicMap {
       width: normalizedOptions.width ?? DEFAULT_WIDTH,
       height: normalizedOptions.height ?? DEFAULT_HEIGHT,
       provinces,
-      provinceLayouts: Object.fromEntries(blueprints.map((blueprint) => [blueprint.id, { ...blueprint.layout }])),
-      provincePolygons: Object.fromEntries(blueprints.map((blueprint) => [blueprint.id, blueprint.polygon])),
+      provinceGeometryById,
+      provinceLayouts: Object.fromEntries(Object.entries(provinceGeometryById).map(([provinceId, geometry]) => [provinceId, { ...geometry.layout }])),
+      provincePolygons: Object.fromEntries(Object.entries(provinceGeometryById).map(([provinceId, geometry]) => [provinceId, geometry.polygon])),
+      provinceLabelLayouts: Object.fromEntries(Object.entries(provinceGeometryById).map(([provinceId, geometry]) => [provinceId, { ...geometry.labelLayout }])),
       paletteByFaction: Object.fromEntries(factions.map((faction) => [faction.id, {
         fill: faction.fill,
         border: faction.border,

--- a/src/application/war/GenerateStrategicMap.js
+++ b/src/application/war/GenerateStrategicMap.js
@@ -410,23 +410,27 @@ function buildRectanglePolygon(layout) {
   return `${layout.x},${layout.y} ${layout.x + layout.w},${layout.y} ${layout.x + layout.w},${layout.y + layout.h} ${layout.x},${layout.y + layout.h}`;
 }
 
-function normalizePolygon(polygon, layout, blueprint) {
-  if (polygon === undefined) {
-    return buildRectanglePolygon(layout);
-  }
-
-  const normalizedPolygon = requireText(polygon, `GenerateStrategicMap ${blueprint.id} polygon`);
-  const points = normalizedPolygon.split(/\s+/);
+function tokenizePolygonPoints(polygon, label) {
+  const points = requireText(polygon, label).split(/\s+/);
 
   if (points.some((point) => !/^[-]?\d+(?:\.\d+)?,[-]?\d+(?:\.\d+)?$/.test(point))) {
-    throw new RangeError(`GenerateStrategicMap ${blueprint.id} polygon must contain x,y point pairs.`);
+    throw new RangeError(`${label} must contain x,y point pairs.`);
   }
 
-  return normalizedPolygon;
+  return points;
+}
+
+function normalizePolygon(polygon, layout, blueprint) {
+  const polygonSource = polygon === undefined ? buildRectanglePolygon(layout) : polygon;
+
+  return tokenizePolygonPoints(
+    polygonSource,
+    `GenerateStrategicMap ${blueprint.id} polygon`,
+  ).join(' ');
 }
 
 function polygonToCssClipPath(polygon) {
-  return `polygon(${polygon.split(' ').map((point) => point.split(',').join('% ')).join('%, ') }%)`;
+  return `polygon(${tokenizePolygonPoints(polygon, 'GenerateStrategicMap polygon').map((point) => point.split(',').join('% ')).join('%, ') }%)`;
 }
 
 function normalizeLabelLayout(labelLayout, layout, blueprint) {

--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -42,6 +42,18 @@ function normalizeTextMap(value, label) {
   return value;
 }
 
+function normalizeGeometryMap(value) {
+  if (value === undefined) {
+    return {};
+  }
+
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('StrategicMapShell provinceGeometryById must be an object.');
+  }
+
+  return value;
+}
+
 function normalizeOverlaySlots(overlaySlots) {
   if (overlaySlots === undefined) {
     return [...DEFAULT_OVERLAY_SLOTS];
@@ -74,12 +86,20 @@ function buildLegend(renderedProvinces, options) {
   };
 }
 
-function enhanceProvince(renderedProvince, options) {
+function enhanceProvince(renderedProvince, options, provinceGeometryById) {
   const selectedProvinceId = String(options.selectedProvinceId ?? '').trim();
   const focusedProvinceId = String(options.focusedProvinceId ?? '').trim();
+  const geometry = provinceGeometryById[renderedProvince.provinceId] ?? {};
 
   return {
     ...renderedProvince,
+    geometry: {
+      layout: geometry.layout ?? null,
+      center: geometry.center ?? null,
+      polygon: geometry.polygon ?? null,
+      shape: geometry.shape ?? null,
+      labelLayout: geometry.labelLayout ?? null,
+    },
     selectionState: {
       selected: renderedProvince.provinceId === selectedProvinceId,
       focused: renderedProvince.provinceId === focusedProvinceId,
@@ -94,11 +114,12 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const subtitle = String(normalizedOptions.subtitle ?? 'Vue d’ensemble des provinces et lignes de front').trim()
     || 'Vue d’ensemble des provinces et lignes de front';
   const overlaySlots = normalizeOverlaySlots(normalizedOptions.overlaySlots);
+  const provinceGeometryById = normalizeGeometryMap(normalizedOptions.provinceGeometryById);
 
   const renderedProvinces = normalizedProvinces
     .slice()
     .sort((left, right) => left.id.localeCompare(right.id))
-    .map((province) => enhanceProvince(renderProvince(province, normalizedOptions), normalizedOptions));
+    .map((province) => enhanceProvince(renderProvince(province, normalizedOptions), normalizedOptions, provinceGeometryById));
 
   const stats = renderedProvinces.reduce(
     (summary, province) => ({

--- a/test/application/war/GenerateStrategicMap.test.js
+++ b/test/application/war/GenerateStrategicMap.test.js
@@ -139,6 +139,21 @@ test('GenerateStrategicMap can derive province ownership from faction home colum
   assert.notDeepEqual(map.provinces.map((province) => province.loyalty), [50, 50]);
 });
 
+test('GenerateStrategicMap normalizes custom polygon whitespace before building CSS shapes', () => {
+  const generator = new GenerateStrategicMap();
+  const map = generator.execute({
+    provinceBlueprints: [{
+      id: 'custom',
+      name: 'Custom',
+      polygon: '10,10   24,12\n36,28\t12,30',
+    }],
+    links: [],
+  });
+
+  assert.equal(map.provinceGeometryById.custom.polygon, '10,10 24,12 36,28 12,30');
+  assert.equal(map.provinceGeometryById.custom.shape, 'polygon(10% 10%, 24% 12%, 36% 28%, 12% 30%)');
+});
+
 test('GenerateStrategicMap validates options, factions, blueprints and links', () => {
   const generator = new GenerateStrategicMap();
 

--- a/test/application/war/GenerateStrategicMap.test.js
+++ b/test/application/war/GenerateStrategicMap.test.js
@@ -33,6 +33,12 @@ test('GenerateStrategicMap returns deterministic strategic provinces and UI busi
   assert.deepEqual(map.paletteByFaction.ember, { fill: '#E8572A', border: '#FFB394' });
   assert.deepEqual(map.provinceLayouts['crown-heart'], { x: 38, y: 18, w: 23, h: 20 });
   assert.equal(map.provincePolygons['red-ridge'], '58,16 73,10 88,18 90,34 80,44 64,42 54,32 52,22');
+  assert.deepEqual(map.provinceLabelLayouts['river-gate'], { x: 21, y: 45, align: 'start', tone: 'frontier' });
+  assert.deepEqual(map.provinceGeometryById['river-gate'].center, { x: 34, y: 56 });
+  assert.equal(
+    map.provinceGeometryById['river-gate'].shape,
+    'polygon(38% 38%, 54% 34%, 66% 40%, 68% 54%, 56% 66%, 40% 64%, 32% 52%, 34% 42%)',
+  );
   assert.deepEqual(map.overlays.culture, []);
   assert.equal(map.panels.culture.focus, null);
   assert.deepEqual(map.businessData.cultureSeeds, []);
@@ -128,6 +134,8 @@ test('GenerateStrategicMap can derive province ownership from faction home colum
     { id: 'a', ownerFactionId: 'west', neighborIds: ['b'], contested: false },
     { id: 'b', ownerFactionId: 'east', neighborIds: ['a'], contested: true },
   ]);
+  assert.deepEqual(map.provinceGeometryById.a.layout, { x: 10, y: 12, w: 22, h: 18 });
+  assert.equal(map.provinceGeometryById.b.polygon, '38,12 60,12 60,30 38,30');
   assert.notDeepEqual(map.provinces.map((province) => province.loyalty), [50, 50]);
 });
 
@@ -139,5 +147,7 @@ test('GenerateStrategicMap validates options, factions, blueprints and links', (
   assert.throws(() => generator.execute({ factions: [{}] }), /faction id is required/);
   assert.throws(() => generator.execute({ provinceBlueprints: null }), /provinceBlueprints must be an array/);
   assert.throws(() => generator.execute({ provinceBlueprints: [{}] }), /province id is required/);
+  assert.throws(() => generator.execute({ provinceBlueprints: [{ id: 'a', name: 'A', layout: { x: 'bad', y: 0, w: 1, h: 1 } }], links: [] }), /layout.x/);
+  assert.throws(() => generator.execute({ provinceBlueprints: [{ id: 'a', name: 'A', polygon: 'broken' }], links: [] }), /polygon must contain x,y point pairs/);
   assert.throws(() => generator.execute({ provinceBlueprints: [{ id: 'a', name: 'A' }], links: [['a', 'missing']] }), /links must reference generated provinces/);
 });

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -44,6 +44,15 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
         'faction-a': { fill: '#2563EB', border: '#1E3A8A' },
         'faction-b': { fill: '#DC2626', border: '#7F1D1D' },
       },
+      provinceGeometryById: {
+        'prov-a': {
+          layout: { x: 10, y: 12, w: 20, h: 18 },
+          center: { x: 20, y: 21 },
+          polygon: '10,12 30,12 30,30 10,30',
+          shape: 'polygon(10% 12%, 30% 12%, 30% 30%, 10% 30%)',
+          labelLayout: { x: 20, y: 18, align: 'middle', tone: 'capital' },
+        },
+      },
     },
   );
 
@@ -54,6 +63,9 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     { selected: false, focused: true },
     { selected: true, focused: false },
   ]);
+  assert.deepEqual(shell.provinces[0].geometry.layout, { x: 10, y: 12, w: 20, h: 18 });
+  assert.equal(shell.provinces[0].geometry.shape, 'polygon(10% 12%, 30% 12%, 30% 30%, 10% 30%)');
+  assert.equal(shell.provinces[1].geometry.layout, null);
   assert.deepEqual(shell.stats, {
     provinceCount: 2,
     contestedCount: 1,
@@ -101,4 +113,5 @@ test('StrategicMapShell falls back to default title and validates inputs', () =>
   assert.throws(() => buildStrategicMapShell([], null), /StrategicMapShell options must be an object/);
   assert.throws(() => buildStrategicMapShell([], { overlaySlots: null }), /overlaySlots must be an array/);
   assert.throws(() => buildStrategicMapShell([], { factionMetaById: [] }), /factionMetaById must be an object/);
+  assert.throws(() => buildStrategicMapShell([], { provinceGeometryById: [] }), /provinceGeometryById must be an object/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -109,8 +109,7 @@ const culturePayload = {
 const strategicMap = new GenerateStrategicMap().execute({ culturePayload });
 const paletteByFaction = strategicMap.paletteByFaction;
 const factionMetaById = strategicMap.factionMetaById;
-const provinceLayouts = strategicMap.provinceLayouts;
-const provincePolygonById = strategicMap.provincePolygons;
+const provinceGeometryById = strategicMap.provinceGeometryById;
 const provinces = strategicMap.provinces;
 
 const overlayLabels = {
@@ -127,14 +126,6 @@ const cityLayoutsById = {
   'southern-crossing': { x: 47, y: 79, labelDx: 0, labelDy: 8 },
 };
 
-const provinceLabelLayouts = {
-  'north-watch': { x: 26, y: 20, align: 'middle', tone: 'standard' },
-  'crown-heart': { x: 49.5, y: 18.5, align: 'middle', tone: 'capital' },
-  'red-ridge': { x: 75, y: 18.5, align: 'middle', tone: 'standard' },
-  'river-gate': { x: 21, y: 45, align: 'start', tone: 'frontier' },
-  'iron-plain': { x: 80, y: 48, align: 'end', tone: 'standard' },
-  'southern-reach': { x: 47, y: 91, align: 'middle', tone: 'frontier' },
-};
 
 const cities = [
   new City({
@@ -490,12 +481,26 @@ function getFocusContext(shell) {
   };
 }
 
-function getProvinceCenter(provinceId) {
-  const layout = provinceLayouts[provinceId];
+function getProvinceGeometry(provinceId) {
+  return provinceGeometryById[provinceId] ?? {};
+}
 
-  if (!layout) {
-    return null;
+function getProvinceLayout(provinceId) {
+  return getProvinceGeometry(provinceId).layout ?? { x: 12, y: 12, w: 76, h: 76 };
+}
+
+function getProvincePolygon(provinceId) {
+  return getProvinceGeometry(provinceId).polygon ?? '12,12 88,12 88,88 12,88';
+}
+
+function getProvinceCenter(provinceId) {
+  const geometry = getProvinceGeometry(provinceId);
+
+  if (geometry.center) {
+    return geometry.center;
   }
+
+  const layout = getProvinceLayout(provinceId);
 
   return {
     x: layout.x + (layout.w / 2),
@@ -574,6 +579,7 @@ function getShell() {
   const scenario = getSelectedMapScenario();
 
   return buildStrategicMapShell(provinces.map(getProvinceStateByTurn), {
+    provinceGeometryById,
     title: scenario?.gameTitle ?? 'Écran stratégique, théâtre continental',
     subtitle: scenario?.gameSubtitle ?? 'Prototype local Alpha prêt à accueillir les overlays inter-domaines',
     paletteByFaction,
@@ -643,8 +649,7 @@ function renderLegend(shell) {
 }
 
 function getProvinceShape(provinceId) {
-  const polygon = provincePolygonById[provinceId] ?? '12,12 88,12 88,88 12,88';
-  return `polygon(${polygon.split(' ').map((point) => point.split(',').join('% ')).join('%, ') }%)`;
+  return getProvinceGeometry(provinceId).shape ?? `polygon(${getProvincePolygon(provinceId).split(' ').map((point) => point.split(',').join('% ')).join('%, ') }%)`;
 }
 
 function renderProvinceSurface(shell, focusContext) {
@@ -657,9 +662,9 @@ function renderProvinceSurface(shell, focusContext) {
         const isMuted = !isSelected && !isFocused && !isNeighbor && (focusContext.selectedProvince || focusContext.focusedProvince);
         return `
           <g class="province-surface ${isSelected ? 'is-selected' : ''} ${isFocused ? 'is-focused' : ''} ${isNeighbor ? 'is-neighbor' : ''} ${isMuted ? 'is-muted' : ''} ${province.contested ? 'is-contested' : ''} ${province.occupied ? 'is-occupied' : ''}" style="--province-fill:${province.style.fill};--province-border:${province.style.border};">
-            <polygon class="province-surface__glow" points="${provincePolygonById[province.provinceId]}"></polygon>
-            <polygon class="province-surface__core" points="${provincePolygonById[province.provinceId]}"></polygon>
-            <polygon class="province-surface__hairline" points="${provincePolygonById[province.provinceId]}"></polygon>
+            <polygon class="province-surface__glow" points="${province.geometry.polygon ?? getProvincePolygon(province.provinceId)}"></polygon>
+            <polygon class="province-surface__core" points="${province.geometry.polygon ?? getProvincePolygon(province.provinceId)}"></polygon>
+            <polygon class="province-surface__hairline" points="${province.geometry.polygon ?? getProvincePolygon(province.provinceId)}"></polygon>
           </g>
         `;
       }).join('')}
@@ -668,7 +673,7 @@ function renderProvinceSurface(shell, focusContext) {
 }
 
 function renderProvinceCard(province, focusContext) {
-  const layout = provinceLayouts[province.provinceId];
+  const layout = province.geometry.layout ?? getProvinceLayout(province.provinceId);
   const badges = province.badges.map((badge) => `<span class="province-badge">${badge}</span>`).join('');
   const isNeighbor = focusContext.neighborIds.has(province.provinceId);
   const isSelected = province.selectionState.selected;
@@ -2188,7 +2193,7 @@ function renderProvinceLabels(shell) {
   return `
     <svg class="map-label-layer" viewBox="0 0 100 100" aria-label="Labels des provinces et points clés">
       ${shell.provinces.map((province) => {
-        const label = provinceLabelLayouts[province.provinceId] ?? { ...getProvinceCenter(province.provinceId), align: 'middle', tone: 'standard' };
+        const label = province.geometry.labelLayout ?? { ...getProvinceCenter(province.provinceId), align: 'middle', tone: 'standard' };
         const city = cities.find((candidate) => candidate.regionId === province.provinceId) ?? null;
         const cityLayout = city ? cityLayoutsById[city.id] : null;
         const cityLabelX = cityLayout ? cityLayout.x + (cityLayout.labelDx ?? 0) : null;
@@ -2218,7 +2223,7 @@ function renderProvincePopup(shell) {
     return '';
   }
 
-  const layout = provinceLayouts[province.provinceId];
+  const layout = province.geometry.layout ?? getProvinceLayout(province.provinceId);
   const controller = factionMetaById[province.controllingFactionId]?.label ?? province.controllingFactionId;
   const status = province.contested ? 'Front contesté' : province.occupied ? 'Sous occupation' : 'Contrôle stable';
 


### PR DESCRIPTION
Alpha: ## Summary
- centralise province geometry in `GenerateStrategicMap`: layout, polygon, CSS clip shape, center, and label placement now come from the generated map contract
- expose that geometry through `buildStrategicMapShell` so rendering consumes one province model instead of parallel web-only maps
- remove duplicated province label/layout wiring from `web/app.js` and keep resilient fallbacks for future generated maps
- validate custom blueprint geometry and keep deterministic rectangle fallback for blueprint-only generated provinces

## Audit notes
- Duplicates found in Alpha scope: province label layouts lived only in `web/app.js` while layouts/polygons came from `GenerateStrategicMap`; rendering then had multiple geometry lookups and inconsistent fallback behavior.
- Fixed in this PR: generator is now the source of truth for province geometry; shell carries the geometry alongside rendered province state.
- Out of Alpha scope / noted only: economy city seed/layout data and intrigue demo data still contain hand-authored scenario fixtures; those belong to economy/intrigue ownership if they need deeper cleanup.
- Existing Gamma PR #401 is still open/conflicting and not touched.

## Tests
- `node --test test/application/war/GenerateStrategicMap.test.js test/ui/war/StrategicMapShell.test.js test/ui/launcher/buildLauncherMapSelection.test.js`
- `node --check web/app.js`
- `git diff --check`
- `npm test` (348 passing)

Fixes #399

Zeta: prête pour validation avant tout merge.
