### PR TITLE
Beta: declutter economy map overlays

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -784,26 +784,26 @@ function getQuadraticPoint(origin, control, destination, t) {
   };
 }
 
-function renderRouteHudMarkers(route, visual) {
+function renderRouteHudMarkers(route, visual, { compact = false } = {}) {
   const routeHud = getRouteHud(route);
   const midpoint = getQuadraticPoint(visual.origin, visual.control, visual.destination, 0.5);
-  const packetCount = Math.max(1, Math.min(4, Math.ceil(route.totalCapacity / 4)));
+  const packetCount = compact ? 1 : Math.max(1, Math.min(3, Math.ceil(route.totalCapacity / 5)));
   const packetMarkup = Array.from({ length: packetCount }, (_, index) => {
-    const t = 0.22 + (index * (0.56 / Math.max(1, packetCount - 1)));
+    const t = compact ? 0.5 : 0.28 + (index * (0.44 / Math.max(1, packetCount - 1)));
     const point = getQuadraticPoint(visual.origin, visual.control, visual.destination, t);
 
-    return `<circle class="economy-route-packet economy-route-packet--${routeHud.tone}" cx="${point.x}" cy="${point.y}" r="${0.72 + (index % 2) * 0.12}" />`;
+    return `<circle class="economy-route-packet economy-route-packet--${routeHud.tone}" cx="${point.x}" cy="${point.y}" r="${compact ? 0.58 : 0.68 + (index % 2) * 0.1}" />`;
   }).join('');
-  const riskTicks = Math.max(0, Math.min(3, Math.floor(route.riskLevel / 25)));
+  const riskTicks = compact ? 0 : Math.max(0, Math.min(2, Math.floor(route.riskLevel / 32)));
   const riskMarkup = Array.from({ length: riskTicks }, (_, index) => `
-    <rect class="economy-route-risk-tick" x="${midpoint.x + 3.2 + (index * 1.35)}" y="${midpoint.y - 4.6}" width="0.82" height="2.2" rx="0.35" />
+    <rect class="economy-route-risk-tick" x="${midpoint.x + 2.7 + (index * 1.15)}" y="${midpoint.y - 4.05}" width="0.72" height="1.85" rx="0.32" />
   `).join('');
 
   return `
-    <g class="economy-route-hud economy-route-hud--${routeHud.tone}" aria-label="${routeHud.label}, capacité ${route.totalCapacity}, risque ${route.riskLevel}">
+    <g class="economy-route-hud economy-route-hud--${routeHud.tone} ${compact ? 'is-compact' : 'is-emphasized'}" aria-label="${routeHud.label}, capacité ${route.totalCapacity}, risque ${route.riskLevel}">
       ${packetMarkup}
-      <circle class="economy-route-hud__plate" cx="${midpoint.x}" cy="${midpoint.y}" r="3.25" />
-      <text class="economy-route-hud__glyph" x="${midpoint.x}" y="calc(${midpoint.y} + 1px)" text-anchor="middle">${routeHud.glyph}</text>
+      ${compact ? '' : `<circle class="economy-route-hud__plate" cx="${midpoint.x}" cy="${midpoint.y}" r="2.7" />`}
+      ${compact ? '' : `<text class="economy-route-hud__glyph" x="${midpoint.x}" y="calc(${midpoint.y} + 1px)" text-anchor="middle">${routeHud.glyph}</text>`}
       ${riskMarkup}
     </g>
   `;
@@ -824,16 +824,19 @@ function getCityResourceHudItems(city, limit = 3) {
     }));
 }
 
-function renderResourceHudBadges(city, position) {
-  const resources = getCityResourceHudItems(city);
-  const startX = position.x - ((resources.length - 1) * 3.4);
-  const y = position.y + (city.marker.size * 12.5);
+function renderResourceHudBadges(city, position, { expanded = false } = {}) {
+  const resources = getCityResourceHudItems(city, expanded ? 3 : 1);
+  const labelDx = Number.isFinite(position.labelDx) ? position.labelDx / 5 : 0;
+  const labelDy = Number.isFinite(position.labelDy) ? position.labelDy / 5 : 0;
+  const gap = expanded ? 5.4 : 0;
+  const startX = position.x + labelDx - ((resources.length - 1) * (gap / 2));
+  const y = position.y + labelDy + (city.marker.size * (expanded ? 10.2 : 8.8));
 
   return resources.map((resource, index) => {
-    const x = startX + (index * 6.8);
+    const x = startX + (index * gap);
     return `
-      <g class="economy-resource-glyph economy-resource-glyph--${resource.tone}" aria-label="${resource.label}: ${resource.quantity}">
-        <circle class="economy-resource-glyph__backplate" cx="${x}%" cy="${y}%" r="2.55" />
+      <g class="economy-resource-glyph ${expanded ? 'is-expanded' : 'is-compact'} economy-resource-glyph--${resource.tone}" aria-label="${resource.label}: ${resource.quantity}">
+        <circle class="economy-resource-glyph__backplate" cx="${x}%" cy="${y}%" r="${expanded ? 2.25 : 1.55}" />
         <text class="economy-resource-glyph__icon" x="${x}%" y="calc(${y}% + 1px)" text-anchor="middle">${resource.glyph}</text>
       </g>
     `;
@@ -899,8 +902,9 @@ function buildRouteVisual(route, origin, destination, index) {
   const modeClass = `is-${route.transportMode}`;
   const emphasisClass = critical ? 'is-critical' : 'is-support';
   const activeClass = inactive ? 'is-inactive' : 'is-active';
-  const amplitude = route.transportMode === 'river' ? 2.8 : route.transportMode === 'land' ? 1.6 : 2.2;
-  const curveLift = 4 + ((index % 2) * 1.8);
+  const amplitude = route.transportMode === 'river' ? 2.2 : route.transportMode === 'land' ? 1.25 : 1.8;
+  const lane = (index % 3) - 1;
+  const curveLift = (3.2 + (Math.abs(lane) * 1.9)) * (lane === 0 ? 1 : lane);
   const controlX = ((origin.x + destination.x) / 2) + (normalX * curveLift);
   const controlY = ((origin.y + destination.y) / 2) + (normalY * curveLift);
   const control = { x: controlX, y: controlY };
@@ -1599,17 +1603,19 @@ function renderEconomyMapOverlay(economyView) {
       : originTension === 'medium' || destinationTension === 'medium'
         ? 'has-medium-tension'
         : 'has-low-tension';
+    const emphasizeRoute = visual.critical || tensionClass === 'has-high-tension';
+    const showRouteLabel = emphasizeRoute || tensionClass === 'has-medium-tension';
 
     return `
-      <g class="economy-route-group ${visual.classes} ${tensionClass}" data-route-id="${route.routeId}">
+      <g class="economy-route-group ${visual.classes} ${tensionClass} ${emphasizeRoute ? 'is-emphasized' : 'is-muted'}" data-route-id="${route.routeId}">
         <path class="economy-route__halo" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__casing" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__line" d="${visual.pathD}" pathLength="100" marker-end="url(#${visual.markerId})" />
         <path class="economy-route__flow" d="${visual.pathD}" pathLength="100" />
-        ${renderRouteHudMarkers(route, visual)}
-        <text class="economy-route__label" text-anchor="middle">
+        ${renderRouteHudMarkers(route, visual, { compact: !emphasizeRoute })}
+        ${showRouteLabel ? `<text class="economy-route__label" text-anchor="middle">
           <textPath href="#route-label-${route.routeId}" startOffset="50%">${route.routeName}</textPath>
-        </text>
+        </text>` : ''}
         <path id="route-label-${route.routeId}" d="${visual.pathD}" fill="none" stroke="none" />
       </g>
     `;
@@ -1624,15 +1630,18 @@ function renderEconomyMapOverlay(economyView) {
 
     const tension = tensionByCityId[city.cityId]?.tensionLevel ?? 'low';
     const isHub = city.tradeRouteIds.length >= 2 || city.resources.totalStock >= 16;
+    const isSelected = state.selectedCityId === city.cityId || state.hoveredCityId === city.cityId;
+    const expandResources = isSelected || tension === 'high';
+    const showResources = expandResources || city.capital || isHub;
 
     return `
-      <g class="economy-city-group ${state.selectedCityId === city.cityId ? 'is-selected' : ''} ${city.capital ? 'is-capital' : ''} ${isHub ? 'is-hub' : ''} is-${tension}-tension" data-city-id="${city.cityId}">
-        <circle class="economy-city-tension-ring" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 10.5}" />
-        ${city.capital ? `<circle class="economy-city-capital-ring" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 12.4}" />` : ''}
-        ${isHub ? `<rect class="economy-city-hub-frame" x="calc(${position.x}% - ${city.marker.size * 9}px)" y="calc(${position.y}% - ${city.marker.size * 9}px)" width="${city.marker.size * 18}" height="${city.marker.size * 18}" rx="${city.marker.size * 4}" ry="${city.marker.size * 4}" />` : ''}
-        <circle class="economy-city economy-city--${city.marker.tone}" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 8}" />
+      <g class="economy-city-group ${isSelected ? 'is-selected' : ''} ${city.capital ? 'is-capital' : ''} ${isHub ? 'is-hub' : ''} is-${tension}-tension" data-city-id="${city.cityId}">
+        <circle class="economy-city-tension-ring" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 9.2}" />
+        ${city.capital ? `<circle class="economy-city-capital-ring" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 10.8}" />` : ''}
+        ${isHub ? `<rect class="economy-city-hub-frame" x="calc(${position.x}% - ${city.marker.size * 7.4}px)" y="calc(${position.y}% - ${city.marker.size * 7.4}px)" width="${city.marker.size * 14.8}" height="${city.marker.size * 14.8}" rx="${city.marker.size * 3.2}" ry="${city.marker.size * 3.2}" />` : ''}
+        <circle class="economy-city economy-city--${city.marker.tone}" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 6.6}" />
         ${city.capital ? `<text class="economy-city-glyph" x="${position.x}%" y="calc(${position.y}% + 1px)" text-anchor="middle">★</text>` : isHub ? `<text class="economy-city-glyph" x="${position.x}%" y="calc(${position.y}% + 1px)" text-anchor="middle">◆</text>` : ''}
-        ${renderResourceHudBadges(city, position)}
+        ${showResources ? renderResourceHudBadges(city, position, { expanded: expandResources }) : ''}
         <circle class="economy-city-hitbox" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 12}" />
         <text class="economy-city-label economy-city-label--sr" x="${position.x}%" y="calc(${position.y}% - 14px)" text-anchor="middle">${city.cityName}</text>
         <text class="economy-city-resource economy-city-resource--sr" x="${position.x}%" y="calc(${position.y}% + 18px)" text-anchor="middle">${city.resources.primaryResourceId ?? 'stock vide'}</text>

--- a/web/styles.css
+++ b/web/styles.css
@@ -673,27 +673,30 @@ button { font: inherit; }
   stroke-linejoin: round;
 }
 .economy-route__halo {
-  stroke: rgba(15, 23, 42, 0.78);
-  stroke-width: 4.6;
-  opacity: 0.95;
+  stroke: rgba(15, 23, 42, 0.62);
+  stroke-width: 3.7;
+  opacity: 0.78;
 }
 .economy-route__casing {
-  stroke: rgba(226, 232, 240, 0.22);
-  stroke-width: 3.4;
+  stroke: rgba(226, 232, 240, 0.16);
+  stroke-width: 2.55;
 }
 .economy-route__line {
-  stroke-width: 2.1;
+  stroke-width: 1.45;
 }
 .economy-route__flow {
-  stroke: rgba(255, 255, 255, 0.95);
-  stroke-width: 0.55;
-  stroke-dasharray: 7 12;
-  animation: economy-route-flow 10s linear infinite;
+  stroke: rgba(255, 255, 255, 0.62);
+  stroke-width: 0.4;
+  stroke-dasharray: 7 15;
+  animation: economy-route-flow 12s linear infinite;
 }
 .economy-route__label {
-  fill: rgba(241, 245, 249, 0.92);
-  font-size: 2.6px;
-  letter-spacing: 0.12em;
+  fill: rgba(241, 245, 249, 0.76);
+  paint-order: stroke;
+  stroke: rgba(8, 15, 28, 0.72);
+  stroke-width: 0.9px;
+  font-size: 2.05px;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 .economy-route.is-land .economy-route__line {
@@ -709,13 +712,24 @@ button { font: inherit; }
   stroke-dasharray: 2 9;
   animation-duration: 7s;
 }
+.economy-route.is-muted .economy-route__halo,
+.economy-route.is-muted .economy-route__casing {
+  opacity: 0.22;
+}
+.economy-route.is-muted .economy-route__line {
+  opacity: 0.58;
+  stroke-width: 1.05;
+}
+.economy-route.is-muted .economy-route__flow {
+  opacity: 0.22;
+}
 .economy-route.is-inactive .economy-route__line,
 .economy-route.is-inactive .economy-route__flow,
 .economy-route.is-inactive .economy-route__label {
-  opacity: 0.4;
+  opacity: 0.34;
 }
 .economy-route.is-inactive .economy-route__line {
-  stroke-dasharray: 4 5;
+  stroke-dasharray: 4 6;
 }
 .economy-route.is-critical .economy-route__halo {
   stroke: rgba(127, 29, 29, 0.88);
@@ -734,23 +748,26 @@ button { font: inherit; }
 }
 .economy-route-hud {
   pointer-events: none;
-  filter: drop-shadow(0 0 7px rgba(8, 15, 28, 0.7));
+  filter: drop-shadow(0 0 5px rgba(8, 15, 28, 0.58));
+}
+.economy-route-hud.is-compact {
+  opacity: 0.58;
 }
 .economy-route-hud__plate {
-  fill: rgba(8, 15, 28, 0.82);
-  stroke: rgba(226, 232, 240, 0.34);
-  stroke-width: 0.72;
+  fill: rgba(8, 15, 28, 0.78);
+  stroke: rgba(226, 232, 240, 0.28);
+  stroke-width: 0.58;
 }
 .economy-route-hud__glyph {
   fill: #e2e8f0;
-  font-size: 3.7px;
+  font-size: 3.05px;
   font-weight: 900;
   dominant-baseline: middle;
 }
 .economy-route-packet {
-  fill: rgba(226, 232, 240, 0.88);
-  stroke: rgba(8, 15, 28, 0.72);
-  stroke-width: 0.28;
+  fill: rgba(226, 232, 240, 0.74);
+  stroke: rgba(8, 15, 28, 0.62);
+  stroke-width: 0.22;
 }
 .economy-route-risk-tick {
   fill: rgba(251, 113, 133, 0.9);
@@ -768,8 +785,8 @@ button { font: inherit; }
 .economy-route-hud--slate .economy-route-hud__plate { stroke: rgba(148, 163, 184, 0.7); }
 .economy-city-tension-ring {
   fill: none;
-  stroke-width: 1.6;
-  opacity: 0.9;
+  stroke-width: 1.15;
+  opacity: 0.72;
 }
 .economy-city-group.is-medium-tension .economy-city-tension-ring {
   stroke: rgba(245, 158, 11, 0.85);
@@ -782,8 +799,8 @@ button { font: inherit; }
   stroke: rgba(34, 197, 94, 0.35);
 }
 .economy-city {
-  stroke: rgba(255, 255, 255, 0.88);
-  stroke-width: 1.6;
+  stroke: rgba(255, 255, 255, 0.84);
+  stroke-width: 1.25;
 }
 .economy-city-capital-ring,
 .economy-city-hub-frame {
@@ -791,18 +808,18 @@ button { font: inherit; }
   pointer-events: none;
 }
 .economy-city-capital-ring {
-  stroke: rgba(250, 204, 21, 0.92);
-  stroke-width: 1.4;
+  stroke: rgba(250, 204, 21, 0.82);
+  stroke-width: 1.05;
   stroke-dasharray: 2.5 2;
-  filter: drop-shadow(0 0 8px rgba(250, 204, 21, 0.35));
+  filter: drop-shadow(0 0 6px rgba(250, 204, 21, 0.28));
 }
 .economy-city-hub-frame {
-  stroke: rgba(191, 219, 254, 0.88);
-  stroke-width: 1.3;
+  stroke: rgba(191, 219, 254, 0.72);
+  stroke-width: 1;
 }
 .economy-city-glyph {
   fill: #f8fafc;
-  font-size: 5px;
+  font-size: 4.1px;
   font-weight: 700;
   pointer-events: none;
 }
@@ -820,7 +837,7 @@ button { font: inherit; }
 .economy-city-group { cursor: pointer; }
 .economy-city-group.is-selected .economy-city {
   stroke: #f8fafc;
-  stroke-width: 2.4;
+  stroke-width: 2.05;
   filter: drop-shadow(0 0 8px rgba(255,255,255,0.35));
 }
 .economy-city--positive { fill: #22c55e; }
@@ -840,18 +857,24 @@ button { font: inherit; }
 .economy-city-resource { fill: #bfdbfe; }
 .economy-resource-glyph {
   pointer-events: none;
-  filter: drop-shadow(0 0 6px rgba(8, 15, 28, 0.65));
+  filter: drop-shadow(0 0 4px rgba(8, 15, 28, 0.58));
+}
+.economy-resource-glyph.is-compact {
+  opacity: 0.72;
 }
 .economy-resource-glyph__backplate {
-  fill: rgba(8, 15, 28, 0.78);
-  stroke: rgba(226, 232, 240, 0.28);
-  stroke-width: 0.7;
+  fill: rgba(8, 15, 28, 0.72);
+  stroke: rgba(226, 232, 240, 0.24);
+  stroke-width: 0.5;
 }
 .economy-resource-glyph__icon {
   fill: #e2e8f0;
-  font-size: 3.2px;
+  font-size: 2.55px;
   font-weight: 800;
   dominant-baseline: middle;
+}
+.economy-resource-glyph.is-expanded .economy-resource-glyph__icon {
+  font-size: 2.9px;
 }
 .economy-resource-glyph--cyan .economy-resource-glyph__backplate { stroke: rgba(56, 189, 248, 0.72); }
 .economy-resource-glyph--cyan .economy-resource-glyph__icon { fill: #7dd3fc; }


### PR DESCRIPTION
Beta: Implements #414.

Scope:
- reduce visual weight of economy route strokes, halos, flows, labels, and HUD packets;
- show full route labels/HUD only for high-tension or critical routes, muting support routes;
- compact city markers/resource badges and expand resource detail only on hover/selection or high tension.

Validation:
- npm test (359 passing)
- node --check web/app.js
- git diff --check

Ready for Zeta validation before merge.