### PR TITLE
Alpha: Add province action queue preview

### DIFF
--- a/test/ui/war/webProvinceActionQueue.test.js
+++ b/test/ui/war/webProvinceActionQueue.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable map exposes selected province action queue and turn resolution preview', () => {
+  assert.match(webAppSource, /function buildSelectedProvinceActionQueue/);
+  assert.match(webAppSource, /function summarizeTurnResolutionPreview/);
+  assert.match(webAppSource, /function renderSelectedProvinceActionQueue/);
+  assert.match(webAppSource, /actionCode/);
+  assert.match(webAppSource, /priority/);
+  assert.match(webAppSource, /orderCost/);
+  assert.match(webAppSource, /mainRisk/);
+  assert.match(webAppSource, /expectedResult/);
+  assert.match(webAppSource, /status: statusByTone/);
+  assert.match(webAppSource, /readyCount/);
+  assert.match(webAppSource, /blockedCount/);
+  assert.match(webAppSource, /impactedFaction/);
+  assert.match(webAppSource, /Résolution prochain tour/);
+  assert.match(webAppSource, /renderSelectedProvinceActionQueue\(province, shell, focusContext, intrigueView\)/);
+  assert.match(stylesSource, /\.province-action-queue/);
+  assert.match(stylesSource, /province-action-queue__item--ready/);
+  assert.match(stylesSource, /province-action-queue__item--risky/);
+  assert.match(stylesSource, /province-action-queue__item--blocked/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1094,6 +1094,92 @@ function renderConflictOutcomePreview(province, shell) {
   `;
 }
 
+function buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView = null) {
+  const outcome = buildConflictOutcomePreview(province, shell);
+  const recommendations = buildProvinceActionRecommendations(province, focusContext, intrigueView);
+  const priorityByTone = { danger: 1, warning: 2, ready: 3, info: 4, neutral: 5 };
+  const statusByTone = { danger: 'blocked', warning: 'risky', ready: 'ready', info: 'ready', neutral: 'ready' };
+  const outcomeRisk = outcome.tone === 'danger' ? 'risque élevé' : outcome.tone === 'warning' ? 'issue disputée' : 'risque maîtrisé';
+
+  return recommendations
+    .map((recommendation, index) => ({
+      actionCode: `WAR-${province.provinceId.toUpperCase()}-${index + 1}`,
+      label: recommendation.title,
+      priority: priorityByTone[recommendation.tone] ?? index + 3,
+      orderCost: recommendation.tone === 'danger' ? '2 ordres + appui' : recommendation.tone === 'warning' ? '1 ordre + contrôle' : '1 ordre',
+      mainRisk: recommendation.tone === 'danger' || recommendation.tone === 'warning' ? recommendation.body : outcomeRisk,
+      expectedResult: outcome.tone === 'success'
+        ? `Résolution favorable: ${recommendation.title.toLowerCase()} peut consolider ${province.label}.`
+        : outcome.tone === 'danger'
+          ? `Résolution fragile: ${recommendation.title.toLowerCase()} doit attendre un appui.`
+          : `Résolution disputée: ${recommendation.title.toLowerCase()} prépare une bascule limitée.`,
+      status: statusByTone[recommendation.tone] ?? 'ready',
+      tone: recommendation.tone,
+    }))
+    .sort((left, right) => left.priority - right.priority || left.actionCode.localeCompare(right.actionCode));
+}
+
+function summarizeTurnResolutionPreview(province, actionQueue) {
+  const readyCount = actionQueue.filter((entry) => entry.status === 'ready').length;
+  const blockedCount = actionQueue.filter((entry) => entry.status === 'blocked').length;
+  const riskyCount = actionQueue.filter((entry) => entry.status === 'risky').length;
+  const topAction = actionQueue[0] ?? null;
+  const impactedFaction = factionMetaById[province.controllingFactionId]?.label ?? province.controllingFactionId;
+
+  return {
+    readyCount,
+    blockedCount,
+    riskyCount,
+    impactedProvince: province.label,
+    impactedFaction,
+    summary: blockedCount > 0
+      ? `${blockedCount} action bloquée: sécuriser ${province.label} avant résolution.`
+      : riskyCount > readyCount
+        ? `${riskyCount} action${riskyCount > 1 ? 's' : ''} risquée${riskyCount > 1 ? 's' : ''}: confirmer seulement avec réserve disponible.`
+        : `${readyCount} action${readyCount > 1 ? 's' : ''} prête${readyCount > 1 ? 's' : ''}: ${topAction?.label ?? 'ordre tactique'} peut partir au prochain tour.`,
+  };
+}
+
+function renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView = null) {
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const resolution = summarizeTurnResolutionPreview(province, actionQueue);
+
+  return `
+    <section class="province-action-queue" aria-label="File d’actions préparées pour la province sélectionnée">
+      <div class="province-action-queue__header">
+        <div>
+          <span>File d’actions</span>
+          <strong>Résolution prochain tour</strong>
+        </div>
+        <small>${resolution.impactedProvince} · ${resolution.impactedFaction}</small>
+      </div>
+      <div class="province-action-queue__summary">
+        <span>${resolution.readyCount} prêtes</span>
+        <span>${resolution.riskyCount} risquées</span>
+        <span>${resolution.blockedCount} bloquées</span>
+      </div>
+      <p>${resolution.summary}</p>
+      <ol class="province-action-queue__list">
+        ${actionQueue.map((entry) => `
+          <li class="province-action-queue__item province-action-queue__item--${entry.status}">
+            <div>
+              <code>${entry.actionCode}</code>
+              <strong>${entry.label}</strong>
+              <p>${entry.expectedResult}</p>
+            </div>
+            <dl>
+              <div><dt>Priorité</dt><dd>${entry.priority}</dd></div>
+              <div><dt>Coût</dt><dd>${entry.orderCost}</dd></div>
+              <div><dt>Risque</dt><dd>${entry.mainRisk}</dd></div>
+              <div><dt>Statut</dt><dd>${entry.status}</dd></div>
+            </dl>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderActiveProvince(shell, economyView = null, intrigueView = null) {
   const focusContext = getFocusContext(shell);
   const province = shell.activeProvince ?? shell.provinces[0] ?? null;
@@ -1137,6 +1223,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       </div>
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
       ${renderConflictOutcomePreview(province, shell)}
+      ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       <div class="context-summary">
         <strong>Comparaison rapide</strong>
         <p>${comparedProvinceNames.length > 0 ? comparedProvinceNames.join(' vs ') : 'Aucune province comparée pour le moment.'}</p>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1748,6 +1748,96 @@ button { font: inherit; }
 .conflict-outcome-preview--success { border-color: rgba(74, 222, 128, 0.34); }
 .conflict-outcome-preview--warning { border-color: rgba(251, 191, 36, 0.36); }
 .conflict-outcome-preview--danger { border-color: rgba(251, 113, 133, 0.42); }
+.province-action-queue {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(30, 41, 59, 0.42));
+  border: 1px solid rgba(129, 140, 248, 0.22);
+}
+.province-action-queue__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.province-action-queue__header span,
+.province-action-queue__header small {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-action-queue__header strong {
+  display: block;
+  margin-top: 3px;
+}
+.province-action-queue__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.province-action-queue__summary span {
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: rgba(8, 15, 28, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  color: #cbd5e1;
+  font-size: 11px;
+}
+.province-action-queue > p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.province-action-queue__list {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.province-action-queue__item {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.44);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-action-queue__item code {
+  display: inline-block;
+  margin-bottom: 4px;
+  color: #bae6fd;
+  font-size: 11px;
+}
+.province-action-queue__item p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.province-action-queue__item dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin: 0;
+}
+.province-action-queue__item dt {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.province-action-queue__item dd {
+  margin: 2px 0 0;
+  font-size: 12px;
+}
+.province-action-queue__item--ready { border-color: rgba(74, 222, 128, 0.28); }
+.province-action-queue__item--risky { border-color: rgba(251, 191, 36, 0.34); }
+.province-action-queue__item--blocked { border-color: rgba(251, 113, 133, 0.4); }
 .context-summary {
   margin-top: 14px;
   padding: 12px;


### PR DESCRIPTION
Alpha: Closes #463.

## Summary
- adds a selected-province action queue derived from existing Alpha war recommendations and conflict preview state
- exposes stable queue entries with action code, label, priority, order cost, main risk, expected result, and ready/risky/blocked status
- adds a compact next-turn resolution summary with ready/risky/blocked counts plus most impacted province/faction
- renders the queue in the existing dark tactical province panel without adding a real global resolution loop
- adds a deterministic web smoke test for the queue contract and HUD styles

## Verification
- npm test
- npm run preview:map -- /tmp/historia-province-action-queue-preview.html
- node --test test/ui/war/webProvinceActionQueue.test.js
- node --check web/app.js
- git diff --check
