### PR TITLE
Delta: Show intrigue turn report deltas

### DIFF
--- a/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
+++ b/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
@@ -1,0 +1,130 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function getResponseTone(response) {
+  if (!response) {
+    return 'masked';
+  }
+
+  if (response.escalationProbability === 'élevée') {
+    return 'worse';
+  }
+
+  if (['contenir', 'exposer'].includes(response.code)) {
+    return 'improved';
+  }
+
+  if (response.code === 'infiltrer') {
+    return 'watch';
+  }
+
+  return 'masked';
+}
+
+function buildResponseDeltas(response, fallbackSummary) {
+  if (!response) {
+    return [];
+  }
+
+  const threatLabel = response.code === 'surveiller'
+    ? 'Menace masquée'
+    : response.escalationProbability === 'élevée'
+      ? 'Menace aggravée'
+      : 'Menace contenue';
+  const sabotageLabel = response.code === 'contenir'
+    ? 'Sabotage évité'
+    : response.code === 'exposer'
+      ? 'Réseau exposé'
+      : response.code === 'infiltrer'
+        ? 'Réseau stabilisé'
+        : 'Signal surveillé';
+
+  return [
+    {
+      type: 'threat',
+      tone: getResponseTone(response),
+      label: threatLabel,
+      detail: fallbackSummary ?? response.effect,
+      score: response.escalationProbability === 'élevée' ? 120 : 90,
+    },
+    {
+      type: 'cooldown',
+      tone: response.cooldownTurns > 0 ? 'watch' : 'improved',
+      label: response.cooldownTurns > 0 ? 'Cooldown restant' : 'Cooldown nul',
+      detail: `${response.cooldownTurns} tour${response.cooldownTurns > 1 ? 's' : ''} avant réponse lourde; chaleur générée +${response.heatGenerated}.`,
+      score: 80 + response.cooldownTurns,
+    },
+    {
+      type: 'network',
+      tone: response.code === 'surveiller' ? 'masked' : response.code === 'exposer' ? 'improved' : 'watch',
+      label: sabotageLabel,
+      detail: response.effect,
+      score: response.code === 'contenir' ? 100 : response.code === 'exposer' ? 95 : 70,
+    },
+  ];
+}
+
+function findSelectedDrillDown(province, intrigueView) {
+  const provinceId = province?.provinceId;
+  const selectedDrillDown = intrigueView?.selectedProvince?.drillDown ?? null;
+
+  if (selectedDrillDown?.locationId === provinceId) {
+    return selectedDrillDown;
+  }
+
+  return (intrigueView?.map?.entries ?? [])
+    .find((entry) => entry.locationId === provinceId)?.drillDown ?? null;
+}
+
+export function buildIntrigueTurnReportDeltas(province, intrigueView, options = {}) {
+  const normalizedOptions = requireObject(options, 'IntrigueTurnReportDeltas options');
+  const previousActionCode = normalizedOptions.previousActionCode ?? null;
+
+  if (!province || !intrigueView) {
+    return {
+      tone: 'masked',
+      summary: 'Rapport intrigue masqué: aucune donnée fiable pour ce tour.',
+      previousAction: null,
+      deltas: [],
+    };
+  }
+
+  const drillDown = findSelectedDrillDown(province, intrigueView);
+
+  if (!drillDown) {
+    return {
+      tone: 'masked',
+      summary: `Renseignement discret sur ${province.label ?? province.provinceId}: aucun delta confirmé ou volontairement masqué.`,
+      previousAction: previousActionCode ? `Action Delta précédente: ${previousActionCode}; résultat non confirmé.` : null,
+      deltas: [],
+    };
+  }
+
+  const response = drillDown.quickResponses?.find((candidate) => candidate.code === previousActionCode)
+    ?? drillDown.quickResponses?.find((candidate) => candidate.code === drillDown.recommendedResponseCode)
+    ?? drillDown.quickResponses?.[0]
+    ?? null;
+  const deltas = buildResponseDeltas(response, drillDown.responseAftermath?.summary)
+    .sort((left, right) => right.score - left.score || left.label.localeCompare(right.label))
+    .slice(0, 4);
+  const worseCount = deltas.filter((delta) => delta.tone === 'worse').length;
+  const improvedCount = deltas.filter((delta) => delta.tone === 'improved').length;
+  const tone = worseCount > 0 ? 'worse' : improvedCount > 0 ? 'improved' : deltas.length > 0 ? 'watch' : 'masked';
+  const lead = deltas[0] ?? null;
+  const actionLabel = response?.label ?? previousActionCode ?? 'inaction';
+
+  return {
+    tone,
+    summary: lead
+      ? `${lead.label}: ${lead.detail}`
+      : `Renseignement discret sur ${drillDown.locationName}: aucun delta confirmé.`,
+    previousAction: `Action Delta résolue: ${actionLabel} sur ${drillDown.locationName}.`,
+    deltas,
+    retaliationRisk: drillDown.responseAftermath?.retaliationRisk ?? 'inconnu',
+  };
+}

--- a/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildIntrigueTurnReportDeltas } from '../../../src/ui/intrigue/buildIntrigueTurnReportDeltas.js';
+
+const province = { provinceId: 'ashlands', label: 'Ashlands' };
+
+function buildIntrigueView(responseOverrides = {}) {
+  const response = {
+    code: 'contenir',
+    label: 'Contenir',
+    cooldownTurns: 2,
+    heatGenerated: 17,
+    escalationProbability: 'moyenne',
+    effect: 'cellule compromise: pression sécuritaire immédiate; opération execution ralentie',
+    ...responseOverrides,
+  };
+
+  return {
+    selectedProvince: {
+      drillDown: {
+        locationId: 'ashlands',
+        locationName: 'Ashlands',
+        recommendedResponseCode: response.code,
+        quickResponses: [response],
+        responseAftermath: {
+          retaliationRisk: response.escalationProbability === 'élevée' ? 'élevé' : 'modéré',
+          summary: 'Plus sûre: Infiltrer; plus efficace: Contenir; représailles modéré.',
+        },
+      },
+    },
+    map: { entries: [] },
+  };
+}
+
+test('buildIntrigueTurnReportDeltas summarizes resolved intrigue action deltas', () => {
+  const report = buildIntrigueTurnReportDeltas(province, buildIntrigueView(), { previousActionCode: 'contenir' });
+
+  assert.equal(report.tone, 'improved');
+  assert.equal(report.previousAction, 'Action Delta résolue: Contenir sur Ashlands.');
+  assert.equal(report.retaliationRisk, 'modéré');
+  assert.match(report.summary, /Sabotage évité|Menace contenue/);
+  assert.deepEqual(report.deltas.map((delta) => delta.type).sort(), ['cooldown', 'network', 'threat']);
+  assert.ok(report.deltas.some((delta) => delta.label === 'Cooldown restant' && /chaleur générée \+17/.test(delta.detail)));
+});
+
+test('buildIntrigueTurnReportDeltas marks aggravated and exposed aftermath clearly', () => {
+  const report = buildIntrigueTurnReportDeltas(province, buildIntrigueView({
+    code: 'exposer',
+    label: 'Exposer',
+    escalationProbability: 'élevée',
+    cooldownTurns: 1,
+    heatGenerated: 23,
+    effect: 'cellule exposée: preuve rendue exploitable, réseau adverse alerté',
+  }));
+
+  assert.equal(report.tone, 'worse');
+  assert.equal(report.retaliationRisk, 'élevé');
+  assert.equal(report.deltas[0].label, 'Menace aggravée');
+  assert.ok(report.deltas.some((delta) => delta.label === 'Réseau exposé'));
+});
+
+test('buildIntrigueTurnReportDeltas keeps unknown intelligence discreet', () => {
+  assert.deepEqual(buildIntrigueTurnReportDeltas(province, null), {
+    tone: 'masked',
+    summary: 'Rapport intrigue masqué: aucune donnée fiable pour ce tour.',
+    previousAction: null,
+    deltas: [],
+  });
+
+  const report = buildIntrigueTurnReportDeltas(province, { map: { entries: [] } }, { previousActionCode: 'surveiller' });
+  assert.equal(report.tone, 'masked');
+  assert.match(report.summary, /aucun delta confirmé/);
+  assert.equal(report.previousAction, 'Action Delta précédente: surveiller; résultat non confirmé.');
+  assert.deepEqual(report.deltas, []);
+});
+
+test('buildIntrigueTurnReportDeltas validates options', () => {
+  assert.throws(() => buildIntrigueTurnReportDeltas(province, buildIntrigueView(), null), /options must be an object/);
+});

--- a/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('playable map wires intrigue aftermath deltas into selected province turn report', () => {
+  assert.match(webAppSource, /buildIntrigueTurnReportDeltas/);
+  assert.match(webAppSource, /function renderIntrigueTurnReportDeltas/);
+  assert.match(webAppSource, /Rapport intrigue dernier tour/);
+  assert.match(webAppSource, /Risque représailles/);
+  assert.match(webAppSource, /renderIntrigueTurnReportDeltas\(province, intrigueView\)/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -13,6 +13,7 @@ import { buildProvinceEconomyTurnReport } from '../src/ui/economy/buildProvinceE
 import { Cellule } from '../src/domain/intrigue/Cellule.js';
 import { OperationClandestine } from '../src/domain/intrigue/OperationClandestine.js';
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
+import { buildIntrigueTurnReportDeltas } from '../src/ui/intrigue/buildIntrigueTurnReportDeltas.js';
 import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMapRecommendations.js';
 import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTimeline.js';
 import { buildCultureConsequenceChips } from '../src/ui/culture/buildCultureConsequenceChips.js';
@@ -1117,6 +1118,35 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
   `;
 }
 
+
+function renderIntrigueTurnReportDeltas(province, intrigueView) {
+  const report = buildIntrigueTurnReportDeltas(province, intrigueView, {
+    previousActionCode: intrigueView?.selectedProvince?.drillDown?.recommendedResponseCode ?? null,
+  });
+
+  return `
+    <section class="province-intrigue-turn-report province-intrigue-turn-report--${report.tone}" aria-label="Rapport intrigue du dernier tour">
+      <div class="province-intrigue-turn-report__header">
+        <strong>Rapport intrigue dernier tour</strong>
+        <span>${report.deltas.length > 0 ? `${report.deltas.length} delta${report.deltas.length > 1 ? 's' : ''}` : 'masqué'}</span>
+      </div>
+      <p>${report.summary}</p>
+      ${report.previousAction ? `<small>${report.previousAction}</small>` : ''}
+      ${report.retaliationRisk ? `<small>Risque représailles: ${report.retaliationRisk}</small>` : ''}
+      ${report.deltas.length > 0 ? `
+        <ul class="province-intrigue-turn-report__list">
+          ${report.deltas.map((delta) => `
+            <li class="province-intrigue-turn-report__delta province-intrigue-turn-report__delta--${delta.tone}">
+              <b>${delta.label}</b>
+              <span>${delta.detail}</span>
+            </li>
+          `).join('')}
+        </ul>
+      ` : ''}
+    </section>
+  `;
+}
+
 function renderProvinceEconomyTurnReport(province, economyView) {
   const previousChoice = buildProvinceLogisticsChoicePreviewView(province, economyView).options[0] ?? null;
   const report = buildProvinceEconomyTurnReport(province, economyView, { previousChoice });
@@ -1398,6 +1428,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}
+      ${renderIntrigueTurnReportDeltas(province, intrigueView)}
       <div class="context-summary">
         <strong>Comparaison rapide</strong>
         <p>${comparedProvinceNames.length > 0 ? comparedProvinceNames.join(' vs ') : 'Aucune province comparée pour le moment.'}</p>

--- a/web/styles.css
+++ b/web/styles.css
@@ -4469,3 +4469,52 @@ button { font: inherit; }
 .intrigue-quick-response em {
   font-style: normal;
 }
+
+
+.province-intrigue-turn-report {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.province-intrigue-turn-report--improved { border-color: rgba(34, 197, 94, 0.32); }
+.province-intrigue-turn-report--worse { border-color: rgba(248, 113, 113, 0.34); }
+.province-intrigue-turn-report--watch { border-color: rgba(250, 204, 21, 0.3); }
+.province-intrigue-turn-report--masked { border-color: rgba(148, 163, 184, 0.16); }
+.province-intrigue-turn-report__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.province-intrigue-turn-report p,
+.province-intrigue-turn-report small {
+  display: block;
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+.province-intrigue-turn-report__list {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.province-intrigue-turn-report__delta {
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.28);
+  border-left: 3px solid rgba(148, 163, 184, 0.4);
+}
+.province-intrigue-turn-report__delta--improved { border-left-color: rgba(34, 197, 94, 0.72); }
+.province-intrigue-turn-report__delta--worse { border-left-color: rgba(248, 113, 113, 0.76); }
+.province-intrigue-turn-report__delta--watch { border-left-color: rgba(250, 204, 21, 0.7); }
+.province-intrigue-turn-report__delta--masked { border-left-color: rgba(148, 163, 184, 0.46); }
+.province-intrigue-turn-report__delta b,
+.province-intrigue-turn-report__delta span {
+  display: block;
+}
+.province-intrigue-turn-report__delta span {
+  margin-top: 3px;
+  color: var(--muted);
+}


### PR DESCRIPTION
Delta: Closes #476.

Summary:
- add an intrigue turn report builder for selected province/hotspot aftermath deltas;
- surface threat, cooldown/heat, sabotage/network outcomes, previous Delta action, retaliation risk, and masked unknown states;
- render the report in selected province details without changing intrigue resolution systems.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
- npm test (401 passing)

Delta: Ready for Zeta validation before merge.