### PR TITLE
Gamma: Improve culture marker readability

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1371,9 +1371,14 @@ function renderCultureEventCard(event, cultureName) {
 
 function renderCultureLegendKey(cultureView) {
   const entriesByType = [...new Map(cultureView.overlay.map((entry) => [entry.markerType, entry])).values()];
+  const active = state.activeOverlaySlot === 'culture-overlay';
 
   return `
-    <div class="culture-symbol-key" aria-label="Langage visuel culture et découvertes">
+    <div class="culture-symbol-key ${active ? 'is-active' : 'is-muted'}" aria-label="Langage visuel culture et découvertes">
+      <div class="culture-symbol-key__status">
+        <strong>${active ? 'Couche culture active' : 'Couche culture en veille'}</strong>
+        <span>${active ? 'Codes compacts et découvertes du focus pour limiter les collisions.' : 'Repères discrets; activez Culture pour les détails.'}</span>
+      </div>
       ${entriesByType.map((entry) => {
         const language = getCultureMarkerLanguage(entry);
         return `
@@ -1386,67 +1391,74 @@ function renderCultureLegendKey(cultureView) {
   `;
 }
 
-function renderCultureMapOverlay(cultureView) {
-  if (state.activeOverlaySlot !== 'culture-overlay') {
+function renderCultureMarker(entry, active) {
+  const center = getProvinceCenter(entry.regionId);
+
+  if (!center) {
     return '';
   }
 
-  const markerNodes = cultureView.overlay.map((entry) => {
+  const selected = entry.regionId === state.selectedProvinceId;
+  const tone = getCultureTone(entry);
+  const radius = active ? Math.max(3.9, Math.min(8.2, entry.zoneContour.radius / 3.4)) : 2.15;
+  const eventBadgeY = center.y - radius - 2.1;
+  const language = getCultureMarkerLanguage(entry);
+  const glyphScale = active ? Math.max(1.75, radius * 0.34) : 1.05;
+  const selectedClass = selected ? 'is-selected' : '';
+  const stateClass = active ? 'is-readable' : 'is-quiet';
+
+  return `
+    <g class="culture-marker culture-marker--${tone} culture-marker--${entry.influenceTier} culture-marker--${entry.markerType} ${selectedClass} ${stateClass}" data-culture-region="${entry.regionId}">
+      <title>${entry.cultureName} · ${entry.regionId} · ${entry.summary}</title>
+      <circle class="culture-marker__aura" cx="${center.x}%" cy="${center.y}%" r="${radius + (active ? 1.8 : 0.9)}"></circle>
+      <circle class="culture-marker__ring" cx="${center.x}%" cy="${center.y}%" r="${radius}"></circle>
+      ${active && selected ? renderCultureMarkerTicks(center, radius, language) : ''}
+      ${active ? `<path class="culture-marker__sigil" d="${language.glyph}" transform="translate(${center.x} ${center.y}) scale(${glyphScale})"></path>` : ''}
+      ${active ? `<text class="culture-marker__code" x="${center.x}%" y="${center.y + radius + 2.4}%" text-anchor="middle">${language.code}</text>` : ''}
+      ${active && entry.eventCount > 0 ? `<g class="culture-event-flag"><circle cx="${center.x + radius + 1.7}%" cy="${eventBadgeY}%" r="1.55"></circle><text x="${center.x + radius + 1.7}%" y="${eventBadgeY + 0.48}%" text-anchor="middle">${entry.eventCount}</text></g>` : ''}
+    </g>
+  `;
+}
+
+function renderCultureMapOverlay(cultureView) {
+  const active = state.activeOverlaySlot === 'culture-overlay';
+  const markerEntries = active
+    ? cultureView.overlay
+    : cultureView.overlay.filter((entry) => entry.dominantInRegion || entry.regionId === state.selectedProvinceId);
+  const markerNodes = markerEntries.map((entry) => renderCultureMarker(entry, active)).join('');
+
+  const discoveryLinks = active ? cultureView.overlay.flatMap((entry) => {
     const center = getProvinceCenter(entry.regionId);
 
     if (!center) {
-      return '';
+      return [];
     }
 
     const selected = entry.regionId === state.selectedProvinceId;
-    const tone = getCultureTone(entry);
-    const radius = Math.max(4.8, Math.min(13, entry.zoneContour.radius / 2.2));
-    const eventBadgeY = center.y - radius - 2.8;
-    const language = getCultureMarkerLanguage(entry);
-    const glyphScale = Math.max(2.2, radius * 0.36);
-    const selectedClass = selected ? 'is-selected' : '';
+    const visibleLinks = entry.regionalDiscoveryLinks.slice(0, selected ? 2 : 1);
 
-    return `
-      <g class="culture-marker culture-marker--${tone} culture-marker--${entry.influenceTier} culture-marker--${entry.markerType} ${selectedClass}" data-culture-region="${entry.regionId}">
-        <circle class="culture-marker__aura" cx="${center.x}%" cy="${center.y}%" r="${radius + 2.6}"></circle>
-        <circle class="culture-marker__ring" cx="${center.x}%" cy="${center.y}%" r="${radius}"></circle>
-        ${renderCultureMarkerTicks(center, radius, language)}
-        <path class="culture-marker__crosshair" d="M ${center.x - radius * 0.62} ${center.y} H ${center.x + radius * 0.62} M ${center.x} ${center.y - radius * 0.62} V ${center.y + radius * 0.62}"></path>
-        <path class="culture-marker__sigil" d="${language.glyph}" transform="translate(${center.x} ${center.y}) scale(${glyphScale})"></path>
-        <text class="culture-marker__code" x="${center.x + radius + 2.6}%" y="${center.y - 1.2}%" text-anchor="start">${language.code}</text>
-        <text class="culture-marker__label" x="${center.x}%" y="${center.y + radius + 4}%" text-anchor="middle">${entry.cultureName}</text>
-        ${entry.eventCount > 0 ? `<g class="culture-event-flag"><path d="M ${center.x - 3.8} ${eventBadgeY - 2.1} H ${center.x + 3.8} L ${center.x + 2.8} ${eventBadgeY + 1.4} H ${center.x - 3.8} Z"></path><text x="${center.x}%" y="${eventBadgeY + 0.15}%" text-anchor="middle">H-${entry.eventCount}</text></g>` : ''}
-      </g>
-    `;
-  }).join('');
+    return visibleLinks.map((link, index) => {
+      const offset = (index - ((visibleLinks.length - 1) / 2)) * 4.2;
+      const tone = getCultureTone(entry);
+      const x = center.x + offset;
+      const y = center.y - 6.3;
 
-  const discoveryLinks = cultureView.overlay.flatMap((entry) => entry.regionalDiscoveryLinks.slice(0, 2).map((link, index) => {
-    const center = getProvinceCenter(entry.regionId);
-
-    if (!center) {
-      return '';
-    }
-
-    const offset = (index - 0.5) * 5.4;
-    const tone = getCultureTone(entry);
-
-    const x = center.x + offset;
-    const y = center.y - 8.4;
-
-    return `
-      <g class="culture-discovery-ping culture-discovery-ping--${tone}">
-        <line class="culture-discovery-ping__leader" x1="${center.x}%" y1="${center.y}%" x2="${x}%" y2="${y}%"></line>
-        <path class="culture-discovery-ping__glyph" d="M ${x} ${y - 1.45} L ${x + 1.45} ${y} L ${x} ${y + 1.45} L ${x - 1.45} ${y} Z M ${x - 0.55} ${y} H ${x + 0.55}"></path>
-        <text x="${x}%" y="${y - 2.15}%" text-anchor="middle">D:${link.discoveryId}</text>
-      </g>
-    `;
-  })).join('');
+      return `
+        <g class="culture-discovery-ping culture-discovery-ping--${tone} ${selected ? 'is-selected' : ''}">
+          <title>${link.discoveryId} · ${entry.cultureName}</title>
+          <line class="culture-discovery-ping__leader" x1="${center.x}%" y1="${center.y}%" x2="${x}%" y2="${y}%"></line>
+          <path class="culture-discovery-ping__glyph" d="M ${x} ${y - 1.05} L ${x + 1.05} ${y} L ${x} ${y + 1.05} L ${x - 1.05} ${y} Z M ${x - 0.42} ${y} H ${x + 0.42}"></path>
+          <text x="${x}%" y="${y - 1.55}%" text-anchor="middle">D${index + 1}</text>
+        </g>
+      `;
+    });
+  }).join('') : '';
 
   return `
-    <svg class="culture-overlay-map" viewBox="0 0 100 100" aria-label="Overlay culture et découvertes">
+    <svg class="culture-overlay-map ${active ? 'is-active' : 'is-muted'}" viewBox="0 0 100 100" aria-label="Overlay culture et découvertes">
       <defs>
         <filter id="cultureHudGlow" x="-40%" y="-40%" width="180%" height="180%">
-          <feGaussianBlur stdDeviation="1.4" result="blur" />
+          <feGaussianBlur stdDeviation="1.1" result="blur" />
           <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
         </filter>
       </defs>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2394,28 +2394,37 @@ button { font: inherit; }
   height: 100%;
   pointer-events: none;
   mix-blend-mode: screen;
-  filter: saturate(1.08);
+  filter: saturate(1.02);
+}
+.culture-overlay-map.is-muted {
+  mix-blend-mode: normal;
+  filter: saturate(0.8);
+  opacity: 0.42;
 }
 .culture-marker {
   filter: url(#cultureHudGlow);
-  opacity: 0.88;
+  opacity: 0.78;
 }
+.culture-marker.is-readable { opacity: 0.9; }
+.culture-marker.is-quiet { opacity: 0.46; }
 .culture-marker__aura {
-  fill: rgba(8, 47, 73, 0.18);
-  stroke: rgba(125, 211, 252, 0.2);
-  stroke-width: 0.36;
+  fill: rgba(8, 47, 73, 0.12);
+  stroke: rgba(125, 211, 252, 0.14);
+  stroke-width: 0.28;
   stroke-dasharray: 1.2 1.1;
 }
 .culture-marker__ring {
-  fill: rgba(2, 6, 23, 0.34);
-  stroke: rgba(125, 211, 252, 0.82);
-  stroke-width: 0.52;
+  fill: rgba(2, 6, 23, 0.28);
+  stroke: rgba(125, 211, 252, 0.68);
+  stroke-width: 0.42;
 }
-.culture-marker__crosshair {
-  fill: none;
-  stroke: rgba(226, 232, 240, 0.6);
-  stroke-width: 0.2;
-  stroke-linecap: round;
+.culture-marker.is-quiet .culture-marker__aura {
+  fill: transparent;
+  stroke-dasharray: none;
+}
+.culture-marker.is-quiet .culture-marker__ring {
+  fill: rgba(15, 23, 42, 0.28);
+  stroke-width: 0.34;
 }
 .culture-marker__icon {
   fill: #e0f2fe;
@@ -2435,31 +2444,26 @@ button { font: inherit; }
 }
 .culture-marker__label { fill: #e2e8f0; }
 .culture-marker__event { fill: #fbbf24; }
-.culture-discovery-ping circle {
-  fill: #fbbf24;
-  stroke: rgba(2, 6, 23, 0.85);
-  stroke-width: 0.26;
-}
 .culture-discovery-ping text {
   fill: #fde68a;
-  font-size: 1.6px;
+  font-size: 1.35px;
 }
 .culture-marker--amber .culture-marker__ring,
-.culture-discovery-ping--amber circle { stroke: rgba(251, 191, 36, 0.88); }
-.culture-marker--amber .culture-marker__aura { fill: rgba(120, 53, 15, 0.22); }
+.culture-discovery-ping--amber .culture-discovery-ping__glyph { stroke: rgba(251, 191, 36, 0.78); }
+.culture-marker--amber .culture-marker__aura { fill: rgba(120, 53, 15, 0.16); }
 .culture-marker--amber .culture-marker__icon { fill: #fde68a; }
 .culture-marker--slate .culture-marker__ring,
-.culture-discovery-ping--slate circle { stroke: rgba(148, 163, 184, 0.88); }
-.culture-marker--slate .culture-marker__aura { fill: rgba(51, 65, 85, 0.24); }
+.culture-discovery-ping--slate .culture-discovery-ping__glyph { stroke: rgba(148, 163, 184, 0.72); }
+.culture-marker--slate .culture-marker__aura { fill: rgba(51, 65, 85, 0.16); }
 .culture-marker--rose .culture-marker__ring,
-.culture-discovery-ping--rose circle { stroke: rgba(251, 113, 133, 0.88); }
-.culture-marker--rose .culture-marker__aura { fill: rgba(136, 19, 55, 0.24); }
+.culture-discovery-ping--rose .culture-discovery-ping__glyph { stroke: rgba(251, 113, 133, 0.76); }
+.culture-marker--rose .culture-marker__aura { fill: rgba(136, 19, 55, 0.18); }
 .culture-marker.is-selected .culture-marker__ring {
-  stroke-width: 0.86;
+  stroke-width: 0.78;
   stroke: #fbbf24;
 }
 .culture-marker.is-selected .culture-marker__aura {
-  stroke: rgba(251, 191, 36, 0.72);
+  stroke: rgba(251, 191, 36, 0.58);
   stroke-dasharray: 0.8 0.7;
 }
 .overlay-panel--culture {
@@ -2623,26 +2627,26 @@ button { font: inherit; }
 
 /* Gamma UI-G2: technical culture marker language */
 .culture-marker__tick {
-  stroke: rgba(226, 232, 240, 0.56);
-  stroke-width: 0.22;
+  stroke: rgba(226, 232, 240, 0.48);
+  stroke-width: 0.18;
   stroke-linecap: round;
 }
 .culture-marker__sigil {
   fill: none;
   stroke: #e0f2fe;
-  stroke-width: 0.28;
+  stroke-width: 0.24;
   stroke-linecap: round;
   stroke-linejoin: round;
   vector-effect: non-scaling-stroke;
 }
 .culture-marker__code {
   fill: #bae6fd;
-  font-size: 1.65px;
+  font-size: 1.38px;
   font-weight: 900;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.14em;
   paint-order: stroke;
-  stroke: rgba(2, 6, 23, 0.9);
-  stroke-width: 0.38px;
+  stroke: rgba(2, 6, 23, 0.92);
+  stroke-width: 0.32px;
 }
 .culture-marker--traditional .culture-marker__sigil,
 .culture-marker--traditional .culture-marker__code { stroke: #fde68a; fill: #fde68a; }
@@ -2652,26 +2656,32 @@ button { font: inherit; }
 .culture-marker--balanced .culture-marker__code { stroke: #a7f3d0; fill: #a7f3d0; }
 .culture-marker--innovation .culture-marker__sigil,
 .culture-marker--innovation .culture-marker__code { stroke: #bae6fd; fill: #bae6fd; }
-.culture-event-flag path {
-  fill: rgba(120, 53, 15, 0.82);
-  stroke: rgba(251, 191, 36, 0.86);
-  stroke-width: 0.28;
+.culture-event-flag circle {
+  fill: rgba(120, 53, 15, 0.78);
+  stroke: rgba(251, 191, 36, 0.82);
+  stroke-width: 0.22;
 }
 .culture-event-flag text {
   fill: #fef3c7;
-  font-size: 1.55px;
+  font-size: 1.25px;
   font-weight: 900;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.04em;
+}
+.culture-discovery-ping {
+  opacity: 0.66;
+}
+.culture-discovery-ping.is-selected {
+  opacity: 0.9;
 }
 .culture-discovery-ping__leader {
-  stroke: rgba(125, 211, 252, 0.28);
-  stroke-width: 0.18;
+  stroke: rgba(125, 211, 252, 0.22);
+  stroke-width: 0.14;
   stroke-dasharray: 0.7 0.8;
 }
 .culture-discovery-ping__glyph {
-  fill: rgba(8, 47, 73, 0.72);
+  fill: rgba(8, 47, 73, 0.62);
   stroke: #67e8f9;
-  stroke-width: 0.26;
+  stroke-width: 0.22;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
@@ -2684,6 +2694,21 @@ button { font: inherit; }
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
   margin: 0 0 12px;
+}
+.culture-symbol-key__status {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 3px;
+  padding: 9px 10px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(125, 211, 252, 0.14);
+}
+.culture-symbol-key__status strong { color: #e0f2fe; }
+.culture-symbol-key__status span { color: var(--muted); font-size: 12px; }
+.culture-symbol-key.is-muted .culture-symbol-key__status {
+  border-color: rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.34);
 }
 .culture-symbol-key__item {
   display: inline-flex;


### PR DESCRIPTION
Gamma: Closes #415.

## Summary
- compact culture markers to avoid covering province names
- keep inactive culture layer visible but subdued with dominant/focused markers only
- simplify permanent badges and discovery pings while moving full IDs into SVG titles
- add legend active/inactive state copy for readability expectations

## Validation
- `node --check web/app.js`
- `git diff --check`
- `npm test` (359 passing)

Gamma: Ready for Zeta validation before merge.
