### PR TITLE
Main: Fix launcher map card start flow

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2487,6 +2487,7 @@ function renderMapSelection() {
       <span class="launcher-map-card__subtitle">${map.subtitle}</span>
       <span class="launcher-map-card__description">${map.description}</span>
       <span class="launcher-map-card__stats">${renderLauncherMapStats(map.stats)}</span>
+      <span class="launcher-map-card__action">${map.playable ? (map.selected ? 'Cliquer encore pour lancer' : 'Sélectionner cette carte') : 'Non disponible'}</span>
     </button>
   `).join('');
 
@@ -2552,7 +2553,16 @@ function bindMapSelectionEvents() {
 
   document.querySelectorAll('[data-map-option]').forEach((element) => {
     element.addEventListener('click', () => {
-      state.selectedMapId = element.dataset.mapOption;
+      const mapId = element.dataset.mapOption;
+      const wasAlreadySelected = state.selectedMapId === mapId;
+      const scenario = mapScenarios.find((candidate) => candidate.id === mapId && candidate.playable !== false);
+
+      state.selectedMapId = mapId;
+
+      if (wasAlreadySelected && scenario) {
+        applyMapScenario(scenario);
+      }
+
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -3267,6 +3267,33 @@ button { font: inherit; }
   color: var(--text);
 }
 
+.launcher-map-card__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 4px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  color: #ecfeff;
+  background: rgba(8, 145, 178, 0.22);
+  border: 1px solid rgba(103, 232, 249, 0.26);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+}
+
+.launcher-map-card.is-selected .launcher-map-card__action {
+  background: linear-gradient(135deg, rgba(8, 145, 178, 0.45), rgba(14, 165, 233, 0.26));
+  border-color: rgba(103, 232, 249, 0.58);
+  box-shadow: 0 12px 30px rgba(8, 145, 178, 0.18);
+}
+
+.launcher-map-card.is-locked .launcher-map-card__action {
+  color: var(--muted);
+  background: rgba(15, 23, 42, 0.42);
+  border-color: rgba(148, 163, 184, 0.16);
+}
+
 @media (max-width: 900px) {
   .launcher-hero,
   .launcher-map-grid {


### PR DESCRIPTION
Main: ## Summary
- Let users launch a playable map by clicking an already-selected map card again.
- Add an explicit per-card action label so the launcher flow is clearer.
- Style the new card action state, including locked maps.

## Verification
- `node --check web/app.js`
- `npm test` (359 passing)
