### PR TITLE
Beta: compare province logistics bottlenecks

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -922,6 +922,83 @@ function renderProvinceEconomyConsequences(province, economyView) {
   `;
 }
 
+function buildProvinceLogisticsBottleneckComparison(province, economyView) {
+  if (!province || !economyView) {
+    return [];
+  }
+
+  const tensionByCityId = Object.fromEntries(economyView.comparison.rows.map((row) => [row.cityId, row]));
+  const cityNameById = Object.fromEntries(economyView.overlay.cities.map((city) => [city.cityId, city.cityName]));
+  const provinceCities = economyView.overlay.cities.filter((city) => city.regionId === province.provinceId);
+  const provinceCityIds = new Set(provinceCities.map((city) => city.cityId));
+  const toneRank = { high: 3, medium: 2, low: 1 };
+
+  return economyView.overlay.routes
+    .filter((route) => route.cityIds.some((cityId) => provinceCityIds.has(cityId)))
+    .map((route) => {
+      const stress = getRouteStressSummary(route, tensionByCityId, cityNameById);
+      const localCityId = route.cityIds.find((cityId) => provinceCityIds.has(cityId)) ?? route.originCityId;
+      const otherCityId = route.cityIds.find((cityId) => !provinceCityIds.has(cityId)) ?? route.destinationCityId;
+      const localTension = tensionByCityId[localCityId]?.tensionLevel ?? 'low';
+      const mainResource = route.resources.slice().sort((left, right) => right.capacity - left.capacity || left.resourceId.localeCompare(right.resourceId))[0] ?? null;
+      const resourceLabel = mainResource ? `${getResourceHud(mainResource.resourceId).label} ${mainResource.capacity}` : 'capacité réservée';
+      const leverage = stress.tone === 'high'
+        ? 'Priorité: sécuriser ce flux avant action province.'
+        : stress.tone === 'medium'
+          ? 'Levier utile: renforcer si action coûteuse.'
+          : 'Levier secondaire: garder en observation.';
+
+      return {
+        routeId: route.routeId,
+        routeName: route.routeName,
+        tone: stress.tone,
+        headline: stress.headline,
+        capacity: route.totalCapacity,
+        tension: localTension,
+        resourceLabel,
+        impactedCity: cityNameById[localCityId] ?? cityNameById[otherCityId] ?? route.destinationCityId,
+        consequence: stress.summary,
+        leverage,
+        score: (toneRank[stress.tone] ?? 0) * 100 + route.riskLevel + route.totalCapacity,
+      };
+    })
+    .sort((left, right) => right.score - left.score || left.routeName.localeCompare(right.routeName))
+    .slice(0, 3);
+}
+
+function renderProvinceLogisticsBottleneckComparison(province, economyView) {
+  const comparisons = buildProvinceLogisticsBottleneckComparison(province, economyView);
+
+  if (comparisons.length < 2) {
+    return '';
+  }
+
+  return `
+    <section class="province-logistics-comparison" aria-label="Comparatif des goulets logistiques">
+      <div class="province-logistics-comparison__header">
+        <strong>Goulets logistiques comparés</strong>
+        <span>${comparisons.length} routes liées</span>
+      </div>
+      ${comparisons.map((entry, index) => `
+        <article class="province-logistics-route province-logistics-route--${entry.tone} ${index === 0 ? 'is-priority' : ''}">
+          <div class="province-logistics-route__rank">${index === 0 ? 'Priorité' : `#${index + 1}`}</div>
+          <div>
+            <strong>${entry.routeName}</strong>
+            <p>${entry.consequence}</p>
+            <small>${entry.leverage}</small>
+          </div>
+          <dl>
+            <div><dt>Capacité</dt><dd>${entry.capacity}</dd></div>
+            <div><dt>Tension</dt><dd>${entry.tension}</dd></div>
+            <div><dt>Ressource</dt><dd>${entry.resourceLabel}</dd></div>
+            <div><dt>Ville</dt><dd>${entry.impactedCity}</dd></div>
+          </dl>
+        </article>
+      `).join('')}
+    </section>
+  `;
+}
+
 function buildConflictOutcomePreview(province, shell) {
   const neighbors = province.neighborIds
     .map((provinceId) => shell.provinces.find((candidate) => candidate.provinceId === provinceId))
@@ -1030,6 +1107,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
         <p>${comparedProvinceNames.length > 0 ? comparedProvinceNames.join(' vs ') : 'Aucune province comparée pour le moment.'}</p>
       </div>
       ${renderProvinceEconomyConsequences(province, economyView)}
+      ${renderProvinceLogisticsBottleneckComparison(province, economyView)}
     </section>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -1765,6 +1765,85 @@ button { font: inherit; }
 .province-economy-recommendation--high { border-color: rgba(251, 113, 133, 0.44); }
 .province-economy-recommendation--medium { border-color: rgba(245, 158, 11, 0.38); }
 .province-economy-recommendation--low { border-color: rgba(74, 222, 128, 0.28); }
+.province-logistics-comparison {
+  display: grid;
+  gap: 9px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(2, 6, 23, 0.62), rgba(8, 47, 73, 0.28));
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.province-logistics-comparison__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-logistics-comparison__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-logistics-route {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px 10px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(8, 15, 28, 0.48);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-logistics-route.is-priority {
+  background: linear-gradient(135deg, rgba(14, 116, 144, 0.18), rgba(8, 15, 28, 0.52));
+}
+.province-logistics-route--high { border-color: rgba(251, 113, 133, 0.45); }
+.province-logistics-route--medium { border-color: rgba(245, 158, 11, 0.38); }
+.province-logistics-route--low { border-color: rgba(74, 222, 128, 0.28); }
+.province-logistics-route__rank {
+  align-self: start;
+  padding: 4px 7px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.72);
+  color: #bae6fd;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-logistics-route p {
+  margin: 4px 0 0;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.38;
+}
+.province-logistics-route small {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+}
+.province-logistics-route dl {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  margin: 0;
+}
+.province-logistics-route dl div {
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.34);
+}
+.province-logistics-route dt {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.province-logistics-route dd {
+  margin: 3px 0 0;
+  font-size: 12px;
+}
 .overlay-anchor {
   flex: 1 1 140px;
   padding: 12px;


### PR DESCRIPTION
Beta: Implements #454.

Scope:
- add a compact bottleneck comparison for routes linked to the selected province;
- show capacity, local supply tension, key resource/city, and probable consequence;
- rank the top route to treat first without adding map noise;
- reuse existing economy view, route stress, city tension, and resource data.

Validation:
- npm test (371 passing)
- node --check web/app.js
- git diff --check

Ready for Zeta validation before merge.