### PR TITLE
Alpha: Add province hover and selection focus states

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -89,6 +89,7 @@ function buildLegend(renderedProvinces, options) {
 function enhanceProvince(renderedProvince, options, provinceGeometryById) {
   const selectedProvinceId = String(options.selectedProvinceId ?? '').trim();
   const focusedProvinceId = String(options.focusedProvinceId ?? '').trim();
+  const hoveredProvinceId = String(options.hoveredProvinceId ?? '').trim();
   const geometry = provinceGeometryById[renderedProvince.provinceId] ?? {};
 
   return {
@@ -103,6 +104,7 @@ function enhanceProvince(renderedProvince, options, provinceGeometryById) {
     selectionState: {
       selected: renderedProvince.provinceId === selectedProvinceId,
       focused: renderedProvince.provinceId === focusedProvinceId,
+      hovered: renderedProvince.provinceId === hoveredProvinceId,
     },
   };
 }
@@ -155,7 +157,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
       })),
     },
     activeProvince: renderedProvinces.find(
-      (province) => province.selectionState.selected || province.selectionState.focused,
+      (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,
   };
 }

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -36,6 +36,7 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
       title: 'Théâtre nord',
       selectedProvinceId: 'prov-c',
       focusedProvinceId: 'prov-a',
+      hoveredProvinceId: 'prov-a',
       factionMetaById: {
         'faction-a': { label: 'Alliance d’Azur' },
         'faction-b': { label: 'Ligue cramoisie' },
@@ -60,8 +61,8 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
   assert.equal(shell.subtitle, 'Vue d’ensemble des provinces et lignes de front');
   assert.deepEqual(shell.provinces.map((province) => province.provinceId), ['prov-a', 'prov-c']);
   assert.deepEqual(shell.provinces.map((province) => province.selectionState), [
-    { selected: false, focused: true },
-    { selected: true, focused: false },
+    { selected: false, focused: true, hovered: true },
+    { selected: true, focused: false, hovered: false },
   ]);
   assert.deepEqual(shell.provinces[0].geometry.layout, { x: 10, y: 12, w: 20, h: 18 });
   assert.equal(shell.provinces[0].geometry.shape, 'polygon(10% 12%, 30% 12%, 30% 30%, 10% 30%)');

--- a/web/app.js
+++ b/web/app.js
@@ -378,6 +378,7 @@ const state = {
   seasonIndex: 0,
   focusedProvinceId: 'crown-heart',
   selectedProvinceId: 'river-gate',
+  hoveredProvinceId: null,
   activeOverlaySlot: 'culture-overlay',
   popupProvinceId: 'river-gate',
   hoveredCityId: 'river-gate-city',
@@ -419,6 +420,7 @@ function applyMapScenario(scenario) {
   state.mapPanY = 0;
   state.mobilePanelSection = 'details';
   state.mobileMapExpanded = true;
+  state.hoveredProvinceId = null;
   state.intrigueFilters = {
     presence: true,
     alerts: true,
@@ -432,12 +434,14 @@ const seasonLabels = ['Printemps', 'Été', 'Automne', 'Hiver'];
 function getFocusContext(shell) {
   const selectedProvince = shell.provinces.find((province) => province.provinceId === state.selectedProvinceId) ?? null;
   const focusedProvince = shell.provinces.find((province) => province.provinceId === state.focusedProvinceId) ?? selectedProvince ?? null;
-  const anchorProvince = selectedProvince ?? focusedProvince;
+  const hoveredProvince = shell.provinces.find((province) => province.provinceId === state.hoveredProvinceId) ?? null;
+  const anchorProvince = hoveredProvince ?? selectedProvince ?? focusedProvince;
   const neighborIds = new Set(anchorProvince?.neighborIds ?? []);
 
   return {
     selectedProvince,
     focusedProvince,
+    hoveredProvince,
     neighborIds,
   };
 }
@@ -547,6 +551,7 @@ function getShell() {
     factionMetaById,
     selectedProvinceId: state.selectedProvinceId,
     focusedProvinceId: state.focusedProvinceId,
+    hoveredProvinceId: state.hoveredProvinceId,
   });
 }
 
@@ -620,9 +625,10 @@ function renderProvinceSurface(shell, focusContext) {
         const isNeighbor = focusContext.neighborIds.has(province.provinceId);
         const isSelected = province.selectionState.selected;
         const isFocused = province.selectionState.focused;
-        const isMuted = !isSelected && !isFocused && !isNeighbor && (focusContext.selectedProvince || focusContext.focusedProvince);
+        const isHovered = province.selectionState.hovered;
+        const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince);
         return `
-          <g class="province-surface ${isSelected ? 'is-selected' : ''} ${isFocused ? 'is-focused' : ''} ${isNeighbor ? 'is-neighbor' : ''} ${isMuted ? 'is-muted' : ''} ${province.contested ? 'is-contested' : ''} ${province.occupied ? 'is-occupied' : ''}" style="--province-fill:${province.style.fill};--province-border:${province.style.border};">
+          <g class="province-surface ${isSelected ? 'is-selected' : ''} ${isFocused ? 'is-focused' : ''} ${isHovered ? 'is-hovered' : ''} ${isNeighbor ? 'is-neighbor' : ''} ${isMuted ? 'is-muted' : ''} ${province.contested ? 'is-contested' : ''} ${province.occupied ? 'is-occupied' : ''}" style="--province-fill:${province.style.fill};--province-border:${province.style.border};">
             <polygon class="province-surface__glow" points="${province.geometry.polygon ?? getProvincePolygon(province.provinceId)}"></polygon>
             <polygon class="province-surface__core" points="${province.geometry.polygon ?? getProvincePolygon(province.provinceId)}"></polygon>
             <polygon class="province-surface__hairline" points="${province.geometry.polygon ?? getProvincePolygon(province.provinceId)}"></polygon>
@@ -639,13 +645,15 @@ function renderProvinceCard(province, focusContext) {
   const isNeighbor = focusContext.neighborIds.has(province.provinceId);
   const isSelected = province.selectionState.selected;
   const isFocused = province.selectionState.focused;
-  const isMuted = !isSelected && !isFocused && !isNeighbor && (focusContext.selectedProvince || focusContext.focusedProvince);
+  const isHovered = province.selectionState.hovered;
+  const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince);
   const tacticalState = province.contested ? 'front contesté' : province.occupied ? 'occupation' : 'contrôle stable';
-  const selectionSignal = isSelected ? 'ACTIF' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
+  const selectionSignal = isSelected ? 'ACTIF' : isHovered ? 'SURVOL' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
   const classes = [
     'province-node',
     isSelected ? 'is-selected' : '',
     isFocused ? 'is-focused' : '',
+    isHovered ? 'is-hovered' : '',
     isNeighbor ? 'is-neighbor' : '',
     isMuted ? 'is-muted' : '',
     province.contested ? 'is-contested' : '',
@@ -2283,7 +2291,7 @@ function renderProvinceLabels(shell) {
         const cityLabelY = cityLayout ? cityLayout.y + (cityLayout.labelDy ?? 0) : null;
 
         return `
-          <g class="province-map-label province-map-label--${label.tone} ${province.selectionState.selected ? 'is-selected' : province.selectionState.focused ? 'is-focused' : ''}">
+          <g class="province-map-label province-map-label--${label.tone} ${province.selectionState.selected ? 'is-selected' : province.selectionState.hovered ? 'is-hovered' : province.selectionState.focused ? 'is-focused' : ''}">
             ${label.leaderNeeded ? `<path class="province-map-label__leader" d="M ${label.center.x} ${label.center.y} L ${label.x} ${label.y - 1.5}"></path>` : ''}
             <rect class="province-map-label__plate" x="${label.rectX}%" y="${label.rectY}%" width="${label.width}%" height="${label.height}%" rx="1.4" ry="1.4"></rect>
             <text class="province-map-label__title" x="${label.titleX}%" y="${label.y}%" text-anchor="${label.align}">${province.label}</text>
@@ -2355,10 +2363,12 @@ function renderStrategicRelations(shell) {
   const relationLines = buildProvinceRelations(shell).map((relation, index) => {
     const linkedToSelection = focusContext.selectedProvince
       && (relation.relationId.includes(focusContext.selectedProvince.provinceId));
+    const linkedToHover = focusContext.hoveredProvince
+      && (relation.relationId.includes(focusContext.hoveredProvince.provinceId));
     const pathD = buildReadableRelationPath(relation, index);
 
     return `
-    <g class="front-link ${linkedToSelection ? 'is-emphasized' : ''}">
+    <g class="front-link ${linkedToSelection ? 'is-emphasized' : ''} ${linkedToHover ? 'is-previewed' : ''}">
       <path class="front-line-casing" d="${pathD}" />
       <path
         class="front-line ${relation.contested ? 'is-contested' : relation.occupied ? 'is-occupied' : relation.stable ? 'is-stable' : ''} ${linkedToSelection ? 'is-emphasized' : ''}"
@@ -2795,16 +2805,19 @@ function render() {
 
   document.querySelectorAll('[data-province-id]').forEach((element) => {
     element.addEventListener('mouseenter', () => {
+      state.hoveredProvinceId = element.dataset.provinceId;
       state.focusedProvinceId = element.dataset.provinceId;
       render();
     });
 
     element.addEventListener('mouseleave', () => {
+      state.hoveredProvinceId = null;
       state.focusedProvinceId = state.selectedProvinceId;
       render();
     });
 
     element.addEventListener('click', () => {
+      state.hoveredProvinceId = null;
       state.focusedProvinceId = element.dataset.provinceId;
       state.selectedProvinceId = element.dataset.provinceId;
       state.popupProvinceId = element.dataset.provinceId;

--- a/web/styles.css
+++ b/web/styles.css
@@ -480,6 +480,11 @@ button { font: inherit; }
   stroke: rgba(251, 191, 36, 0.72);
   opacity: 0.28;
 }
+.province-surface.is-hovered .province-surface__core {
+  stroke: #a5f3fc;
+  stroke-width: 1.55;
+  filter: drop-shadow(0 0 10px rgba(103, 232, 249, 0.26));
+}
 .province-surface.is-focused .province-surface__core,
 .province-surface.is-selected .province-surface__core {
   stroke: #67e8f9;
@@ -488,11 +493,15 @@ button { font: inherit; }
 .province-surface.is-selected .province-surface__core {
   filter: drop-shadow(0 0 0 rgba(0,0,0,0)) drop-shadow(0 0 16px rgba(34, 211, 238, 0.48)) drop-shadow(0 0 28px rgba(251, 191, 36, 0.18));
 }
+.province-surface.is-hovered .province-surface__glow,
 .province-surface.is-selected .province-surface__glow,
 .province-surface.is-focused .province-surface__glow {
   stroke: #67e8f9;
   stroke-width: 3.4;
   opacity: 0.34;
+}
+.province-surface.is-hovered .province-surface__glow {
+  opacity: 0.26;
 }
 .province-surface.is-occupied .province-surface__hairline {
   stroke-dasharray: 3 2;
@@ -553,13 +562,18 @@ button { font: inherit; }
   fill: #fda4af;
 }
 .province-map-label.is-selected .province-map-label__title,
-.province-map-label.is-focused .province-map-label__title {
+.province-map-label.is-focused .province-map-label__title,
+.province-map-label.is-hovered .province-map-label__title {
   fill: #67e8f9;
 }
+.province-map-label.is-hovered .province-map-label__plate,
 .province-map-label.is-selected .province-map-label__plate,
 .province-map-label.is-focused .province-map-label__plate {
   fill: rgba(8, 15, 28, 0.86);
   stroke: rgba(103, 232, 249, 0.48);
+}
+.province-map-label.is-hovered .province-map-label__plate {
+  stroke: rgba(165, 243, 252, 0.34);
 }
 .city-map-label__leader {
   stroke: rgba(226, 232, 240, 0.38);
@@ -617,6 +631,14 @@ button { font: inherit; }
 .front-line.is-emphasized {
   stroke-width: 0.9;
   opacity: 1;
+}
+.front-link.is-previewed .front-line {
+  stroke-width: 0.74;
+  opacity: 0.9;
+}
+.front-link.is-previewed .front-line-casing {
+  stroke-width: 1.9;
+  opacity: 0.9;
 }
 .front-link.is-emphasized .front-line-casing {
   stroke-width: 2.1;
@@ -1128,19 +1150,24 @@ button { font: inherit; }
   transition: opacity 160ms ease, transform 160ms ease, border-color 160ms ease, color 160ms ease;
 }
 .province-node:hover::after,
+.province-node.is-hovered::after,
 .province-node.is-focused::after,
 .province-node.is-selected::after {
   opacity: 1;
   transform: translateY(0);
 }
-.province-node:hover, .province-node.is-focused {
+.province-node:hover, .province-node.is-hovered, .province-node.is-focused {
   transform: translateY(-2px);
   filter: drop-shadow(0 0 14px rgba(103, 232, 249, 0.24));
 }
 .province-node:hover::before,
+.province-node.is-hovered::before,
 .province-node.is-focused::before {
   border-color: rgba(103, 232, 249, 0.34);
   background: linear-gradient(135deg, rgba(103, 232, 249, 0.1), transparent 36%, rgba(251, 191, 36, 0.07));
+}
+.province-node.is-hovered {
+  z-index: 5;
 }
 .province-node.is-selected {
   z-index: 6;
@@ -1192,6 +1219,7 @@ button { font: inherit; }
   transition: opacity 160ms ease;
 }
 .province-node:hover .province-node__terrain::before,
+.province-node.is-hovered .province-node__terrain::before,
 .province-node.is-focused .province-node__terrain::before,
 .province-node.is-selected .province-node__terrain::before {
   opacity: 1;
@@ -1210,8 +1238,12 @@ button { font: inherit; }
 }
 .province-node.is-selected .province-node__focus-rail,
 .province-node.is-neighbor .province-node__focus-rail,
+.province-node.is-hovered .province-node__focus-rail,
 .province-node.is-focused .province-node__focus-rail {
   opacity: 1;
+}
+.province-node.is-hovered .province-node__focus-rail {
+  opacity: 0.78;
 }
 .province-node__signal,
 .province-node__name, .province-node__meta, .province-node__badges, .province-node__link { position: relative; z-index: 1; }
@@ -1234,9 +1266,14 @@ button { font: inherit; }
   box-shadow: 0 0 12px rgba(251, 191, 36, 0.2);
 }
 .province-node.is-focused .province-node__signal,
+.province-node.is-hovered .province-node__signal,
 .province-node:hover .province-node__signal {
   border-color: rgba(103, 232, 249, 0.42);
   color: #cffafe;
+}
+.province-node.is-hovered .province-node__signal {
+  background: rgba(8, 47, 73, 0.68);
+  box-shadow: 0 0 12px rgba(103, 232, 249, 0.18);
 }
 .province-node__name {
   font-weight: 800;
@@ -1249,6 +1286,7 @@ button { font: inherit; }
   transition: opacity 160ms ease, transform 160ms ease;
 }
 .province-node:hover .province-node__name,
+.province-node.is-hovered .province-node__name,
 .province-node.is-focused .province-node__name,
 .province-node.is-selected .province-node__name,
 .province-node.is-neighbor .province-node__name {
@@ -1263,12 +1301,14 @@ button { font: inherit; }
   opacity: 0;
 }
 .province-node:hover .province-node__meta,
+.province-node.is-hovered .province-node__meta,
 .province-node.is-focused .province-node__meta,
 .province-node.is-selected .province-node__meta {
   opacity: 1;
 }
 .province-node__badges { display: none; flex-wrap: wrap; gap: 6px; }
 .province-node.is-selected .province-node__badges,
+.province-node.is-hovered .province-node__badges,
 .province-node.is-focused .province-node__badges { display: flex; }
 .province-node__link {
   margin-top: 8px;


### PR DESCRIPTION
Alpha: Closes #423.

## Summary
- adds a first-class hovered province state to the strategic map shell contract
- separates hover/focus/selected visual classes so hover preview is distinct from active selection
- previews hovered province borders/front links while keeping the selected province emphasis stronger
- clears hover state on click/scenario switches so overlay focus remains predictable

## Verification
- npm test
- npm run preview:map -- /tmp/historia-map-hover-selection-preview.html
- node --check web/app.js
- node --check src/ui/war/StrategicMapShell.js
- git diff --check
