### PR TITLE
Main: Fix playable map runtime launch

### DIFF
--- a/src/ui/intrigue/buildIntrigueWebDemo.js
+++ b/src/ui/intrigue/buildIntrigueWebDemo.js
@@ -48,8 +48,8 @@ function compareHotspots(left, right) {
     return right.sabotageRiskScore - left.sabotageRiskScore;
   }
 
-  if (right.metrics.exposedCellCount !== left.metrics.exposedCellCount) {
-    return right.metrics.exposedCellCount - left.metrics.exposedCellCount;
+  if (right.exposedCellCount !== left.exposedCellCount) {
+    return right.exposedCellCount - left.exposedCellCount;
   }
 
   return left.locationId.localeCompare(right.locationId);

--- a/web/app.js
+++ b/web/app.js
@@ -1,4 +1,5 @@
 import { GenerateStrategicMap } from '../src/application/war/GenerateStrategicMap.js';
+import { Province } from '../src/domain/war/Province.js';
 import { City } from '../src/domain/economy/City.js';
 import { TradeRoute } from '../src/domain/economy/TradeRoute.js';
 import { buildEconomySeedFromStrategicMap } from '../src/application/economy/BuildEconomySeedFromStrategicMap.js';


### PR DESCRIPTION
Main: ## Summary
- Import `Province` in the web runtime so turn-state province cloning no longer crashes after launcher start.
- Fix intrigue hotspot sorting to use the flattened hotspot fields produced by `buildHotspotEntry`.

## Verified in WSL browser automation
- `node --check web/app.js`
- `node --test test/ui/intrigue/buildIntrigueWebDemo.test.js`
- `npm test` (359 passing)
- Playwright Chromium WSL end-to-end:
  - launcher opens
  - map card click enters the game
  - launch button enters the game
  - `Carte opérationnelle` visible
  - no browser console/page errors

Screenshots captured locally:
- `/tmp/historia-browser-check/03-after-card-click.png`
- `/tmp/historia-browser-check/04-after-launch-button.png`
