### PR TITLE
Epsilon: Add climate mitigation recovery forecast

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -504,6 +504,201 @@ function buildSelectedClimateMitigationChoices(comparison, timingRecommendation)
   };
 }
 
+const MITIGATION_RECOVERY_BASE_DAYS = Object.freeze({
+  'wait-monitor': 7,
+  'evacuate-risk-zones': 10,
+  'irrigate-reserves': 14,
+  'fortify-routes': 18,
+  'stockpile-supplies': 12,
+});
+
+const MITIGATION_RECOVERY_EFFECTS = Object.freeze({
+  'wait-monitor': {
+    stability: 'stable',
+    harvestImpact: 'neutre',
+    logisticsImpact: 'neutre',
+    relapseBias: 0,
+  },
+  'evacuate-risk-zones': {
+    stability: 'guarded',
+    harvestImpact: 'récoltes ralenties',
+    logisticsImpact: 'mobilité civile sécurisée',
+    relapseBias: -1,
+  },
+  'irrigate-reserves': {
+    stability: 'improving',
+    harvestImpact: 'récoltes protégées',
+    logisticsImpact: 'ravitaillement sous tension',
+    relapseBias: -2,
+  },
+  'fortify-routes': {
+    stability: 'guarded',
+    harvestImpact: 'récoltes exposées',
+    logisticsImpact: 'routes stabilisées',
+    relapseBias: -1,
+  },
+  'stockpile-supplies': {
+    stability: 'cautious',
+    harvestImpact: 'réserves amorties',
+    logisticsImpact: 'stock local renforcé',
+    relapseBias: 0,
+  },
+});
+
+function clampRecoveryDays(days) {
+  return Math.max(3, Math.min(30, days));
+}
+
+function getRelapseRisk(score) {
+  if (score >= 3) {
+    return 'high';
+  }
+
+  if (score >= 1) {
+    return 'medium';
+  }
+
+  return 'low';
+}
+
+function getRecoveryConfidence(comparison, forecastEntries) {
+  if (comparison.state === 'not-needed') {
+    return 'high';
+  }
+
+  if (forecastEntries.some((entry) => entry.relapseRisk === 'high')) {
+    return 'medium';
+  }
+
+  return comparison.state === 'ready' ? 'medium' : 'high';
+}
+
+function buildRecoveryEntry(choice, comparison, timingRecommendation) {
+  const current = comparison.current;
+  const preview = comparison.preview ?? null;
+  const activeRiskLevel = preview?.riskLevel ?? current.riskLevel;
+  const activeAnomaly = preview?.anomaly ?? current.anomaly;
+  const riskScore = getClimateRiskScore(activeRiskLevel);
+  const effects = MITIGATION_RECOVERY_EFFECTS[choice.choiceId] ?? MITIGATION_RECOVERY_EFFECTS['stockpile-supplies'];
+  const baseDays = MITIGATION_RECOVERY_BASE_DAYS[choice.choiceId] ?? 12;
+  const anomalyDelay = activeAnomaly === 'drought' || activeAnomaly === 'flood' ? 4 : activeAnomaly ? 2 : 0;
+  const timingDelay = timingRecommendation.direction === 'riskier'
+    ? 3
+    : timingRecommendation.direction === 'safer'
+      ? -2
+      : 0;
+  const recoveryDays = clampRecoveryDays(baseDays + (riskScore * 3) + anomalyDelay + timingDelay);
+  const relapseRisk = getRelapseRisk(riskScore + anomalyDelay / 3 + effects.relapseBias);
+  const nextCriticalSeason = preview?.label ?? current.label;
+
+  return {
+    choiceId: choice.choiceId,
+    label: choice.label,
+    recoveryWindowDays: recoveryDays,
+    expectedStability: effects.stability,
+    harvestImpact: effects.harvestImpact,
+    logisticsImpact: effects.logisticsImpact,
+    relapseRisk,
+    nextCriticalSeason,
+    confidence: relapseRisk === 'high' ? 'medium' : 'high',
+    summary: `${choice.label}: récupération ~${recoveryDays}j, rechute ${relapseRisk} avant ${nextCriticalSeason}.`,
+  };
+}
+
+function pickRecoverySummary(forecastEntries) {
+  const relapseRank = { low: 0, medium: 1, high: 2 };
+  const stabilityRank = { stable: 0, improving: 1, cautious: 2, guarded: 3 };
+  const sortedBySafety = forecastEntries
+    .slice()
+    .sort((left, right) => {
+      const relapseComparison = relapseRank[left.relapseRisk] - relapseRank[right.relapseRisk];
+
+      if (relapseComparison !== 0) {
+        return relapseComparison;
+      }
+
+      return left.recoveryWindowDays - right.recoveryWindowDays;
+    });
+  const sortedByCaution = forecastEntries
+    .slice()
+    .sort((left, right) => {
+      const stabilityComparison = stabilityRank[right.expectedStability] - stabilityRank[left.expectedStability];
+
+      if (stabilityComparison !== 0) {
+        return stabilityComparison;
+      }
+
+      return right.recoveryWindowDays - left.recoveryWindowDays;
+    });
+  const sortedByRisk = forecastEntries
+    .slice()
+    .sort((left, right) => {
+      const relapseComparison = relapseRank[right.relapseRisk] - relapseRank[left.relapseRisk];
+
+      if (relapseComparison !== 0) {
+        return relapseComparison;
+      }
+
+      return right.recoveryWindowDays - left.recoveryWindowDays;
+    });
+
+  return {
+    bestMitigation: sortedBySafety[0]?.choiceId ?? null,
+    prudentOption: sortedByCaution[0]?.choiceId ?? null,
+    riskyOption: sortedByRisk[0]?.choiceId ?? null,
+  };
+}
+
+function buildSelectedClimateRecoveryForecast(comparison, timingRecommendation, mitigationChoices) {
+  if (mitigationChoices.state === 'no-selection') {
+    return {
+      state: 'no-selection',
+      compact: true,
+      forecasts: [],
+      copy: 'Sélectionnez une province pour voir la récupération climat.',
+    };
+  }
+
+  if (mitigationChoices.state === 'missing-climate-data') {
+    return {
+      state: 'missing-climate-data',
+      compact: true,
+      regionId: mitigationChoices.regionId,
+      forecasts: [],
+      copy: 'Forecast indisponible: données climat manquantes.',
+    };
+  }
+
+  const forecasts = mitigationChoices.choices
+    .map((choice) => buildRecoveryEntry(choice, comparison, timingRecommendation))
+    .sort((left, right) => {
+      if (left.recoveryWindowDays !== right.recoveryWindowDays) {
+        return left.recoveryWindowDays - right.recoveryWindowDays;
+      }
+
+      return left.choiceId.localeCompare(right.choiceId);
+    });
+  const summary = pickRecoverySummary(forecasts);
+  const confidence = mitigationChoices.state === 'not-needed'
+    ? 'high'
+    : getRecoveryConfidence(comparison, forecasts);
+
+  return {
+    state: mitigationChoices.state === 'not-needed' ? 'stable' : 'ready',
+    compact: true,
+    regionId: mitigationChoices.regionId,
+    confidence,
+    summary: {
+      ...summary,
+      confidence,
+    },
+    forecasts,
+    copy: forecasts.length > 0
+      ? `Récupération estimée: ${forecasts[0].label} en ~${forecasts[0].recoveryWindowDays}j.`
+      : 'Aucune récupération climat à prévoir.',
+  };
+}
+
 function buildSelectedClimateImpactComparison(regions, options, seasonPreview) {
   const selectedRegionId = normalizeSelectedRegionId(options);
 
@@ -998,6 +1193,10 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
 
   const selectedClimateImpactComparison = buildSelectedClimateImpactComparison(regions, normalizedOptions, seasonPreview);
   const selectedClimateTimingRecommendation = buildSelectedClimateTimingRecommendation(selectedClimateImpactComparison);
+  const selectedClimateMitigationChoices = buildSelectedClimateMitigationChoices(
+    selectedClimateImpactComparison,
+    selectedClimateTimingRecommendation,
+  );
 
   return {
     title: 'Carte climat et catastrophes',
@@ -1017,9 +1216,11 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     regionalRiskMode: buildRegionalRiskMode(regions),
     selectedClimateImpactComparison,
     selectedClimateTimingRecommendation,
-    selectedClimateMitigationChoices: buildSelectedClimateMitigationChoices(
+    selectedClimateMitigationChoices,
+    selectedClimateRecoveryForecast: buildSelectedClimateRecoveryForecast(
       selectedClimateImpactComparison,
       selectedClimateTimingRecommendation,
+      selectedClimateMitigationChoices,
     ),
     ...(seasonPreview?.active ? { seasonPreview: buildSeasonPreviewPanel(states, seasonPreview, seasonLabels) } : {}),
     legend: buildLegend(stateEntries, catastropheEntries, seasonLabels, seasonPreview),

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -294,6 +294,12 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
       choices: [],
       copy: 'Sélectionnez une province pour afficher les réponses climat.',
     },
+    selectedClimateRecoveryForecast: {
+      state: 'no-selection',
+      compact: true,
+      forecasts: [],
+      copy: 'Sélectionnez une province pour voir la récupération climat.',
+    },
     legend: {
       title: 'Légende climat',
       compact: true,
@@ -1077,4 +1083,157 @@ test('buildClimateMapOverlay keeps mitigation fallback deterministic for low or 
     ],
     copy: 'Risque climat bas: surveiller sans mobiliser.',
   });
+});
+
+test('buildClimateMapOverlay forecasts recovery for dry anomaly mitigation choices sorted by recovery window', () => {
+  const overlay = buildClimateMapOverlay([
+    {
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: 35,
+      precipitationLevel: 8,
+      droughtIndex: 78,
+      anomaly: 'heatwave',
+    },
+  ], {
+    selectedRegionId: 'sunreach',
+    seasonLabels: { summer: 'Été', autumn: 'Automne' },
+    seasonPreview: {
+      season: 'autumn',
+      impactsByRegion: {
+        sunreach: { strategicImpact: 'critical', anomaly: 'drought' },
+      },
+    },
+  });
+
+  assert.deepEqual(overlay.selectedClimateRecoveryForecast, {
+    state: 'ready',
+    compact: true,
+    regionId: 'sunreach',
+    confidence: 'medium',
+    summary: {
+      bestMitigation: 'evacuate-risk-zones',
+      prudentOption: 'fortify-routes',
+      riskyOption: 'fortify-routes',
+      confidence: 'medium',
+    },
+    forecasts: [
+      {
+        choiceId: 'evacuate-risk-zones',
+        label: 'Évacuer les zones exposées',
+        recoveryWindowDays: 20,
+        expectedStability: 'guarded',
+        harvestImpact: 'récoltes ralenties',
+        logisticsImpact: 'mobilité civile sécurisée',
+        relapseRisk: 'medium',
+        nextCriticalSeason: 'Automne',
+        confidence: 'high',
+        summary: 'Évacuer les zones exposées: récupération ~20j, rechute medium avant Automne.',
+      },
+      {
+        choiceId: 'irrigate-reserves',
+        label: 'Irriguer et rationner',
+        recoveryWindowDays: 24,
+        expectedStability: 'improving',
+        harvestImpact: 'récoltes protégées',
+        logisticsImpact: 'ravitaillement sous tension',
+        relapseRisk: 'medium',
+        nextCriticalSeason: 'Automne',
+        confidence: 'high',
+        summary: 'Irriguer et rationner: récupération ~24j, rechute medium avant Automne.',
+      },
+      {
+        choiceId: 'fortify-routes',
+        label: 'Fortifier routes et abris',
+        recoveryWindowDays: 28,
+        expectedStability: 'guarded',
+        harvestImpact: 'récoltes exposées',
+        logisticsImpact: 'routes stabilisées',
+        relapseRisk: 'medium',
+        nextCriticalSeason: 'Automne',
+        confidence: 'high',
+        summary: 'Fortifier routes et abris: récupération ~28j, rechute medium avant Automne.',
+      },
+    ],
+    copy: 'Récupération estimée: Évacuer les zones exposées en ~20j.',
+  });
+});
+
+test('buildClimateMapOverlay forecasts wet/catastrophe recovery with route fortification available', () => {
+  const overlay = buildClimateMapOverlay([
+    {
+      regionId: 'delta',
+      season: 'spring',
+      temperatureC: 18,
+      precipitationLevel: 88,
+      droughtIndex: 4,
+      anomaly: 'flood',
+    },
+  ], {
+    selectedRegionId: 'delta',
+    seasonLabels: { spring: 'Printemps' },
+    catastrophes: [
+      {
+        id: 'flood-1',
+        regionIds: ['delta'],
+        type: 'flood',
+        severity: 'major',
+        status: 'active',
+        startedAt: '2026-05-11T00:00:00.000Z',
+        impact: { logistics: -8 },
+      },
+    ],
+  });
+
+  assert.equal(overlay.selectedClimateMitigationChoices.choices.some((choice) => choice.choiceId === 'fortify-routes'), true);
+  assert.deepEqual(overlay.selectedClimateRecoveryForecast.forecasts.map((forecast) => forecast.choiceId), [
+    'evacuate-risk-zones',
+    'irrigate-reserves',
+    'fortify-routes',
+  ]);
+  assert.equal(overlay.selectedClimateRecoveryForecast.forecasts.find((forecast) => forecast.choiceId === 'fortify-routes').logisticsImpact, 'routes stabilisées');
+  assert.equal(overlay.selectedClimateRecoveryForecast.forecasts.find((forecast) => forecast.choiceId === 'fortify-routes').nextCriticalSeason, 'Printemps');
+});
+
+test('buildClimateMapOverlay keeps recovery forecast graceful for stable and missing climate data', () => {
+  assert.deepEqual(buildClimateMapOverlay([], { selectedRegionId: 'missing' }).selectedClimateRecoveryForecast, {
+    state: 'missing-climate-data',
+    compact: true,
+    regionId: 'missing',
+    forecasts: [],
+    copy: 'Forecast indisponible: données climat manquantes.',
+  });
+
+  const stableForecast = buildClimateMapOverlay([
+    {
+      regionId: 'plain',
+      season: 'winter',
+      temperatureC: 5,
+      precipitationLevel: 44,
+      droughtIndex: 8,
+    },
+  ], { selectedRegionId: 'plain' }).selectedClimateRecoveryForecast;
+
+  assert.equal(stableForecast.state, 'stable');
+  assert.equal(stableForecast.confidence, 'high');
+  assert.deepEqual(stableForecast.summary, {
+    bestMitigation: 'wait-monitor',
+    prudentOption: 'wait-monitor',
+    riskyOption: 'wait-monitor',
+    confidence: 'high',
+  });
+  assert.deepEqual(stableForecast.forecasts, [
+    {
+      choiceId: 'wait-monitor',
+      label: 'Attendre et surveiller',
+      recoveryWindowDays: 7,
+      expectedStability: 'stable',
+      harvestImpact: 'neutre',
+      logisticsImpact: 'neutre',
+      relapseRisk: 'low',
+      nextCriticalSeason: 'winter',
+      confidence: 'high',
+      summary: 'Attendre et surveiller: récupération ~7j, rechute low avant winter.',
+    },
+  ]);
 });


### PR DESCRIPTION
Epsilon: Implements #467.\n\nSummary:\n- adds selectedClimateRecoveryForecast beside existing selected mitigation choices;\n- exposes deterministic per-mitigation recovery window, expected stability, harvest/logistics impact, relapse risk, next critical season, and confidence;\n- summarizes best, prudent, and risky options for the selected province;\n- covers no-selection, missing-data, stable, dry anomaly, wet/catastrophe, and sorted forecast cases without adding simulation complexity.\n\nValidation:\n- npm test -- test/ui/climate/buildClimateMapOverlay.test.js\n- npm test (381 passing)\n- node --check src/ui/climate/buildClimateMapOverlay.js\n- node --check web/app.js\n- git diff --check\n\nZeta, peux-tu valider cette PR avant merge ?