### PR TITLE
Gamma: Add culture map recommendations

### DIFF
--- a/src/ui/culture/buildCultureMapRecommendations.js
+++ b/src/ui/culture/buildCultureMapRecommendations.js
@@ -1,0 +1,100 @@
+function normalizeText(value, fallback = '') {
+  return String(value ?? fallback).trim();
+}
+
+function sortPins(pins) {
+  return pins
+    .slice()
+    .sort((left, right) => (right.importance ?? -1) - (left.importance ?? -1) || normalizeText(left.name).localeCompare(normalizeText(right.name)));
+}
+
+function buildPinRecommendation(pin, selectedRegionId) {
+  const isEvent = pin.kind === 'event';
+  const title = isEvent ? 'Suivre le repère culturel' : 'Exploiter la découverte locale';
+  const hook = isEvent
+    ? `${normalizeText(pin.name, 'Événement culturel')} peut orienter la prochaine action en ${selectedRegionId}.`
+    : `${normalizeText(pin.name, 'Découverte')} donne un angle court pour la province sélectionnée.`;
+
+  return {
+    recommendationId: `${selectedRegionId}:${pin.pinId}:recommendation`,
+    tone: isEvent ? 'event' : 'discovery',
+    title,
+    hook,
+    detail: `${normalizeText(pin.type, isEvent ? 'événement' : 'découverte')} · ${normalizeText(pin.cultureName, pin.cultureId)}${pin.importance ? ` · IMP-${pin.importance}` : ''}`,
+    sourcePinId: pin.pinId,
+  };
+}
+
+export function buildCultureMapRecommendations({ selectedRegionId, selectedMarker = null, selectedCluster = null } = {}) {
+  const regionId = normalizeText(selectedRegionId, 'province');
+  const pins = sortPins(selectedCluster?.pins ?? []);
+
+  if (pins.length > 0) {
+    const topPin = pins[0];
+    const recommendation = buildPinRecommendation(topPin, regionId);
+
+    return {
+      state: 'linked',
+      regionId,
+      summary: `${selectedCluster.label} · ${pins.length} pistes liées`,
+      recommendations: [
+        recommendation,
+        ...pins.slice(1, 3).map((pin) => buildPinRecommendation(pin, regionId)),
+      ],
+    };
+  }
+
+  if (selectedCluster) {
+    return {
+      state: 'empty-cluster',
+      regionId,
+      summary: `${selectedCluster.label} · aucun pin lié`,
+      recommendations: [
+        {
+          recommendationId: `${regionId}:${selectedCluster.clusterId}:empty`,
+          tone: 'neutral',
+          title: 'Observer le voisinage culturel',
+          hook: 'Cluster visible, mais aucun événement ou découverte exploitable pour l’instant.',
+          detail: selectedCluster.summary,
+          sourcePinId: null,
+        },
+      ],
+    };
+  }
+
+  if (selectedMarker) {
+    return {
+      state: 'marker',
+      regionId,
+      summary: `${selectedMarker.cultureName} · ${selectedMarker.influenceTier}`,
+      recommendations: [
+        {
+          recommendationId: `${regionId}:${selectedMarker.overlayId}:marker`,
+          tone: selectedMarker.eventCount > 0 ? 'event' : 'neutral',
+          title: selectedMarker.eventCount > 0 ? 'Lire le repère historique' : 'Surveiller l’influence culturelle',
+          hook: selectedMarker.eventCount > 0
+            ? `${selectedMarker.eventCount} repère${selectedMarker.eventCount > 1 ? 's' : ''} historique${selectedMarker.eventCount > 1 ? 's' : ''} alimente${selectedMarker.eventCount > 1 ? 'nt' : ''} cette province.`
+            : 'Influence culturelle stable; gardez la province comme référence sans action urgente.',
+          detail: `${selectedMarker.discoveries.length} découvertes · score ${selectedMarker.influenceScore}`,
+          sourcePinId: null,
+        },
+      ],
+    };
+  }
+
+  return {
+    state: 'neutral',
+    regionId,
+    summary: 'Aucun signal culturel prioritaire',
+    recommendations: [
+      {
+        recommendationId: `${regionId}:culture-neutral`,
+        tone: 'neutral',
+        title: 'Aucune action culturelle immédiate',
+        hook: 'Sélection sans cluster, découverte ou événement culturel exploitable.',
+        detail: 'Activez Culture ou choisissez une province voisine pour plus de contexte.',
+        sourcePinId: null,
+      },
+    ],
+  };
+}

--- a/test/ui/culture/buildCultureMapRecommendations.test.js
+++ b/test/ui/culture/buildCultureMapRecommendations.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCultureMapRecommendations } from '../../../src/ui/culture/buildCultureMapRecommendations.js';
+
+test('buildCultureMapRecommendations prioritizes cluster event and discovery pins', () => {
+  const recommendations = buildCultureMapRecommendations({
+    selectedRegionId: 'shared-bay',
+    selectedCluster: {
+      clusterId: 'shared-bay:culture-cluster',
+      label: '2 cultures · 2 découvertes',
+      summary: 'Delta Scribes, Harbor Compact',
+      pins: [
+        {
+          pinId: 'shared-bay:culture-harbor:discovery:tidal-ledgers',
+          kind: 'discovery',
+          name: 'tidal-ledgers',
+          type: 'Découverte',
+          cultureId: 'culture-harbor',
+          cultureName: 'Harbor Compact',
+          importance: null,
+        },
+        {
+          pinId: 'shared-bay:culture-harbor:event:event-harbor-forum',
+          kind: 'event',
+          name: 'Harbor Forum',
+          type: 'knowledge',
+          cultureId: 'culture-harbor',
+          cultureName: 'Harbor Compact',
+          importance: 4,
+        },
+      ],
+    },
+  });
+
+  assert.equal(recommendations.state, 'linked');
+  assert.equal(recommendations.summary, '2 cultures · 2 découvertes · 2 pistes liées');
+  assert.deepEqual(recommendations.recommendations.map((entry) => entry.title), [
+    'Suivre le repère culturel',
+    'Exploiter la découverte locale',
+  ]);
+  assert.equal(recommendations.recommendations[0].sourcePinId, 'shared-bay:culture-harbor:event:event-harbor-forum');
+  assert.equal(recommendations.recommendations[0].detail, 'knowledge · Harbor Compact · IMP-4');
+});
+
+test('buildCultureMapRecommendations falls back gracefully for empty clusters and quiet markers', () => {
+  assert.deepEqual(
+    buildCultureMapRecommendations({
+      selectedRegionId: 'silent-fen',
+      selectedCluster: {
+        clusterId: 'silent-fen:culture-cluster',
+        label: '2 cultures · 0 découvertes',
+        summary: 'Quiet Houses',
+        pins: [],
+      },
+    }).recommendations[0],
+    {
+      recommendationId: 'silent-fen:silent-fen:culture-cluster:empty',
+      tone: 'neutral',
+      title: 'Observer le voisinage culturel',
+      hook: 'Cluster visible, mais aucun événement ou découverte exploitable pour l’instant.',
+      detail: 'Quiet Houses',
+      sourcePinId: null,
+    },
+  );
+
+  const markerRecommendations = buildCultureMapRecommendations({
+    selectedRegionId: 'north-watch',
+    selectedMarker: {
+      overlayId: 'north-watch:culture-aurora',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      eventCount: 1,
+      discoveries: ['tidal-ledgers'],
+      influenceScore: 79,
+    },
+  });
+
+  assert.equal(markerRecommendations.state, 'marker');
+  assert.equal(markerRecommendations.recommendations[0].title, 'Lire le repère historique');
+});

--- a/web/app.js
+++ b/web/app.js
@@ -11,6 +11,7 @@ import { buildCityComparisonPanel } from '../src/ui/economy/buildCityComparisonP
 import { Cellule } from '../src/domain/intrigue/Cellule.js';
 import { OperationClandestine } from '../src/domain/intrigue/OperationClandestine.js';
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
+import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMapRecommendations.js';
 
 const culturePayload = {
   cultures: [
@@ -1757,6 +1758,26 @@ function renderCultureClusterSummary(cluster, active) {
   `;
 }
 
+function renderCultureRecommendationPanel(recommendationView) {
+  return `
+    <article class="culture-recommendation-panel culture-recommendation-panel--${recommendationView.state}">
+      <div class="culture-recommendation-panel__header">
+        <span>Conseil culture</span>
+        <strong>${recommendationView.summary}</strong>
+      </div>
+      <div class="culture-recommendation-panel__items">
+        ${recommendationView.recommendations.map((recommendation) => `
+          <section class="culture-recommendation culture-recommendation--${recommendation.tone}">
+            <b>${recommendation.title}</b>
+            <p>${recommendation.hook}</p>
+            <small>${recommendation.detail}</small>
+          </section>
+        `).join('')}
+      </div>
+    </article>
+  `;
+}
+
 function renderCultureClusterPinList(cluster) {
   if (!cluster) {
     return '';
@@ -1852,6 +1873,11 @@ function renderCultureSidePanel(cultureView) {
   const focusSeed = focus ? cultureView.seeds.find((seed) => seed.cultureId === focus.cultureId) : null;
   const selectedCluster = buildCultureClusterSummaries(cultureView.overlay)
     .find((cluster) => cluster.regionIds.includes(state.selectedProvinceId)) ?? null;
+  const recommendationView = buildCultureMapRecommendations({
+    selectedRegionId: state.selectedProvinceId,
+    selectedMarker: focus,
+    selectedCluster,
+  });
 
   return `
     <section class="panel overlay-panel overlay-panel--culture">
@@ -1867,6 +1893,7 @@ function renderCultureSidePanel(cultureView) {
         <div class="overlay-anchor"><span>Repères</span><strong>${cultureView.metrics.eventCount}</strong></div>
       </div>
       ${renderCultureLegendKey(cultureView)}
+      ${renderCultureRecommendationPanel(recommendationView)}
       ${renderCultureClusterPinList(selectedCluster)}
       ${focus ? `
         <article class="culture-focus-card culture-focus-card--${getCultureTone(focus)}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -3103,6 +3103,47 @@ button { font: inherit; }
   color: var(--muted);
   margin: 0;
 }
+.culture-recommendation-panel {
+  border: 1px solid rgba(125, 211, 252, 0.2);
+  border-radius: 16px;
+  background:
+    linear-gradient(145deg, rgba(8, 47, 73, 0.42), rgba(2, 6, 23, 0.56)),
+    rgba(15, 23, 42, 0.46);
+  padding: 12px;
+  margin-bottom: 12px;
+}
+.culture-recommendation-panel__header {
+  display: grid;
+  gap: 3px;
+  margin-bottom: 9px;
+}
+.culture-recommendation-panel__header span {
+  color: var(--accent);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.culture-recommendation-panel__header strong { color: #f8fafc; }
+.culture-recommendation-panel__items {
+  display: grid;
+  gap: 8px;
+}
+.culture-recommendation {
+  padding: 9px 10px;
+  border-radius: 13px;
+  background: rgba(15, 23, 42, 0.64);
+  border: 1px solid rgba(125, 211, 252, 0.12);
+}
+.culture-recommendation--event { border-color: rgba(251, 191, 36, 0.28); }
+.culture-recommendation--discovery { border-color: rgba(34, 211, 238, 0.24); }
+.culture-recommendation b { color: #e0f2fe; }
+.culture-recommendation--event b { color: #fde68a; }
+.culture-recommendation p {
+  color: #cbd5e1;
+  margin: 4px 0;
+  font-size: 13px;
+}
+.culture-recommendation small { color: var(--muted); }
 .culture-symbol-key {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Gamma: Closes #445.

## Summary
- add a reusable culture recommendation builder driven by selected marker/cluster pin data
- surface concise culture-aware recommendation copy in the selected province culture panel
- provide neutral fallbacks for quiet provinces or empty clusters
- add focused tests for event/discovery prioritization and fallback copy

## Validation
- `node --check web/app.js`
- `git diff --check`
- `npm test` (370 passing)

Gamma: Ready for Zeta validation before merge.
