### PR TITLE
Delta: Add intrigue response aftermath preview

### DIFF
--- a/src/ui/intrigue/buildIntrigueWebDemo.js
+++ b/src/ui/intrigue/buildIntrigueWebDemo.js
@@ -133,7 +133,87 @@ function buildHotspotActionHints(entry, hotspot, activeOperations) {
 }
 
 
-function buildHotspotQuickResponses(entry, hotspot, activeOperations) {
+function getIntrigueCelluleState(cellule) {
+  if (!cellule) {
+    return 'aucune cellule locale';
+  }
+
+  if (cellule.status === 'compromised' || cellule.exposure >= 70) {
+    return 'cellule compromise';
+  }
+
+  if (cellule.exposure >= 45) {
+    return 'cellule exposée';
+  }
+
+  if (cellule.sleeper || cellule.status === 'dormant') {
+    return 'cellule dormante';
+  }
+
+  return 'cellule active';
+}
+
+function getEscalationProbabilityLabel(score) {
+  if (score >= 65) {
+    return 'élevée';
+  }
+
+  if (score >= 35) {
+    return 'moyenne';
+  }
+
+  return 'faible';
+}
+
+function buildResponseAftermath(response, entry, activeOperations, primaryCellule) {
+  const activeOperation = activeOperations[0] ?? null;
+  const celluleState = getIntrigueCelluleState(primaryCellule);
+  const baseHeat = Math.round(entry.sabotageRiskScore / 10) + (activeOperations.length * 3);
+  const activeOperationSuffix = activeOperation ? `; opération ${activeOperation.phase} ralentie` : '';
+  const aftermathByCode = {
+    contenir: {
+      cooldownTurns: 2,
+      heatGenerated: baseHeat + 8,
+      escalationScore: 44 + (entry.metrics.exposedCellCount * 12) + (entry.sabotageRiskLevel === 'high' ? 18 : 0),
+      effect: `${celluleState}: pression sécuritaire immédiate${activeOperationSuffix}`,
+      countermeasure: 'Préparer rotation de patrouilles et couverture discrète au tour suivant.',
+    },
+    infiltrer: {
+      cooldownTurns: activeOperation ? 3 : 2,
+      heatGenerated: baseHeat + 5,
+      escalationScore: 30 + (activeOperation ? 12 : 0) + (primaryCellule?.sleeper ? 6 : 0),
+      effect: `${celluleState}: réseau cartographié sans résolution automatique${activeOperationSuffix}`,
+      countermeasure: 'Limiter l’exposition des agents et vérifier les relais compromis.',
+    },
+    exposer: {
+      cooldownTurns: 1,
+      heatGenerated: baseHeat + 14,
+      escalationScore: 58 + (entry.metrics.exposedCellCount * 10),
+      effect: `${celluleState}: preuve rendue exploitable, réseau adverse alerté`,
+      countermeasure: 'Coordonner message public et sécuriser témoins avant représailles.',
+    },
+    surveiller: {
+      cooldownTurns: entry.sabotageRiskLevel === 'low' ? 1 : 0,
+      heatGenerated: Math.max(1, Math.round(baseHeat / 2)),
+      escalationScore: 12 + (entry.metrics.sabotageOperationCount * 8),
+      effect: `${celluleState}: aucun changement direct, signal maintenu visible`,
+      countermeasure: 'Recontrôler le hotspot après le prochain tour ou si la chaleur monte.',
+    },
+  };
+  const aftermath = aftermathByCode[response.code] ?? aftermathByCode.surveiller;
+  const escalationProbability = getEscalationProbabilityLabel(aftermath.escalationScore);
+
+  return {
+    cooldownTurns: aftermath.cooldownTurns,
+    heatGenerated: aftermath.heatGenerated,
+    escalationProbability,
+    celluleState,
+    effect: aftermath.effect,
+    countermeasure: aftermath.countermeasure,
+  };
+}
+
+function buildHotspotQuickResponses(entry, hotspot, activeOperations, primaryCellule = null) {
   const responses = [];
   const riskLabel = entry.sabotageRiskLevel === 'high' ? 'élevé' : entry.sabotageRiskLevel === 'medium' ? 'moyen' : 'faible';
   const hasImmediateThreat = hotspot.severity === 'critical' || entry.sabotageRiskLevel === 'high' || entry.metrics.exposedCellCount > 0;
@@ -180,10 +260,53 @@ function buildHotspotQuickResponses(entry, hotspot, activeOperations) {
     benefit: 'Maintient le signal visible sans encombrer la carte',
   });
 
-  return responses.slice(0, 3).map((response) => ({
-    ...response,
-    summary: `${response.cost} · ${response.risk} · ${response.benefit}`,
-  }));
+  return responses.slice(0, 3).map((response) => {
+    const aftermath = buildResponseAftermath(response, entry, activeOperations, primaryCellule);
+
+    return {
+      ...response,
+      cooldownTurns: aftermath.cooldownTurns,
+      heatGenerated: aftermath.heatGenerated,
+      escalationProbability: aftermath.escalationProbability,
+      effect: aftermath.effect,
+      countermeasure: aftermath.countermeasure,
+      summary: `${response.cost} · ${response.risk} · ${response.benefit}`,
+      aftermathSummary: `Cooldown ${aftermath.cooldownTurns} tour${aftermath.cooldownTurns > 1 ? 's' : ''} · chaleur +${aftermath.heatGenerated} · escalade ${aftermath.escalationProbability}`,
+    };
+  });
+}
+
+function buildResponseAftermathSummary(quickResponses) {
+  const escalationRank = { faible: 1, moyenne: 2, élevée: 3 };
+  const effectivenessRank = { contenir: 4, exposer: 3, infiltrer: 2, surveiller: 1 };
+  const safest = quickResponses.slice().sort((left, right) => {
+    const leftEscalation = escalationRank[left.escalationProbability] ?? 0;
+    const rightEscalation = escalationRank[right.escalationProbability] ?? 0;
+
+    return leftEscalation - rightEscalation
+      || left.heatGenerated - right.heatGenerated
+      || left.cooldownTurns - right.cooldownTurns
+      || left.code.localeCompare(right.code);
+  })[0] ?? null;
+  const mostEffective = quickResponses.slice().sort((left, right) => {
+    const leftEffectiveness = effectivenessRank[left.code] ?? 0;
+    const rightEffectiveness = effectivenessRank[right.code] ?? 0;
+
+    return rightEffectiveness - leftEffectiveness
+      || left.cooldownTurns - right.cooldownTurns
+      || left.code.localeCompare(right.code);
+  })[0] ?? null;
+  const retaliationRank = Math.max(0, ...quickResponses.map((response) => escalationRank[response.escalationProbability] ?? 0));
+  const retaliationRisk = retaliationRank >= 3 ? 'élevé' : retaliationRank >= 2 ? 'modéré' : 'faible';
+
+  return {
+    safestResponseCode: safest?.code ?? null,
+    mostEffectiveResponseCode: mostEffective?.code ?? null,
+    retaliationRisk,
+    summary: safest && mostEffective
+      ? `Plus sûre: ${safest.label}; plus efficace: ${mostEffective.label}; représailles ${retaliationRisk}.`
+      : 'Aucune réponse rapide disponible pour ce hotspot.',
+  };
 }
 
 function buildHotspotDrillDown(entry, cellules, operations, locationNames) {
@@ -220,7 +343,9 @@ function buildHotspotDrillDown(entry, cellules, operations, locationNames) {
     activeOperations.length > 0 ? `${activeOperations.length} opération${activeOperations.length > 1 ? 's' : ''} active${activeOperations.length > 1 ? 's' : ''}` : null,
   ].filter(Boolean);
   const actionHints = buildHotspotActionHints(entry, hotspot, activeOperations);
-  const quickResponses = buildHotspotQuickResponses(entry, hotspot, activeOperations);
+  const primaryCellule = locationCellules[0] ?? null;
+  const quickResponses = buildHotspotQuickResponses(entry, hotspot, activeOperations, primaryCellule);
+  const responseAftermath = buildResponseAftermathSummary(quickResponses);
 
   return {
     locationId: entry.locationId,
@@ -239,6 +364,7 @@ function buildHotspotDrillDown(entry, cellules, operations, locationNames) {
     actionHints,
     recommendedResponseCode: quickResponses.find((response) => response.recommended)?.code ?? quickResponses[0]?.code ?? null,
     quickResponses,
+    responseAftermath,
   };
 }
 

--- a/test/ui/intrigue/buildIntrigueWebDemo.test.js
+++ b/test/ui/intrigue/buildIntrigueWebDemo.test.js
@@ -133,7 +133,13 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
         cost: '2 ordres sécurité',
         risk: 'Escalade moyen',
         benefit: 'Réduit la fenêtre de sabotage immédiate',
+        cooldownTurns: 2,
+        heatGenerated: 17,
+        escalationProbability: 'moyenne',
+        effect: 'cellule compromise: pression sécuritaire immédiate; opération execution ralentie',
+        countermeasure: 'Préparer rotation de patrouilles et couverture discrète au tour suivant.',
         summary: '2 ordres sécurité · Escalade moyen · Réduit la fenêtre de sabotage immédiate',
+        aftermathSummary: 'Cooldown 2 tours · chaleur +17 · escalade moyenne',
       },
       {
         code: 'infiltrer',
@@ -142,7 +148,13 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
         cost: '1 agent disponible',
         risk: 'Chaleur opérationnelle accrue',
         benefit: 'Identifie cellule, cible ou commanditaire prioritaire',
+        cooldownTurns: 3,
+        heatGenerated: 14,
+        escalationProbability: 'moyenne',
+        effect: 'cellule compromise: réseau cartographié sans résolution automatique; opération execution ralentie',
+        countermeasure: 'Limiter l’exposition des agents et vérifier les relais compromis.',
         summary: '1 agent disponible · Chaleur opérationnelle accrue · Identifie cellule, cible ou commanditaire prioritaire',
+        aftermathSummary: 'Cooldown 3 tours · chaleur +14 · escalade moyenne',
       },
       {
         code: 'exposer',
@@ -151,9 +163,21 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
         cost: '1 preuve exploitable',
         risk: 'Réseau adverse alerté',
         benefit: 'Convertit une cellule exposée en avantage public',
+        cooldownTurns: 1,
+        heatGenerated: 23,
+        escalationProbability: 'élevée',
+        effect: 'cellule compromise: preuve rendue exploitable, réseau adverse alerté',
+        countermeasure: 'Coordonner message public et sécuriser témoins avant représailles.',
         summary: '1 preuve exploitable · Réseau adverse alerté · Convertit une cellule exposée en avantage public',
+        aftermathSummary: 'Cooldown 1 tour · chaleur +23 · escalade élevée',
       },
     ],
+    responseAftermath: {
+      safestResponseCode: 'infiltrer',
+      mostEffectiveResponseCode: 'contenir',
+      retaliationRisk: 'élevé',
+      summary: 'Plus sûre: Infiltrer; plus efficace: Contenir; représailles élevé.',
+    },
   });
   assert.deepEqual(demo.hotspots, [
     {
@@ -206,7 +230,13 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
             cost: '2 ordres sécurité',
             risk: 'Escalade moyen',
             benefit: 'Réduit la fenêtre de sabotage immédiate',
+            cooldownTurns: 2,
+            heatGenerated: 17,
+            escalationProbability: 'moyenne',
+            effect: 'cellule compromise: pression sécuritaire immédiate; opération execution ralentie',
+            countermeasure: 'Préparer rotation de patrouilles et couverture discrète au tour suivant.',
             summary: '2 ordres sécurité · Escalade moyen · Réduit la fenêtre de sabotage immédiate',
+            aftermathSummary: 'Cooldown 2 tours · chaleur +17 · escalade moyenne',
           },
           {
             code: 'infiltrer',
@@ -215,7 +245,13 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
             cost: '1 agent disponible',
             risk: 'Chaleur opérationnelle accrue',
             benefit: 'Identifie cellule, cible ou commanditaire prioritaire',
+            cooldownTurns: 3,
+            heatGenerated: 14,
+            escalationProbability: 'moyenne',
+            effect: 'cellule compromise: réseau cartographié sans résolution automatique; opération execution ralentie',
+            countermeasure: 'Limiter l’exposition des agents et vérifier les relais compromis.',
             summary: '1 agent disponible · Chaleur opérationnelle accrue · Identifie cellule, cible ou commanditaire prioritaire',
+            aftermathSummary: 'Cooldown 3 tours · chaleur +14 · escalade moyenne',
           },
           {
             code: 'exposer',
@@ -224,9 +260,21 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
             cost: '1 preuve exploitable',
             risk: 'Réseau adverse alerté',
             benefit: 'Convertit une cellule exposée en avantage public',
+            cooldownTurns: 1,
+            heatGenerated: 23,
+            escalationProbability: 'élevée',
+            effect: 'cellule compromise: preuve rendue exploitable, réseau adverse alerté',
+            countermeasure: 'Coordonner message public et sécuriser témoins avant représailles.',
             summary: '1 preuve exploitable · Réseau adverse alerté · Convertit une cellule exposée en avantage public',
+            aftermathSummary: 'Cooldown 1 tour · chaleur +23 · escalade élevée',
           },
         ],
+        responseAftermath: {
+          safestResponseCode: 'infiltrer',
+          mostEffectiveResponseCode: 'contenir',
+          retaliationRisk: 'élevé',
+          summary: 'Plus sûre: Infiltrer; plus efficace: Contenir; représailles élevé.',
+        },
       },
     },
     {
@@ -273,7 +321,13 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
             cost: '1 agent disponible',
             risk: 'Chaleur opérationnelle accrue',
             benefit: 'Identifie cellule, cible ou commanditaire prioritaire',
+            cooldownTurns: 3,
+            heatGenerated: 10,
+            escalationProbability: 'moyenne',
+            effect: 'cellule active: réseau cartographié sans résolution automatique; opération infiltration ralentie',
+            countermeasure: 'Limiter l’exposition des agents et vérifier les relais compromis.',
             summary: '1 agent disponible · Chaleur opérationnelle accrue · Identifie cellule, cible ou commanditaire prioritaire',
+            aftermathSummary: 'Cooldown 3 tours · chaleur +10 · escalade moyenne',
           },
           {
             code: 'surveiller',
@@ -282,9 +336,21 @@ test('buildIntrigueWebDemo assembles alert badge, hotspots, and panels for the w
             cost: '0 ordre lourd',
             risk: 'Menace différée possible',
             benefit: 'Maintient le signal visible sans encombrer la carte',
+            cooldownTurns: 1,
+            heatGenerated: 3,
+            escalationProbability: 'faible',
+            effect: 'cellule active: aucun changement direct, signal maintenu visible',
+            countermeasure: 'Recontrôler le hotspot après le prochain tour ou si la chaleur monte.',
             summary: '0 ordre lourd · Menace différée possible · Maintient le signal visible sans encombrer la carte',
+            aftermathSummary: 'Cooldown 1 tour · chaleur +3 · escalade faible',
           },
         ],
+        responseAftermath: {
+          safestResponseCode: 'surveiller',
+          mostEffectiveResponseCode: 'infiltrer',
+          retaliationRisk: 'modéré',
+          summary: 'Plus sûre: Surveiller; plus efficace: Infiltrer; représailles modéré.',
+        },
       },
     },
   ]);
@@ -388,4 +454,56 @@ test('buildIntrigueWebDemo rejects invalid inputs', () => {
   assert.throws(() => buildIntrigueWebDemo({ cellules: [], operations: [null] }), /OperationClandestine instances or plain objects/);
   assert.throws(() => buildIntrigueWebDemo({ cellules: [], operations: [] }, null), /options must be an object/);
   assert.throws(() => buildIntrigueWebDemo({ cellules: [], operations: [] }, { locationNames: [] }), /locationNames must be an object/);
+});
+
+test('buildIntrigueWebDemo projects quick response aftermath, cooldowns, and fallback states', () => {
+  const demo = buildIntrigueWebDemo({
+    alertLevel: 'surveille',
+    cellules: [
+      new Cellule({
+        id: 'cell-dormant',
+        factionId: 'shadow-league',
+        codename: 'Lantern',
+        locationId: 'harbor',
+        memberIds: ['ag-4'],
+        assetIds: ['asset-4'],
+        secrecy: 80,
+        loyalty: 58,
+        exposure: 18,
+        sleeper: true,
+      }),
+      new Cellule({
+        id: 'cell-exposed',
+        factionId: 'shadow-league',
+        codename: 'Torch',
+        locationId: 'market',
+        memberIds: ['ag-5'],
+        assetIds: ['asset-5'],
+        secrecy: 35,
+        loyalty: 52,
+        exposure: 74,
+      }),
+    ],
+    operations: [],
+  }, {
+    locationNames: {
+      harbor: 'Harbor',
+      market: 'Market',
+    },
+  });
+
+  const harborDrillDown = demo.map.entries.find((entry) => entry.locationId === 'harbor').drillDown;
+  const marketDrillDown = demo.map.entries.find((entry) => entry.locationId === 'market').drillDown;
+
+  assert.equal(harborDrillDown.recommendedResponseCode, 'infiltrer');
+  assert.equal(harborDrillDown.quickResponses[0].effect, 'cellule dormante: réseau cartographié sans résolution automatique');
+  assert.equal(harborDrillDown.quickResponses[0].cooldownTurns, 2);
+  assert.equal(harborDrillDown.responseAftermath.safestResponseCode, 'surveiller');
+  assert.equal(harborDrillDown.responseAftermath.mostEffectiveResponseCode, 'infiltrer');
+
+  assert.equal(marketDrillDown.recommendedResponseCode, 'contenir');
+  assert.equal(marketDrillDown.quickResponses[0].escalationProbability, 'moyenne');
+  assert.equal(marketDrillDown.quickResponses[1].code, 'exposer');
+  assert.match(marketDrillDown.quickResponses[1].countermeasure, /témoins/);
+  assert.equal(marketDrillDown.responseAftermath.retaliationRisk, 'élevé');
 });

--- a/test/ui/intrigue/webIntrigueQuickResponses.test.js
+++ b/test/ui/intrigue/webIntrigueQuickResponses.test.js
@@ -10,4 +10,8 @@ test('intrigue side panel renders quick response choices from hotspot drill-down
   assert.match(webAppSource, /intrigue-quick-response/);
   assert.match(webAppSource, /recommandée/);
   assert.match(webAppSource, /response\.summary/);
+  assert.match(webAppSource, /Après-coup probable/);
+  assert.match(webAppSource, /responseAftermath\.summary/);
+  assert.match(webAppSource, /response\.aftermathSummary/);
+  assert.match(webAppSource, /response\.countermeasure/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -2729,6 +2729,10 @@ function renderIntrigueSidePanel(intrigueView) {
                   </article>
                 `).join('')}
               </div>
+              <div class="intrigue-response-aftermath" aria-label="Résumé aftermath intrigue">
+                <strong>Après-coup probable</strong>
+                <p>${intrigueView.selectedProvince.drillDown.responseAftermath.summary}</p>
+              </div>
               <div class="intrigue-quick-responses" aria-label="Réponses rapides intrigue">
                 ${intrigueView.selectedProvince.drillDown.quickResponses.map((response) => `
                   <article class="intrigue-quick-response ${response.recommended ? 'is-recommended' : ''}">
@@ -2737,6 +2741,9 @@ function renderIntrigueSidePanel(intrigueView) {
                       ${response.recommended ? '<b>recommandée</b>' : ''}
                     </div>
                     <span>${response.summary}</span>
+                    <small>${response.aftermathSummary}</small>
+                    <em>${response.effect}</em>
+                    <em>${response.countermeasure}</em>
                   </article>
                 `).join('')}
               </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -4255,6 +4255,17 @@ button { font: inherit; }
   color: var(--muted);
 }
 
+.intrigue-response-aftermath {
+  margin-top: 10px;
+  padding: 9px 10px;
+  border-radius: 13px;
+  background: rgba(14, 165, 233, 0.09);
+  border: 1px solid rgba(56, 189, 248, 0.2);
+}
+.intrigue-response-aftermath p {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
 .intrigue-quick-responses {
   display: grid;
   gap: 8px;
@@ -4282,8 +4293,13 @@ button { font: inherit; }
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
-.intrigue-quick-response span {
+.intrigue-quick-response span,
+.intrigue-quick-response small,
+.intrigue-quick-response em {
   display: block;
   margin-top: 3px;
   color: var(--muted);
+}
+.intrigue-quick-response em {
+  font-style: normal;
 }


### PR DESCRIPTION
Delta: Closes #466.

Summary:
- enrich intrigue quick responses with projected cooldown, heat, escalation probability, cellule/operation effect, and recommended countermeasure;
- add selected-hotspot aftermath summary for safest response, most effective response, and retaliation risk;
- render aftermath/cooldown previews in the existing intrigue side panel without adding backend operation resolution.

Validation:
- git diff --check origin/main...HEAD
- node --check web/app.js
- node --test test/ui/intrigue/buildIntrigueWebDemo.test.js test/ui/intrigue/webIntrigueQuickResponses.test.js
- npm test (387 passing)

Delta: Ready for Zeta validation before merge.