### PR TITLE
Alpha: Clarify province shapes and borders

### DIFF
--- a/src/ui/war/buildStrategicMapPreviewHtml.js
+++ b/src/ui/war/buildStrategicMapPreviewHtml.js
@@ -107,22 +107,71 @@ function renderLegend(shell) {
   `).join('');
 }
 
+function buildReadableRelationPath(relation, index) {
+  const dx = relation.destination.x - relation.origin.x;
+  const dy = relation.destination.y - relation.origin.y;
+  const length = Math.hypot(dx, dy) || 1;
+  const bend = ((index % 3) - 1) * 2.8;
+  const controlX = ((relation.origin.x + relation.destination.x) / 2) - (dy / length) * bend;
+  const controlY = ((relation.origin.y + relation.destination.y) / 2) + (dx / length) * bend;
+
+  return `M ${relation.origin.x} ${relation.origin.y} Q ${controlX.toFixed(2)} ${controlY.toFixed(2)} ${relation.destination.x} ${relation.destination.y}`;
+}
+
 function renderRelationLines(shell) {
-  return buildProvinceRelations(shell.provinces).map((relation) => `
-    <line
-      class="relation-line ${relation.contested ? 'is-contested' : relation.occupied ? 'is-occupied' : ''}"
-      x1="${relation.origin.x}"
-      y1="${relation.origin.y}"
-      x2="${relation.destination.x}"
-      y2="${relation.destination.y}"
-    />
-  `).join('');
+  return buildProvinceRelations(shell.provinces).map((relation, index) => {
+    const pathD = buildReadableRelationPath(relation, index);
+
+    return `
+      <g class="relation-link">
+        <path class="relation-line-casing" d="${pathD}"></path>
+        <path class="relation-line ${relation.contested ? 'is-contested' : relation.occupied ? 'is-occupied' : ''}" d="${pathD}"></path>
+      </g>
+    `;
+  }).join('');
+}
+
+function getLabelAnchorOffset(align) {
+  if (align === 'start') {
+    return { rectX: 0, textPadding: 1.2 };
+  }
+
+  if (align === 'end') {
+    return { rectX: -19.2, textPadding: -1.2 };
+  }
+
+  return { rectX: -9.6, textPadding: 0 };
+}
+
+function getProvinceLabelModel(province) {
+  const center = getCenter(province);
+  const label = province.geometry.labelLayout ?? center;
+
+  if (!label || !center) {
+    return null;
+  }
+
+  const align = label.align ?? 'middle';
+  const offset = getLabelAnchorOffset(align);
+
+  return {
+    ...label,
+    align,
+    center,
+    leaderNeeded: Math.abs(label.x - center.x) > 4 || Math.abs(label.y - center.y) > 4,
+    titleX: label.x + offset.textPadding,
+    rectX: label.x + offset.rectX,
+    rectY: label.y - 4.4,
+    subtitleY: label.y + 4.25,
+    width: 19.2,
+    height: 7.8,
+  };
 }
 
 function renderProvinceShapes(shell) {
   return shell.provinces.map((province) => {
     const polygon = province.geometry.polygon;
-    const label = province.geometry.labelLayout ?? getCenter(province);
+    const label = getProvinceLabelModel(province);
 
     if (!polygon || !label) {
       return '';
@@ -131,8 +180,10 @@ function renderProvinceShapes(shell) {
     return `
       <g class="province ${province.contested ? 'is-contested' : ''} ${province.occupied ? 'is-occupied' : ''}" style="--fill:${escapeHtml(province.style.fill)};--border:${escapeHtml(province.style.border)}">
         <polygon class="province-shape" points="${escapeHtml(polygon)}"></polygon>
-        <text class="province-label" x="${label.x}" y="${label.y}" text-anchor="${escapeHtml(label.align ?? 'middle')}">${escapeHtml(province.label)}</text>
-        <text class="province-meta" x="${label.x}" y="${label.y + 3.6}" text-anchor="${escapeHtml(label.align ?? 'middle')}">${escapeHtml(province.contested ? 'Front' : province.occupied ? 'Occupation' : `Valeur ${province.strategicValue}`)}</text>
+        ${label.leaderNeeded ? `<path class="province-label-leader" d="M ${label.center.x} ${label.center.y} L ${label.x} ${label.y - 1.5}"></path>` : ''}
+        <rect class="province-label-plate" x="${label.rectX}" y="${label.rectY}" width="${label.width}" height="${label.height}" rx="1.4" ry="1.4"></rect>
+        <text class="province-label" x="${label.titleX}" y="${label.y}" text-anchor="${escapeHtml(label.align)}">${escapeHtml(province.label)}</text>
+        <text class="province-meta" x="${label.titleX}" y="${label.subtitleY}" text-anchor="${escapeHtml(label.align)}">${escapeHtml(province.contested ? 'Front' : province.occupied ? 'Occupation' : `Valeur ${province.strategicValue}`)}</text>
       </g>
     `;
   }).join('');
@@ -185,14 +236,18 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .map-panel { padding:18px; }
     svg { width:100%; height:auto; display:block; border-radius:18px; background:linear-gradient(160deg, rgba(15,35,60,0.96), rgba(8,13,25,0.98)); border:1px solid rgba(125, 211, 252, 0.14); }
     .grid-line { stroke:rgba(148,163,184,0.10); stroke-width:0.22; }
-    .relation-line { stroke:rgba(148, 163, 184, 0.5); stroke-width:0.75; stroke-dasharray:1.4 1.1; }
-    .relation-line.is-contested { stroke:#f59e0b; stroke-width:1.05; }
+    .relation-line, .relation-line-casing { fill:none; stroke-linecap:round; stroke-linejoin:round; }
+    .relation-line-casing { stroke:rgba(5, 10, 20, 0.78); stroke-width:1.7; opacity:0.9; }
+    .relation-line { stroke:rgba(148, 163, 184, 0.48); stroke-width:0.56; stroke-dasharray:1.3 1.15; }
+    .relation-line.is-contested { stroke:#f59e0b; stroke-width:0.82; }
     .relation-line.is-occupied { stroke:#38bdf8; }
-    .province-shape { fill:var(--fill); stroke:var(--border); stroke-width:0.9; filter:drop-shadow(0 0 0.7px rgba(255,255,255,0.4)); opacity:0.86; }
-    .province.is-contested .province-shape { stroke:#fbbf24; stroke-width:1.35; stroke-dasharray:2 1.2; }
-    .province.is-occupied .province-shape { opacity:0.72; }
-    .province-label { fill:#f8fafc; font-size:2.9px; font-weight:800; paint-order:stroke; stroke:#020617; stroke-width:0.7; stroke-linejoin:round; }
-    .province-meta { fill:#cbd5e1; font-size:1.95px; font-weight:700; paint-order:stroke; stroke:#020617; stroke-width:0.46; }
+    .province-shape { fill:var(--fill); stroke:var(--border); stroke-width:1.18; filter:drop-shadow(0 0 0.7px rgba(255,255,255,0.32)); opacity:0.88; }
+    .province.is-contested .province-shape { stroke:#fbbf24; stroke-width:1.45; stroke-dasharray:2 1.2; }
+    .province.is-occupied .province-shape { opacity:0.76; }
+    .province-label-leader { fill:none; stroke:rgba(226, 232, 240, 0.36); stroke-width:0.28; stroke-dasharray:0.7 0.85; }
+    .province-label-plate { fill:rgba(5,10,20,0.74); stroke:rgba(226,232,240,0.18); stroke-width:0.22; }
+    .province-label { fill:#f8fafc; font-size:2.75px; font-weight:900; paint-order:stroke; stroke:#020617; stroke-width:0.7; stroke-linejoin:round; letter-spacing:0.04em; }
+    .province-meta { fill:#cbd5e1; font-size:1.65px; font-weight:700; paint-order:stroke; stroke:#020617; stroke-width:0.46; letter-spacing:0.05em; }
     .side { padding:18px; display:grid; gap:18px; }
     .stats { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); gap:10px; }
     .stat-card { background:rgba(8, 13, 25, 0.76); border:1px solid rgba(148, 163, 184, 0.16); border-radius:16px; padding:12px; }

--- a/test/ui/war/buildStrategicMapPreviewHtml.test.js
+++ b/test/ui/war/buildStrategicMapPreviewHtml.test.js
@@ -15,6 +15,9 @@ test('buildStrategicMapPreviewHtml renders a screenshot-ready preview from the g
   assert.match(html, /GenerateStrategicMap/);
   assert.match(html, /buildStrategicMapShell/);
   assert.match(html, /points="38,38 54,34 66,40 68,54 56,66 40,64 32,52 34,42"/);
+  assert.match(html, /class="relation-line-casing"/);
+  assert.match(html, /class="province-label-plate"/);
+  assert.match(html, /class="province-label-leader"/);
   assert.match(html, /Porte du Fleuve/);
   assert.match(html, /historia-alpha-strategic-map-v1/);
   assert.equal((html.match(/class="province /g) ?? []).length, generatedMap.provinces.length);

--- a/web/app.js
+++ b/web/app.js
@@ -2150,11 +2150,42 @@ function renderBottomTray(economyView, intrigueView, cultureView) {
   `;
 }
 
+function getLabelAnchorOffset(align) {
+  if (align === 'start') {
+    return { rectX: 0, textPadding: 1.2 };
+  }
+
+  if (align === 'end') {
+    return { rectX: -19.2, textPadding: -1.2 };
+  }
+
+  return { rectX: -9.6, textPadding: 0 };
+}
+
+function getProvinceLabelModel(province) {
+  const center = getProvinceCenter(province.provinceId);
+  const label = province.geometry.labelLayout ?? { ...center, align: 'middle', tone: 'standard' };
+  const offset = getLabelAnchorOffset(label.align);
+  const leaderNeeded = Math.abs(label.x - center.x) > 4 || Math.abs(label.y - center.y) > 4;
+
+  return {
+    ...label,
+    center,
+    leaderNeeded,
+    titleX: label.x + offset.textPadding,
+    rectX: label.x + offset.rectX,
+    rectY: label.y - 4.4,
+    subtitleY: label.y + 4.25,
+    width: 19.2,
+    height: 7.8,
+  };
+}
+
 function renderProvinceLabels(shell) {
   return `
     <svg class="map-label-layer" viewBox="0 0 100 100" aria-label="Labels des provinces et points clés">
       ${shell.provinces.map((province) => {
-        const label = province.geometry.labelLayout ?? { ...getProvinceCenter(province.provinceId), align: 'middle', tone: 'standard' };
+        const label = getProvinceLabelModel(province);
         const city = cities.find((candidate) => candidate.regionId === province.provinceId) ?? null;
         const cityLayout = city ? cityLayoutsById[city.id] : null;
         const cityLabelX = cityLayout ? cityLayout.x + (cityLayout.labelDx ?? 0) : null;
@@ -2162,8 +2193,10 @@ function renderProvinceLabels(shell) {
 
         return `
           <g class="province-map-label province-map-label--${label.tone} ${province.selectionState.selected ? 'is-selected' : province.selectionState.focused ? 'is-focused' : ''}">
-            <text class="province-map-label__title" x="${label.x}%" y="${label.y}%" text-anchor="${label.align}">${province.label}</text>
-            <text class="province-map-label__subtitle" x="${label.x}%" y="${label.y + 3.4}%" text-anchor="${label.align}">${province.contested ? 'Front actif' : province.occupied ? 'Occupation' : `Valeur ${province.strategicValue}`}</text>
+            ${label.leaderNeeded ? `<path class="province-map-label__leader" d="M ${label.center.x} ${label.center.y} L ${label.x} ${label.y - 1.5}"></path>` : ''}
+            <rect class="province-map-label__plate" x="${label.rectX}%" y="${label.rectY}%" width="${label.width}%" height="${label.height}%" rx="1.4" ry="1.4"></rect>
+            <text class="province-map-label__title" x="${label.titleX}%" y="${label.y}%" text-anchor="${label.align}">${province.label}</text>
+            <text class="province-map-label__subtitle" x="${label.titleX}%" y="${label.subtitleY}%" text-anchor="${label.align}">${province.contested ? 'Front actif' : province.occupied ? 'Occupation' : `Valeur ${province.strategicValue}`}</text>
             ${city && cityLayout ? `
               <g class="city-map-label ${city.capital ? 'is-capital' : 'is-key'} ${state.selectedCityId === city.id ? 'is-selected' : ''}">
                 <line class="city-map-label__leader" x1="${cityLayout.x}%" y1="${cityLayout.y}%" x2="${cityLabelX}%" y2="${cityLabelY}%"></line>
@@ -2215,20 +2248,32 @@ function renderProvincePopup(shell) {
   `;
 }
 
+function buildReadableRelationPath(relation, index) {
+  const dx = relation.destination.x - relation.origin.x;
+  const dy = relation.destination.y - relation.origin.y;
+  const length = Math.hypot(dx, dy) || 1;
+  const bend = ((index % 3) - 1) * 2.8;
+  const controlX = ((relation.origin.x + relation.destination.x) / 2) - (dy / length) * bend;
+  const controlY = ((relation.origin.y + relation.destination.y) / 2) + (dx / length) * bend;
+
+  return `M ${relation.origin.x} ${relation.origin.y} Q ${controlX.toFixed(2)} ${controlY.toFixed(2)} ${relation.destination.x} ${relation.destination.y}`;
+}
+
 function renderStrategicRelations(shell) {
   const focusContext = getFocusContext(shell);
-  const relationLines = buildProvinceRelations(shell).map((relation) => {
+  const relationLines = buildProvinceRelations(shell).map((relation, index) => {
     const linkedToSelection = focusContext.selectedProvince
       && (relation.relationId.includes(focusContext.selectedProvince.provinceId));
+    const pathD = buildReadableRelationPath(relation, index);
 
     return `
-    <line
-      class="front-line ${relation.contested ? 'is-contested' : relation.occupied ? 'is-occupied' : relation.stable ? 'is-stable' : ''} ${linkedToSelection ? 'is-emphasized' : ''}"
-      x1="${relation.origin.x}%"
-      y1="${relation.origin.y}%"
-      x2="${relation.destination.x}%"
-      y2="${relation.destination.y}%"
-    />
+    <g class="front-link ${linkedToSelection ? 'is-emphasized' : ''}">
+      <path class="front-line-casing" d="${pathD}" />
+      <path
+        class="front-line ${relation.contested ? 'is-contested' : relation.occupied ? 'is-occupied' : relation.stable ? 'is-stable' : ''} ${linkedToSelection ? 'is-emphasized' : ''}"
+        d="${pathD}"
+      />
+    </g>
   `;
   }).join('');
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -449,24 +449,24 @@ button { font: inherit; }
   vector-effect: non-scaling-stroke;
 }
 .province-surface__core {
-  fill: color-mix(in srgb, var(--province-fill) 70%, #08111f 30%);
-  stroke: color-mix(in srgb, var(--province-border) 72%, #67e8f9 28%);
-  stroke-width: 0.95;
-  filter: drop-shadow(0 10px 18px rgba(2, 6, 23, 0.28)) drop-shadow(0 0 5px rgba(103, 232, 249, 0.16));
+  fill: color-mix(in srgb, var(--province-fill) 74%, #08111f 26%);
+  stroke: color-mix(in srgb, var(--province-border) 84%, #e2e8f0 16%);
+  stroke-width: 1.18;
+  filter: drop-shadow(0 10px 18px rgba(2, 6, 23, 0.28)) drop-shadow(0 0 4px rgba(103, 232, 249, 0.12));
 }
 .province-surface__glow {
   fill: transparent;
-  stroke: color-mix(in srgb, var(--province-border) 50%, #67e8f9 50%);
-  stroke-width: 2.8;
-  opacity: 0.16;
-  filter: blur(0.7px) drop-shadow(0 0 10px rgba(103, 232, 249, 0.28));
+  stroke: color-mix(in srgb, var(--province-border) 54%, #67e8f9 46%);
+  stroke-width: 2.15;
+  opacity: 0.12;
+  filter: blur(0.45px) drop-shadow(0 0 8px rgba(103, 232, 249, 0.2));
 }
 .province-surface__hairline {
   fill: transparent;
-  stroke: rgba(226, 232, 240, 0.28);
-  stroke-width: 0.28;
-  stroke-dasharray: 0.9 1.6;
-  opacity: 0.72;
+  stroke: rgba(248, 250, 252, 0.46);
+  stroke-width: 0.42;
+  stroke-dasharray: none;
+  opacity: 0.82;
 }
 .province-surface.is-muted polygon {
   opacity: 0.38;
@@ -483,7 +483,7 @@ button { font: inherit; }
 .province-surface.is-focused .province-surface__core,
 .province-surface.is-selected .province-surface__core {
   stroke: #67e8f9;
-  stroke-width: 1.65;
+  stroke-width: 1.85;
 }
 .province-surface.is-selected .province-surface__core {
   filter: drop-shadow(0 0 0 rgba(0,0,0,0)) drop-shadow(0 0 16px rgba(34, 211, 238, 0.48)) drop-shadow(0 0 28px rgba(251, 191, 36, 0.18));
@@ -517,21 +517,33 @@ button { font: inherit; }
   paint-order: stroke fill;
   stroke-linejoin: round;
 }
+.province-map-label__plate {
+  fill: rgba(5, 10, 20, 0.72);
+  stroke: rgba(226, 232, 240, 0.16);
+  stroke-width: 0.22;
+  filter: drop-shadow(0 1.8px 3px rgba(2, 6, 23, 0.42));
+}
+.province-map-label__leader {
+  fill: none;
+  stroke: rgba(226, 232, 240, 0.34);
+  stroke-width: 0.28;
+  stroke-dasharray: 0.7 0.85;
+}
 .province-map-label__title {
   fill: #f8fafc;
-  stroke: rgba(5, 10, 20, 0.94);
-  stroke-width: 1.8;
-  font-size: 3.2px;
-  font-weight: 800;
-  letter-spacing: 0.16em;
+  stroke: rgba(5, 10, 20, 0.96);
+  stroke-width: 1.45;
+  font-size: 2.75px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 .province-map-label__subtitle {
-  fill: rgba(186, 230, 253, 0.86);
-  stroke: rgba(5, 10, 20, 0.94);
-  stroke-width: 1.4;
-  font-size: 2px;
-  letter-spacing: 0.18em;
+  fill: rgba(186, 230, 253, 0.88);
+  stroke: rgba(5, 10, 20, 0.96);
+  stroke-width: 1.05;
+  font-size: 1.65px;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 .province-map-label--capital .province-map-label__title {
@@ -543,6 +555,11 @@ button { font: inherit; }
 .province-map-label.is-selected .province-map-label__title,
 .province-map-label.is-focused .province-map-label__title {
   fill: #67e8f9;
+}
+.province-map-label.is-selected .province-map-label__plate,
+.province-map-label.is-focused .province-map-label__plate {
+  fill: rgba(8, 15, 28, 0.86);
+  stroke: rgba(103, 232, 249, 0.48);
 }
 .city-map-label__leader {
   stroke: rgba(226, 232, 240, 0.38);
@@ -562,34 +579,53 @@ button { font: inherit; }
 .city-map-label.is-selected .city-map-label__title {
   fill: #bfdbfe;
 }
+.front-link {
+  pointer-events: none;
+}
+.front-line,
+.front-line-casing {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.front-line-casing {
+  stroke: rgba(5, 10, 20, 0.74);
+  stroke-width: 1.65;
+  opacity: 0.86;
+}
 .front-line {
-  stroke: rgba(148, 163, 184, 0.28);
-  stroke-width: 0.45;
+  stroke: rgba(148, 163, 184, 0.3);
+  stroke-width: 0.42;
+  opacity: 0.72;
 }
 .front-line.is-stable {
-  stroke: rgba(191, 219, 254, 0.7);
-  stroke-width: 0.55;
+  stroke: rgba(191, 219, 254, 0.58);
+  stroke-width: 0.48;
 }
 .front-line.is-occupied {
-  stroke: rgba(251, 191, 36, 0.95);
-  stroke-width: 0.6;
-  stroke-dasharray: 1.1 0.8;
-  filter: drop-shadow(0 0 6px rgba(251, 191, 36, 0.35));
+  stroke: rgba(251, 191, 36, 0.88);
+  stroke-width: 0.58;
+  stroke-dasharray: 1.1 1.05;
+  filter: drop-shadow(0 0 4px rgba(251, 191, 36, 0.28));
 }
 .front-line.is-contested {
   stroke: rgba(251, 113, 133, 0.9);
-  stroke-width: 0.72;
-  stroke-dasharray: 1.3 1;
-  filter: drop-shadow(0 0 6px rgba(251, 113, 133, 0.55));
+  stroke-width: 0.68;
+  stroke-dasharray: 1.15 1.2;
+  filter: drop-shadow(0 0 5px rgba(251, 113, 133, 0.42));
 }
 .front-line.is-emphasized {
-  stroke-width: 1;
+  stroke-width: 0.9;
   opacity: 1;
+}
+.front-link.is-emphasized .front-line-casing {
+  stroke-width: 2.1;
+  opacity: 0.92;
 }
 .province-ring {
   fill: none;
-  stroke-width: 0.45;
-  opacity: 0.85;
+  stroke-width: 0.34;
+  opacity: 0.58;
 }
 .province-ring.is-stable {
   stroke: rgba(226, 232, 240, 0.28);
@@ -1024,8 +1060,8 @@ button { font: inherit; }
   content: '';
   position: absolute;
   inset: 0;
-  border: 1px solid rgba(103, 232, 249, 0.1);
-  background: linear-gradient(135deg, rgba(103, 232, 249, 0.05), transparent 38%, rgba(251, 191, 36, 0.045));
+  border: 1px solid rgba(103, 232, 249, 0.08);
+  background: linear-gradient(135deg, rgba(103, 232, 249, 0.025), transparent 42%, rgba(251, 191, 36, 0.025));
   clip-path: var(--province-shape);
   pointer-events: none;
 }
@@ -1161,18 +1197,36 @@ button { font: inherit; }
 }
 .province-node__name {
   font-weight: 800;
-  font-size: 18px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  text-shadow: 0 2px 10px rgba(2, 6, 23, 0.88);
-}
-.province-node__meta {
-  font-size: 12px;
-  color: rgba(186, 230, 253, 0.86);
+  font-size: 14px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+  text-shadow: 0 2px 10px rgba(2, 6, 23, 0.88);
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 160ms ease, transform 160ms ease;
 }
-.province-node__badges { display: flex; flex-wrap: wrap; gap: 6px; }
+.province-node:hover .province-node__name,
+.province-node.is-focused .province-node__name,
+.province-node.is-selected .province-node__name,
+.province-node.is-neighbor .province-node__name {
+  opacity: 1;
+  transform: translateY(0);
+}
+.province-node__meta {
+  font-size: 11px;
+  color: rgba(186, 230, 253, 0.86);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0;
+}
+.province-node:hover .province-node__meta,
+.province-node.is-focused .province-node__meta,
+.province-node.is-selected .province-node__meta {
+  opacity: 1;
+}
+.province-node__badges { display: none; flex-wrap: wrap; gap: 6px; }
+.province-node.is-selected .province-node__badges,
+.province-node.is-focused .province-node__badges { display: flex; }
 .province-node__link {
   margin-top: 8px;
   font-size: 11px;


### PR DESCRIPTION
Alpha: Closes #413.

## Summary
- strengthens province silhouettes and border hierarchy without adding generation logic
- moves map labels onto compact plates with leader lines when they sit away from the province center
- renders front relations as cased curved paths so borders, labels, and active selections stay visually separated
- mirrors the readability treatment in the exportable QA strategic map preview

## Verification
- npm test
- npm run preview:map -- /tmp/historia-map-readability-preview.html
- node --check web/app.js
- node --check src/ui/war/buildStrategicMapPreviewHtml.js
- git diff --check
