### PR TITLE
Beta: preview logistics reroute choices

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1,0 +1,128 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+const TONE_RANK = Object.freeze({ high: 3, medium: 2, low: 1 });
+
+function getRouteTone(route, localTension) {
+  if (!route.active || route.riskLevel >= 70 || localTension === 'high') {
+    return 'high';
+  }
+
+  if (route.riskLevel >= 55 || route.totalCapacity >= 9 || localTension === 'medium') {
+    return 'medium';
+  }
+
+  return 'low';
+}
+
+function getMainResource(route, resourceLabelById) {
+  const resource = (route.resources ?? [])
+    .slice()
+    .sort((left, right) => right.capacity - left.capacity || left.resourceId.localeCompare(right.resourceId))[0] ?? null;
+
+  if (!resource) {
+    return { resourceId: 'reserve', label: 'capacité réservée', capacity: 0 };
+  }
+
+  return {
+    ...resource,
+    label: resourceLabelById[resource.resourceId] ?? resource.resourceId,
+  };
+}
+
+function buildChoiceForRoute(route, localCity, localTension, resourceLabelById) {
+  const mainResource = getMainResource(route, resourceLabelById);
+  const tone = getRouteTone(route, localTension);
+  const overloaded = route.totalCapacity >= 9;
+  const risky = route.riskLevel >= 55;
+  const inactive = !route.active;
+  const action = inactive
+    ? 'Réparer route'
+    : risky
+      ? 'Sécuriser convoi'
+      : overloaded
+        ? 'Détourner flux'
+        : localTension !== 'low'
+          ? 'Stocker localement'
+          : 'Maintenir veille';
+  const cost = inactive
+    ? '2 équipes · 1 stock outil'
+    : risky
+      ? '1 escorte · 1 ordre'
+      : overloaded
+        ? '1 relais · coordination routes'
+        : '1 dépôt local';
+  const delay = inactive ? '2 tours' : overloaded ? '1-2 tours' : '1 tour';
+  const residualRisk = Math.max(5, route.riskLevel - (inactive ? 18 : risky ? 14 : overloaded ? 9 : 5));
+  const impact = tone === 'high'
+    ? `Réduit la tension ${localTension} et protège ${mainResource.label}.`
+    : tone === 'medium'
+      ? `Soulage ${mainResource.label} sans masquer le risque résiduel.`
+      : `Maintient ${localCity.cityName} stable avec surveillance légère.`;
+
+  return {
+    routeId: route.routeId,
+    action,
+    tone,
+    cost,
+    delay,
+    routes: [route.routeName],
+    resources: [mainResource.label],
+    affectedCity: localCity.cityName,
+    residualRisk,
+    impact,
+    score: (TONE_RANK[tone] ?? 0) * 100 + route.riskLevel + route.totalCapacity + (localTension === 'high' ? 20 : localTension === 'medium' ? 10 : 0),
+  };
+}
+
+export function buildProvinceLogisticsChoicePreview(province, economyView, options = {}) {
+  const normalizedOptions = requireObject(options, 'ProvinceLogisticsChoicePreview options');
+  const resourceLabelById = requireObject(normalizedOptions.resourceLabelById ?? {}, 'ProvinceLogisticsChoicePreview resourceLabelById');
+
+  if (!province || !economyView) {
+    return { recommendedOptionId: null, summary: 'Aucune donnée logistique disponible.', options: [] };
+  }
+
+  const cities = economyView.overlay?.cities ?? [];
+  const routes = economyView.overlay?.routes ?? [];
+  const tensionByCityId = Object.fromEntries((economyView.comparison?.rows ?? []).map((row) => [row.cityId, row.tensionLevel ?? 'low']));
+  const provinceCities = cities.filter((city) => city.regionId === province.provinceId);
+  const provinceCityIds = new Set(provinceCities.map((city) => city.cityId));
+
+  const routeChoices = routes
+    .filter((route) => route.cityIds.some((cityId) => provinceCityIds.has(cityId)))
+    .map((route) => {
+      const localCityId = route.cityIds.find((cityId) => provinceCityIds.has(cityId));
+      const localCity = provinceCities.find((city) => city.cityId === localCityId) ?? provinceCities[0];
+      const localTension = tensionByCityId[localCity?.cityId] ?? 'low';
+      return localCity ? buildChoiceForRoute(route, localCity, localTension, resourceLabelById) : null;
+    })
+    .filter(Boolean)
+    .sort((left, right) => right.score - left.score || left.action.localeCompare(right.action))
+    .slice(0, 4)
+    .map((choice, index) => ({
+      ...choice,
+      optionId: `${province.provinceId}:${choice.routeId}:${index}`,
+      recommended: index === 0,
+    }));
+
+  if (routeChoices.length === 0) {
+    return {
+      recommendedOptionId: null,
+      summary: 'Aucun reroutage utile: aucune route liée à la province sélectionnée.',
+      options: [],
+    };
+  }
+
+  const recommended = routeChoices[0];
+  return {
+    recommendedOptionId: recommended.optionId,
+    summary: `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.impact}`,
+    options: routeChoices,
+  };
+}

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildProvinceLogisticsChoicePreview } from '../../../src/ui/economy/buildProvinceLogisticsChoicePreview.js';
+
+const province = { provinceId: 'river-gate' };
+
+function buildEconomyView() {
+  return {
+    overlay: {
+      cities: [
+        { cityId: 'river-city', cityName: 'River Gate', regionId: 'river-gate' },
+        { cityId: 'iron-city', cityName: 'Iron Plain', regionId: 'iron-plain' },
+        { cityId: 'port-city', cityName: 'Crown Port', regionId: 'crown-heart' },
+      ],
+      routes: [
+        {
+          routeId: 'safe-road',
+          routeName: 'Safe Road',
+          cityIds: ['river-city', 'port-city'],
+          active: true,
+          riskLevel: 18,
+          totalCapacity: 4,
+          resources: [{ resourceId: 'grain', capacity: 2 }],
+        },
+        {
+          routeId: 'ember-line',
+          routeName: 'Ember Line',
+          cityIds: ['river-city', 'iron-city'],
+          active: true,
+          riskLevel: 68,
+          totalCapacity: 10,
+          resources: [{ resourceId: 'tools', capacity: 6 }],
+        },
+      ],
+    },
+    comparison: {
+      rows: [
+        { cityId: 'river-city', tensionLevel: 'high' },
+        { cityId: 'iron-city', tensionLevel: 'low' },
+        { cityId: 'port-city', tensionLevel: 'low' },
+      ],
+    },
+  };
+}
+
+test('buildProvinceLogisticsChoicePreview ranks the most constrained route as recommended', () => {
+  const preview = buildProvinceLogisticsChoicePreview(province, buildEconomyView(), {
+    resourceLabelById: { grain: 'Grain', tools: 'Outils' },
+  });
+
+  assert.equal(preview.options.length, 2);
+  assert.equal(preview.recommendedOptionId, preview.options[0].optionId);
+  assert.equal(preview.options[0].routeId, 'ember-line');
+  assert.equal(preview.options[0].recommended, true);
+  assert.equal(preview.options[0].action, 'Sécuriser convoi');
+  assert.deepEqual(preview.options[0].resources, ['Outils']);
+  assert.match(preview.summary, /Ember Line/);
+});
+
+test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and impact labels', () => {
+  const preview = buildProvinceLogisticsChoicePreview(province, buildEconomyView());
+  const option = preview.options[0];
+
+  assert.ok(option.cost.length > 0);
+  assert.ok(option.delay.length > 0);
+  assert.equal(typeof option.residualRisk, 'number');
+  assert.ok(option.impact.includes('tools') || option.impact.includes('ressource'));
+  assert.deepEqual(option.routes, ['Ember Line']);
+});
+
+test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
+  const preview = buildProvinceLogisticsChoicePreview({ provinceId: 'isolated' }, buildEconomyView());
+
+  assert.equal(preview.recommendedOptionId, null);
+  assert.deepEqual(preview.options, []);
+  assert.match(preview.summary, /Aucun reroutage utile/);
+});
+
+test('buildProvinceLogisticsChoicePreview validates options', () => {
+  assert.throws(() => buildProvinceLogisticsChoicePreview(province, buildEconomyView(), null), /options must be an object/);
+  assert.throws(() => buildProvinceLogisticsChoicePreview(province, buildEconomyView(), { resourceLabelById: [] }), /resourceLabelById must be an object/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -8,6 +8,7 @@ import { buildLauncherMapSelection } from '../src/ui/launcher/buildLauncherMapSe
 import { buildEconomyMapOverlay } from '../src/ui/economy/buildEconomyMapOverlay.js';
 import { buildCityStockPanel } from '../src/ui/economy/buildCityStockPanel.js';
 import { buildCityComparisonPanel } from '../src/ui/economy/buildCityComparisonPanel.js';
+import { buildProvinceLogisticsChoicePreview } from '../src/ui/economy/buildProvinceLogisticsChoicePreview.js';
 import { Cellule } from '../src/domain/intrigue/Cellule.js';
 import { OperationClandestine } from '../src/domain/intrigue/OperationClandestine.js';
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
@@ -1034,6 +1035,44 @@ function renderProvinceLogisticsBottleneckComparison(province, economyView) {
   `;
 }
 
+function renderProvinceLogisticsChoicePreview(province, economyView) {
+  const preview = buildProvinceLogisticsChoicePreview(province, economyView, {
+    resourceLabelById: Object.fromEntries(Object.entries(resourceHudById).map(([resourceId, hud]) => [resourceId, hud.label])),
+  });
+
+  if (preview.options.length === 0) {
+    return '';
+  }
+
+  return `
+    <section class="province-logistics-choice-preview" aria-label="Aperçu reroutage et réparation logistique">
+      <div class="province-logistics-choice-preview__header">
+        <strong>Aperçu choix logistiques</strong>
+        <span>${preview.options.length} options</span>
+      </div>
+      <p>${preview.summary}</p>
+      <div class="province-logistics-choice-list">
+        ${preview.options.map((option) => `
+          <article class="province-logistics-choice province-logistics-choice--${option.tone} ${option.recommended ? 'is-recommended' : ''}">
+            <div class="province-logistics-choice__title">
+              <strong>${option.action}</strong>
+              <span>${option.recommended ? 'recommandé' : option.delay}</span>
+            </div>
+            <p>${option.impact}</p>
+            <dl>
+              <div><dt>Coût</dt><dd>${option.cost}</dd></div>
+              <div><dt>Délai</dt><dd>${option.delay}</dd></div>
+              <div><dt>Route</dt><dd>${option.routes.join(', ')}</dd></div>
+              <div><dt>Ressource</dt><dd>${option.resources.join(', ')}</dd></div>
+              <div><dt>Risque résiduel</dt><dd>${option.residualRisk}</dd></div>
+            </dl>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function buildConflictOutcomePreview(province, shell) {
   const neighbors = province.neighborIds
     .map((provinceId) => shell.provinces.find((candidate) => candidate.provinceId === provinceId))
@@ -1143,6 +1182,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       </div>
       ${renderProvinceEconomyConsequences(province, economyView)}
       ${renderProvinceLogisticsBottleneckComparison(province, economyView)}
+      ${renderProvinceLogisticsChoicePreview(province, economyView)}
     </section>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -1875,6 +1875,77 @@ button { font: inherit; }
   margin: 3px 0 0;
   font-size: 12px;
 }
+.province-logistics-choice-preview {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(12, 74, 110, 0.34), rgba(8, 15, 28, 0.58));
+  border: 1px solid rgba(56, 189, 248, 0.18);
+}
+.province-logistics-choice-preview__header,
+.province-logistics-choice__title {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-logistics-choice-preview__header span,
+.province-logistics-choice__title span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-logistics-choice-preview > p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.province-logistics-choice-list {
+  display: grid;
+  gap: 8px;
+}
+.province-logistics-choice {
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-logistics-choice.is-recommended {
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.18), 0 0 18px rgba(56, 189, 248, 0.08);
+}
+.province-logistics-choice--high { border-color: rgba(251, 113, 133, 0.44); }
+.province-logistics-choice--medium { border-color: rgba(245, 158, 11, 0.36); }
+.province-logistics-choice--low { border-color: rgba(74, 222, 128, 0.28); }
+.province-logistics-choice p {
+  margin: 5px 0 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.38;
+}
+.province-logistics-choice dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin: 8px 0 0;
+}
+.province-logistics-choice dl div {
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(8, 15, 28, 0.42);
+}
+.province-logistics-choice dt {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.province-logistics-choice dd {
+  margin: 3px 0 0;
+  font-size: 12px;
+}
 .overlay-anchor {
   flex: 1 1 140px;
   padding: 12px;


### PR DESCRIPTION
Beta: Implements #464.

Scope:
- add a reusable province logistics choice preview builder for reroute/repair/player choice options;
- list concrete options with cost, delay, routes, relieved resources, residual risk, and expected impact;
- recommend the strongest option while preserving residual risk copy;
- wire the preview into selected province details without adding a deep economy simulation.

Validation:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
- npm test (382 passing)
- node --check web/app.js
- git diff --check

Ready for Zeta validation before merge.