### PR TITLE
Delta: Add intrigue hotspot action hints

### DIFF
--- a/src/ui/intrigue/buildIntrigueWebDemo.js
+++ b/src/ui/intrigue/buildIntrigueWebDemo.js
@@ -76,6 +76,62 @@ function buildHotspotEntry(entry) {
   };
 }
 
+function buildHotspotActionHints(entry, hotspot, activeOperations) {
+  if (entry.sabotageRiskLevel === 'high' || entry.metrics.exposedCellCount > 0) {
+    return [
+      {
+        code: 'renforcer-securite',
+        label: 'Renforcer sécurité',
+        priority: 'high',
+        description: 'Prioriser les contre-mesures locales et réduire les fenêtres de sabotage.',
+      },
+      {
+        code: 'enqueter',
+        label: 'Enquêter',
+        priority: 'high',
+        description: 'Identifier les cellules exposées et relier les opérations actives au foyer.',
+      },
+    ];
+  }
+
+  if (entry.sabotageRiskLevel === 'medium' || hotspot.severity === 'warning') {
+    return [
+      {
+        code: 'enqueter',
+        label: 'Enquêter',
+        priority: 'medium',
+        description: 'Vérifier les signaux moyens avant qu’ils ne deviennent critiques.',
+      },
+      {
+        code: 'surveiller',
+        label: 'Surveiller',
+        priority: 'medium',
+        description: 'Garder le hotspot dans le suivi de tour sans encombrer la carte.',
+      },
+    ];
+  }
+
+  if (entry.sabotageRiskLevel === 'low' || activeOperations.length > 0) {
+    return [
+      {
+        code: 'surveiller',
+        label: 'Surveiller',
+        priority: 'low',
+        description: 'Conserver un œil léger sur l’activité et la chaleur opérationnelle.',
+      },
+    ];
+  }
+
+  return [
+    {
+      code: 'ignorer',
+      label: 'Ignorer',
+      priority: 'low',
+      description: 'Aucun signal fort; laisser ce foyer hors des priorités immédiates.',
+    },
+  ];
+}
+
 function buildHotspotDrillDown(entry, cellules, operations, locationNames) {
   const locationCellules = cellules
     .filter((cellule) => cellule.locationId === entry.locationId && cellule.status !== 'dismantled')
@@ -109,6 +165,7 @@ function buildHotspotDrillDown(entry, cellules, operations, locationNames) {
     entry.metrics.sleeperCellCount > 0 ? `${entry.metrics.sleeperCellCount} cellule${entry.metrics.sleeperCellCount > 1 ? 's' : ''} dormante${entry.metrics.sleeperCellCount > 1 ? 's' : ''}` : null,
     activeOperations.length > 0 ? `${activeOperations.length} opération${activeOperations.length > 1 ? 's' : ''} active${activeOperations.length > 1 ? 's' : ''}` : null,
   ].filter(Boolean);
+  const actionHints = buildHotspotActionHints(entry, hotspot, activeOperations);
 
   return {
     locationId: entry.locationId,
@@ -116,17 +173,15 @@ function buildHotspotDrillDown(entry, cellules, operations, locationNames) {
     signalType,
     severity: hotspot.severity,
     criticality: hotspot.severity === 'critical' ? 'critical' : hotspot.severity === 'warning' ? 'elevated' : 'watch',
+    riskBand: entry.sabotageRiskLevel === 'high' ? 'élevé' : entry.sabotageRiskLevel === 'medium' ? 'moyen' : 'faible',
     affectedFactionIds: factionIds,
     targetFactionIds,
     primaryCelluleId: locationCellules[0]?.id ?? null,
     primaryOperationId: activeOperations[0]?.id ?? null,
     summary: reasons[0] ?? `Présence clandestine ${entry.presenceLevel}`,
     reasons: reasons.length > 0 ? reasons : [`Présence clandestine ${entry.presenceLevel}`],
-    actionHint: hotspot.severity === 'critical'
-      ? 'Inspecter les cellules exposées et interrompre les sabotages en cours.'
-      : activeOperations.length > 0
-        ? 'Suivre les opérations actives et vérifier la chaleur opérationnelle.'
-        : 'Garder le foyer en observation sans surcharger la carte.',
+    actionHint: actionHints[0].description,
+    actionHints,
   };
 }
 

--- a/test/ui/intrigue/buildIntrigueWebDemo.test.js
+++ b/test/ui/intrigue/buildIntrigueWebDemo.test.js
@@ -102,13 +102,28 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
     signalType: 'sabotage',
     severity: 'critical',
     criticality: 'critical',
+    riskBand: 'moyen',
     affectedFactionIds: ['shadow-league'],
     targetFactionIds: ['sun-empire'],
     primaryCelluleId: 'cell-ash-2',
     primaryOperationId: 'op-ash-1',
     summary: 'Risque sabotage medium (61)',
     reasons: ['Risque sabotage medium (61)', '1 cellule exposée', '1 cellule dormante', '1 opération active'],
-    actionHint: 'Inspecter les cellules exposées et interrompre les sabotages en cours.',
+    actionHint: 'Prioriser les contre-mesures locales et réduire les fenêtres de sabotage.',
+    actionHints: [
+      {
+        code: 'renforcer-securite',
+        label: 'Renforcer sécurité',
+        priority: 'high',
+        description: 'Prioriser les contre-mesures locales et réduire les fenêtres de sabotage.',
+      },
+      {
+        code: 'enqueter',
+        label: 'Enquêter',
+        priority: 'high',
+        description: 'Identifier les cellules exposées et relier les opérations actives au foyer.',
+      },
+    ],
   });
   assert.deepEqual(demo.hotspots, [
     {
@@ -130,13 +145,42 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
         signalType: 'sabotage',
         severity: 'critical',
         criticality: 'critical',
+        riskBand: 'moyen',
         affectedFactionIds: ['shadow-league'],
         targetFactionIds: ['sun-empire'],
         primaryCelluleId: 'cell-ash-2',
         primaryOperationId: 'op-ash-1',
         summary: 'Risque sabotage medium (61)',
         reasons: ['Risque sabotage medium (61)', '1 cellule exposée', '1 cellule dormante', '1 opération active'],
-        actionHint: 'Inspecter les cellules exposées et interrompre les sabotages en cours.',
+        actionHint: 'Prioriser les contre-mesures locales et réduire les fenêtres de sabotage.',
+    actionHints: [
+      {
+        code: 'renforcer-securite',
+        label: 'Renforcer sécurité',
+        priority: 'high',
+        description: 'Prioriser les contre-mesures locales et réduire les fenêtres de sabotage.',
+      },
+      {
+        code: 'enqueter',
+        label: 'Enquêter',
+        priority: 'high',
+        description: 'Identifier les cellules exposées et relier les opérations actives au foyer.',
+      },
+    ],
+        actionHints: [
+          {
+            code: 'renforcer-securite',
+            label: 'Renforcer sécurité',
+            priority: 'high',
+            description: 'Prioriser les contre-mesures locales et réduire les fenêtres de sabotage.',
+          },
+          {
+            code: 'enqueter',
+            label: 'Enquêter',
+            priority: 'high',
+            description: 'Identifier les cellules exposées et relier les opérations actives au foyer.',
+          },
+        ],
       },
     },
     {
@@ -158,13 +202,22 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
         signalType: 'sabotage',
         severity: 'watch',
         criticality: 'watch',
+        riskBand: 'faible',
         affectedFactionIds: ['shadow-league'],
         targetFactionIds: ['sun-empire'],
         primaryCelluleId: 'cell-river-1',
         primaryOperationId: 'op-river-1',
         summary: 'Risque sabotage low (20)',
         reasons: ['Risque sabotage low (20)', '1 opération active'],
-        actionHint: 'Suivre les opérations actives et vérifier la chaleur opérationnelle.',
+        actionHint: 'Conserver un œil léger sur l’activité et la chaleur opérationnelle.',
+        actionHints: [
+          {
+            code: 'surveiller',
+            label: 'Surveiller',
+            priority: 'low',
+            description: 'Conserver un œil léger sur l’activité et la chaleur opérationnelle.',
+          },
+        ],
       },
     },
   ]);

--- a/test/ui/intrigue/buildIntrigueWebDemo.test.js
+++ b/test/ui/intrigue/buildIntrigueWebDemo.test.js
@@ -153,20 +153,6 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
         summary: 'Risque sabotage medium (61)',
         reasons: ['Risque sabotage medium (61)', '1 cellule exposée', '1 cellule dormante', '1 opération active'],
         actionHint: 'Prioriser les contre-mesures locales et réduire les fenêtres de sabotage.',
-    actionHints: [
-      {
-        code: 'renforcer-securite',
-        label: 'Renforcer sécurité',
-        priority: 'high',
-        description: 'Prioriser les contre-mesures locales et réduire les fenêtres de sabotage.',
-      },
-      {
-        code: 'enqueter',
-        label: 'Enquêter',
-        priority: 'high',
-        description: 'Identifier les cellules exposées et relier les opérations actives au foyer.',
-      },
-    ],
         actionHints: [
           {
             code: 'renforcer-securite',

--- a/web/app.js
+++ b/web/app.js
@@ -2057,7 +2057,7 @@ function renderIntrigueSidePanel(intrigueView) {
             <div class="intrigue-drilldown intrigue-drilldown--${intrigueView.selectedProvince.drillDown.criticality}">
               <div class="intrigue-drilldown__header">
                 <span>Signal ${intrigueView.selectedProvince.drillDown.signalType}</span>
-                <strong>${intrigueView.selectedProvince.drillDown.criticality}</strong>
+                <strong>risque ${intrigueView.selectedProvince.drillDown.riskBand}</strong>
               </div>
               <p>${intrigueView.selectedProvince.drillDown.summary}</p>
               <div class="intrigue-drilldown__context">
@@ -2068,6 +2068,14 @@ function renderIntrigueSidePanel(intrigueView) {
               <ul>
                 ${intrigueView.selectedProvince.drillDown.reasons.map((reason) => `<li>${reason}</li>`).join('')}
               </ul>
+              <div class="intrigue-action-hints" aria-label="Indices d'action intrigue">
+                ${intrigueView.selectedProvince.drillDown.actionHints.map((hint) => `
+                  <article class="intrigue-action-hint intrigue-action-hint--${hint.priority}">
+                    <strong>${hint.label}</strong>
+                    <span>${hint.description}</span>
+                  </article>
+                `).join('')}
+              </div>
               <small>${intrigueView.selectedProvince.drillDown.actionHint}</small>
             </div>
           ` : ''}

--- a/web/styles.css
+++ b/web/styles.css
@@ -3633,3 +3633,25 @@ button { font: inherit; }
   padding-left: 18px;
   color: #cbd5e1;
 }
+.intrigue-action-hints {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+.intrigue-action-hint {
+  padding: 9px 10px;
+  border-radius: 13px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.intrigue-action-hint--high { border-color: rgba(251, 113, 133, 0.34); }
+.intrigue-action-hint--medium { border-color: rgba(250, 204, 21, 0.3); }
+.intrigue-action-hint--low { border-color: rgba(96, 165, 250, 0.26); }
+.intrigue-action-hint strong,
+.intrigue-action-hint span {
+  display: block;
+}
+.intrigue-action-hint span {
+  margin-top: 3px;
+  color: var(--muted);
+}


### PR DESCRIPTION
Delta: Closes #436.

Summary:
- add descriptive action hints to hotspot drill-downs for reinforce security, investigate, watch, or ignore paths;
- expose low/medium/high risk bands in the selected hotspot panel without adding permanent map clutter;
- render action hint cards in the existing intrigue drill-down panel.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/intrigue/buildIntrigueWebDemo.test.js
- npm test (362 passing)

Delta: Ready for Zeta validation before merge.