### PR TITLE
Gamma: Add culture turn report deltas

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1,0 +1,117 @@
+function normalizeText(value, fallback = '') {
+  return String(value ?? fallback).trim();
+}
+
+function buildDelta({ deltaId, tone, label, value, reason, regionId, cultureName }) {
+  return {
+    deltaId,
+    tone,
+    label,
+    value,
+    reason,
+    regionId,
+    cultureName,
+  };
+}
+
+function buildTimelineDeltas(localTimeline, regionId) {
+  return (localTimeline?.items ?? []).map((item) => buildDelta({
+    deltaId: `${regionId}:timeline:${item.timelineId}`,
+    tone: item.signal,
+    label: item.kind === 'event' ? 'Événement déclenché' : 'Découverte visible',
+    value: item.title,
+    reason: item.summary,
+    regionId: normalizeText(item.regionId, regionId),
+    cultureName: normalizeText(item.cultureName, 'Culture locale'),
+  }));
+}
+
+function buildMarkerDeltas(selectedMarker, regionId) {
+  if (!selectedMarker) {
+    return [];
+  }
+
+  const deltas = [buildDelta({
+    deltaId: `${regionId}:influence:${selectedMarker.overlayId}`,
+    tone: selectedMarker.influenceTier === 'dominant' || selectedMarker.influenceTier === 'strong' ? 'opportunity' : 'identity',
+    label: 'Influence culturelle',
+    value: `${selectedMarker.cultureName} · ${selectedMarker.influenceScore}`,
+    reason: `${selectedMarker.influenceTier} · ${selectedMarker.discoveries.length} découverte${selectedMarker.discoveries.length > 1 ? 's' : ''}`,
+    regionId,
+    cultureName: selectedMarker.cultureName,
+  })];
+
+  if ((selectedMarker.activeResearchCount ?? 0) > 0 || (selectedMarker.unlockedResearchIds ?? []).length > 0) {
+    deltas.push(buildDelta({
+      deltaId: `${regionId}:research:${selectedMarker.overlayId}`,
+      tone: 'research',
+      label: 'Recherche culturelle',
+      value: `${selectedMarker.activeResearchCount ?? 0} active${selectedMarker.activeResearchCount > 1 ? 's' : ''}`,
+      reason: (selectedMarker.unlockedResearchIds ?? []).slice(0, 2).join(', ') || 'Progression liée aux découvertes locales',
+      regionId,
+      cultureName: selectedMarker.cultureName,
+    }));
+  }
+
+  return deltas;
+}
+
+function buildConsequenceDeltas(consequenceChips, regionId) {
+  return (consequenceChips ?? [])
+    .filter((chip) => chip.tone === 'risk' || chip.tone === 'opportunity')
+    .map((chip) => buildDelta({
+      deltaId: `${regionId}:chip:${chip.chipId}`,
+      tone: chip.tone,
+      label: chip.tone === 'risk' ? 'Tension culturelle' : 'Opportunité culturelle',
+      value: chip.label,
+      reason: chip.explanation,
+      regionId: normalizeText(chip.regionId, regionId),
+      cultureName: normalizeText(chip.cultureName, 'Culture locale'),
+    }));
+}
+
+function dedupeAndSort(deltas) {
+  return [...new Map(deltas.map((delta) => [
+    `${delta.tone}:${delta.label}:${delta.value}:${delta.regionId}`,
+    delta,
+  ])).values()]
+    .sort((left, right) => {
+      const toneRank = { risk: 5, opportunity: 4, research: 3, identity: 2, neutral: 1 };
+      return (toneRank[right.tone] ?? 0) - (toneRank[left.tone] ?? 0) || left.label.localeCompare(right.label);
+    })
+    .slice(0, 4);
+}
+
+export function buildCultureTurnReportDeltas({
+  turn = 1,
+  selectedRegionId,
+  selectedMarker = null,
+  selectedCluster = null,
+  localTimeline = null,
+  consequenceChips = [],
+} = {}) {
+  const regionId = normalizeText(selectedRegionId ?? selectedMarker?.regionId ?? selectedCluster?.regionIds?.[0], 'province');
+  const deltas = dedupeAndSort([
+    ...buildTimelineDeltas(localTimeline, regionId),
+    ...buildMarkerDeltas(selectedMarker, regionId),
+    ...buildConsequenceDeltas(consequenceChips, regionId),
+  ]);
+
+  if (deltas.length === 0) {
+    return {
+      state: 'quiet',
+      turn,
+      regionId,
+      summary: 'Aucun delta culture/découverte visible ce tour.',
+      deltas: [],
+    };
+  }
+
+  return {
+    state: 'active',
+    turn,
+    regionId,
+    summary: `Tour ${turn}: ${deltas.length} delta${deltas.length > 1 ? 's' : ''} culture/découverte à vérifier.`,
+    deltas,
+  };
+}

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCultureTurnReportDeltas } from '../../../src/ui/culture/buildCultureTurnReportDeltas.js';
+
+test('buildCultureTurnReportDeltas summarizes selected culture event, research, and consequence deltas', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 4,
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes', 'tidal-ledgers'],
+      activeResearchCount: 1,
+      unlockedResearchIds: ['tidal-ledgers'],
+    },
+    localTimeline: {
+      items: [
+        {
+          timelineId: 'river-gate:event:event-archive-opening',
+          kind: 'event',
+          signal: 'opportunity',
+          title: 'Ouverture des archives',
+          summary: 'Opportunité culturelle à exploiter maintenant.',
+          regionId: 'river-gate',
+          cultureName: 'Compact d’Aurora',
+        },
+      ],
+    },
+    consequenceChips: [
+      {
+        chipId: 'risk:river-gate:Compact d’Aurora:Tension mémorielle:event-risk',
+        tone: 'risk',
+        label: 'Tension mémorielle',
+        explanation: 'Un souvenir conflictuel colore le choix.',
+        regionId: 'river-gate',
+        cultureName: 'Compact d’Aurora',
+      },
+    ],
+  });
+
+  assert.equal(report.state, 'active');
+  assert.equal(report.summary, 'Tour 4: 4 deltas culture/découverte à vérifier.');
+  assert.deepEqual(report.deltas.map((delta) => [delta.tone, delta.label, delta.value]), [
+    ['risk', 'Tension culturelle', 'Tension mémorielle'],
+    ['opportunity', 'Événement déclenché', 'Ouverture des archives'],
+    ['opportunity', 'Influence culturelle', 'Compact d’Aurora · 82'],
+    ['research', 'Recherche culturelle', '1 active'],
+  ]);
+});
+
+test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
+  assert.deepEqual(buildCultureTurnReportDeltas({ turn: 2, selectedRegionId: 'quiet-field' }), {
+    state: 'quiet',
+    turn: 2,
+    regionId: 'quiet-field',
+    summary: 'Aucun delta culture/découverte visible ce tour.',
+    deltas: [],
+  });
+});

--- a/web/app.js
+++ b/web/app.js
@@ -15,6 +15,7 @@ import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js
 import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMapRecommendations.js';
 import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTimeline.js';
 import { buildCultureConsequenceChips } from '../src/ui/culture/buildCultureConsequenceChips.js';
+import { buildCultureTurnReportDeltas } from '../src/ui/culture/buildCultureTurnReportDeltas.js';
 
 const culturePayload = {
   cultures: [
@@ -826,6 +827,52 @@ function buildProvinceActionRecommendations(province, focusContext, intrigueView
   return recommendations.slice(0, 3);
 }
 
+function getSelectedCultureContext(regionId = state.selectedProvinceId) {
+  const cultureView = getCultureViewModel();
+  const selectedMarker = cultureView.overlay.find((entry) => entry.regionId === regionId) ?? null;
+  const selectedCluster = buildCultureClusterSummaries(cultureView.overlay)
+    .find((cluster) => cluster.regionIds.includes(regionId)) ?? null;
+  const localTimeline = buildCultureLocalTimeline({
+    selectedRegionId: regionId,
+    selectedMarker,
+    selectedCluster,
+  });
+  const consequenceChips = buildCultureConsequenceChips({
+    province: { provinceId: regionId },
+    action: { title: state.lastTurnSummary },
+    selectedMarker,
+    selectedCluster,
+    localTimeline,
+  });
+
+  return {
+    cultureView,
+    selectedMarker,
+    selectedCluster,
+    localTimeline,
+    consequenceChips,
+  };
+}
+
+function renderCultureTurnReport(report) {
+  return `
+    <div class="culture-turn-report culture-turn-report--${report.state}" aria-label="Deltas culturels du tour">
+      <strong>${report.summary}</strong>
+      ${report.deltas.length > 0 ? `
+        <ul>
+          ${report.deltas.map((delta) => `
+            <li class="culture-turn-report__delta culture-turn-report__delta--${delta.tone}">
+              <span>${delta.label}</span>
+              <b>${delta.value}</b>
+              <small>${delta.cultureName} · ${delta.regionId} · ${delta.reason}</small>
+            </li>
+          `).join('')}
+        </ul>
+      ` : '<span>Culture stable: aucun événement, découverte ou tension nouvelle à remonter.</span>'}
+    </div>
+  `;
+}
+
 function renderCultureConsequenceChips(chips) {
   return `
     <div class="culture-consequence-chips" aria-label="Conséquences culturelles">
@@ -841,15 +888,7 @@ function renderCultureConsequenceChips(chips) {
 
 function renderProvinceActionRecommendations(province, focusContext, intrigueView = null) {
   const recommendations = buildProvinceActionRecommendations(province, focusContext, intrigueView);
-  const cultureView = getCultureViewModel();
-  const selectedMarker = cultureView.overlay.find((entry) => entry.regionId === province.provinceId) ?? null;
-  const selectedCluster = buildCultureClusterSummaries(cultureView.overlay)
-    .find((cluster) => cluster.regionIds.includes(province.provinceId)) ?? null;
-  const localTimeline = buildCultureLocalTimeline({
-    selectedRegionId: province.provinceId,
-    selectedMarker,
-    selectedCluster,
-  });
+  const { selectedMarker, selectedCluster, localTimeline } = getSelectedCultureContext(province.provinceId);
 
   return `
     <div class="province-action-recommendations" aria-label="Actions recommandées pour la province sélectionnée">
@@ -3666,6 +3705,15 @@ function render() {
   const focusContext = getFocusContext(shell);
   const intrigueView = getIntrigueViewModel();
   const cultureView = getCultureViewModel();
+  const selectedCultureContext = getSelectedCultureContext();
+  const cultureTurnReport = buildCultureTurnReportDeltas({
+    turn: state.turn,
+    selectedRegionId: state.selectedProvinceId,
+    selectedMarker: selectedCultureContext.selectedMarker,
+    selectedCluster: selectedCultureContext.selectedCluster,
+    localTimeline: selectedCultureContext.localTimeline,
+    consequenceChips: selectedCultureContext.consequenceChips,
+  });
 
   document.querySelector('#app').innerHTML = `
     <main class="shell-root">
@@ -3689,6 +3737,7 @@ function render() {
               <span>${economyView.pulse.city.name}, stock ${economyView.pulse.delta.stockDelta > 0 ? '+' : ''}${economyView.pulse.delta.stockDelta}, stabilité ${economyView.pulse.delta.stabilityDelta > 0 ? '+' : ''}${economyView.pulse.delta.stabilityDelta}, prospérité ${economyView.pulse.delta.prosperityDelta > 0 ? '+' : ''}${economyView.pulse.delta.prosperityDelta}</span>
             </div>
           ` : ''}
+          ${renderCultureTurnReport(cultureTurnReport)}
         </div>
         <div class="hero-stats">
           ${renderStat('Provinces', shell.stats.provinceCount, 'neutral')}

--- a/web/styles.css
+++ b/web/styles.css
@@ -111,6 +111,51 @@ button { font: inherit; }
   color: var(--muted);
   font-size: 13px;
 }
+.culture-turn-report {
+  margin-top: 12px;
+  max-width: 58ch;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.culture-turn-report > strong {
+  display: block;
+  color: #e0f2fe;
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+.culture-turn-report ul {
+  display: grid;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.culture-turn-report__delta {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 3px 8px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(125, 211, 252, 0.12);
+}
+.culture-turn-report__delta span {
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.culture-turn-report__delta b { color: #f8fafc; }
+.culture-turn-report__delta small {
+  grid-column: 2;
+  color: var(--muted);
+}
+.culture-turn-report__delta--risk { border-color: rgba(251, 113, 133, 0.26); }
+.culture-turn-report__delta--opportunity { border-color: rgba(251, 191, 36, 0.28); }
+.culture-turn-report__delta--research { border-color: rgba(34, 211, 238, 0.22); }
+.culture-turn-report--quiet > span { color: var(--muted); }
 .hero-stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Gamma: Closes #475.

## Summary
- add a reusable culture turn report delta builder for selected marker, timeline, and consequence-chip signals
- surface compact culture/discovery deltas in the map turn report area
- include quiet-state copy when no cultural delta is visible
- add deterministic tests for event, influence, research, tension, and quiet report outputs

## Validation
- `node --check web/app.js`
- `git diff --check`
- `npm test` (389 passing)

Gamma: Ready for Zeta validation before merge.
