### PR TITLE
Alpha: Show resolved conflict deltas

### DIFF
--- a/test/ui/war/webResolvedConflictDeltas.test.js
+++ b/test/ui/war/webResolvedConflictDeltas.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable map exposes resolved conflict deltas in the turn report', () => {
+  assert.match(webAppSource, /function buildResolvedConflictDeltas/);
+  assert.match(webAppSource, /function renderResolvedConflictDeltas/);
+  assert.match(webAppSource, /Rapport dernier tour/);
+  assert.match(webAppSource, /Contrôle \/ front/);
+  assert.match(webAppSource, /Pression/);
+  assert.match(webAppSource, /Pertes \/ risque/);
+  assert.match(webAppSource, /Action résolue/);
+  assert.match(webAppSource, /Aucun changement militaire résolu/);
+  assert.match(webAppSource, /resolvedActionCode/);
+  assert.match(webAppSource, /renderResolvedConflictDeltas\(province, shell, focusContext, intrigueView\)/);
+  assert.match(stylesSource, /\.resolved-conflict-deltas/);
+  assert.match(stylesSource, /resolved-conflict-delta--success/);
+  assert.match(stylesSource, /resolved-conflict-delta--warning/);
+  assert.match(stylesSource, /resolved-conflict-delta--danger/);
+  assert.match(stylesSource, /resolved-conflict-deltas\.is-empty/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1219,6 +1219,70 @@ function renderSelectedProvinceActionQueue(province, shell, focusContext, intrig
   `;
 }
 
+function buildResolvedConflictDeltas(province, shell, actionQueue) {
+  if (actionQueue.length === 0) {
+    return {
+      empty: true,
+      summary: 'Aucun changement militaire résolu sur cette province au dernier tour.',
+      deltas: [],
+    };
+  }
+
+  const outcome = buildConflictOutcomePreview(province, shell);
+  const resolvedAction = actionQueue.find((entry) => entry.status === 'ready') ?? actionQueue[0];
+  const pressureDelta = outcome.tone === 'success' ? '-1 pression' : outcome.tone === 'danger' ? '+1 risque' : 'pression stable';
+  const controlDelta = province.contested ? 'front contesté maintenu' : province.occupied ? 'occupation stabilisée' : 'contrôle inchangé';
+  const lossDelta = resolvedAction.status === 'blocked' ? 'pertes évitées' : resolvedAction.status === 'risky' ? 'risque accru' : 'risque contenu';
+
+  return {
+    empty: false,
+    summary: `${resolvedAction.label}: ${outcome.title.toLowerCase()} pour ${province.label}.`,
+    resolvedActionCode: resolvedAction.actionCode,
+    impactedProvince: province.label,
+    deltas: [
+      { tone: outcome.tone, label: 'Contrôle / front', value: controlDelta },
+      { tone: outcome.tone === 'danger' ? 'danger' : 'warning', label: 'Pression', value: pressureDelta },
+      { tone: resolvedAction.status === 'ready' ? 'success' : resolvedAction.status === 'blocked' ? 'neutral' : 'danger', label: 'Pertes / risque', value: lossDelta },
+      { tone: resolvedAction.status === 'ready' ? 'success' : resolvedAction.status === 'blocked' ? 'neutral' : 'warning', label: 'Action résolue', value: resolvedAction.status === 'blocked' ? 'échec bloqué' : 'succès partiel' },
+    ],
+  };
+}
+
+function renderResolvedConflictDeltas(province, shell, focusContext, intrigueView = null) {
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const report = buildResolvedConflictDeltas(province, shell, actionQueue);
+
+  if (report.empty) {
+    return `
+      <section class="resolved-conflict-deltas is-empty" aria-label="Rapport de résolution militaire">
+        <strong>Rapport dernier tour</strong>
+        <p>${report.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="resolved-conflict-deltas" aria-label="Rapport de résolution militaire">
+      <div class="resolved-conflict-deltas__header">
+        <div>
+          <span>Rapport dernier tour</span>
+          <strong>${report.impactedProvince}</strong>
+        </div>
+        <code>${report.resolvedActionCode}</code>
+      </div>
+      <p>${report.summary}</p>
+      <div class="resolved-conflict-delta-list">
+        ${report.deltas.map((delta) => `
+          <article class="resolved-conflict-delta resolved-conflict-delta--${delta.tone}">
+            <span>${delta.label}</span>
+            <strong>${delta.value}</strong>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderActiveProvince(shell, economyView = null, intrigueView = null) {
   const focusContext = getFocusContext(shell);
   const province = shell.activeProvince ?? shell.provinces[0] ?? null;
@@ -1263,6 +1327,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
+      ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}
       <div class="context-summary">
         <strong>Comparaison rapide</strong>
         <p>${comparedProvinceNames.length > 0 ? comparedProvinceNames.join(' vs ') : 'Aucune province comparée pour le moment.'}</p>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1838,6 +1838,66 @@ button { font: inherit; }
 .province-action-queue__item--ready { border-color: rgba(74, 222, 128, 0.28); }
 .province-action-queue__item--risky { border-color: rgba(251, 191, 36, 0.34); }
 .province-action-queue__item--blocked { border-color: rgba(251, 113, 133, 0.4); }
+.resolved-conflict-deltas {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.66), rgba(8, 15, 28, 0.6));
+  border: 1px solid rgba(56, 189, 248, 0.2);
+}
+.resolved-conflict-deltas__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.resolved-conflict-deltas__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.resolved-conflict-deltas__header strong {
+  display: block;
+  margin-top: 3px;
+}
+.resolved-conflict-deltas__header code {
+  color: #bae6fd;
+  font-size: 11px;
+}
+.resolved-conflict-deltas p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.resolved-conflict-delta-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.resolved-conflict-delta {
+  padding: 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.resolved-conflict-delta span {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+.resolved-conflict-delta strong {
+  font-size: 12px;
+}
+.resolved-conflict-delta--success { border-color: rgba(74, 222, 128, 0.32); }
+.resolved-conflict-delta--warning { border-color: rgba(251, 191, 36, 0.32); }
+.resolved-conflict-delta--danger { border-color: rgba(251, 113, 133, 0.38); }
+.resolved-conflict-delta--neutral { border-color: rgba(148, 163, 184, 0.18); }
+.resolved-conflict-deltas.is-empty { border-style: dashed; }
 .context-summary {
   margin-top: 14px;
   padding: 12px;


### PR DESCRIPTION
Alpha: Closes #473.

## Summary
- adds a selected-province last-turn military report derived from the existing Alpha action queue and conflict preview data
- surfaces readable resolved deltas for control/front, pressure, losses/risk, and action success/failure
- includes a clear empty state for provinces with no resolved military changes
- renders the report in the existing tactical map panel without adding a new combat-resolution loop
- adds a deterministic web smoke test for the report contract and HUD styles

## Verification
- npm test
- npm run preview:map -- /tmp/historia-resolved-conflict-deltas-preview.html
- node --test test/ui/war/webResolvedConflictDeltas.test.js
- node --check web/app.js
- git diff --check
