### PR TITLE
Main: Start launcher map on first click

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2487,7 +2487,7 @@ function renderMapSelection() {
       <span class="launcher-map-card__subtitle">${map.subtitle}</span>
       <span class="launcher-map-card__description">${map.description}</span>
       <span class="launcher-map-card__stats">${renderLauncherMapStats(map.stats)}</span>
-      <span class="launcher-map-card__action">${map.playable ? (map.selected ? 'Cliquer encore pour lancer' : 'Sélectionner cette carte') : 'Non disponible'}</span>
+      <span class="launcher-map-card__action">${map.playable ? 'Cliquer pour lancer' : 'Non disponible'}</span>
     </button>
   `).join('');
 
@@ -2554,12 +2554,11 @@ function bindMapSelectionEvents() {
   document.querySelectorAll('[data-map-option]').forEach((element) => {
     element.addEventListener('click', () => {
       const mapId = element.dataset.mapOption;
-      const wasAlreadySelected = state.selectedMapId === mapId;
       const scenario = mapScenarios.find((candidate) => candidate.id === mapId && candidate.playable !== false);
 
       state.selectedMapId = mapId;
 
-      if (wasAlreadySelected && scenario) {
+      if (scenario) {
         applyMapScenario(scenario);
       }
 


### PR DESCRIPTION
Main: ## Summary
- Make playable launcher map cards start the game on the first click.
- Keep the selected map id in sync before applying the scenario.
- Update the card action copy to remove the ambiguous two-step flow.

## Verification
- `node --check web/app.js`
- `npm test` (359 passing)
