### PR TITLE
Gamma: Add cultural consequence chips

### DIFF
--- a/src/ui/culture/buildCultureConsequenceChips.js
+++ b/src/ui/culture/buildCultureConsequenceChips.js
@@ -1,0 +1,159 @@
+const SEVERITY_BY_TONE = Object.freeze({
+  opportunity: 4,
+  risk: 3,
+  research: 2,
+  identity: 1,
+  neutral: 0,
+});
+
+function normalizeText(value, fallback = '') {
+  return String(value ?? fallback).trim();
+}
+
+function normalizeRegion(value, fallback = 'province') {
+  return normalizeText(value, fallback);
+}
+
+function buildChip({ tone, label, explanation, cultureName, regionId, severity, sourceId }) {
+  return {
+    chipId: `${tone}:${regionId}:${cultureName}:${label}:${sourceId ?? 'source'}`,
+    tone,
+    label,
+    explanation,
+    cultureName,
+    regionId,
+    severity,
+  };
+}
+
+function dedupeAndSort(chips) {
+  const chipsByKey = new Map();
+
+  for (const chip of chips) {
+    const key = `${chip.tone}:${chip.label}:${chip.cultureName}:${chip.regionId}`;
+    const existingChip = chipsByKey.get(key);
+
+    if (!existingChip || chip.severity > existingChip.severity) {
+      chipsByKey.set(key, chip);
+    }
+  }
+
+  return [...chipsByKey.values()]
+    .sort((left, right) => right.severity - left.severity || left.label.localeCompare(right.label));
+}
+
+function chipFromTimelineItem(item, actionTitle, fallbackRegionId) {
+  const tone = ['opportunity', 'risk', 'research'].includes(item.signal) ? item.signal : 'identity';
+  const regionId = normalizeRegion(item.regionId, fallbackRegionId);
+  const cultureName = normalizeText(item.cultureName, 'Culture locale');
+  const severity = Math.max(SEVERITY_BY_TONE[tone] ?? 0, Math.min(5, Math.max(1, item.importance ?? 1)));
+  const label = tone === 'opportunity'
+    ? 'Ouverture culturelle'
+    : tone === 'risk'
+      ? 'Tension mémorielle'
+      : tone === 'research'
+        ? 'Piste recherche'
+        : 'Identité locale';
+
+  return buildChip({
+    tone,
+    label,
+    explanation: `${normalizeText(item.title, label)} influence “${actionTitle}”.`,
+    cultureName,
+    regionId,
+    severity,
+    sourceId: item.timelineId,
+  });
+}
+
+function chipsFromMarker(marker, actionTitle, fallbackRegionId) {
+  if (!marker) {
+    return [];
+  }
+
+  const regionId = normalizeRegion(marker.regionId, fallbackRegionId);
+  const cultureName = normalizeText(marker.cultureName, 'Culture locale');
+  const chips = [];
+
+  if ((marker.eventCount ?? 0) > 0) {
+    chips.push(buildChip({
+      tone: (marker.influenceTier === 'dominant' || marker.influenceTier === 'strong') ? 'opportunity' : 'risk',
+      label: 'Repère historique',
+      explanation: `${marker.eventCount} événement${marker.eventCount > 1 ? 's' : ''} à relire avant “${actionTitle}”.`,
+      cultureName,
+      regionId,
+      severity: (marker.influenceTier === 'dominant' || marker.influenceTier === 'strong') ? 4 : 3,
+      sourceId: marker.overlayId,
+    }));
+  }
+
+  if ((marker.discoveries ?? []).length > 0) {
+    chips.push(buildChip({
+      tone: 'research',
+      label: 'Découverte liée',
+      explanation: `${marker.discoveries.length} découverte${marker.discoveries.length > 1 ? 's' : ''} peut guider l’action.`,
+      cultureName,
+      regionId,
+      severity: 2,
+      sourceId: marker.overlayId,
+    }));
+  }
+
+  if (chips.length === 0) {
+    chips.push(buildChip({
+      tone: 'identity',
+      label: 'Identité locale',
+      explanation: `Tenir compte de ${cultureName} sans urgence culturelle.`,
+      cultureName,
+      regionId,
+      severity: 1,
+      sourceId: marker.overlayId,
+    }));
+  }
+
+  return chips;
+}
+
+export function buildCultureConsequenceChips({
+  province = null,
+  action = null,
+  selectedMarker = null,
+  selectedCluster = null,
+  localTimeline = null,
+} = {}) {
+  const regionId = normalizeRegion(province?.provinceId ?? selectedMarker?.regionId ?? selectedCluster?.regionIds?.[0]);
+  const actionTitle = normalizeText(action?.title, 'action province');
+  const timelineItems = localTimeline?.items ?? [];
+  const chips = [
+    ...timelineItems.map((item) => chipFromTimelineItem(item, actionTitle, regionId)),
+    ...chipsFromMarker(selectedMarker, actionTitle, regionId),
+  ];
+
+  if (selectedCluster && (selectedCluster.pins?.length ?? 0) === 0) {
+    chips.push(buildChip({
+      tone: 'identity',
+      label: 'Cluster calme',
+      explanation: 'Aucun événement actif, mais le voisinage culturel reste pertinent.',
+      cultureName: normalizeText(selectedCluster.summary, 'Cluster culturel'),
+      regionId,
+      severity: 1,
+      sourceId: selectedCluster.clusterId,
+    }));
+  }
+
+  const sortedChips = dedupeAndSort(chips).slice(0, 3);
+
+  if (sortedChips.length > 0) {
+    return sortedChips;
+  }
+
+  return [buildChip({
+    tone: 'neutral',
+    label: 'Culture calme',
+    explanation: 'Aucune conséquence culturelle immédiate pour ce choix.',
+    cultureName: 'Aucun signal',
+    regionId,
+    severity: 0,
+    sourceId: actionTitle,
+  })];
+}

--- a/test/ui/culture/buildCultureConsequenceChips.test.js
+++ b/test/ui/culture/buildCultureConsequenceChips.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCultureConsequenceChips } from '../../../src/ui/culture/buildCultureConsequenceChips.js';
+
+test('buildCultureConsequenceChips deduplicates and sorts cultural signals by severity', () => {
+  const chips = buildCultureConsequenceChips({
+    province: { provinceId: 'river-gate' },
+    action: { title: 'Renforcer le front' },
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      eventCount: 1,
+      discoveries: ['archive-routes'],
+    },
+    localTimeline: {
+      items: [
+        {
+          timelineId: 'river-gate:event:event-archive-opening',
+          signal: 'opportunity',
+          title: 'Ouverture des archives',
+          regionId: 'river-gate',
+          cultureName: 'Compact d’Aurora',
+          importance: 5,
+        },
+        {
+          timelineId: 'river-gate:event:event-archive-opening-copy',
+          signal: 'opportunity',
+          title: 'Ouverture des archives',
+          regionId: 'river-gate',
+          cultureName: 'Compact d’Aurora',
+          importance: 4,
+        },
+        {
+          timelineId: 'river-gate:discovery:tidal-ledgers',
+          signal: 'research',
+          title: 'tidal-ledgers',
+          regionId: 'river-gate',
+          cultureName: 'Compact d’Aurora',
+          importance: null,
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(chips.map((chip) => [chip.tone, chip.label, chip.severity]), [
+    ['opportunity', 'Ouverture culturelle', 5],
+    ['opportunity', 'Repère historique', 4],
+    ['research', 'Découverte liée', 2],
+  ]);
+  assert.equal(chips[0].explanation, 'Ouverture des archives influence “Renforcer le front”.');
+});
+
+test('buildCultureConsequenceChips exposes calm fallbacks for empty or quiet culture context', () => {
+  assert.deepEqual(buildCultureConsequenceChips({
+    province: { provinceId: 'quiet-field' },
+    action: { title: 'Garder en observation' },
+  }), [
+    {
+      chipId: 'neutral:quiet-field:Aucun signal:Culture calme:Garder en observation',
+      tone: 'neutral',
+      label: 'Culture calme',
+      explanation: 'Aucune conséquence culturelle immédiate pour ce choix.',
+      cultureName: 'Aucun signal',
+      regionId: 'quiet-field',
+      severity: 0,
+    },
+  ]);
+
+  assert.deepEqual(buildCultureConsequenceChips({
+    province: { provinceId: 'shared-bay' },
+    action: { title: 'Préparer la manœuvre' },
+    selectedCluster: {
+      clusterId: 'shared-bay:culture-cluster',
+      summary: 'Delta Scribes, Harbor Compact',
+      regionIds: ['shared-bay'],
+      pins: [],
+    },
+  })[0], {
+    chipId: 'identity:shared-bay:Delta Scribes, Harbor Compact:Cluster calme:shared-bay:culture-cluster',
+    tone: 'identity',
+    label: 'Cluster calme',
+    explanation: 'Aucun événement actif, mais le voisinage culturel reste pertinent.',
+    cultureName: 'Delta Scribes, Harbor Compact',
+    regionId: 'shared-bay',
+    severity: 1,
+  });
+});

--- a/web/app.js
+++ b/web/app.js
@@ -13,6 +13,7 @@ import { OperationClandestine } from '../src/domain/intrigue/OperationClandestin
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
 import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMapRecommendations.js';
 import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTimeline.js';
+import { buildCultureConsequenceChips } from '../src/ui/culture/buildCultureConsequenceChips.js';
 
 const culturePayload = {
   cultures: [
@@ -824,8 +825,30 @@ function buildProvinceActionRecommendations(province, focusContext, intrigueView
   return recommendations.slice(0, 3);
 }
 
+function renderCultureConsequenceChips(chips) {
+  return `
+    <div class="culture-consequence-chips" aria-label="Conséquences culturelles">
+      ${chips.map((chip) => `
+        <span class="culture-consequence-chip culture-consequence-chip--${chip.tone}" title="${chip.explanation}">
+          <b>${chip.label}</b>
+          <small>${chip.cultureName} · ${chip.regionId} · S${chip.severity}</small>
+        </span>
+      `).join('')}
+    </div>
+  `;
+}
+
 function renderProvinceActionRecommendations(province, focusContext, intrigueView = null) {
   const recommendations = buildProvinceActionRecommendations(province, focusContext, intrigueView);
+  const cultureView = getCultureViewModel();
+  const selectedMarker = cultureView.overlay.find((entry) => entry.regionId === province.provinceId) ?? null;
+  const selectedCluster = buildCultureClusterSummaries(cultureView.overlay)
+    .find((cluster) => cluster.regionIds.includes(province.provinceId)) ?? null;
+  const localTimeline = buildCultureLocalTimeline({
+    selectedRegionId: province.provinceId,
+    selectedMarker,
+    selectedCluster,
+  });
 
   return `
     <div class="province-action-recommendations" aria-label="Actions recommandées pour la province sélectionnée">
@@ -834,12 +857,23 @@ function renderProvinceActionRecommendations(province, focusContext, intrigueVie
         <span>${province.selectionState.selected ? 'sélection active' : 'focus tactique'}</span>
       </div>
       <div class="province-action-list">
-        ${recommendations.map((recommendation) => `
-          <article class="province-action-card province-action-card--${recommendation.tone}">
-            <strong>${recommendation.title}</strong>
-            <p>${recommendation.body}</p>
-          </article>
-        `).join('')}
+        ${recommendations.map((recommendation) => {
+          const cultureChips = buildCultureConsequenceChips({
+            province,
+            action: recommendation,
+            selectedMarker,
+            selectedCluster,
+            localTimeline,
+          });
+
+          return `
+            <article class="province-action-card province-action-card--${recommendation.tone}">
+              <strong>${recommendation.title}</strong>
+              <p>${recommendation.body}</p>
+              ${renderCultureConsequenceChips(cultureChips)}
+            </article>
+          `;
+        }).join('')}
       </div>
     </div>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -1668,6 +1668,37 @@ button { font: inherit; }
 .province-action-card--warning { border-color: rgba(251, 191, 36, 0.32); }
 .province-action-card--ready { border-color: rgba(74, 222, 128, 0.28); }
 .province-action-card--info { border-color: rgba(56, 189, 248, 0.3); }
+.culture-consequence-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 9px;
+}
+.culture-consequence-chip {
+  display: inline-grid;
+  gap: 2px;
+  max-width: 100%;
+  padding: 5px 7px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.68);
+  border: 1px solid rgba(125, 211, 252, 0.14);
+}
+.culture-consequence-chip b {
+  color: #e0f2fe;
+  font-size: 11px;
+  line-height: 1;
+}
+.culture-consequence-chip small {
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.1;
+}
+.culture-consequence-chip--opportunity { border-color: rgba(251, 191, 36, 0.34); }
+.culture-consequence-chip--opportunity b { color: #fde68a; }
+.culture-consequence-chip--risk { border-color: rgba(251, 113, 133, 0.3); }
+.culture-consequence-chip--risk b { color: #fecdd3; }
+.culture-consequence-chip--research { border-color: rgba(34, 211, 238, 0.26); }
+.culture-consequence-chip--identity { border-color: rgba(167, 243, 208, 0.22); }
 .conflict-outcome-preview {
   margin-top: 14px;
   padding: 12px;


### PR DESCRIPTION
Gamma: Closes #465.

## Summary
- add a reusable culture consequence chip builder for province actions
- derive chip tone, label, explanation, culture/region, and severity from marker/cluster/timeline signals
- render compact cultural consequence chips on selected province action cards
- add deterministic tests for dedupe, severity ordering, readable labels, and calm fallback states

## Validation
- `node --check web/app.js`
- `git diff --check`
- `npm test` (378 passing)

Gamma: Ready for Zeta validation before merge.
