### PR TITLE
Epsilon: Add climate mitigation choices

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -379,6 +379,131 @@ function buildSelectedClimateTimingRecommendation(comparison) {
   };
 }
 
+function buildMitigationChoice(choiceId, label, effect, timing, tone, linkedSignals) {
+  return {
+    choiceId,
+    label,
+    effect,
+    timing,
+    tone,
+    compact: true,
+    placement: 'province-panel-compact',
+    obscuresMap: false,
+    linkedSignals,
+  };
+}
+
+function buildSelectedClimateMitigationChoices(comparison, timingRecommendation) {
+  if (comparison.state === 'no-selection') {
+    return {
+      state: 'no-selection',
+      compact: true,
+      choices: [],
+      copy: 'Sélectionnez une province pour afficher les réponses climat.',
+    };
+  }
+
+  if (comparison.state === 'missing-climate-data') {
+    return {
+      state: 'missing-climate-data',
+      compact: true,
+      regionId: comparison.regionId,
+      choices: [],
+      copy: 'Aucune mitigation climat proposée: données indisponibles.',
+    };
+  }
+
+  const current = comparison.current;
+  const preview = comparison.preview ?? null;
+  const activeRiskLevel = preview?.riskLevel ?? current.riskLevel;
+  const activeAnomaly = preview?.anomaly ?? current.anomaly;
+  const previewLabel = preview?.label ?? current.label;
+  const linkedSignals = {
+    legendKeys: [
+      `season:${current.season}`,
+      ...(preview ? [`season-preview:${preview.season}`] : []),
+      ...(activeAnomaly ? [`anomaly:${activeAnomaly}`] : []),
+    ],
+    previewSeason: preview?.season ?? null,
+    timingDirection: timingRecommendation.direction ?? 'steady',
+  };
+
+  if (current.riskLevel === 'stable' && !activeAnomaly && activeRiskLevel === 'stable') {
+    return {
+      state: 'not-needed',
+      compact: true,
+      regionId: comparison.regionId,
+      choices: [
+        buildMitigationChoice(
+          'wait-monitor',
+          'Attendre et surveiller',
+          'Conserve les ressources tant que le risque reste bas.',
+          `${previewLabel}: pas de mitigation active nécessaire.`,
+          'neutral',
+          linkedSignals,
+        ),
+      ],
+      copy: 'Risque climat bas: surveiller sans mobiliser.',
+    };
+  }
+
+  const choices = [];
+
+  if (activeRiskLevel === 'critical' || current.riskLevel === 'critical') {
+    choices.push(buildMitigationChoice(
+      'evacuate-risk-zones',
+      'Évacuer les zones exposées',
+      'Réduit les pertes civiles et l’instabilité si le risque culmine.',
+      `${previewLabel}: priorité immédiate avant aggravation saisonnière.`,
+      'danger',
+      linkedSignals,
+    ));
+  }
+
+  if (activeAnomaly === 'drought' || current.anomaly === 'heatwave' || activeRiskLevel !== 'stable') {
+    choices.push(buildMitigationChoice(
+      'irrigate-reserves',
+      'Irriguer et rationner',
+      'Protège les récoltes et limite la pression logistique.',
+      `${previewLabel}: utile avant le pic de sécheresse/chaleur.`,
+      'warning',
+      linkedSignals,
+    ));
+  }
+
+  if (activeAnomaly === 'storm' || activeAnomaly === 'flood' || activeRiskLevel === 'critical') {
+    choices.push(buildMitigationChoice(
+      'fortify-routes',
+      'Fortifier routes et abris',
+      'Réduit les ruptures de circulation et sécurise les marqueurs clés.',
+      `${previewLabel}: préparer avant les perturbations visibles sur la carte.`,
+      'warning',
+      linkedSignals,
+    ));
+  }
+
+  choices.push(buildMitigationChoice(
+    'stockpile-supplies',
+    'Stocker des vivres',
+    'Augmente la marge de sécurité pour population, armée et récoltes.',
+    timingRecommendation.urgency === 'wait-for-preview'
+      ? `${previewLabel}: stocker maintenant, agir quand la fenêtre devient plus sûre.`
+      : `${previewLabel}: réserve courte avant décision provinciale.`,
+    activeRiskLevel === 'critical' ? 'danger' : 'warning',
+    linkedSignals,
+  ));
+
+  const uniqueChoices = [...new Map(choices.map((choice) => [choice.choiceId, choice])).values()].slice(0, 3);
+
+  return {
+    state: 'ready',
+    compact: true,
+    regionId: comparison.regionId,
+    choices: uniqueChoices,
+    copy: uniqueChoices.map((choice) => choice.label).join(' · '),
+  };
+}
+
 function buildSelectedClimateImpactComparison(regions, options, seasonPreview) {
   const selectedRegionId = normalizeSelectedRegionId(options);
 
@@ -872,6 +997,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     });
 
   const selectedClimateImpactComparison = buildSelectedClimateImpactComparison(regions, normalizedOptions, seasonPreview);
+  const selectedClimateTimingRecommendation = buildSelectedClimateTimingRecommendation(selectedClimateImpactComparison);
 
   return {
     title: 'Carte climat et catastrophes',
@@ -890,7 +1016,11 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     catastropheZones: buildCatastropheZones(catastropheEntries, readabilityProfile),
     regionalRiskMode: buildRegionalRiskMode(regions),
     selectedClimateImpactComparison,
-    selectedClimateTimingRecommendation: buildSelectedClimateTimingRecommendation(selectedClimateImpactComparison),
+    selectedClimateTimingRecommendation,
+    selectedClimateMitigationChoices: buildSelectedClimateMitigationChoices(
+      selectedClimateImpactComparison,
+      selectedClimateTimingRecommendation,
+    ),
     ...(seasonPreview?.active ? { seasonPreview: buildSeasonPreviewPanel(states, seasonPreview, seasonLabels) } : {}),
     legend: buildLegend(stateEntries, catastropheEntries, seasonLabels, seasonPreview),
     ...(!readabilityProfile.overlaySelected ? {

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -288,6 +288,12 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
       relevant: false,
       copy: 'Sélectionnez une province pour afficher le timing climat.',
     },
+    selectedClimateMitigationChoices: {
+      state: 'no-selection',
+      compact: true,
+      choices: [],
+      copy: 'Sélectionnez une province pour afficher les réponses climat.',
+    },
     legend: {
       title: 'Légende climat',
       compact: true,
@@ -952,5 +958,123 @@ test('buildClimateMapOverlay provides climate timing fallback recommendations', 
     urgency: 'normal',
     tone: 'neutral',
     copy: 'Timing climat normal: aucune contrainte notable pour cette province.',
+  });
+});
+
+test('buildClimateMapOverlay offers compact mitigation choices for selected at-risk provinces', () => {
+  const overlay = buildClimateMapOverlay([
+    {
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 34,
+      precipitationLevel: 10,
+      droughtIndex: 76,
+      anomaly: 'heatwave',
+    },
+  ], {
+    selectedRegionId: 'sunreach',
+    seasonLabels: { summer: 'Été', autumn: 'Automne' },
+    seasonPreview: {
+      season: 'autumn',
+      impactsByRegion: {
+        sunreach: { strategicImpact: 'critical', anomaly: 'drought' },
+      },
+    },
+  });
+
+  assert.deepEqual(overlay.selectedClimateMitigationChoices, {
+    state: 'ready',
+    compact: true,
+    regionId: 'sunreach',
+    choices: [
+      {
+        choiceId: 'evacuate-risk-zones',
+        label: 'Évacuer les zones exposées',
+        effect: 'Réduit les pertes civiles et l’instabilité si le risque culmine.',
+        timing: 'Automne: priorité immédiate avant aggravation saisonnière.',
+        tone: 'danger',
+        compact: true,
+        placement: 'province-panel-compact',
+        obscuresMap: false,
+        linkedSignals: {
+          legendKeys: ['season:summer', 'season-preview:autumn', 'anomaly:drought'],
+          previewSeason: 'autumn',
+          timingDirection: 'time-sensitive',
+        },
+      },
+      {
+        choiceId: 'irrigate-reserves',
+        label: 'Irriguer et rationner',
+        effect: 'Protège les récoltes et limite la pression logistique.',
+        timing: 'Automne: utile avant le pic de sécheresse/chaleur.',
+        tone: 'warning',
+        compact: true,
+        placement: 'province-panel-compact',
+        obscuresMap: false,
+        linkedSignals: {
+          legendKeys: ['season:summer', 'season-preview:autumn', 'anomaly:drought'],
+          previewSeason: 'autumn',
+          timingDirection: 'time-sensitive',
+        },
+      },
+      {
+        choiceId: 'fortify-routes',
+        label: 'Fortifier routes et abris',
+        effect: 'Réduit les ruptures de circulation et sécurise les marqueurs clés.',
+        timing: 'Automne: préparer avant les perturbations visibles sur la carte.',
+        tone: 'warning',
+        compact: true,
+        placement: 'province-panel-compact',
+        obscuresMap: false,
+        linkedSignals: {
+          legendKeys: ['season:summer', 'season-preview:autumn', 'anomaly:drought'],
+          previewSeason: 'autumn',
+          timingDirection: 'time-sensitive',
+        },
+      },
+    ],
+    copy: 'Évacuer les zones exposées · Irriguer et rationner · Fortifier routes et abris',
+  });
+});
+
+test('buildClimateMapOverlay keeps mitigation fallback deterministic for low or missing climate risk', () => {
+  assert.deepEqual(buildClimateMapOverlay([], { selectedRegionId: 'missing' }).selectedClimateMitigationChoices, {
+    state: 'missing-climate-data',
+    compact: true,
+    regionId: 'missing',
+    choices: [],
+    copy: 'Aucune mitigation climat proposée: données indisponibles.',
+  });
+
+  assert.deepEqual(buildClimateMapOverlay([
+    {
+      regionId: 'delta',
+      season: 'winter',
+      temperatureC: 2,
+      precipitationLevel: 40,
+      droughtIndex: 9,
+    },
+  ], { selectedRegionId: 'delta' }).selectedClimateMitigationChoices, {
+    state: 'not-needed',
+    compact: true,
+    regionId: 'delta',
+    choices: [
+      {
+        choiceId: 'wait-monitor',
+        label: 'Attendre et surveiller',
+        effect: 'Conserve les ressources tant que le risque reste bas.',
+        timing: 'winter: pas de mitigation active nécessaire.',
+        tone: 'neutral',
+        compact: true,
+        placement: 'province-panel-compact',
+        obscuresMap: false,
+        linkedSignals: {
+          legendKeys: ['season:winter'],
+          previewSeason: null,
+          timingDirection: 'steady',
+        },
+      },
+    ],
+    copy: 'Risque climat bas: surveiller sans mobiliser.',
   });
 });


### PR DESCRIPTION
Epsilon: Implements #457.\n\nSummary:\n- adds compact selectedClimateMitigationChoices for selected province climate risk responses;\n- derives deterministic 1-3 choices such as evacuation, irrigation, fortification, stockpiling, or monitoring from existing risk/anomaly/preview data;\n- includes expected effect, seasonal timing, and linked legend/preview signals without covering the map;\n- keeps fallbacks for no selection, missing climate data, and low-risk provinces.\n\nValidation:\n- npm test -- test/ui/climate/buildClimateMapOverlay.test.js\n- npm test (373 passing)\n- node --check src/ui/climate/buildClimateMapOverlay.js\n- node --check web/app.js\n- git diff --check\n\nZeta, peux-tu valider cette PR avant merge ?