### PR TITLE
Alpha: Preview conflict outcomes

### DIFF
--- a/test/ui/war/webConflictOutcomePreview.test.js
+++ b/test/ui/war/webConflictOutcomePreview.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('playable map province details expose likely conflict outcome preview', () => {
+  assert.match(webAppSource, /function buildConflictOutcomePreview/);
+  assert.match(webAppSource, /function renderConflictOutcomePreview/);
+  assert.match(webAppSource, /Issue probable/);
+  assert.match(webAppSource, /Victoire probable/);
+  assert.match(webAppSource, /Issue disputée/);
+  assert.match(webAppSource, /Risque élevé/);
+  assert.match(webAppSource, /Pression de front/);
+  assert.match(webAppSource, /Ravitaillement/);
+  assert.match(webAppSource, /Contrôle adjacent/);
+  assert.match(webAppSource, /renderConflictOutcomePreview\(province, shell\)/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -922,6 +922,66 @@ function renderProvinceEconomyConsequences(province, economyView) {
   `;
 }
 
+function buildConflictOutcomePreview(province, shell) {
+  const neighbors = province.neighborIds
+    .map((provinceId) => shell.provinces.find((candidate) => candidate.provinceId === provinceId))
+    .filter(Boolean);
+  const alliedNeighbors = neighbors.filter((neighbor) => neighbor.controllingFactionId === province.controllingFactionId).length;
+  const hostileNeighbors = neighbors.length - alliedNeighbors;
+  const supplyScore = { stable: 2, strained: 1, disrupted: -1, collapsed: -2 }[province.supplyLevel] ?? 0;
+  const frontPressureScore = province.contested ? -2 : province.occupied ? -1 : hostileNeighbors > alliedNeighbors ? -1 : 1;
+  const stabilityScore = province.loyalty >= 70 ? 1 : province.loyalty < 45 ? -1 : 0;
+  const totalScore = supplyScore + frontPressureScore + stabilityScore + (alliedNeighbors > hostileNeighbors ? 1 : 0);
+  const tone = totalScore >= 2 ? 'success' : totalScore <= -2 ? 'danger' : 'warning';
+  const title = totalScore >= 2 ? 'Victoire probable' : totalScore <= -2 ? 'Risque élevé' : 'Issue disputée';
+
+  return {
+    tone,
+    title,
+    summary: totalScore >= 2
+      ? 'La province dispose de suffisamment d’appuis pour tenter une action limitée.'
+      : totalScore <= -2
+        ? 'Action risquée: sécuriser appuis et ravitaillement avant confirmation.'
+        : 'Résultat incertain: une préparation ciblée peut faire basculer l’issue.',
+    factors: [
+      {
+        label: 'Pression de front',
+        value: province.contested ? 'front actif' : hostileNeighbors > 0 ? `${hostileNeighbors} voisin${hostileNeighbors > 1 ? 's' : ''} adverse${hostileNeighbors > 1 ? 's' : ''}` : 'front calme',
+      },
+      {
+        label: 'Ravitaillement',
+        value: province.supplyLevel,
+      },
+      {
+        label: 'Contrôle adjacent',
+        value: `${alliedNeighbors} appui${alliedNeighbors > 1 ? 's' : ''} / ${hostileNeighbors} menace${hostileNeighbors > 1 ? 's' : ''}`,
+      },
+    ],
+  };
+}
+
+function renderConflictOutcomePreview(province, shell) {
+  const preview = buildConflictOutcomePreview(province, shell);
+
+  return `
+    <section class="conflict-outcome-preview conflict-outcome-preview--${preview.tone}" aria-label="Issue probable de conflit">
+      <div class="conflict-outcome-preview__header">
+        <span>Issue probable</span>
+        <strong>${preview.title}</strong>
+      </div>
+      <p>${preview.summary}</p>
+      <div class="conflict-outcome-factors">
+        ${preview.factors.map((factor) => `
+          <div class="conflict-outcome-factor">
+            <span>${factor.label}</span>
+            <strong>${factor.value}</strong>
+          </div>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderActiveProvince(shell, economyView = null, intrigueView = null) {
   const focusContext = getFocusContext(shell);
   const province = shell.activeProvince ?? shell.provinces[0] ?? null;
@@ -964,6 +1024,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
         </div>
       </div>
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
+      ${renderConflictOutcomePreview(province, shell)}
       <div class="context-summary">
         <strong>Comparaison rapide</strong>
         <p>${comparedProvinceNames.length > 0 ? comparedProvinceNames.join(' vs ') : 'Aucune province comparée pour le moment.'}</p>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1668,6 +1668,55 @@ button { font: inherit; }
 .province-action-card--warning { border-color: rgba(251, 191, 36, 0.32); }
 .province-action-card--ready { border-color: rgba(74, 222, 128, 0.28); }
 .province-action-card--info { border-color: rgba(56, 189, 248, 0.3); }
+.conflict-outcome-preview {
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(2, 6, 23, 0.64), rgba(15, 23, 42, 0.56));
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.conflict-outcome-preview__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+.conflict-outcome-preview__header span {
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.conflict-outcome-preview > p {
+  margin: 8px 0 0;
+  color: #cbd5e1;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.conflict-outcome-factors {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+}
+.conflict-outcome-factor {
+  padding: 9px;
+  border-radius: 12px;
+  background: rgba(8, 15, 28, 0.52);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.conflict-outcome-factor span {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+.conflict-outcome-factor strong {
+  font-size: 12px;
+}
+.conflict-outcome-preview--success { border-color: rgba(74, 222, 128, 0.34); }
+.conflict-outcome-preview--warning { border-color: rgba(251, 191, 36, 0.36); }
+.conflict-outcome-preview--danger { border-color: rgba(251, 113, 133, 0.42); }
 .context-summary {
   margin-top: 14px;
   padding: 12px;


### PR DESCRIPTION
Alpha: Closes #453.

## Summary
- adds a selected-province “Issue probable” preview for conflict/front actions
- scores the preview from existing province/map context: front pressure, supply, adjacent control, and local stability
- distinguishes likely victory, contested outcome, and high risk without modal flow or a map refactor
- styles the preview in the existing dark HUD panel and adds a focused smoke test

## Verification
- npm test
- npm run preview:map -- /tmp/historia-conflict-outcome-preview.html
- node --test test/ui/war/webConflictOutcomePreview.test.js
- node --check web/app.js
- git diff --check
