### PR TITLE
Gamma: Add local culture event timeline

### DIFF
--- a/src/ui/culture/buildCultureLocalTimeline.js
+++ b/src/ui/culture/buildCultureLocalTimeline.js
@@ -1,0 +1,96 @@
+function normalizeText(value, fallback = '') {
+  return String(value ?? fallback).trim();
+}
+
+function classifyEvent(event) {
+  if ((event.importance ?? 0) >= 4) {
+    return 'opportunity';
+  }
+
+  if ((event.discoveries ?? []).length > 0) {
+    return 'research';
+  }
+
+  return 'risk';
+}
+
+function buildEventItem(event, cultureName, regionId) {
+  const signal = classifyEvent(event);
+
+  return {
+    timelineId: `${regionId}:event:${event.eventId}`,
+    kind: 'event',
+    signal,
+    title: normalizeText(event.title, 'Repère culturel'),
+    regionId,
+    cultureName: normalizeText(cultureName, 'Culture locale'),
+    importance: event.importance ?? null,
+    summary: signal === 'opportunity'
+      ? 'Opportunité culturelle à exploiter maintenant.'
+      : signal === 'research'
+        ? 'Indice utile pour orienter une recherche locale.'
+        : 'Signal faible à surveiller avant une action majeure.',
+    detail: normalizeText(event.summary, event.label),
+    date: normalizeText(event.triggeredAt).slice(0, 10),
+  };
+}
+
+function buildDiscoveryItem(pin, regionId) {
+  return {
+    timelineId: `${regionId}:discovery:${pin.pinId}`,
+    kind: 'discovery',
+    signal: 'research',
+    title: normalizeText(pin.name, 'Découverte'),
+    regionId,
+    cultureName: normalizeText(pin.cultureName, pin.cultureId),
+    importance: pin.importance ?? null,
+    summary: 'Découverte disponible comme piste courte de progression.',
+    detail: normalizeText(pin.type, 'Découverte'),
+    date: '',
+  };
+}
+
+export function buildCultureLocalTimeline({ selectedRegionId, selectedMarker = null, selectedCluster = null } = {}) {
+  const regionId = normalizeText(selectedRegionId, 'province');
+  const eventItems = (selectedMarker?.eventPopups ?? [])
+    .map((event) => buildEventItem(event, selectedMarker.cultureName, regionId));
+  const clusterPinItems = (selectedCluster?.pins ?? [])
+    .map((pin) => (pin.kind === 'event'
+      ? {
+        timelineId: `${regionId}:pin:${pin.pinId}`,
+        kind: 'event',
+        signal: (pin.importance ?? 0) >= 4 ? 'opportunity' : 'risk',
+        title: normalizeText(pin.name, 'Repère culturel'),
+        regionId: normalizeText(pin.regionId, regionId),
+        cultureName: normalizeText(pin.cultureName, pin.cultureId),
+        importance: pin.importance ?? null,
+        summary: (pin.importance ?? 0) >= 4
+          ? 'Événement fort du cluster à traiter en priorité.'
+          : 'Événement local à garder dans le fil de décision.',
+        detail: normalizeText(pin.type, 'événement'),
+        date: '',
+      }
+      : buildDiscoveryItem(pin, normalizeText(pin.regionId, regionId))));
+
+  const items = [...new Map([...eventItems, ...clusterPinItems].map((item) => [item.timelineId, item])).values()]
+    .sort((left, right) => (right.importance ?? -1) - (left.importance ?? -1) || left.title.localeCompare(right.title))
+    .slice(0, 3);
+
+  if (items.length === 0) {
+    return {
+      state: 'empty',
+      regionId,
+      heading: 'Chronologie locale calme',
+      summary: 'Aucun événement ou découverte culturelle immédiate pour cette province.',
+      items: [],
+    };
+  }
+
+  return {
+    state: 'active',
+    regionId,
+    heading: 'Chronologie locale',
+    summary: `${items.length} signal${items.length > 1 ? 's' : ''} culturel${items.length > 1 ? 's' : ''} lié${items.length > 1 ? 's' : ''} à la province sélectionnée.`,
+    items,
+  };
+}

--- a/test/ui/culture/buildCultureLocalTimeline.test.js
+++ b/test/ui/culture/buildCultureLocalTimeline.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCultureLocalTimeline } from '../../../src/ui/culture/buildCultureLocalTimeline.js';
+
+test('buildCultureLocalTimeline prioritizes local events and cluster discovery pins', () => {
+  const timeline = buildCultureLocalTimeline({
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      cultureName: 'Compact d’Aurora',
+      eventPopups: [
+        {
+          eventId: 'event-archive-opening',
+          title: 'Ouverture des archives',
+          summary: 'Les cartes anciennes révèlent une passe sûre.',
+          triggeredAt: '2026-04-20T00:00:00.000Z',
+          importance: 5,
+          discoveries: ['archive-routes'],
+        },
+      ],
+    },
+    selectedCluster: {
+      pins: [
+        {
+          pinId: 'river-gate:culture-aurora:discovery:tidal-ledgers',
+          kind: 'discovery',
+          name: 'tidal-ledgers',
+          type: 'Découverte',
+          regionId: 'river-gate',
+          cultureId: 'culture-aurora',
+          cultureName: 'Compact d’Aurora',
+          importance: null,
+        },
+      ],
+    },
+  });
+
+  assert.equal(timeline.state, 'active');
+  assert.equal(timeline.summary, '2 signals culturels liés à la province sélectionnée.');
+  assert.deepEqual(timeline.items.map((item) => [item.kind, item.signal, item.title]), [
+    ['event', 'opportunity', 'Ouverture des archives'],
+    ['discovery', 'research', 'tidal-ledgers'],
+  ]);
+  assert.equal(timeline.items[0].date, '2026-04-20');
+});
+
+test('buildCultureLocalTimeline returns a calm empty state without local signals', () => {
+  assert.deepEqual(buildCultureLocalTimeline({ selectedRegionId: 'quiet-field' }), {
+    state: 'empty',
+    regionId: 'quiet-field',
+    heading: 'Chronologie locale calme',
+    summary: 'Aucun événement ou découverte culturelle immédiate pour cette province.',
+    items: [],
+  });
+});

--- a/web/app.js
+++ b/web/app.js
@@ -12,6 +12,7 @@ import { Cellule } from '../src/domain/intrigue/Cellule.js';
 import { OperationClandestine } from '../src/domain/intrigue/OperationClandestine.js';
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
 import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMapRecommendations.js';
+import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTimeline.js';
 
 const culturePayload = {
   cultures: [
@@ -2055,6 +2056,31 @@ function renderCultureRecommendationPanel(recommendationView) {
   `;
 }
 
+function renderCultureLocalTimeline(timelineView) {
+  return `
+    <article class="culture-local-timeline culture-local-timeline--${timelineView.state}">
+      <div class="culture-local-timeline__header">
+        <span>${timelineView.heading}</span>
+        <strong>${timelineView.summary}</strong>
+      </div>
+      ${timelineView.items.length > 0 ? `
+        <ol>
+          ${timelineView.items.map((item) => `
+            <li class="culture-local-timeline__item culture-local-timeline__item--${item.signal}">
+              <span>${item.signal}</span>
+              <div>
+                <b>${item.title}</b>
+                <p>${item.summary}</p>
+                <small>${item.cultureName} · ${item.regionId}${item.importance ? ` · IMP-${item.importance}` : ''}${item.date ? ` · ${item.date}` : ''}</small>
+              </div>
+            </li>
+          `).join('')}
+        </ol>
+      ` : '<p>Aucun signal local; sélectionnez un cluster ou une province culturelle dense.</p>'}
+    </article>
+  `;
+}
+
 function renderCultureClusterPinList(cluster) {
   if (!cluster) {
     return '';
@@ -2155,6 +2181,11 @@ function renderCultureSidePanel(cultureView) {
     selectedMarker: focus,
     selectedCluster,
   });
+  const localTimelineView = buildCultureLocalTimeline({
+    selectedRegionId: state.selectedProvinceId,
+    selectedMarker: focus,
+    selectedCluster,
+  });
 
   return `
     <section class="panel overlay-panel overlay-panel--culture">
@@ -2171,6 +2202,7 @@ function renderCultureSidePanel(cultureView) {
       </div>
       ${renderCultureLegendKey(cultureView)}
       ${renderCultureRecommendationPanel(recommendationView)}
+      ${renderCultureLocalTimeline(localTimelineView)}
       ${renderCultureClusterPinList(selectedCluster)}
       ${focus ? `
         <article class="culture-focus-card culture-focus-card--${getCultureTone(focus)}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -3313,6 +3313,64 @@ button { font: inherit; }
   font-size: 13px;
 }
 .culture-recommendation small { color: var(--muted); }
+.culture-local-timeline {
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.42);
+  padding: 12px;
+  margin-bottom: 12px;
+}
+.culture-local-timeline__header {
+  display: grid;
+  gap: 3px;
+  margin-bottom: 9px;
+}
+.culture-local-timeline__header span {
+  color: var(--accent);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.culture-local-timeline__header strong { color: #f8fafc; }
+.culture-local-timeline ol {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.culture-local-timeline__item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 9px;
+  padding: 9px;
+  border-radius: 13px;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(125, 211, 252, 0.12);
+}
+.culture-local-timeline__item > span {
+  align-self: start;
+  padding: 3px 6px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.14);
+  color: #bae6fd;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-local-timeline__item--opportunity { border-color: rgba(251, 191, 36, 0.3); }
+.culture-local-timeline__item--opportunity > span { background: rgba(120, 53, 15, 0.36); color: #fde68a; }
+.culture-local-timeline__item--risk { border-color: rgba(251, 113, 133, 0.24); }
+.culture-local-timeline__item--risk > span { background: rgba(136, 19, 55, 0.3); color: #fecdd3; }
+.culture-local-timeline__item b { color: #e0f2fe; }
+.culture-local-timeline__item p,
+.culture-local-timeline > p {
+  color: #cbd5e1;
+  margin: 3px 0;
+  font-size: 13px;
+}
+.culture-local-timeline__item small { color: var(--muted); }
 .culture-symbol-key {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Gamma: Closes #455.

## Summary
- add a reusable local culture timeline builder for selected province marker/cluster signals
- render a compact 2-3 item local timeline in the culture side panel
- classify items as opportunity, risk, or research using existing event/discovery data
- include a calm empty state when no local culture signal is available

## Validation
- `node --check web/app.js`
- `git diff --check`
- `npm test` (373 passing)

Gamma: Ready for Zeta validation before merge.
