### PR TITLE
Beta: wire economy seed from strategic map

### DIFF
--- a/src/application/economy/BuildEconomySeedFromStrategicMap.js
+++ b/src/application/economy/BuildEconomySeedFromStrategicMap.js
@@ -1,0 +1,100 @@
+import { seedEconomyFromStrategicMap } from './SeedEconomyFromStrategicMap.js';
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireText(value, label) {
+  const normalizedValue = String(value ?? '').trim();
+
+  if (!normalizedValue) {
+    throw new RangeError(`${label} is required.`);
+  }
+
+  return normalizedValue;
+}
+
+function normalizePosition(value, label) {
+  const position = requireObject(value, label);
+
+  if (!Number.isFinite(position.x) || !Number.isFinite(position.y)) {
+    throw new RangeError(`${label} must expose finite x and y coordinates.`);
+  }
+
+  return { ...position, x: position.x, y: position.y };
+}
+
+function centerPositionFromLayout(layout, label) {
+  const normalizedLayout = requireObject(layout, label);
+
+  if (![normalizedLayout.x, normalizedLayout.y, normalizedLayout.w, normalizedLayout.h].every(Number.isFinite)) {
+    throw new RangeError(`${label} must expose finite x, y, w and h coordinates.`);
+  }
+
+  return {
+    x: normalizedLayout.x + (normalizedLayout.w / 2),
+    y: normalizedLayout.y + (normalizedLayout.h / 2),
+  };
+}
+
+function listMapProvinces(generatedMap) {
+  if (!Array.isArray(generatedMap.provinces)) {
+    throw new TypeError('BuildEconomySeedFromStrategicMap generatedMap.provinces must be an array.');
+  }
+
+  return generatedMap.provinces.map((province) => requireObject(province, 'BuildEconomySeedFromStrategicMap province'));
+}
+
+export function buildProvincePositionById(generatedMap, explicitProvincePositionById = {}) {
+  const map = requireObject(generatedMap, 'BuildEconomySeedFromStrategicMap generatedMap');
+  const explicitPositions = requireObject(explicitProvincePositionById, 'BuildEconomySeedFromStrategicMap explicitProvincePositionById');
+  const existingPositions = requireObject(map.provincePositionById ?? {}, 'BuildEconomySeedFromStrategicMap provincePositionById');
+  const provinceLayouts = requireObject(map.provinceLayouts ?? {}, 'BuildEconomySeedFromStrategicMap provinceLayouts');
+  const provincePositionById = {};
+
+  for (const province of listMapProvinces(map).sort((left, right) => String(left.id).localeCompare(String(right.id)))) {
+    const provinceId = requireText(province.id, 'BuildEconomySeedFromStrategicMap province.id');
+    const explicitPosition = explicitPositions[provinceId];
+    const existingPosition = existingPositions[provinceId];
+    const layout = provinceLayouts[provinceId];
+
+    if (explicitPosition !== undefined) {
+      provincePositionById[provinceId] = normalizePosition(explicitPosition, `BuildEconomySeedFromStrategicMap explicitProvincePositionById.${provinceId}`);
+      continue;
+    }
+
+    if (existingPosition !== undefined) {
+      provincePositionById[provinceId] = normalizePosition(existingPosition, `BuildEconomySeedFromStrategicMap provincePositionById.${provinceId}`);
+      continue;
+    }
+
+    if (layout !== undefined) {
+      provincePositionById[provinceId] = centerPositionFromLayout(layout, `BuildEconomySeedFromStrategicMap provinceLayouts.${provinceId}`);
+    }
+  }
+
+  return provincePositionById;
+}
+
+export function buildEconomySeedFromStrategicMap(generatedMap, options = {}) {
+  const map = requireObject(generatedMap, 'BuildEconomySeedFromStrategicMap generatedMap');
+  const normalizedOptions = requireObject(options, 'BuildEconomySeedFromStrategicMap options');
+  const provincePositionById = buildProvincePositionById(
+    map,
+    normalizedOptions.provincePositionById ?? {},
+  );
+  const seedOptions = { ...normalizedOptions };
+  delete seedOptions.provincePositionById;
+
+  return seedEconomyFromStrategicMap(
+    {
+      ...map,
+      provincePositionById,
+    },
+    seedOptions,
+  );
+}

--- a/test/application/economy/BuildEconomySeedFromStrategicMap.test.js
+++ b/test/application/economy/BuildEconomySeedFromStrategicMap.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildEconomySeedFromStrategicMap, buildProvincePositionById } from '../../../src/application/economy/BuildEconomySeedFromStrategicMap.js';
+
+function createStrategicMap() {
+  return {
+    provinceLayouts: {
+      'crown-heart': { x: 40, y: 20, w: 20, h: 10 },
+      'river-gate': { x: 20, y: 50, w: 30, h: 12 },
+    },
+    provinces: [
+      {
+        id: 'river-gate',
+        name: 'Porte du Fleuve',
+        ownerFactionId: 'aurora',
+        controllingFactionId: 'ember',
+        supplyLevel: 'disrupted',
+        loyalty: 39,
+        strategicValue: 7,
+        contested: true,
+        neighborIds: ['crown-heart'],
+      },
+      {
+        id: 'crown-heart',
+        name: 'Coeur de Couronne',
+        ownerFactionId: 'aurora',
+        supplyLevel: 'stable',
+        loyalty: 78,
+        strategicValue: 9,
+        capital: true,
+        neighborIds: ['river-gate'],
+      },
+    ],
+  };
+}
+
+test('buildProvincePositionById derives province centers from strategic map layouts', () => {
+  assert.deepEqual(buildProvincePositionById(createStrategicMap()), {
+    'crown-heart': { x: 50, y: 25 },
+    'river-gate': { x: 35, y: 56 },
+  });
+});
+
+test('buildEconomySeedFromStrategicMap wires generated positions into seeded city layouts', () => {
+  const seed = buildEconomySeedFromStrategicMap(createStrategicMap(), {
+    cityIdByProvinceId: {
+      'crown-heart': 'crown-port',
+      'river-gate': 'river-gate-city',
+    },
+    cityPositionByProvinceId: {
+      'river-gate': { x: 34, y: 58, labelDx: -5 },
+    },
+    resourceHintsByProvinceId: {
+      'crown-heart': { fish: 8 },
+      'river-gate': { tools: 2 },
+    },
+  });
+
+  assert.deepEqual(seed.cityPositionById, {
+    'crown-port': { x: 50, y: 25 },
+    'river-gate-city': { x: 34, y: 58, labelDx: -5 },
+  });
+  assert.deepEqual(seed.cities.map((city) => city.id), ['crown-port', 'river-gate-city']);
+  assert.deepEqual(seed.routes.map((route) => route.id), ['route:crown-heart:river-gate']);
+  assert.equal(seed.metrics.cityCount, 2);
+  assert.equal(seed.metrics.routeCount, 1);
+});
+
+test('buildEconomySeedFromStrategicMap rejects malformed layout coordinates', () => {
+  assert.throws(
+    () => buildEconomySeedFromStrategicMap({ provinces: [{ id: 'broken' }], provinceLayouts: { broken: { x: 1, y: 2, w: 'bad', h: 4 } } }),
+    /provinceLayouts.broken must expose finite x, y, w and h coordinates/,
+  );
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1,7 +1,7 @@
-import { Province } from '../src/domain/war/Province.js';
 import { GenerateStrategicMap } from '../src/application/war/GenerateStrategicMap.js';
 import { City } from '../src/domain/economy/City.js';
 import { TradeRoute } from '../src/domain/economy/TradeRoute.js';
+import { buildEconomySeedFromStrategicMap } from '../src/application/economy/BuildEconomySeedFromStrategicMap.js';
 import { buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
 import { buildLauncherMapSelection } from '../src/ui/launcher/buildLauncherMapSelection.js';
 import { buildEconomyMapOverlay } from '../src/ui/economy/buildEconomyMapOverlay.js';
@@ -119,88 +119,44 @@ const overlayLabels = {
   'intrigue-overlay': 'Intrigue',
 };
 
-const cityLayoutsById = {
-  'crown-port': { x: 49.5, y: 28, labelDx: 0, labelDy: -6 },
-  'river-gate-city': { x: 34, y: 56, labelDx: -8, labelDy: 7 },
-  'iron-plain-city': { x: 62, y: 55, labelDx: 8, labelDy: -6 },
-  'southern-crossing': { x: 47, y: 79, labelDx: 0, labelDy: 8 },
+const cityPositionByProvinceId = {
+  'crown-heart': { x: 49.5, y: 28, labelDx: 0, labelDy: -6 },
+  'river-gate': { x: 34, y: 56, labelDx: -8, labelDy: 7 },
+  'iron-plain': { x: 62, y: 55, labelDx: 8, labelDy: -6 },
+  'southern-reach': { x: 47, y: 79, labelDx: 0, labelDy: 8 },
 };
 
 
-const cities = [
-  new City({
-    id: 'crown-port',
-    name: 'Port de Couronne',
-    regionId: 'crown-heart',
-    population: 145,
-    prosperity: 78,
-    stability: 72,
-    stockByResource: { grain: 12, fish: 14, timber: 7 },
-    tradeRouteIds: ['aurora-river', 'southern-grainway'],
-    capital: true,
-  }),
-  new City({
-    id: 'river-gate-city',
-    name: 'Porte du Fleuve',
-    regionId: 'river-gate',
-    population: 102,
-    prosperity: 49,
-    stability: 37,
-    stockByResource: { grain: 3, tools: 2, timber: 4 },
-    tradeRouteIds: ['aurora-river', 'ember-foundry-line'],
-  }),
-  new City({
-    id: 'iron-plain-city',
-    name: 'Forge des Plaines',
-    regionId: 'iron-plain',
-    population: 93,
-    prosperity: 57,
-    stability: 52,
-    stockByResource: { ore: 11, tools: 5, grain: 2 },
-    tradeRouteIds: ['ember-foundry-line'],
-  }),
-  new City({
-    id: 'southern-crossing',
-    name: 'Passage du Sud',
-    regionId: 'southern-reach',
-    population: 81,
-    prosperity: 43,
-    stability: 41,
-    stockByResource: { grain: 2, horses: 4, timber: 1 },
-    tradeRouteIds: ['southern-grainway'],
-  }),
-];
-
-const routes = [
-  new TradeRoute({
-    id: 'aurora-river',
-    name: 'Artère fluviale',
-    stopCityIds: ['crown-port', 'river-gate-city'],
-    distance: 5,
-    capacityByResource: { grain: 6, fish: 5, timber: 3 },
-    transportMode: 'river',
-    riskLevel: 24,
-  }),
-  new TradeRoute({
-    id: 'ember-foundry-line',
-    name: 'Ligne des fonderies',
-    stopCityIds: ['river-gate-city', 'iron-plain-city'],
-    distance: 4,
-    capacityByResource: { ore: 5, tools: 3, grain: 2 },
-    transportMode: 'land',
-    riskLevel: 61,
-  }),
-  new TradeRoute({
-    id: 'southern-grainway',
-    name: 'Route des moissons',
-    stopCityIds: ['crown-port', 'southern-crossing'],
-    distance: 6,
-    capacityByResource: { grain: 4, timber: 2, horses: 2 },
-    transportMode: 'land',
-    riskLevel: 42,
-    active: false,
-  }),
-];
+const economySeed = buildEconomySeedFromStrategicMap(strategicMap, {
+  cityIdByProvinceId: {
+    'north-watch': 'north-watch-city',
+    'crown-heart': 'crown-port',
+    'red-ridge': 'red-ridge-city',
+    'river-gate': 'river-gate-city',
+    'iron-plain': 'iron-plain-city',
+    'southern-reach': 'southern-crossing',
+  },
+  cityNameByProvinceId: {
+    'north-watch': 'Guet du Nord',
+    'crown-heart': 'Port de Couronne',
+    'red-ridge': 'Bastion Rouge',
+    'river-gate': 'Porte du Fleuve',
+    'iron-plain': 'Forge des Plaines',
+    'southern-reach': 'Passage du Sud',
+  },
+  cityPositionByProvinceId,
+  resourceHintsByProvinceId: {
+    'north-watch': { timber: 6, game: 4 },
+    'crown-heart': { fish: 14, timber: 7 },
+    'red-ridge': { ore: 9, stone: 4 },
+    'river-gate': { tools: 2, timber: 4 },
+    'iron-plain': { ore: 11, tools: 5 },
+    'southern-reach': { grain: 6, horses: 4, timber: 1 },
+  },
+});
+const cityLayoutsById = economySeed.cityPositionById;
+const cities = economySeed.cities;
+const routes = economySeed.routes;
 
 const intrigueCellules = [
   new Cellule({
@@ -307,7 +263,9 @@ const intrigueOperations = [
 ];
 
 const desiredStockByCityId = {
+  'north-watch-city': { grain: 8, timber: 5, game: 3 },
   'crown-port': { grain: 10, fish: 10, timber: 5 },
+  'red-ridge-city': { grain: 5, ore: 7, stone: 3 },
   'river-gate-city': { grain: 9, tools: 4, timber: 5 },
   'iron-plain-city': { ore: 8, tools: 4, grain: 5 },
   'southern-crossing': { grain: 7, horses: 3, timber: 3 },
@@ -316,9 +274,11 @@ const desiredStockByCityId = {
 
 const resourceHudById = {
   fish: { glyph: '◒', label: 'Vivres maritimes', tone: 'cyan' },
+  game: { glyph: '◌', label: 'Gibier', tone: 'green' },
   grain: { glyph: '▦', label: 'Grain', tone: 'amber' },
   horses: { glyph: '♞', label: 'Remonte', tone: 'green' },
   ore: { glyph: '◆', label: 'Minerai', tone: 'slate' },
+  stone: { glyph: '◇', label: 'Pierre', tone: 'slate' },
   timber: { glyph: '▰', label: 'Bois', tone: 'green' },
   tools: { glyph: '⚙', label: 'Outillage', tone: 'cyan' },
 };


### PR DESCRIPTION
Beta: reprise propre de la carte Historia côté économie/logistique pour #406.

## Scope Beta
- Ajoute `buildEconomySeedFromStrategicMap` pour dériver les positions de villes depuis `provincePositionById` ou les centres de `provinceLayouts`.
- Branche le prototype web économie/logistique sur `seedEconomyFromStrategicMap` au lieu de maintenir villes/routes en dur.
- Garde le périmètre hors Alpha/Gamma/Delta/Epsilon: pas de changement au générateur de provinces, culture, intrigue ou climat.

## Validations
- `npm test` OK (356 tests)
- `node --check web/app.js` OK
- `git diff --check` OK

Zeta, peux-tu valider cette PR avant tout merge ?