### PR TITLE
Epsilon: Compare selected climate preview impact

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -206,6 +206,7 @@ function normalizeSeasonPreview(options, seasonLabels, seasonStyleByType) {
     label,
     active: preview.active === undefined ? true : Boolean(preview.active),
     badge,
+    impactsByRegion: preview.impactsByRegion ?? preview.regions,
     copy: String(preview.copy ?? `Aperçu saison suivante: ${label}`).trim() || `Aperçu saison suivante: ${label}`,
   };
 }
@@ -234,6 +235,104 @@ function buildSeasonPreviewPanel(states, seasonPreview, seasonLabels) {
       obscuresMap: false,
     },
     copy: `${seasonPreview.label} preview on ${changedRegionCount}/${states.length} regions`,
+  };
+}
+
+function normalizeSelectedRegionId(options) {
+  const selectedRegionId = options.selectedRegionId ?? options.selectedProvinceId ?? options.focusedRegionId ?? options.focusedProvinceId;
+
+  if (selectedRegionId === undefined || selectedRegionId === null) {
+    return null;
+  }
+
+  return String(selectedRegionId).trim() || null;
+}
+
+function normalizePreviewImpacts(options, seasonPreview) {
+  const previewImpacts = options.previewImpactsByRegion ?? seasonPreview?.impactsByRegion ?? seasonPreview?.regions;
+
+  if (previewImpacts === undefined || previewImpacts === null) {
+    return {};
+  }
+
+  return requireObject(previewImpacts, 'ClimateMapOverlay previewImpactsByRegion');
+}
+
+function summarizeRegionClimate(region) {
+  return region.strategicSignals?.summary ?? `${region.seasonLabel}, ${region.strategicImpact}`;
+}
+
+function buildSelectedClimateImpactComparison(regions, options, seasonPreview) {
+  const selectedRegionId = normalizeSelectedRegionId(options);
+
+  if (!selectedRegionId) {
+    return {
+      state: 'no-selection',
+      compact: true,
+      copy: 'Sélectionnez une province pour comparer son climat.',
+    };
+  }
+
+  const region = regions.find((candidate) => candidate.regionId === selectedRegionId);
+
+  if (!region) {
+    return {
+      state: 'missing-climate-data',
+      compact: true,
+      regionId: selectedRegionId,
+      copy: 'Aucune donnée climat disponible pour cette province.',
+    };
+  }
+
+  if (!seasonPreview?.active) {
+    return {
+      state: 'no-preview',
+      compact: true,
+      regionId: selectedRegionId,
+      current: {
+        season: region.season,
+        label: region.seasonLabel,
+        riskLevel: region.strategicImpact,
+        anomaly: region.anomaly,
+        summary: summarizeRegionClimate(region),
+      },
+      copy: `${region.seasonLabel}: ${region.strategicImpact}`,
+    };
+  }
+
+  const previewImpacts = normalizePreviewImpacts(options, seasonPreview);
+  const previewImpact = previewImpacts[selectedRegionId] ?? {};
+  const previewRiskLevel = String(previewImpact.riskLevel ?? previewImpact.strategicImpact ?? region.strategicImpact).trim()
+    || region.strategicImpact;
+  const previewAnomaly = previewImpact.anomaly === undefined ? region.anomaly : previewImpact.anomaly;
+  const previewSummary = String(previewImpact.summary ?? `${seasonPreview.label}: ${previewRiskLevel}`).trim()
+    || `${seasonPreview.label}: ${previewRiskLevel}`;
+
+  return {
+    state: 'ready',
+    compact: true,
+    regionId: selectedRegionId,
+    current: {
+      season: region.season,
+      label: region.seasonLabel,
+      riskLevel: region.strategicImpact,
+      anomaly: region.anomaly,
+      summary: summarizeRegionClimate(region),
+    },
+    preview: {
+      season: seasonPreview.season,
+      label: seasonPreview.label,
+      riskLevel: previewRiskLevel,
+      anomaly: previewAnomaly,
+      summary: previewSummary,
+      projected: true,
+    },
+    delta: {
+      seasonChanged: region.season !== seasonPreview.season,
+      riskChanged: region.strategicImpact !== previewRiskLevel,
+      anomalyChanged: region.anomaly !== previewAnomaly,
+    },
+    copy: `${region.seasonLabel} ${region.strategicImpact} → ${seasonPreview.label} ${previewRiskLevel}`,
   };
 }
 
@@ -671,6 +770,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     seasonalPanel: buildSeasonSummary(states, seasonLabels, seasonStyleByType),
     catastropheZones: buildCatastropheZones(catastropheEntries, readabilityProfile),
     regionalRiskMode: buildRegionalRiskMode(regions),
+    selectedClimateImpactComparison: buildSelectedClimateImpactComparison(regions, normalizedOptions, seasonPreview),
     ...(seasonPreview?.active ? { seasonPreview: buildSeasonPreviewPanel(states, seasonPreview, seasonLabels) } : {}),
     legend: buildLegend(stateEntries, catastropheEntries, seasonLabels, seasonPreview),
     ...(!readabilityProfile.overlaySelected ? {

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -277,6 +277,11 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
         summary: 'Été, logistique severe, stabilité moderate, récoltes high',
       },
     ],
+    selectedClimateImpactComparison: {
+      state: 'no-selection',
+      compact: true,
+      copy: 'Sélectionnez une province pour comparer son climat.',
+    },
     legend: {
       title: 'Légende climat',
       compact: true,
@@ -768,5 +773,89 @@ test('buildClimateMapOverlay exposes lightweight season preview controls and edg
       },
     },
     summary: 'Hiver → Printemps',
+  });
+});
+
+test('buildClimateMapOverlay compares selected province current and preview climate impact compactly', () => {
+  const overlay = buildClimateMapOverlay([
+    {
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 33,
+      precipitationLevel: 11,
+      droughtIndex: 74,
+      anomaly: 'heatwave',
+    },
+  ], {
+    selectedRegionId: 'sunreach',
+    seasonLabels: { summer: 'Été', autumn: 'Automne' },
+    seasonPreview: {
+      season: 'autumn',
+      impactsByRegion: {
+        sunreach: {
+          strategicImpact: 'strained',
+          anomaly: null,
+          summary: 'Automne: pression réduite, routes encore fragiles',
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(overlay.selectedClimateImpactComparison, {
+    state: 'ready',
+    compact: true,
+    regionId: 'sunreach',
+    current: {
+      season: 'summer',
+      label: 'Été',
+      riskLevel: 'critical',
+      anomaly: 'heatwave',
+      summary: 'logistique elevated, stabilité moderate, récoltes moderate',
+    },
+    preview: {
+      season: 'autumn',
+      label: 'Automne',
+      riskLevel: 'strained',
+      anomaly: null,
+      summary: 'Automne: pression réduite, routes encore fragiles',
+      projected: true,
+    },
+    delta: {
+      seasonChanged: true,
+      riskChanged: true,
+      anomalyChanged: true,
+    },
+    copy: 'Été critical → Automne strained',
+  });
+});
+
+test('buildClimateMapOverlay reports compact selected climate comparison empty states', () => {
+  assert.deepEqual(buildClimateMapOverlay([], { selectedRegionId: 'missing' }).selectedClimateImpactComparison, {
+    state: 'missing-climate-data',
+    compact: true,
+    regionId: 'missing',
+    copy: 'Aucune donnée climat disponible pour cette province.',
+  });
+
+  assert.deepEqual(buildClimateMapOverlay([
+    {
+      regionId: 'delta',
+      season: 'winter',
+      temperatureC: 2,
+      precipitationLevel: 40,
+      droughtIndex: 9,
+    },
+  ], { selectedRegionId: 'delta' }).selectedClimateImpactComparison, {
+    state: 'no-preview',
+    compact: true,
+    regionId: 'delta',
+    current: {
+      season: 'winter',
+      label: 'winter',
+      riskLevel: 'stable',
+      anomaly: null,
+      summary: 'logistique low, stabilité low, récoltes low',
+    },
+    copy: 'winter: stable',
   });
 });


### PR DESCRIPTION
Epsilon: Implements #437.\n\nSummary:\n- adds a compact selectedClimateImpactComparison model to the climate map overlay;\n- compares selected province current season/risk/anomaly with the active season preview;\n- supports optional preview impacts by region without changing core climate rules;\n- adds clear no-selection, missing-data, and no-preview states.\n\nValidation:\n- npm test -- test/ui/climate/buildClimateMapOverlay.test.js\n- npm test (365 passing)\n- node --check src/ui/climate/buildClimateMapOverlay.js\n- node --check web/app.js\n- git diff --check\n\nZeta, peux-tu valider cette PR avant merge ?