### PR TITLE
Alpha: Add province action recommendations

### DIFF
--- a/test/ui/war/webProvinceActionRecommendations.test.js
+++ b/test/ui/war/webProvinceActionRecommendations.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('playable map province details expose contextual action recommendations', () => {
+  assert.match(webAppSource, /function buildProvinceActionRecommendations/);
+  assert.match(webAppSource, /function renderProvinceActionRecommendations/);
+  assert.match(webAppSource, /Actions recommandées/);
+  assert.match(webAppSource, /Renforcer le front/);
+  assert.match(webAppSource, /Inspecter les routes/);
+  assert.match(webAppSource, /Comparer le risque climat/);
+  assert.match(webAppSource, /renderProvinceActionRecommendations\(province, focusContext\)/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -707,6 +707,83 @@ function renderOverlaySlots(shell) {
   }).join('');
 }
 
+function buildProvinceActionRecommendations(province, focusContext) {
+  const recommendations = [];
+  const neighborCount = focusContext.neighborIds.size;
+  const linkedCity = cities.find((city) => city.regionId === province.provinceId) ?? null;
+
+  if (province.contested) {
+    recommendations.push({
+      tone: 'danger',
+      title: 'Renforcer le front',
+      body: 'Prioriser garnison, ravitaillement et reconnaissance avant la prochaine poussée.',
+    });
+  } else if (province.occupied) {
+    recommendations.push({
+      tone: 'warning',
+      title: 'Stabiliser l’occupation',
+      body: 'Comparer contrôle et propriétaire avant de déplacer des forces voisines.',
+    });
+  } else {
+    recommendations.push({
+      tone: 'ready',
+      title: 'Préparer la manœuvre',
+      body: neighborCount > 0 ? `Scanner ${neighborCount} province${neighborCount > 1 ? 's' : ''} voisine${neighborCount > 1 ? 's' : ''} avant l’ordre.` : 'Aucun voisin direct: garder la province en réserve.',
+    });
+  }
+
+  if (['disrupted', 'collapsed'].includes(province.supplyLevel)) {
+    recommendations.push({
+      tone: 'warning',
+      title: 'Inspecter les routes',
+      body: 'Ouvrir la couche économie pour repérer les convois et points de rupture.',
+    });
+  } else if (province.loyalty < 50) {
+    recommendations.push({
+      tone: 'warning',
+      title: 'Surveiller l’agitation',
+      body: 'Croiser avec intrigue/culture avant d’engager une action longue.',
+    });
+  } else if (linkedCity) {
+    recommendations.push({
+      tone: 'info',
+      title: 'Contrôler le hub local',
+      body: `Vérifier ${linkedCity.name} pour stocks, stabilité et relais logistiques.`,
+    });
+  }
+
+  recommendations.push({
+    tone: province.strategicValue >= 6 ? 'info' : 'neutral',
+    title: province.strategicValue >= 6 ? 'Comparer le risque climat' : 'Garder en observation',
+    body: province.strategicValue >= 6
+      ? 'Comparer l’impact climat avant de verrouiller une décision coûteuse.'
+      : 'Conserver comme point d’appui et réévaluer après le prochain tour.',
+  });
+
+  return recommendations.slice(0, 3);
+}
+
+function renderProvinceActionRecommendations(province, focusContext) {
+  const recommendations = buildProvinceActionRecommendations(province, focusContext);
+
+  return `
+    <div class="province-action-recommendations" aria-label="Actions recommandées pour la province sélectionnée">
+      <div class="province-action-recommendations__header">
+        <strong>Actions recommandées</strong>
+        <span>${province.selectionState.selected ? 'sélection active' : 'focus tactique'}</span>
+      </div>
+      <div class="province-action-list">
+        ${recommendations.map((recommendation) => `
+          <article class="province-action-card province-action-card--${recommendation.tone}">
+            <strong>${recommendation.title}</strong>
+            <p>${recommendation.body}</p>
+          </article>
+        `).join('')}
+      </div>
+    </div>
+  `;
+}
+
 function renderActiveProvince(shell) {
   const focusContext = getFocusContext(shell);
   const province = shell.activeProvince ?? shell.provinces[0] ?? null;
@@ -748,6 +825,7 @@ function renderActiveProvince(shell) {
           <strong>${focusContext.focusedProvince?.label ?? province.label}</strong>
         </div>
       </div>
+      ${renderProvinceActionRecommendations(province, focusContext)}
       <div class="context-summary">
         <strong>Comparaison rapide</strong>
         <p>${comparedProvinceNames.length > 0 ? comparedProvinceNames.join(' vs ') : 'Aucune province comparée pour le moment.'}</p>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1624,6 +1624,50 @@ button { font: inherit; }
   color: var(--muted);
   margin-bottom: 4px;
 }
+.province-action-recommendations {
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.7), rgba(8, 15, 28, 0.58));
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.province-action-recommendations__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+.province-action-recommendations__header span {
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-action-list {
+  display: grid;
+  gap: 8px;
+}
+.province-action-card {
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-action-card strong {
+  display: block;
+  margin-bottom: 4px;
+}
+.province-action-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+.province-action-card--danger { border-color: rgba(251, 113, 133, 0.34); }
+.province-action-card--warning { border-color: rgba(251, 191, 36, 0.32); }
+.province-action-card--ready { border-color: rgba(74, 222, 128, 0.28); }
+.province-action-card--info { border-color: rgba(56, 189, 248, 0.3); }
 .context-summary {
   margin-top: 14px;
   padding: 12px;


### PR DESCRIPTION
Alpha: Closes #443.

## Summary
- adds contextual province action recommendations to the selected/focused province detail panel
- derives 2-3 non-blocking recommendations from existing war/map state such as contested, occupied, supply, loyalty, neighbors, city hub, and strategic value
- styles the recommendation cards to fit the current tactical panel conventions without modal flow
- adds a smoke test covering the recommendation affordance in the playable map surface

## Verification
- npm test
- npm run preview:map -- /tmp/historia-province-actions-preview.html
- node --check web/app.js
- git diff --check
