### PR TITLE
Beta: add economy overlay filters

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -392,6 +392,11 @@ const state = {
   mapPanY: 0,
   lastTurnSummary: 'Le théâtre reste sous tension, sans bascule majeure.',
   selectedIntrigueOperationId: 'op-river-ashes',
+  economyFilters: {
+    criticalRoutes: false,
+    resourceMarkers: true,
+    cityLabels: false,
+  },
   intrigueFilters: {
     presence: true,
     alerts: true,
@@ -421,6 +426,11 @@ function applyMapScenario(scenario) {
   state.mobilePanelSection = 'details';
   state.mobileMapExpanded = true;
   state.hoveredProvinceId = null;
+  state.economyFilters = {
+    criticalRoutes: false,
+    resourceMarkers: true,
+    cityLabels: false,
+  };
   state.intrigueFilters = {
     presence: true,
     alerts: true,
@@ -1642,6 +1652,7 @@ function renderEconomyMapOverlay(economyView) {
     return '';
   }
 
+  const filters = state.economyFilters;
   const tensionByCityId = Object.fromEntries(economyView.comparison.rows.map((row) => [row.cityId, row]));
   const heatNodes = economyView.overlay.cities.map((city) => {
     const position = city.marker.position;
@@ -1679,15 +1690,16 @@ function renderEconomyMapOverlay(economyView) {
         ? 'has-medium-tension'
         : 'has-low-tension';
     const emphasizeRoute = visual.critical || tensionClass === 'has-high-tension';
-    const showRouteLabel = emphasizeRoute || tensionClass === 'has-medium-tension';
+    const routeFiltered = filters.criticalRoutes && !emphasizeRoute;
+    const showRouteLabel = !routeFiltered && (emphasizeRoute || tensionClass === 'has-medium-tension');
 
     return `
-      <g class="economy-route-group ${visual.classes} ${tensionClass} ${emphasizeRoute ? 'is-emphasized' : 'is-muted'}" data-route-id="${route.routeId}">
+      <g class="economy-route-group ${visual.classes} ${tensionClass} ${emphasizeRoute ? 'is-emphasized' : 'is-muted'} ${routeFiltered ? 'is-filtered' : ''}" data-route-id="${route.routeId}" aria-label="${routeFiltered ? 'Route secondaire atténuée par filtre' : 'Route économie visible'}">
         <path class="economy-route__halo" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__casing" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__line" d="${visual.pathD}" pathLength="100" marker-end="url(#${visual.markerId})" />
         <path class="economy-route__flow" d="${visual.pathD}" pathLength="100" />
-        ${renderRouteHudMarkers(route, visual, { compact: !emphasizeRoute })}
+        ${renderRouteHudMarkers(route, visual, { compact: !emphasizeRoute || routeFiltered })}
         ${showRouteLabel ? `<text class="economy-route__label" text-anchor="middle">
           <textPath href="#route-label-${route.routeId}" startOffset="50%">${route.routeName}</textPath>
         </text>` : ''}
@@ -1707,19 +1719,21 @@ function renderEconomyMapOverlay(economyView) {
     const isHub = city.tradeRouteIds.length >= 2 || city.resources.totalStock >= 16;
     const isSelected = state.selectedCityId === city.cityId || state.hoveredCityId === city.cityId;
     const expandResources = isSelected || tension === 'high';
-    const showResources = expandResources || city.capital || isHub;
+    const keepResourceWarning = tension === 'high';
+    const showResources = keepResourceWarning || (filters.resourceMarkers && (expandResources || city.capital || isHub));
+    const showCityLabels = filters.cityLabels && (isSelected || city.capital || isHub || tension !== 'low');
 
     return `
-      <g class="economy-city-group ${isSelected ? 'is-selected' : ''} ${city.capital ? 'is-capital' : ''} ${isHub ? 'is-hub' : ''} is-${tension}-tension" data-city-id="${city.cityId}">
+      <g class="economy-city-group ${isSelected ? 'is-selected' : ''} ${city.capital ? 'is-capital' : ''} ${isHub ? 'is-hub' : ''} is-${tension}-tension ${!filters.resourceMarkers && showResources ? 'has-forced-resource-warning' : ''}" data-city-id="${city.cityId}">
         <circle class="economy-city-tension-ring" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 9.2}" />
         ${city.capital ? `<circle class="economy-city-capital-ring" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 10.8}" />` : ''}
         ${isHub ? `<rect class="economy-city-hub-frame" x="calc(${position.x}% - ${city.marker.size * 7.4}px)" y="calc(${position.y}% - ${city.marker.size * 7.4}px)" width="${city.marker.size * 14.8}" height="${city.marker.size * 14.8}" rx="${city.marker.size * 3.2}" ry="${city.marker.size * 3.2}" />` : ''}
         <circle class="economy-city economy-city--${city.marker.tone}" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 6.6}" />
         ${city.capital ? `<text class="economy-city-glyph" x="${position.x}%" y="calc(${position.y}% + 1px)" text-anchor="middle">★</text>` : isHub ? `<text class="economy-city-glyph" x="${position.x}%" y="calc(${position.y}% + 1px)" text-anchor="middle">◆</text>` : ''}
-        ${showResources ? renderResourceHudBadges(city, position, { expanded: expandResources }) : ''}
+        ${showResources ? renderResourceHudBadges(city, position, { expanded: expandResources && filters.resourceMarkers }) : ''}
         <circle class="economy-city-hitbox" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 12}" />
-        <text class="economy-city-label economy-city-label--sr" x="${position.x}%" y="calc(${position.y}% - 14px)" text-anchor="middle">${city.cityName}</text>
-        <text class="economy-city-resource economy-city-resource--sr" x="${position.x}%" y="calc(${position.y}% + 18px)" text-anchor="middle">${city.resources.primaryResourceId ?? 'stock vide'}</text>
+        <text class="economy-city-label ${showCityLabels ? '' : 'economy-city-label--sr'}" x="${position.x}%" y="calc(${position.y}% - 14px)" text-anchor="middle">${city.cityName}</text>
+        <text class="economy-city-resource ${showCityLabels ? '' : 'economy-city-resource--sr'}" x="${position.x}%" y="calc(${position.y}% + 18px)" text-anchor="middle">${city.resources.primaryResourceId ?? 'stock vide'}</text>
       </g>
     `;
   }).join('');
@@ -2024,13 +2038,33 @@ function renderEconomySidePanel(economyView, cultureView) {
     `;
   }
 
+  const filters = state.economyFilters;
+  const tensionByCityId = Object.fromEntries(economyView.comparison.rows.map((row) => [row.cityId, row]));
+  const criticalRouteCount = economyView.overlay.routes.filter((route) => {
+    const originTension = tensionByCityId[route.originCityId]?.tensionLevel ?? 'low';
+    const destinationTension = tensionByCityId[route.destinationCityId]?.tensionLevel ?? 'low';
+    return route.riskLevel >= 55 || route.totalCapacity >= 9 || originTension === 'high' || destinationTension === 'high';
+  }).length;
+  const resourceSignalCopy = filters.resourceMarkers
+    ? 'ressources compactes visibles'
+    : 'ressources masquées sauf tension forte';
+  const routeSignalCopy = filters.criticalRoutes
+    ? `${criticalRouteCount} routes critiques gardées nettes`
+    : 'routes critiques et support visibles';
+
   return `
     <section class="panel overlay-panel overlay-panel--economy">
       <div class="panel-header economy-panel-header">
         <p class="eyebrow">Economy HUD</p>
         <h3>Overlay actif, Économie</h3>
-        <p>${economyView.overlay.summary} · lecture verre dépoli haute densité</p>
+        <p>${economyView.overlay.summary} · ${routeSignalCopy} · ${resourceSignalCopy}</p>
       </div>
+      <section class="economy-filter-bar" aria-label="Filtres économie">
+        <button type="button" class="economy-filter-chip ${filters.criticalRoutes ? 'is-active' : ''}" data-economy-filter="criticalRoutes" aria-pressed="${filters.criticalRoutes}">Routes critiques</button>
+        <button type="button" class="economy-filter-chip ${filters.resourceMarkers ? 'is-active' : ''}" data-economy-filter="resourceMarkers" aria-pressed="${filters.resourceMarkers}">Ressources</button>
+        <button type="button" class="economy-filter-chip ${filters.cityLabels ? 'is-active' : ''}" data-economy-filter="cityLabels" aria-pressed="${filters.cityLabels}">Labels logistiques</button>
+        <small>${filters.criticalRoutes ? 'Routes secondaires atténuées, pas supprimées.' : 'Vue lisible par défaut.'} ${filters.cityLabels ? 'Labels clés affichés.' : 'Labels détaillés au survol/sélection.'}</small>
+      </section>
       ${renderEconomyKpiStrip(economyView)}
       ${renderEconomyFocusPanel(economyView)}
       <div class="economy-route-list">
@@ -2995,6 +3029,14 @@ function render() {
   document.querySelectorAll('[data-intrigue-operation-id]').forEach((element) => {
     element.addEventListener('click', () => {
       state.selectedIntrigueOperationId = element.dataset.intrigueOperationId;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-economy-filter]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const key = element.dataset.economyFilter;
+      state.economyFilters[key] = !state.economyFilters[key];
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -781,6 +781,18 @@ button { font: inherit; }
 .economy-route.is-muted .economy-route__flow {
   opacity: 0.22;
 }
+.economy-route.is-filtered .economy-route__halo,
+.economy-route.is-filtered .economy-route__casing,
+.economy-route.is-filtered .economy-route__flow {
+  opacity: 0.08;
+}
+.economy-route.is-filtered .economy-route__line {
+  opacity: 0.24;
+  stroke-dasharray: 2 8;
+}
+.economy-route.is-filtered .economy-route-hud {
+  opacity: 0.28;
+}
 .economy-route.is-inactive .economy-route__line,
 .economy-route.is-inactive .economy-route__flow,
 .economy-route.is-inactive .economy-route__label {
@@ -913,6 +925,17 @@ button { font: inherit; }
   opacity: 0;
 }
 .economy-city-resource { fill: #bfdbfe; }
+.economy-city-label:not(.economy-city-label--sr),
+.economy-city-resource:not(.economy-city-resource--sr) {
+  paint-order: stroke;
+  stroke: rgba(8, 15, 28, 0.78);
+  stroke-width: 0.8px;
+  filter: drop-shadow(0 0 4px rgba(8, 15, 28, 0.72));
+}
+.economy-city-group.has-forced-resource-warning .economy-resource-glyph__backplate {
+  stroke: rgba(251, 113, 133, 0.78);
+  stroke-dasharray: 1.5 1.5;
+}
 .economy-resource-glyph {
   pointer-events: none;
   filter: drop-shadow(0 0 4px rgba(8, 15, 28, 0.58));
@@ -1585,13 +1608,28 @@ button { font: inherit; }
   gap: 10px;
   margin-top: 14px;
 }
-.intrigue-filter-bar {
+.intrigue-filter-bar,
+.economy-filter-bar {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 14px;
 }
-.intrigue-filter-chip {
+.economy-filter-bar {
+  margin-bottom: 14px;
+  padding: 10px;
+  border-radius: 16px;
+  background: rgba(8, 15, 28, 0.38);
+  border: 1px solid rgba(103, 232, 249, 0.12);
+}
+.economy-filter-bar small {
+  flex-basis: 100%;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+.intrigue-filter-chip,
+.economy-filter-chip {
   border: 1px solid rgba(148, 163, 184, 0.16);
   background: linear-gradient(180deg, rgba(15, 23, 42, 0.68), rgba(8, 15, 28, 0.48));
   color: var(--muted);
@@ -1602,7 +1640,8 @@ button { font: inherit; }
   text-transform: uppercase;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
-.intrigue-filter-chip.is-active {
+.intrigue-filter-chip.is-active,
+.economy-filter-chip.is-active {
   color: #ecfeff;
   border-color: rgba(103, 232, 249, 0.42);
   background: linear-gradient(180deg, rgba(8, 145, 178, 0.24), rgba(8, 15, 28, 0.52));


### PR DESCRIPTION
Beta: Implements #424.

Scope:
- add economy overlay filter chips for critical-route focus, resource markers, and logistics labels;
- keep default behavior close to the current readable view;
- attenuate filtered secondary routes instead of making them disappear;
- preserve high-tension resource warnings even when resource markers are hidden.

Validation:
- npm test (360 passing)
- node --check web/app.js
- git diff --check

Ready for Zeta validation before merge.