### PR TITLE
Gamma: Add culture cluster summaries

### DIFF
--- a/src/application/culture/buildGeneratedMapCultureData.js
+++ b/src/application/culture/buildGeneratedMapCultureData.js
@@ -151,6 +151,7 @@ export function buildGeneratedMapCultureData(culturePayload = {}, options = {}) 
     normalizedOptions.regionIdsByCulture,
   );
   const overlay = buildCultureMapOverlay(normalizedCulturePayload, {
+    clusterSummaries: true,
     ...(normalizedOptions.cultureOverlay ?? {}),
     regionIdsByCulture,
   });

--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -292,6 +292,30 @@ function buildZoneContour(influenceTier, overlapCount, zoneRank) {
   };
 }
 
+function buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById) {
+  const cultureIds = regionPresence.map((entry) => entry.cultureId).sort();
+  const cultureNames = regionPresence.map((entry) => entry.cultureName).sort();
+  const discoveryIds = [...new Set(regionPresence.flatMap((entry) => (
+    cultureSignalsById.get(entry.cultureId)?.signals.highlightedDiscoveries ?? []
+  )))].sort();
+  const eventCount = regionPresence.reduce((total, entry) => (
+    total + (cultureSignalsById.get(entry.cultureId)?.signals.eventCount ?? 0)
+  ), 0);
+
+  return {
+    clusterId: `${regionId}:culture-cluster`,
+    regionId,
+    cultureIds,
+    cultureNames,
+    cultureCount: cultureIds.length,
+    discoveryIds,
+    discoveryCount: discoveryIds.length,
+    eventCount,
+    label: `${cultureIds.length} cultures · ${discoveryIds.length} découvertes`,
+    summary: `${cultureNames.slice(0, 3).join(', ')}${cultureNames.length > 3 ? '…' : ''}`,
+  };
+}
+
 export function buildCultureMapOverlay(payload, options = {}) {
   const normalizedPayload = requireObject(payload, 'CultureMapOverlay payload');
   const normalizedOptions = requireObject(options, 'CultureMapOverlay options');
@@ -338,6 +362,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
     }),
   );
   const regionPresenceMap = buildRegionPresenceMap(cultures, regionIdsByCulture, cultureSignalsById);
+  const includeClusterSummaries = normalizedOptions.clusterSummaries === true;
 
   return cultures
     .flatMap((culture) => {
@@ -352,6 +377,9 @@ export function buildCultureMapOverlay(payload, options = {}) {
         const overlapCount = regionPresence.length;
         const dominantCulture = regionPresence[0] ?? null;
         const zoneBand = buildZoneBand(zoneRank, overlapCount);
+        const clusterSummary = includeClusterSummaries && overlapCount > 1
+          ? buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById)
+          : null;
 
         const regionalDiscoveryLinks = cultureState.signals.highlightedDiscoveries.map((discoveryId) => {
           const linkedEvents = cultureState.signals.orderedHistoricalEvents.filter((historicalEvent) => historicalEvent.discoveryIds.includes(discoveryId));
@@ -417,6 +445,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           zoneBand,
           dominantInRegion: dominantCulture?.cultureId === culture.id,
           competingCultureIds: regionPresence.filter((entry) => entry.cultureId !== culture.id).map((entry) => entry.cultureId),
+          ...(clusterSummary ? { clusterSummary } : {}),
           zoneContour: buildZoneContour(cultureState.influenceTier, overlapCount, zoneRank),
           style,
           zoneStyle: buildZoneStyle(markerType, cultureState.influenceTier, style, zoneBand),

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -614,6 +614,92 @@ test('buildCultureMapOverlay supports plain payloads and style overrides', () =>
   assert.equal(overlay[0].zoneStyle.glow, 'sparking');
 });
 
+test('buildCultureMapOverlay can summarize overlapping culture clusters', () => {
+  const overlay = buildCultureMapOverlay(
+    {
+      cultures: [
+        {
+          id: 'culture-harbor',
+          name: 'Harbor Compact',
+          archetype: 'maritime',
+          primaryLanguage: 'harbor-cant',
+          valueIds: ['trade'],
+          traditionIds: ['pilots'],
+          openness: 70,
+          cohesion: 62,
+          researchDrive: 76,
+        },
+        {
+          id: 'culture-delta',
+          name: 'Delta Scribes',
+          archetype: 'scholarly',
+          primaryLanguage: 'delta-script',
+          valueIds: ['archives'],
+          traditionIds: ['flood-books'],
+          openness: 64,
+          cohesion: 58,
+          researchDrive: 72,
+        },
+      ],
+      researchStates: [
+        {
+          id: 'research-harbor',
+          cultureId: 'culture-harbor',
+          topicId: 'tidal-ledgers',
+          status: 'active',
+          progress: 50,
+          discoveredConceptIds: ['tidal-ledgers'],
+        },
+        {
+          id: 'research-delta',
+          cultureId: 'culture-delta',
+          topicId: 'flood-archives',
+          status: 'completed',
+          progress: 100,
+          completedAt: '2026-04-19T00:00:00.000Z',
+          discoveredConceptIds: ['flood-archives'],
+        },
+      ],
+      historicalEvents: [],
+    },
+    {
+      clusterSummaries: true,
+      regionIdsByCulture: {
+        'culture-harbor': ['shared-bay'],
+        'culture-delta': ['shared-bay'],
+      },
+    },
+  );
+
+  assert.equal(overlay.length, 2);
+  assert.deepEqual(overlay.map((entry) => entry.clusterSummary), [
+    {
+      clusterId: 'shared-bay:culture-cluster',
+      regionId: 'shared-bay',
+      cultureIds: ['culture-delta', 'culture-harbor'],
+      cultureNames: ['Delta Scribes', 'Harbor Compact'],
+      cultureCount: 2,
+      discoveryIds: ['flood-archives', 'tidal-ledgers'],
+      discoveryCount: 2,
+      eventCount: 0,
+      label: '2 cultures · 2 découvertes',
+      summary: 'Delta Scribes, Harbor Compact',
+    },
+    {
+      clusterId: 'shared-bay:culture-cluster',
+      regionId: 'shared-bay',
+      cultureIds: ['culture-delta', 'culture-harbor'],
+      cultureNames: ['Delta Scribes', 'Harbor Compact'],
+      cultureCount: 2,
+      discoveryIds: ['flood-archives', 'tidal-ledgers'],
+      discoveryCount: 2,
+      eventCount: 0,
+      label: '2 cultures · 2 découvertes',
+      summary: 'Delta Scribes, Harbor Compact',
+    },
+  ]);
+});
+
 test('buildCultureMapOverlay rejects invalid inputs', () => {
   assert.throws(() => buildCultureMapOverlay(null), /payload must be an object/);
   assert.throws(

--- a/web/app.js
+++ b/web/app.js
@@ -1458,7 +1458,7 @@ function renderCultureLegendKey(cultureView) {
   `;
 }
 
-function renderCultureMarker(entry, active) {
+function renderCultureMarker(entry, active, clusteredRegionIds = new Set()) {
   const center = getProvinceCenter(entry.regionId);
 
   if (!center) {
@@ -1466,23 +1466,92 @@ function renderCultureMarker(entry, active) {
   }
 
   const selected = entry.regionId === state.selectedProvinceId;
+  const clustered = clusteredRegionIds.has(entry.regionId);
   const tone = getCultureTone(entry);
-  const radius = active ? Math.max(3.9, Math.min(8.2, entry.zoneContour.radius / 3.4)) : 2.15;
+  const radius = active ? Math.max(3.9, Math.min(8.2, entry.zoneContour.radius / (clustered ? 4.2 : 3.4))) : 2.15;
   const eventBadgeY = center.y - radius - 2.1;
   const language = getCultureMarkerLanguage(entry);
-  const glyphScale = active ? Math.max(1.75, radius * 0.34) : 1.05;
+  const glyphScale = active ? Math.max(1.55, radius * 0.32) : 1.05;
   const selectedClass = selected ? 'is-selected' : '';
   const stateClass = active ? 'is-readable' : 'is-quiet';
+  const clusterClass = clustered ? 'is-clustered' : '';
 
   return `
-    <g class="culture-marker culture-marker--${tone} culture-marker--${entry.influenceTier} culture-marker--${entry.markerType} ${selectedClass} ${stateClass}" data-culture-region="${entry.regionId}">
+    <g class="culture-marker culture-marker--${tone} culture-marker--${entry.influenceTier} culture-marker--${entry.markerType} ${selectedClass} ${stateClass} ${clusterClass}" data-culture-region="${entry.regionId}">
       <title>${entry.cultureName} · ${entry.regionId} · ${entry.summary}</title>
       <circle class="culture-marker__aura" cx="${center.x}%" cy="${center.y}%" r="${radius + (active ? 1.8 : 0.9)}"></circle>
       <circle class="culture-marker__ring" cx="${center.x}%" cy="${center.y}%" r="${radius}"></circle>
       ${active && selected ? renderCultureMarkerTicks(center, radius, language) : ''}
       ${active ? `<path class="culture-marker__sigil" d="${language.glyph}" transform="translate(${center.x} ${center.y}) scale(${glyphScale})"></path>` : ''}
       ${active ? `<text class="culture-marker__code" x="${center.x}%" y="${center.y + radius + 2.4}%" text-anchor="middle">${language.code}</text>` : ''}
-      ${active && entry.eventCount > 0 ? `<g class="culture-event-flag"><circle cx="${center.x + radius + 1.7}%" cy="${eventBadgeY}%" r="1.55"></circle><text x="${center.x + radius + 1.7}%" y="${eventBadgeY + 0.48}%" text-anchor="middle">${entry.eventCount}</text></g>` : ''}
+      ${active && entry.eventCount > 0 && !clustered ? `<g class="culture-event-flag"><circle cx="${center.x + radius + 1.7}%" cy="${eventBadgeY}%" r="1.55"></circle><text x="${center.x + radius + 1.7}%" y="${eventBadgeY + 0.48}%" text-anchor="middle">${entry.eventCount}</text></g>` : ''}
+    </g>
+  `;
+}
+
+function buildCultureClusterSummaries(entries) {
+  const remaining = entries
+    .map((entry) => ({ entry, center: getProvinceCenter(entry.regionId) }))
+    .filter((item) => item.center)
+    .sort((left, right) => left.center.x - right.center.x || left.center.y - right.center.y);
+  const clusters = [];
+  const usedRegionIds = new Set();
+
+  remaining.forEach((item) => {
+    if (usedRegionIds.has(item.entry.regionId)) {
+      return;
+    }
+
+    const members = remaining.filter((candidate) => (
+      !usedRegionIds.has(candidate.entry.regionId)
+      && Math.hypot(candidate.center.x - item.center.x, candidate.center.y - item.center.y) <= 14
+    ));
+
+    if (members.length < 3 && !item.entry.clusterSummary) {
+      return;
+    }
+
+    members.forEach((member) => usedRegionIds.add(member.entry.regionId));
+    const entriesInCluster = members.map((member) => member.entry);
+    const cultureIds = [...new Set(entriesInCluster.flatMap((entry) => entry.clusterSummary?.cultureIds ?? [entry.cultureId]))].sort();
+    const cultureNames = [...new Set(entriesInCluster.flatMap((entry) => entry.clusterSummary?.cultureNames ?? [entry.cultureName]))].sort();
+    const discoveryIds = [...new Set(entriesInCluster.flatMap((entry) => entry.clusterSummary?.discoveryIds ?? entry.discoveries))].sort();
+    const eventCount = entriesInCluster.reduce((total, entry) => total + (entry.clusterSummary?.eventCount ?? entry.eventCount), 0);
+    const centroid = members.reduce((accumulator, member) => ({
+      x: accumulator.x + member.center.x,
+      y: accumulator.y + member.center.y,
+    }), { x: 0, y: 0 });
+    const anchor = {
+      x: Math.max(9, Math.min(91, centroid.x / members.length)),
+      y: Math.max(5, Math.min(94, (centroid.y / members.length) - 7.4)),
+    };
+
+    clusters.push({
+      clusterId: `culture-cluster:${entriesInCluster.map((entry) => entry.regionId).sort().join(':')}`,
+      anchor,
+      regionIds: entriesInCluster.map((entry) => entry.regionId).sort(),
+      cultureIds,
+      cultureNames,
+      cultureCount: cultureIds.length,
+      discoveryCount: discoveryIds.length,
+      eventCount,
+      label: `${cultureIds.length} cultures · ${discoveryIds.length} découvertes`,
+      summary: `${cultureNames.slice(0, 2).join(', ')}${cultureNames.length > 2 ? '…' : ''}`,
+    });
+  });
+
+  return clusters;
+}
+
+function renderCultureClusterSummary(cluster, active) {
+  const detail = `${cluster.summary} · régions ${cluster.regionIds.join(', ')} · cultures ${cluster.cultureIds.join(', ')}`;
+
+  return `
+    <g class="culture-cluster-summary ${active ? 'is-active' : 'is-muted'}" data-culture-cluster="${cluster.clusterId}">
+      <title>${detail}</title>
+      <rect x="${cluster.anchor.x - 7.8}%" y="${cluster.anchor.y - 3.1}%" width="15.6%" height="6.2%" rx="2.2%"></rect>
+      <text class="culture-cluster-summary__count" x="${cluster.anchor.x - 5.9}%" y="${cluster.anchor.y + 0.45}%">C${cluster.cultureCount}</text>
+      <text class="culture-cluster-summary__label" x="${cluster.anchor.x - 0.7}%" y="${cluster.anchor.y + 0.45}%">D${cluster.discoveryCount}${cluster.eventCount > 0 ? ` · H${cluster.eventCount}` : ''}</text>
     </g>
   `;
 }
@@ -1492,7 +1561,10 @@ function renderCultureMapOverlay(cultureView) {
   const markerEntries = active
     ? cultureView.overlay
     : cultureView.overlay.filter((entry) => entry.dominantInRegion || entry.regionId === state.selectedProvinceId);
-  const markerNodes = markerEntries.map((entry) => renderCultureMarker(entry, active)).join('');
+  const clusterSummaries = buildCultureClusterSummaries(markerEntries);
+  const clusteredRegionIds = new Set(clusterSummaries.flatMap((cluster) => cluster.regionIds));
+  const markerNodes = markerEntries.map((entry) => renderCultureMarker(entry, active, clusteredRegionIds)).join('');
+  const clusterNodes = clusterSummaries.map((cluster) => renderCultureClusterSummary(cluster, active)).join('');
 
   const discoveryLinks = active ? cultureView.overlay.flatMap((entry) => {
     const center = getProvinceCenter(entry.regionId);
@@ -1502,6 +1574,12 @@ function renderCultureMapOverlay(cultureView) {
     }
 
     const selected = entry.regionId === state.selectedProvinceId;
+    const clustered = clusteredRegionIds.has(entry.regionId);
+
+    if (clustered && !selected) {
+      return [];
+    }
+
     const visibleLinks = entry.regionalDiscoveryLinks.slice(0, selected ? 2 : 1);
 
     return visibleLinks.map((link, index) => {
@@ -1530,6 +1608,7 @@ function renderCultureMapOverlay(cultureView) {
         </filter>
       </defs>
       ${markerNodes}
+      ${clusterNodes}
       ${discoveryLinks}
     </svg>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -2544,6 +2544,13 @@ button { font: inherit; }
 }
 .culture-marker.is-readable { opacity: 0.9; }
 .culture-marker.is-quiet { opacity: 0.46; }
+.culture-marker.is-clustered:not(.is-selected) {
+  opacity: 0.54;
+}
+.culture-marker.is-clustered:not(.is-selected) .culture-marker__code,
+.culture-marker.is-clustered:not(.is-selected) .culture-marker__sigil {
+  opacity: 0.72;
+}
 .culture-marker__aura {
   fill: rgba(8, 47, 73, 0.12);
   stroke: rgba(125, 211, 252, 0.14);
@@ -2826,6 +2833,29 @@ button { font: inherit; }
 .culture-discovery-ping--amber .culture-discovery-ping__glyph { stroke: #fcd34d; fill: rgba(120, 53, 15, 0.72); }
 .culture-discovery-ping--rose .culture-discovery-ping__leader { stroke: rgba(251, 113, 133, 0.3); }
 .culture-discovery-ping--rose .culture-discovery-ping__glyph { stroke: #fda4af; fill: rgba(136, 19, 55, 0.66); }
+.culture-cluster-summary {
+  opacity: 0.88;
+  filter: url(#cultureHudGlow);
+}
+.culture-cluster-summary.is-muted {
+  opacity: 0.5;
+}
+.culture-cluster-summary rect {
+  fill: rgba(2, 6, 23, 0.74);
+  stroke: rgba(125, 211, 252, 0.48);
+  stroke-width: 0.24;
+}
+.culture-cluster-summary__count,
+.culture-cluster-summary__label {
+  font-size: 1.55px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.92);
+  stroke-width: 0.3px;
+}
+.culture-cluster-summary__count { fill: #bae6fd; }
+.culture-cluster-summary__label { fill: #fde68a; }
 .culture-symbol-key {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Gamma: Closes #425.

## Summary
- add opt-in culture cluster summaries to overlay data for overlapping cultures in the same region
- enable generated map culture overlays to carry those summaries for the web map
- render compact C/D/H cluster badges for dense culture groups while keeping individual marker titles/details available
- keep inactive culture view subdued but still informative with summary badges

## Validation
- `node --check web/app.js`
- `git diff --check`
- `npm test` (361 passing)

Gamma: Ready for Zeta validation before merge.
