### PR TITLE
Beta: show economy turn report deltas

### DIFF
--- a/src/ui/economy/buildProvinceEconomyTurnReport.js
+++ b/src/ui/economy/buildProvinceEconomyTurnReport.js
@@ -1,0 +1,128 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function formatSigned(value) {
+  return value > 0 ? `+${value}` : `${value}`;
+}
+
+function getDeltaTone(value, invert = false) {
+  if (value === 0) {
+    return 'neutral';
+  }
+
+  const improved = invert ? value < 0 : value > 0;
+  return improved ? 'improved' : 'worse';
+}
+
+function summarizeRouteDelta(route, delta) {
+  if (!delta) {
+    return null;
+  }
+
+  if (delta.activeDelta !== 0) {
+    return {
+      type: 'route',
+      tone: delta.activeDelta > 0 ? 'improved' : 'worse',
+      label: delta.activeDelta > 0 ? 'Route réparée' : 'Route dégradée',
+      detail: `${route.routeName}: ${delta.activeDelta > 0 ? 'flux réouvert' : 'flux interrompu'}, risque ${formatSigned(delta.riskDelta)}.`,
+      score: 120 + Math.abs(delta.riskDelta),
+    };
+  }
+
+  if (delta.riskDelta !== 0) {
+    return {
+      type: 'route',
+      tone: getDeltaTone(delta.riskDelta, true),
+      label: delta.riskDelta < 0 ? 'Stress logistique réduit' : 'Stress logistique accru',
+      detail: `${route.routeName}: risque ${formatSigned(delta.riskDelta)} depuis le dernier tour.`,
+      score: 90 + Math.abs(delta.riskDelta),
+    };
+  }
+
+  return null;
+}
+
+function summarizeCityDelta(city, delta) {
+  if (!delta) {
+    return null;
+  }
+
+  const productionDelta = delta.stockDelta ?? 0;
+  const stabilityDelta = delta.stabilityDelta ?? 0;
+  const prosperityDelta = delta.prosperityDelta ?? 0;
+  const strongest = [
+    { key: 'stock', label: productionDelta >= 0 ? 'Approvisionnement renforcé' : 'Approvisionnement en baisse', value: productionDelta, invert: false },
+    { key: 'stability', label: stabilityDelta >= 0 ? 'Stabilité logistique gagnée' : 'Stabilité logistique perdue', value: stabilityDelta, invert: false },
+    { key: 'prosperity', label: prosperityDelta >= 0 ? 'Gain économique' : 'Coût économique', value: prosperityDelta, invert: false },
+  ].sort((left, right) => Math.abs(right.value) - Math.abs(left.value))[0];
+
+  if (!strongest || strongest.value === 0) {
+    return null;
+  }
+
+  return {
+    type: 'city',
+    tone: getDeltaTone(strongest.value, strongest.invert),
+    label: strongest.label,
+    detail: `${city.cityName}: stock ${formatSigned(productionDelta)}, stabilité ${formatSigned(stabilityDelta)}, prospérité ${formatSigned(prosperityDelta)}.`,
+    score: 70 + Math.abs(strongest.value),
+  };
+}
+
+export function buildProvinceEconomyTurnReport(province, economyView, options = {}) {
+  const normalizedOptions = requireObject(options, 'ProvinceEconomyTurnReport options');
+  const previousChoice = normalizedOptions.previousChoice ?? null;
+
+  if (!province || !economyView) {
+    return {
+      tone: 'neutral',
+      summary: 'Aucun rapport économie/logistique disponible pour ce tour.',
+      previousAction: null,
+      deltas: [],
+    };
+  }
+
+  const cities = economyView.overlay?.cities ?? [];
+  const routes = economyView.overlay?.routes ?? [];
+  const deltaByCityId = economyView.deltaByCityId ?? {};
+  const routeDeltaById = economyView.routeDeltaById ?? {};
+  const provinceCities = cities.filter((city) => city.regionId === province.provinceId);
+  const provinceCityIds = new Set(provinceCities.map((city) => city.cityId));
+  const provinceRoutes = routes.filter((route) => route.cityIds.some((cityId) => provinceCityIds.has(cityId)));
+
+  const routeDeltas = provinceRoutes
+    .map((route) => summarizeRouteDelta(route, routeDeltaById[route.routeId]))
+    .filter(Boolean);
+  const cityDeltas = provinceCities
+    .map((city) => summarizeCityDelta(city, deltaByCityId[city.cityId]))
+    .filter(Boolean);
+  const deltas = [...routeDeltas, ...cityDeltas]
+    .sort((left, right) => right.score - left.score || left.label.localeCompare(right.label))
+    .slice(0, 4);
+
+  if (deltas.length === 0) {
+    return {
+      tone: 'neutral',
+      summary: `Aucun changement économie/logistique notable sur ${province.label ?? province.provinceId}.`,
+      previousAction: previousChoice ? `${previousChoice.action}: aucun delta mesurable ce tour.` : null,
+      deltas: [],
+    };
+  }
+
+  const improvedCount = deltas.filter((delta) => delta.tone === 'improved').length;
+  const worseCount = deltas.filter((delta) => delta.tone === 'worse').length;
+  const tone = worseCount > improvedCount ? 'worse' : improvedCount > 0 ? 'improved' : 'neutral';
+  const lead = deltas[0];
+
+  return {
+    tone,
+    summary: `${lead.label}: ${lead.detail}`,
+    previousAction: previousChoice ? `Action Beta précédente: ${previousChoice.action} sur ${previousChoice.routes?.join(', ') ?? 'route locale'}.` : null,
+    deltas,
+  };
+}

--- a/test/ui/economy/buildProvinceEconomyTurnReport.test.js
+++ b/test/ui/economy/buildProvinceEconomyTurnReport.test.js
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildProvinceEconomyTurnReport } from '../../../src/ui/economy/buildProvinceEconomyTurnReport.js';
+
+const province = { provinceId: 'river-gate', label: 'Porte du Fleuve' };
+
+function buildEconomyView({ routeDelta = -12, stockDelta = 4, stabilityDelta = 1 } = {}) {
+  return {
+    overlay: {
+      cities: [
+        { cityId: 'river-city', cityName: 'River Gate', regionId: 'river-gate' },
+        { cityId: 'port-city', cityName: 'Crown Port', regionId: 'crown-heart' },
+      ],
+      routes: [
+        {
+          routeId: 'river-road',
+          routeName: 'River Road',
+          cityIds: ['river-city', 'port-city'],
+        },
+      ],
+    },
+    deltaByCityId: {
+      'river-city': { stockDelta, stabilityDelta, prosperityDelta: 0 },
+    },
+    routeDeltaById: {
+      'river-road': { riskDelta: routeDelta, activeDelta: 0, capacityDelta: 0 },
+    },
+  };
+}
+
+test('buildProvinceEconomyTurnReport recommends visible improved logistics deltas first', () => {
+  const report = buildProvinceEconomyTurnReport(province, buildEconomyView(), {
+    previousChoice: { action: 'Sécuriser convoi', routes: ['River Road'] },
+  });
+
+  assert.equal(report.tone, 'improved');
+  assert.match(report.summary, /Stress logistique réduit/);
+  assert.match(report.previousAction, /Action Beta précédente: Sécuriser convoi/);
+  assert.equal(report.deltas[0].type, 'route');
+  assert.equal(report.deltas[0].tone, 'improved');
+  assert.match(report.deltas[0].detail, /risque -12/);
+});
+
+test('buildProvinceEconomyTurnReport surfaces degradation and economic cost labels', () => {
+  const report = buildProvinceEconomyTurnReport(province, buildEconomyView({ routeDelta: 8, stockDelta: -3 }));
+
+  assert.equal(report.tone, 'worse');
+  assert.ok(report.deltas.some((delta) => delta.label === 'Stress logistique accru'));
+  assert.ok(report.deltas.some((delta) => delta.label === 'Approvisionnement en baisse'));
+});
+
+test('buildProvinceEconomyTurnReport detects repaired or broken route state changes', () => {
+  const economyView = buildEconomyView();
+  economyView.routeDeltaById['river-road'] = { riskDelta: -4, activeDelta: 1, capacityDelta: 0 };
+
+  const report = buildProvinceEconomyTurnReport(province, economyView);
+
+  assert.equal(report.deltas[0].label, 'Route réparée');
+  assert.equal(report.deltas[0].tone, 'improved');
+});
+
+test('buildProvinceEconomyTurnReport returns a neutral empty state when nothing changed', () => {
+  const report = buildProvinceEconomyTurnReport(province, buildEconomyView({ routeDelta: 0, stockDelta: 0, stabilityDelta: 0 }));
+
+  assert.equal(report.tone, 'neutral');
+  assert.deepEqual(report.deltas, []);
+  assert.match(report.summary, /Aucun changement économie\/logistique notable/);
+});
+
+test('buildProvinceEconomyTurnReport validates options', () => {
+  assert.throws(() => buildProvinceEconomyTurnReport(province, buildEconomyView(), null), /options must be an object/);
+});

--- a/test/ui/economy/webProvinceEconomyTurnReport.test.js
+++ b/test/ui/economy/webProvinceEconomyTurnReport.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable map wires province economy turn report into selected province details', () => {
+  assert.match(webAppSource, /buildProvinceEconomyTurnReport/);
+  assert.match(webAppSource, /function renderProvinceEconomyTurnReport/);
+  assert.match(webAppSource, /Rapport économie dernier tour/);
+  assert.match(webAppSource, /routeDeltaById/);
+  assert.match(webAppSource, /previousChoice/);
+  assert.match(webAppSource, /renderProvinceEconomyTurnReport\(province, economyView\)/);
+  assert.match(stylesSource, /\.province-economy-turn-report/);
+  assert.match(stylesSource, /province-economy-turn-report--improved/);
+  assert.match(stylesSource, /province-economy-turn-report__delta--worse/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9,6 +9,7 @@ import { buildEconomyMapOverlay } from '../src/ui/economy/buildEconomyMapOverlay
 import { buildCityStockPanel } from '../src/ui/economy/buildCityStockPanel.js';
 import { buildCityComparisonPanel } from '../src/ui/economy/buildCityComparisonPanel.js';
 import { buildProvinceLogisticsChoicePreview } from '../src/ui/economy/buildProvinceLogisticsChoicePreview.js';
+import { buildProvinceEconomyTurnReport } from '../src/ui/economy/buildProvinceEconomyTurnReport.js';
 import { Cellule } from '../src/domain/intrigue/Cellule.js';
 import { OperationClandestine } from '../src/domain/intrigue/OperationClandestine.js';
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
@@ -1035,10 +1036,14 @@ function renderProvinceLogisticsBottleneckComparison(province, economyView) {
   `;
 }
 
-function renderProvinceLogisticsChoicePreview(province, economyView) {
-  const preview = buildProvinceLogisticsChoicePreview(province, economyView, {
+function buildProvinceLogisticsChoicePreviewView(province, economyView) {
+  return buildProvinceLogisticsChoicePreview(province, economyView, {
     resourceLabelById: Object.fromEntries(Object.entries(resourceHudById).map(([resourceId, hud]) => [resourceId, hud.label])),
   });
+}
+
+function renderProvinceLogisticsChoicePreview(province, economyView) {
+  const preview = buildProvinceLogisticsChoicePreviewView(province, economyView);
 
   if (preview.options.length === 0) {
     return '';
@@ -1069,6 +1074,32 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
           </article>
         `).join('')}
       </div>
+    </section>
+  `;
+}
+
+function renderProvinceEconomyTurnReport(province, economyView) {
+  const previousChoice = buildProvinceLogisticsChoicePreviewView(province, economyView).options[0] ?? null;
+  const report = buildProvinceEconomyTurnReport(province, economyView, { previousChoice });
+
+  return `
+    <section class="province-economy-turn-report province-economy-turn-report--${report.tone}" aria-label="Rapport économie et logistique du dernier tour">
+      <div class="province-economy-turn-report__header">
+        <strong>Rapport économie dernier tour</strong>
+        <span>${report.deltas.length > 0 ? `${report.deltas.length} delta${report.deltas.length > 1 ? 's' : ''}` : 'stable'}</span>
+      </div>
+      <p>${report.summary}</p>
+      ${report.previousAction ? `<small>${report.previousAction}</small>` : ''}
+      ${report.deltas.length > 0 ? `
+        <ul class="province-economy-turn-report__list">
+          ${report.deltas.map((delta) => `
+            <li class="province-economy-turn-report__delta province-economy-turn-report__delta--${delta.tone}">
+              <b>${delta.label}</b>
+              <span>${delta.detail}</span>
+            </li>
+          `).join('')}
+        </ul>
+      ` : ''}
     </section>
   `;
 }
@@ -1268,6 +1299,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
         <p>${comparedProvinceNames.length > 0 ? comparedProvinceNames.join(' vs ') : 'Aucune province comparée pour le moment.'}</p>
       </div>
       ${renderProvinceEconomyConsequences(province, economyView)}
+      ${renderProvinceEconomyTurnReport(province, economyView)}
       ${renderProvinceLogisticsBottleneckComparison(province, economyView)}
       ${renderProvinceLogisticsChoicePreview(province, economyView)}
     </section>
@@ -1301,11 +1333,11 @@ function getCityStateByTurn(city, explicitTurn = state.turn) {
   });
 }
 
-function getRouteStateByTurn(route) {
+function getRouteStateByTurn(route, explicitTurn = state.turn, explicitSeasonIndex = state.seasonIndex) {
   return new TradeRoute({
     ...route.toJSON(),
-    active: route.id === 'southern-grainway' ? state.seasonIndex !== 3 : route.active,
-    riskLevel: Math.max(0, Math.min(100, route.riskLevel + (route.id === 'ember-foundry-line' ? state.turn * 3 : state.seasonIndex === 3 ? 8 : -2))),
+    active: route.id === 'southern-grainway' ? explicitSeasonIndex !== 3 : route.active,
+    riskLevel: Math.max(0, Math.min(100, route.riskLevel + (route.id === 'ember-foundry-line' ? explicitTurn * 3 : explicitSeasonIndex === 3 ? 8 : -2))),
   });
 }
 
@@ -1473,6 +1505,8 @@ function getEconomyViewModel() {
   const previousTurn = Math.max(1, state.turn - 1);
   const previousCities = cities.map((city) => getCityStateByTurn(city, previousTurn));
   const liveRoutes = routes.map(getRouteStateByTurn);
+  const previousSeasonIndex = (state.seasonIndex + seasonLabels.length - 1) % seasonLabels.length;
+  const previousRoutes = routes.map((route) => getRouteStateByTurn(route, previousTurn, previousSeasonIndex));
   const overlay = buildEconomyMapOverlay(liveCities, liveRoutes, { cityPositionById: cityLayoutsById });
   const comparison = buildCityComparisonPanel(liveCities, { desiredStockByCityId });
   const stockPanels = Object.fromEntries(
@@ -1492,11 +1526,23 @@ function getEconomyViewModel() {
     }),
   );
 
+  const routeDeltaById = Object.fromEntries(
+    liveRoutes.map((route) => {
+      const previousRoute = previousRoutes.find((candidate) => candidate.id === route.id) ?? route;
+
+      return [route.id, {
+        riskDelta: route.riskLevel - previousRoute.riskLevel,
+        activeDelta: Number(route.active) - Number(previousRoute.active),
+        capacityDelta: route.totalCapacity - previousRoute.totalCapacity,
+      }];
+    }),
+  );
+
   const pulse = liveCities
     .map((city) => ({ city, delta: deltaByCityId[city.id] }))
     .sort((left, right) => Math.abs(right.delta.stockDelta) - Math.abs(left.delta.stockDelta))[0] ?? null;
 
-  return { overlay, comparison, stockPanels, cities: liveCities, routes: liveRoutes, deltaByCityId, pulse };
+  return { overlay, comparison, stockPanels, cities: liveCities, routes: liveRoutes, deltaByCityId, routeDeltaById, pulse };
 }
 
 function buildRouteVisual(route, origin, destination, index) {

--- a/web/styles.css
+++ b/web/styles.css
@@ -2036,6 +2036,67 @@ button { font: inherit; }
   margin: 3px 0 0;
   font-size: 12px;
 }
+.province-economy-turn-report {
+  display: grid;
+  gap: 9px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(8, 47, 73, 0.32), rgba(15, 23, 42, 0.56));
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.province-economy-turn-report__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-economy-turn-report__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-economy-turn-report > p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.province-economy-turn-report > small {
+  color: var(--muted);
+  line-height: 1.35;
+}
+.province-economy-turn-report--improved { border-color: rgba(74, 222, 128, 0.32); }
+.province-economy-turn-report--worse { border-color: rgba(251, 113, 133, 0.4); }
+.province-economy-turn-report--neutral { border-color: rgba(148, 163, 184, 0.18); }
+.province-economy-turn-report__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.province-economy-turn-report__delta {
+  display: grid;
+  gap: 3px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.province-economy-turn-report__delta b {
+  color: #e0f2fe;
+  font-size: 12px;
+}
+.province-economy-turn-report__delta span {
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-economy-turn-report__delta--improved { border-color: rgba(74, 222, 128, 0.26); }
+.province-economy-turn-report__delta--worse { border-color: rgba(251, 113, 133, 0.34); }
+.province-economy-turn-report__delta--neutral { border-color: rgba(148, 163, 184, 0.16); }
 .overlay-anchor {
   flex: 1 1 140px;
   padding: 12px;


### PR DESCRIPTION
Beta: Implements #474.

Scope:
- add a reusable province economy/logistics turn report builder;
- compare selected-province route and city deltas from existing economy state;
- surface repaired/degraded routes, logistics stress, stock/stability/prosperity deltas, and the prior Beta choice context;
- wire a compact report into the selected province panel with neutral empty state.

Validation:
- node --test test/ui/economy/buildProvinceEconomyTurnReport.test.js test/ui/economy/webProvinceEconomyTurnReport.test.js
- npm test (393 passing)
- node --check web/app.js
- node --check src/ui/economy/buildProvinceEconomyTurnReport.js
- git diff --check

Ready for Zeta validation before merge.