### PR TITLE
Gamma: Link culture clusters to discovery and event pins

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -295,12 +295,32 @@ function buildZoneContour(influenceTier, overlapCount, zoneRank) {
 function buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById) {
   const cultureIds = regionPresence.map((entry) => entry.cultureId).sort();
   const cultureNames = regionPresence.map((entry) => entry.cultureName).sort();
-  const discoveryIds = [...new Set(regionPresence.flatMap((entry) => (
+  const discoveryPins = regionPresence.flatMap((entry) => (
     cultureSignalsById.get(entry.cultureId)?.signals.highlightedDiscoveries ?? []
-  )))].sort();
-  const eventCount = regionPresence.reduce((total, entry) => (
-    total + (cultureSignalsById.get(entry.cultureId)?.signals.eventCount ?? 0)
-  ), 0);
+  ).map((discoveryId) => ({
+    pinId: `${regionId}:${entry.cultureId}:discovery:${discoveryId}`,
+    kind: 'discovery',
+    name: discoveryId,
+    type: 'Découverte',
+    regionId,
+    cultureId: entry.cultureId,
+    cultureName: entry.cultureName,
+    importance: null,
+  }))).sort((left, right) => left.name.localeCompare(right.name) || left.cultureId.localeCompare(right.cultureId));
+  const eventPins = regionPresence.flatMap((entry) => (
+    cultureSignalsById.get(entry.cultureId)?.signals.orderedHistoricalEvents ?? []
+  ).map((historicalEvent) => ({
+    pinId: `${regionId}:${entry.cultureId}:event:${historicalEvent.id}`,
+    kind: 'event',
+    name: historicalEvent.title,
+    type: historicalEvent.category,
+    regionId,
+    cultureId: entry.cultureId,
+    cultureName: entry.cultureName,
+    importance: historicalEvent.importance,
+  }))).sort((left, right) => (right.importance ?? 0) - (left.importance ?? 0) || left.name.localeCompare(right.name));
+  const discoveryIds = [...new Set(discoveryPins.map((pin) => pin.name))].sort();
+  const eventCount = eventPins.length;
 
   return {
     clusterId: `${regionId}:culture-cluster`,
@@ -311,6 +331,7 @@ function buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById)
     discoveryIds,
     discoveryCount: discoveryIds.length,
     eventCount,
+    pins: [...eventPins, ...discoveryPins],
     label: `${cultureIds.length} cultures · ${discoveryIds.length} découvertes`,
     summary: `${cultureNames.slice(0, 3).join(', ')}${cultureNames.length > 3 ? '…' : ''}`,
   };

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -614,7 +614,7 @@ test('buildCultureMapOverlay supports plain payloads and style overrides', () =>
   assert.equal(overlay[0].zoneStyle.glow, 'sparking');
 });
 
-test('buildCultureMapOverlay can summarize overlapping culture clusters', () => {
+test('buildCultureMapOverlay can summarize overlapping culture clusters with discovery and event pins', () => {
   const overlay = buildCultureMapOverlay(
     {
       cultures: [
@@ -660,7 +660,19 @@ test('buildCultureMapOverlay can summarize overlapping culture clusters', () => 
           discoveredConceptIds: ['flood-archives'],
         },
       ],
-      historicalEvents: [],
+      historicalEvents: [
+        {
+          id: 'event-harbor-forum',
+          title: 'Harbor Forum',
+          category: 'knowledge',
+          summary: 'Pilots compare flood archive routes.',
+          era: 'map-play',
+          importance: 4,
+          triggeredAt: '2026-04-20T00:00:00.000Z',
+          affectedCultureIds: ['culture-harbor'],
+          discoveryIds: ['tidal-ledgers'],
+        },
+      ],
     },
     {
       clusterSummaries: true,
@@ -672,32 +684,54 @@ test('buildCultureMapOverlay can summarize overlapping culture clusters', () => 
   );
 
   assert.equal(overlay.length, 2);
-  assert.deepEqual(overlay.map((entry) => entry.clusterSummary), [
-    {
-      clusterId: 'shared-bay:culture-cluster',
-      regionId: 'shared-bay',
-      cultureIds: ['culture-delta', 'culture-harbor'],
-      cultureNames: ['Delta Scribes', 'Harbor Compact'],
-      cultureCount: 2,
-      discoveryIds: ['flood-archives', 'tidal-ledgers'],
-      discoveryCount: 2,
-      eventCount: 0,
-      label: '2 cultures · 2 découvertes',
-      summary: 'Delta Scribes, Harbor Compact',
-    },
-    {
-      clusterId: 'shared-bay:culture-cluster',
-      regionId: 'shared-bay',
-      cultureIds: ['culture-delta', 'culture-harbor'],
-      cultureNames: ['Delta Scribes', 'Harbor Compact'],
-      cultureCount: 2,
-      discoveryIds: ['flood-archives', 'tidal-ledgers'],
-      discoveryCount: 2,
-      eventCount: 0,
-      label: '2 cultures · 2 découvertes',
-      summary: 'Delta Scribes, Harbor Compact',
-    },
+  assert.deepEqual(overlay.map((entry) => entry.clusterSummary?.label), [
+    '2 cultures · 2 découvertes',
+    '2 cultures · 2 découvertes',
   ]);
+  assert.deepEqual(overlay[0].clusterSummary, {
+    clusterId: 'shared-bay:culture-cluster',
+    regionId: 'shared-bay',
+    cultureIds: ['culture-delta', 'culture-harbor'],
+    cultureNames: ['Delta Scribes', 'Harbor Compact'],
+    cultureCount: 2,
+    discoveryIds: ['flood-archives', 'tidal-ledgers'],
+    discoveryCount: 2,
+    eventCount: 1,
+    pins: [
+      {
+        pinId: 'shared-bay:culture-harbor:event:event-harbor-forum',
+        kind: 'event',
+        name: 'Harbor Forum',
+        type: 'knowledge',
+        regionId: 'shared-bay',
+        cultureId: 'culture-harbor',
+        cultureName: 'Harbor Compact',
+        importance: 4,
+      },
+      {
+        pinId: 'shared-bay:culture-delta:discovery:flood-archives',
+        kind: 'discovery',
+        name: 'flood-archives',
+        type: 'Découverte',
+        regionId: 'shared-bay',
+        cultureId: 'culture-delta',
+        cultureName: 'Delta Scribes',
+        importance: null,
+      },
+      {
+        pinId: 'shared-bay:culture-harbor:discovery:tidal-ledgers',
+        kind: 'discovery',
+        name: 'tidal-ledgers',
+        type: 'Découverte',
+        regionId: 'shared-bay',
+        cultureId: 'culture-harbor',
+        cultureName: 'Harbor Compact',
+        importance: null,
+      },
+    ],
+    label: '2 cultures · 2 découvertes',
+    summary: 'Delta Scribes, Harbor Compact',
+  });
 });
 
 test('buildCultureMapOverlay rejects invalid inputs', () => {

--- a/web/app.js
+++ b/web/app.js
@@ -1527,7 +1527,31 @@ function buildCultureClusterSummaries(entries) {
     const cultureIds = [...new Set(entriesInCluster.flatMap((entry) => entry.clusterSummary?.cultureIds ?? [entry.cultureId]))].sort();
     const cultureNames = [...new Set(entriesInCluster.flatMap((entry) => entry.clusterSummary?.cultureNames ?? [entry.cultureName]))].sort();
     const discoveryIds = [...new Set(entriesInCluster.flatMap((entry) => entry.clusterSummary?.discoveryIds ?? entry.discoveries))].sort();
-    const eventCount = entriesInCluster.reduce((total, entry) => total + (entry.clusterSummary?.eventCount ?? entry.eventCount), 0);
+    const pins = entriesInCluster.flatMap((entry) => entry.clusterSummary?.pins ?? [
+      ...entry.eventPopups.map((event) => ({
+        pinId: `${entry.regionId}:${entry.cultureId}:event:${event.eventId}`,
+        kind: 'event',
+        name: event.title,
+        type: 'événement',
+        regionId: entry.regionId,
+        cultureId: entry.cultureId,
+        cultureName: entry.cultureName,
+        importance: event.importance,
+      })),
+      ...entry.regionalDiscoveryLinks.map((link) => ({
+        pinId: link.linkId,
+        kind: 'discovery',
+        name: link.discoveryId,
+        type: 'Découverte',
+        regionId: entry.regionId,
+        cultureId: entry.cultureId,
+        cultureName: entry.cultureName,
+        importance: null,
+      })),
+    ]);
+    const dedupedPins = [...new Map(pins.map((pin) => [pin.pinId, pin])).values()]
+      .sort((left, right) => (right.importance ?? -1) - (left.importance ?? -1) || left.name.localeCompare(right.name));
+    const eventCount = dedupedPins.filter((pin) => pin.kind === 'event').length;
     const centroid = members.reduce((accumulator, member) => ({
       x: accumulator.x + member.center.x,
       y: accumulator.y + member.center.y,
@@ -1546,6 +1570,7 @@ function buildCultureClusterSummaries(entries) {
       cultureCount: cultureIds.length,
       discoveryCount: discoveryIds.length,
       eventCount,
+      pins: dedupedPins,
       label: `${cultureIds.length} cultures · ${discoveryIds.length} découvertes`,
       summary: `${cultureNames.slice(0, 2).join(', ')}${cultureNames.length > 2 ? '…' : ''}`,
     });
@@ -1556,6 +1581,20 @@ function buildCultureClusterSummaries(entries) {
 
 function renderCultureClusterSummary(cluster, active) {
   const detail = `${cluster.summary} · régions ${cluster.regionIds.join(', ')} · cultures ${cluster.cultureIds.join(', ')}`;
+  const visiblePins = active ? cluster.pins.slice(0, 4) : [];
+  const pinNodes = visiblePins.map((pin, index) => {
+    const x = cluster.anchor.x - 5.4 + (index * 3.6);
+    const y = cluster.anchor.y + 5.4;
+    const pinCode = pin.kind === 'event' ? `H${pin.importance ?? ''}` : `D${index + 1}`;
+
+    return `
+      <g class="culture-cluster-pin culture-cluster-pin--${pin.kind}">
+        <title>${pin.name} · ${pin.type} · ${pin.regionId}${pin.importance ? ` · importance ${pin.importance}` : ''}</title>
+        <circle cx="${x}%" cy="${y}%" r="1.35"></circle>
+        <text x="${x}%" y="${y + 0.43}%" text-anchor="middle">${pinCode}</text>
+      </g>
+    `;
+  }).join('');
 
   return `
     <g class="culture-cluster-summary ${active ? 'is-active' : 'is-muted'}" data-culture-cluster="${cluster.clusterId}">
@@ -1563,7 +1602,36 @@ function renderCultureClusterSummary(cluster, active) {
       <rect x="${cluster.anchor.x - 7.8}%" y="${cluster.anchor.y - 3.1}%" width="15.6%" height="6.2%" rx="2.2%"></rect>
       <text class="culture-cluster-summary__count" x="${cluster.anchor.x - 5.9}%" y="${cluster.anchor.y + 0.45}%">C${cluster.cultureCount}</text>
       <text class="culture-cluster-summary__label" x="${cluster.anchor.x - 0.7}%" y="${cluster.anchor.y + 0.45}%">D${cluster.discoveryCount}${cluster.eventCount > 0 ? ` · H${cluster.eventCount}` : ''}</text>
+      ${pinNodes}
     </g>
+  `;
+}
+
+function renderCultureClusterPinList(cluster) {
+  if (!cluster) {
+    return '';
+  }
+
+  const pins = cluster.pins.slice(0, 5);
+
+  return `
+    <article class="culture-cluster-pin-list">
+      <div class="culture-cluster-pin-list__header">
+        <span>Cluster sélectionné</span>
+        <strong>${cluster.label}</strong>
+      </div>
+      ${pins.length > 0 ? `
+        <ul>
+          ${pins.map((pin) => `
+            <li class="culture-cluster-pin-list__item culture-cluster-pin-list__item--${pin.kind}">
+              <b>${pin.kind === 'event' ? 'Événement' : 'Découverte'}</b>
+              <span>${pin.name}</span>
+              <small>${pin.type} · ${pin.regionId}${pin.importance ? ` · IMP-${pin.importance}` : ''}</small>
+            </li>
+          `).join('')}
+        </ul>
+      ` : '<p>Aucun événement ou découverte lié à ce cluster.</p>'}
+    </article>
   `;
 }
 
@@ -1632,6 +1700,8 @@ function renderCultureSidePanel(cultureView) {
 
   const focus = cultureView.selectedMarker ?? cultureView.panel.focus;
   const focusSeed = focus ? cultureView.seeds.find((seed) => seed.cultureId === focus.cultureId) : null;
+  const selectedCluster = buildCultureClusterSummaries(cultureView.overlay)
+    .find((cluster) => cluster.regionIds.includes(state.selectedProvinceId)) ?? null;
 
   return `
     <section class="panel overlay-panel overlay-panel--culture">
@@ -1647,6 +1717,7 @@ function renderCultureSidePanel(cultureView) {
         <div class="overlay-anchor"><span>Repères</span><strong>${cultureView.metrics.eventCount}</strong></div>
       </div>
       ${renderCultureLegendKey(cultureView)}
+      ${renderCultureClusterPinList(selectedCluster)}
       ${focus ? `
         <article class="culture-focus-card culture-focus-card--${getCultureTone(focus)}">
           <div class="culture-focus-card__header">

--- a/web/styles.css
+++ b/web/styles.css
@@ -2895,6 +2895,75 @@ button { font: inherit; }
 }
 .culture-cluster-summary__count { fill: #bae6fd; }
 .culture-cluster-summary__label { fill: #fde68a; }
+.culture-cluster-pin circle {
+  fill: rgba(8, 47, 73, 0.78);
+  stroke: rgba(125, 211, 252, 0.74);
+  stroke-width: 0.2;
+}
+.culture-cluster-pin--event circle {
+  fill: rgba(120, 53, 15, 0.82);
+  stroke: rgba(251, 191, 36, 0.86);
+}
+.culture-cluster-pin text {
+  fill: #e0f2fe;
+  font-size: 1.05px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.92);
+  stroke-width: 0.24px;
+}
+.culture-cluster-pin--event text { fill: #fef3c7; }
+.culture-cluster-pin-list {
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.44);
+  padding: 12px;
+  margin-bottom: 12px;
+}
+.culture-cluster-pin-list__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.culture-cluster-pin-list__header span {
+  color: var(--accent);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.culture-cluster-pin-list__header strong { color: #f8fafc; }
+.culture-cluster-pin-list ul {
+  display: grid;
+  gap: 7px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.culture-cluster-pin-list__item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 2px 8px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(125, 211, 252, 0.12);
+}
+.culture-cluster-pin-list__item b {
+  color: #bae6fd;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+.culture-cluster-pin-list__item--event b { color: #fde68a; }
+.culture-cluster-pin-list__item span { color: #f8fafc; }
+.culture-cluster-pin-list__item small {
+  grid-column: 2;
+  color: var(--muted);
+}
+.culture-cluster-pin-list p {
+  color: var(--muted);
+  margin: 0;
+}
 .culture-symbol-key {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Gamma: Closes #435.

## Summary
- enrich culture cluster summaries with discovery/event pins using existing culture overlay data
- render compact cluster pin markers for active culture overlays
- add a selected-cluster mini-list in the culture side panel with empty-state copy
- update cluster overlay test coverage for discovery/event pin payloads

## Validation
- `node --check web/app.js`
- `git diff --check`
- `npm test` (362 passing)

Gamma: Ready for Zeta validation before merge.
