### PR TITLE
Beta: add route stress summaries

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -383,6 +383,8 @@ const state = {
   popupProvinceId: 'river-gate',
   hoveredCityId: 'river-gate-city',
   selectedCityId: 'river-gate-city',
+  hoveredRouteId: null,
+  selectedRouteId: null,
   comparedCityIds: ['river-gate-city', 'crown-port'],
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
   mobilePanelSection: 'details',
@@ -426,6 +428,8 @@ function applyMapScenario(scenario) {
   state.mobilePanelSection = 'details';
   state.mobileMapExpanded = true;
   state.hoveredProvinceId = null;
+  state.hoveredRouteId = null;
+  state.selectedRouteId = null;
   state.economyFilters = {
     criticalRoutes: false,
     resourceMarkers: true,
@@ -875,6 +879,74 @@ function renderRouteManifest(route) {
     <div class="economy-route-card__manifest">
       ${resources.map((resource) => `<span class="economy-resource-chip economy-resource-chip--${resource.tone}" title="${resource.label}">${resource.glyph} ${resource.resourceId} ${resource.capacity}</span>`).join('')}
     </div>
+  `;
+}
+
+function getRouteStressSummary(route, tensionByCityId, cityNameById = {}) {
+  const originTension = tensionByCityId[route.originCityId]?.tensionLevel ?? 'low';
+  const destinationTension = tensionByCityId[route.destinationCityId]?.tensionLevel ?? 'low';
+  const resources = route.resources.slice().sort((left, right) => right.capacity - left.capacity || left.resourceId.localeCompare(right.resourceId));
+  const mainResource = resources[0];
+  const mainResourceLabel = mainResource ? getResourceHud(mainResource.resourceId).label : 'capacité réservée';
+  const highTension = originTension === 'high' || destinationTension === 'high';
+  const stressedEndpoint = originTension === 'high'
+    ? cityNameById[route.originCityId] ?? route.originCityId
+    : destinationTension === 'high'
+      ? cityNameById[route.destinationCityId] ?? route.destinationCityId
+      : null;
+  const drivers = [];
+
+  if (!route.active) {
+    drivers.push('route inactive: bascule logistique à prévoir');
+  }
+
+  if (route.riskLevel >= 70) {
+    drivers.push(`risque ${route.riskLevel}: convoi vulnérable`);
+  } else if (route.riskLevel >= 55) {
+    drivers.push(`risque ${route.riskLevel}: escorte utile`);
+  }
+
+  if (route.totalCapacity >= 9) {
+    drivers.push(`surcharge ${route.totalCapacity}: goulot possible`);
+  } else if (route.totalCapacity >= 6) {
+    drivers.push(`flux dense ${route.totalCapacity}: surveiller débit`);
+  }
+
+  if (highTension) {
+    drivers.push(`${stressedEndpoint} en tension: route prioritaire`);
+  }
+
+  if (mainResource) {
+    drivers.push(`${mainResourceLabel} (${mainResource.capacity}) ressource clé`);
+  }
+
+  const tone = !route.active || route.riskLevel >= 70 || highTension
+    ? 'high'
+    : route.riskLevel >= 55 || route.totalCapacity >= 9
+      ? 'medium'
+      : 'low';
+  const headline = tone === 'high'
+    ? 'Priorité logistique'
+    : tone === 'medium'
+      ? 'Flux à surveiller'
+      : 'Route stable';
+
+  return {
+    tone,
+    headline,
+    drivers: drivers.slice(0, 3),
+    summary: drivers.slice(0, 2).join(' · ') || 'Flux stable, pas de goulot visible',
+  };
+}
+
+function renderRouteStressBadge(route, stress, visual) {
+  const midpoint = getQuadraticPoint(visual.origin, visual.control, visual.destination, 0.5);
+
+  return `
+    <g class="economy-route-stress economy-route-stress--${stress.tone}" aria-label="${stress.headline}: ${stress.summary}">
+      <rect x="${midpoint.x - 9.4}" y="${midpoint.y - 8.6}" width="18.8" height="4.4" rx="2.2" />
+      <text x="${midpoint.x}" y="${midpoint.y - 5.55}" text-anchor="middle">${stress.headline}</text>
+    </g>
   `;
 }
 
@@ -1805,6 +1877,7 @@ function renderEconomyMapOverlay(economyView) {
 
   const filters = state.economyFilters;
   const tensionByCityId = Object.fromEntries(economyView.comparison.rows.map((row) => [row.cityId, row]));
+  const cityNameById = Object.fromEntries(economyView.overlay.cities.map((city) => [city.cityId, city.cityName]));
   const heatNodes = economyView.overlay.cities.map((city) => {
     const position = city.marker.position;
     const tension = tensionByCityId[city.cityId];
@@ -1843,14 +1916,19 @@ function renderEconomyMapOverlay(economyView) {
     const emphasizeRoute = visual.critical || tensionClass === 'has-high-tension';
     const routeFiltered = filters.criticalRoutes && !emphasizeRoute;
     const showRouteLabel = !routeFiltered && (emphasizeRoute || tensionClass === 'has-medium-tension');
+    const routeFocused = state.hoveredRouteId === route.routeId || state.selectedRouteId === route.routeId;
+    const stress = getRouteStressSummary(route, tensionByCityId, cityNameById);
 
     return `
-      <g class="economy-route-group ${visual.classes} ${tensionClass} ${emphasizeRoute ? 'is-emphasized' : 'is-muted'} ${routeFiltered ? 'is-filtered' : ''}" data-route-id="${route.routeId}" aria-label="${routeFiltered ? 'Route secondaire atténuée par filtre' : 'Route économie visible'}">
+      <g class="economy-route-group ${visual.classes} ${tensionClass} ${emphasizeRoute ? 'is-emphasized' : 'is-muted'} ${routeFiltered ? 'is-filtered' : ''} ${routeFocused ? 'is-focused' : ''}" data-route-id="${route.routeId}" aria-label="${routeFiltered ? 'Route secondaire atténuée par filtre' : 'Route économie visible'}: ${stress.summary}">
+        <title>${route.routeName}: ${stress.headline} — ${stress.summary}</title>
+        <path class="economy-route-hitbox" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__halo" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__casing" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__line" d="${visual.pathD}" pathLength="100" marker-end="url(#${visual.markerId})" />
         <path class="economy-route__flow" d="${visual.pathD}" pathLength="100" />
         ${renderRouteHudMarkers(route, visual, { compact: !emphasizeRoute || routeFiltered })}
+        ${routeFocused ? renderRouteStressBadge(route, stress, visual) : ''}
         ${showRouteLabel ? `<text class="economy-route__label" text-anchor="middle">
           <textPath href="#route-label-${route.routeId}" startOffset="50%">${route.routeName}</textPath>
         </text>` : ''}
@@ -2209,6 +2287,11 @@ function renderEconomySidePanel(economyView, cultureView) {
 
   const filters = state.economyFilters;
   const tensionByCityId = Object.fromEntries(economyView.comparison.rows.map((row) => [row.cityId, row]));
+  const cityNameById = Object.fromEntries(economyView.overlay.cities.map((city) => [city.cityId, city.cityName]));
+  const selectedRoute = economyView.overlay.routes.find((route) => route.routeId === (state.hoveredRouteId ?? state.selectedRouteId))
+    ?? economyView.overlay.routes.find((route) => route.routeId === state.selectedRouteId)
+    ?? null;
+  const selectedRouteStress = selectedRoute ? getRouteStressSummary(selectedRoute, tensionByCityId, cityNameById) : null;
   const criticalRouteCount = economyView.overlay.routes.filter((route) => {
     const originTension = tensionByCityId[route.originCityId]?.tensionLevel ?? 'low';
     const destinationTension = tensionByCityId[route.destinationCityId]?.tensionLevel ?? 'low';
@@ -2236,6 +2319,19 @@ function renderEconomySidePanel(economyView, cultureView) {
       </section>
       ${renderEconomyKpiStrip(economyView)}
       ${renderEconomyFocusPanel(economyView)}
+      ${selectedRoute && selectedRouteStress ? `
+        <article class="economy-route-stress-panel economy-route-stress-panel--${selectedRouteStress.tone}">
+          <div class="economy-route-stress-panel__header">
+            <span>Route suivie</span>
+            <strong>${selectedRoute.routeName}</strong>
+            <b>${selectedRouteStress.headline}</b>
+          </div>
+          <p>${selectedRouteStress.summary}</p>
+          <ul>
+            ${selectedRouteStress.drivers.map((driver) => `<li>${driver}</li>`).join('')}
+          </ul>
+        </article>
+      ` : ''}
       <div class="economy-route-list">
         ${economyView.overlay.routes.map((route) => {
           const originTension = tensionByCityId[route.originCityId]?.tensionLevel ?? 'low';
@@ -2246,14 +2342,18 @@ function renderEconomySidePanel(economyView, cultureView) {
               ? 'has-medium-tension'
               : 'has-low-tension';
 
+          const stress = getRouteStressSummary(route, tensionByCityId, cityNameById);
+          const routeFocused = state.hoveredRouteId === route.routeId || state.selectedRouteId === route.routeId;
+
           return `
-            <article class="economy-route-card ${route.active ? '' : 'is-inactive'} ${route.transportMode === 'river' ? 'is-river' : route.transportMode === 'sea' ? 'is-sea' : 'is-land'} ${route.riskLevel >= 55 || route.totalCapacity >= 9 ? 'is-critical' : ''} ${tensionClass}">
+            <article class="economy-route-card ${route.active ? '' : 'is-inactive'} ${route.transportMode === 'river' ? 'is-river' : route.transportMode === 'sea' ? 'is-sea' : 'is-land'} ${route.riskLevel >= 55 || route.totalCapacity >= 9 ? 'is-critical' : ''} ${tensionClass} ${routeFocused ? 'is-selected' : ''}" data-route-id="${route.routeId}" title="${stress.headline}: ${stress.summary}">
               <div class="economy-route-card__header"><strong>${route.routeName}</strong><span>${getRouteHud(route).glyph}</span></div>
               <div class="economy-route-card__stats">
                 <span>${route.transportMode}</span>
                 <span>risque ${route.riskLevel}</span>
                 <span>capacité ${route.totalCapacity}</span>
               </div>
+              <p class="economy-route-card__stress economy-route-card__stress--${stress.tone}">${stress.headline}: ${stress.summary}</p>
               ${renderRouteManifest(route)}
             </article>
           `;
@@ -3069,6 +3169,19 @@ function render() {
 
       state.selectedCityId = cityId;
       state.hoveredCityId = cityId;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-route-id]').forEach((element) => {
+    element.addEventListener('mouseenter', () => {
+      state.hoveredRouteId = element.dataset.routeId;
+      render();
+    });
+
+    element.addEventListener('click', () => {
+      state.selectedRouteId = element.dataset.routeId;
+      state.hoveredRouteId = element.dataset.routeId;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -725,10 +725,17 @@ button { font: inherit; }
 .economy-route__halo,
 .economy-route__casing,
 .economy-route__line,
-.economy-route__flow {
+.economy-route__flow,
+.economy-route-hitbox {
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+.economy-route-hitbox {
+  stroke: transparent;
+  stroke-width: 8;
+  pointer-events: stroke;
+  cursor: pointer;
 }
 .economy-route__halo {
   stroke: rgba(15, 23, 42, 0.62);
@@ -793,6 +800,30 @@ button { font: inherit; }
 .economy-route.is-filtered .economy-route-hud {
   opacity: 0.28;
 }
+.economy-route.is-focused .economy-route__line {
+  opacity: 1;
+  stroke-width: 2.25;
+  filter: drop-shadow(0 0 8px rgba(103, 232, 249, 0.38));
+}
+.economy-route-stress {
+  pointer-events: none;
+  filter: drop-shadow(0 0 7px rgba(8, 15, 28, 0.78));
+}
+.economy-route-stress rect {
+  fill: rgba(8, 15, 28, 0.86);
+  stroke: rgba(226, 232, 240, 0.32);
+  stroke-width: 0.42;
+}
+.economy-route-stress text {
+  fill: #e2e8f0;
+  font-size: 1.8px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.economy-route-stress--high rect { stroke: rgba(251, 113, 133, 0.78); }
+.economy-route-stress--medium rect { stroke: rgba(245, 158, 11, 0.72); }
+.economy-route-stress--low rect { stroke: rgba(74, 222, 128, 0.58); }
 .economy-route.is-inactive .economy-route__line,
 .economy-route.is-inactive .economy-route__flow,
 .economy-route.is-inactive .economy-route__label {
@@ -2209,6 +2240,10 @@ button { font: inherit; }
 .economy-route-card.is-inactive {
   opacity: 0.68;
 }
+.economy-route-card.is-selected {
+  border-color: rgba(103, 232, 249, 0.46);
+  box-shadow: inset 0 0 0 1px rgba(103, 232, 249, 0.16), 0 0 22px rgba(103, 232, 249, 0.08);
+}
 .economy-route-card__header span {
   display: inline-grid;
   place-items: center;
@@ -2234,6 +2269,56 @@ button { font: inherit; }
   border-radius: 999px;
   background: rgba(8, 15, 28, 0.48);
   border: 1px solid rgba(148, 163, 184, 0.1);
+}
+.economy-route-card__stress {
+  margin: 2px 0 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.economy-route-card__stress--high { color: #fecdd3; }
+.economy-route-card__stress--medium { color: #fde68a; }
+.economy-route-card__stress--low { color: #bbf7d0; }
+.economy-route-stress-panel {
+  margin-top: 14px;
+  padding: 13px;
+  border-radius: 16px;
+  background: rgba(8, 15, 28, 0.54);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.economy-route-stress-panel--high { border-color: rgba(251, 113, 133, 0.4); }
+.economy-route-stress-panel--medium { border-color: rgba(245, 158, 11, 0.36); }
+.economy-route-stress-panel--low { border-color: rgba(74, 222, 128, 0.28); }
+.economy-route-stress-panel__header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 8px;
+  align-items: center;
+}
+.economy-route-stress-panel__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.economy-route-stress-panel__header strong { grid-column: 1; }
+.economy-route-stress-panel__header b {
+  grid-row: 1 / span 2;
+  grid-column: 2;
+  color: #e0f2fe;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+.economy-route-stress-panel p {
+  margin: 8px 0 0;
+  color: #dbeafe;
+  font-size: 12px;
+}
+.economy-route-stress-panel ul {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 12px;
 }
 .economy-legend-panel {
   margin-top: 14px;


### PR DESCRIPTION
Beta: Implements #434.

Scope:
- add short economy route stress summaries from existing route/city tension data;
- expose route summaries through SVG title/aria text, focused map badges, and route cards;
- support hover/click route selection without adding new economic data sources;
- keep changes scoped to Beta economy UI.

Validation:
- npm test (362 passing)
- node --check web/app.js
- git diff --check

Ready for Zeta validation before merge.