### PR TITLE
Delta: Add intrigue hotspot drilldown

### DIFF
--- a/src/ui/intrigue/buildIntrigueWebDemo.js
+++ b/src/ui/intrigue/buildIntrigueWebDemo.js
@@ -76,6 +76,60 @@ function buildHotspotEntry(entry) {
   };
 }
 
+function buildHotspotDrillDown(entry, cellules, operations, locationNames) {
+  const locationCellules = cellules
+    .filter((cellule) => cellule.locationId === entry.locationId && cellule.status !== 'dismantled')
+    .sort((left, right) => {
+      if (right.exposure !== left.exposure) {
+        return right.exposure - left.exposure;
+      }
+
+      return left.id.localeCompare(right.id);
+    });
+  const activeOperations = operations
+    .filter((operation) => operation.theaterId === entry.locationId && operation.type === 'sabotage' && !operation.isResolved)
+    .sort((left, right) => {
+      if (right.heat !== left.heat) {
+        return right.heat - left.heat;
+      }
+
+      return left.id.localeCompare(right.id);
+    });
+  const hotspot = buildHotspotEntry(entry);
+  const signalType = entry.sabotageRiskLevel === 'high' || entry.metrics.sabotageOperationCount > 0
+    ? 'sabotage'
+    : entry.metrics.exposedCellCount > 0
+      ? 'exposure'
+      : 'presence';
+  const factionIds = [...new Set(locationCellules.map((cellule) => cellule.factionId))].sort();
+  const targetFactionIds = [...new Set(activeOperations.map((operation) => operation.targetFactionId))].sort();
+  const reasons = [
+    entry.sabotageRiskLevel !== 'none' ? `Risque sabotage ${entry.sabotageRiskLevel} (${entry.sabotageRiskScore})` : null,
+    entry.metrics.exposedCellCount > 0 ? `${entry.metrics.exposedCellCount} cellule${entry.metrics.exposedCellCount > 1 ? 's' : ''} exposée${entry.metrics.exposedCellCount > 1 ? 's' : ''}` : null,
+    entry.metrics.sleeperCellCount > 0 ? `${entry.metrics.sleeperCellCount} cellule${entry.metrics.sleeperCellCount > 1 ? 's' : ''} dormante${entry.metrics.sleeperCellCount > 1 ? 's' : ''}` : null,
+    activeOperations.length > 0 ? `${activeOperations.length} opération${activeOperations.length > 1 ? 's' : ''} active${activeOperations.length > 1 ? 's' : ''}` : null,
+  ].filter(Boolean);
+
+  return {
+    locationId: entry.locationId,
+    locationName: locationNames[entry.locationId] ?? entry.locationName,
+    signalType,
+    severity: hotspot.severity,
+    criticality: hotspot.severity === 'critical' ? 'critical' : hotspot.severity === 'warning' ? 'elevated' : 'watch',
+    affectedFactionIds: factionIds,
+    targetFactionIds,
+    primaryCelluleId: locationCellules[0]?.id ?? null,
+    primaryOperationId: activeOperations[0]?.id ?? null,
+    summary: reasons[0] ?? `Présence clandestine ${entry.presenceLevel}`,
+    reasons: reasons.length > 0 ? reasons : [`Présence clandestine ${entry.presenceLevel}`],
+    actionHint: hotspot.severity === 'critical'
+      ? 'Inspecter les cellules exposées et interrompre les sabotages en cours.'
+      : activeOperations.length > 0
+        ? 'Suivre les opérations actives et vérifier la chaleur opérationnelle.'
+        : 'Garder le foyer en observation sans surcharger la carte.',
+  };
+}
+
 function buildCellulesPanel(cellules, locationNames) {
   return cellules
     .slice()
@@ -171,7 +225,18 @@ export function buildIntrigueWebDemo(payload, options = {}) {
   const alertBadge = buildAlertLevelBadge(normalizedPayload.alertLevel ?? 0, {
     prefix: normalizedOptions.alertPrefix ?? 'Alerte',
   });
-  const hotspots = mapOverlay.map(buildHotspotEntry).sort(compareHotspots);
+  const drillDownByLocation = new Map(mapOverlay.map((entry) => [
+    entry.locationId,
+    buildHotspotDrillDown(entry, cellules, operations, locationNames),
+  ]));
+  const mapEntries = mapOverlay.map((entry) => ({
+    ...entry,
+    drillDown: drillDownByLocation.get(entry.locationId),
+  }));
+  const hotspots = mapEntries.map((entry) => ({
+    ...buildHotspotEntry(entry),
+    drillDown: drillDownByLocation.get(entry.locationId),
+  })).sort(compareHotspots);
   const exposedCellCount = cellules.filter((cellule) => cellule.isExposed).length;
   const sleeperCellCount = cellules.filter((cellule) => cellule.sleeper).length;
   const activeSabotageCount = operations.filter((operation) => operation.type === 'sabotage' && !operation.isResolved).length;
@@ -214,7 +279,7 @@ export function buildIntrigueWebDemo(payload, options = {}) {
     },
     map: {
       title: 'Couche intrigue',
-      entries: mapOverlay,
+      entries: mapEntries,
       legend: {
         presenceLevels: [
           { code: 'low', label: 'Présence faible', marker: '◔' },

--- a/test/ui/intrigue/buildIntrigueWebDemo.test.js
+++ b/test/ui/intrigue/buildIntrigueWebDemo.test.js
@@ -96,6 +96,20 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
   assert.equal(demo.summary, '1 foyers critiques, 2 sabotages actifs, alerte critique');
   assert.equal(demo.alertBadge.level.code, 'critique');
   assert.equal(demo.map.entries.length, 2);
+  assert.deepEqual(demo.map.entries[0].drillDown, {
+    locationId: 'ashlands',
+    locationName: 'Ashlands',
+    signalType: 'sabotage',
+    severity: 'critical',
+    criticality: 'critical',
+    affectedFactionIds: ['shadow-league'],
+    targetFactionIds: ['sun-empire'],
+    primaryCelluleId: 'cell-ash-2',
+    primaryOperationId: 'op-ash-1',
+    summary: 'Risque sabotage medium (61)',
+    reasons: ['Risque sabotage medium (61)', '1 cellule exposée', '1 cellule dormante', '1 opération active'],
+    actionHint: 'Inspecter les cellules exposées et interrompre les sabotages en cours.',
+  });
   assert.deepEqual(demo.hotspots, [
     {
       locationId: 'ashlands',
@@ -110,6 +124,20 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
       celluleCount: 2,
       operationCount: 1,
       visualCue: '◑ elevated',
+      drillDown: {
+        locationId: 'ashlands',
+        locationName: 'Ashlands',
+        signalType: 'sabotage',
+        severity: 'critical',
+        criticality: 'critical',
+        affectedFactionIds: ['shadow-league'],
+        targetFactionIds: ['sun-empire'],
+        primaryCelluleId: 'cell-ash-2',
+        primaryOperationId: 'op-ash-1',
+        summary: 'Risque sabotage medium (61)',
+        reasons: ['Risque sabotage medium (61)', '1 cellule exposée', '1 cellule dormante', '1 opération active'],
+        actionHint: 'Inspecter les cellules exposées et interrompre les sabotages en cours.',
+      },
     },
     {
       locationId: 'riverlands',
@@ -124,6 +152,20 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
       celluleCount: 1,
       operationCount: 1,
       visualCue: '◔ normal',
+      drillDown: {
+        locationId: 'riverlands',
+        locationName: 'Riverlands',
+        signalType: 'sabotage',
+        severity: 'watch',
+        criticality: 'watch',
+        affectedFactionIds: ['shadow-league'],
+        targetFactionIds: ['sun-empire'],
+        primaryCelluleId: 'cell-river-1',
+        primaryOperationId: 'op-river-1',
+        summary: 'Risque sabotage low (20)',
+        reasons: ['Risque sabotage low (20)', '1 opération active'],
+        actionHint: 'Suivre les opérations actives et vérifier la chaleur opérationnelle.',
+      },
     },
   ]);
   assert.deepEqual(demo.panels.cellules[0], {

--- a/web/app.js
+++ b/web/app.js
@@ -1272,6 +1272,7 @@ function getIntrigueViewModel() {
       exposedCellCount: selectedEntry.metrics.exposedCellCount,
       sleeperCellCount: selectedEntry.metrics.sleeperCellCount,
       activeOperationCount: selectedOperations.length,
+      drillDown: selectedEntry.drillDown,
       reasons: selectedRiskReasons.length > 0 ? selectedRiskReasons : ['Aucun signal Delta notable'],
       guidance: selectedEntry.sabotageRiskLevel === 'high'
         ? 'Priorite a la surveillance locale, les marqueurs rouges concentrent le risque actif.'
@@ -1888,6 +1889,24 @@ function renderIntrigueSidePanel(intrigueView) {
           <div class="intrigue-status-pill-row">
             ${intrigueView.selectedProvince.reasons.map((reason) => `<span class="intrigue-status-pill intrigue-status-pill--${intrigueView.selectedProvince.sabotageRiskLevel === 'high' ? 'compromised' : intrigueView.selectedProvince.sabotageRiskLevel === 'medium' ? 'exposed' : 'active'}">${reason}</span>`).join('')}
           </div>
+          ${intrigueView.selectedProvince.drillDown ? `
+            <div class="intrigue-drilldown intrigue-drilldown--${intrigueView.selectedProvince.drillDown.criticality}">
+              <div class="intrigue-drilldown__header">
+                <span>Signal ${intrigueView.selectedProvince.drillDown.signalType}</span>
+                <strong>${intrigueView.selectedProvince.drillDown.criticality}</strong>
+              </div>
+              <p>${intrigueView.selectedProvince.drillDown.summary}</p>
+              <div class="intrigue-drilldown__context">
+                <span>Province: ${intrigueView.selectedProvince.drillDown.locationName}</span>
+                <span>Faction: ${intrigueView.selectedProvince.drillDown.affectedFactionIds.join(', ') || 'inconnue'}</span>
+                <span>Cible: ${intrigueView.selectedProvince.drillDown.targetFactionIds.join(', ') || 'aucune'}</span>
+              </div>
+              <ul>
+                ${intrigueView.selectedProvince.drillDown.reasons.map((reason) => `<li>${reason}</li>`).join('')}
+              </ul>
+              <small>${intrigueView.selectedProvince.drillDown.actionHint}</small>
+            </div>
+          ` : ''}
         </section>
       ` : ''}
       <div class="intrigue-legend-strip" aria-label="Légende heatmap sabotage">

--- a/web/styles.css
+++ b/web/styles.css
@@ -3466,3 +3466,32 @@ button { font: inherit; }
     min-height: 260px;
   }
 }
+.intrigue-drilldown {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.38);
+  border: 1px solid rgba(103, 232, 249, 0.14);
+}
+.intrigue-drilldown--critical { border-color: rgba(251, 113, 133, 0.34); }
+.intrigue-drilldown--elevated { border-color: rgba(250, 204, 21, 0.28); }
+.intrigue-drilldown__header,
+.intrigue-drilldown__context {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: space-between;
+}
+.intrigue-drilldown__header span,
+.intrigue-drilldown__context,
+.intrigue-drilldown small {
+  color: var(--muted);
+}
+.intrigue-drilldown p,
+.intrigue-drilldown ul {
+  margin: 8px 0 0;
+}
+.intrigue-drilldown ul {
+  padding-left: 18px;
+  color: #cbd5e1;
+}


### PR DESCRIPTION
Delta: Closes #426.

Summary:
- add a structured drill-down payload to intrigue hotspots and map entries with signal type, criticality, affected factions, targets, reasons, and action hints;
- surface the selected hotspot drill-down in the intrigue side panel instead of adding permanent map clutter;
- keep reduced/critical-only map signal behavior intact while making selected hotspots explainable.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/intrigue/buildIntrigueWebDemo.test.js
- npm test (360 passing)

Delta: Ready for Zeta validation before merge.