### PR TITLE
Epsilon: Show climate turn report deltas

### DIFF
--- a/src/ui/climate/buildClimateTurnReportDeltas.js
+++ b/src/ui/climate/buildClimateTurnReportDeltas.js
@@ -1,0 +1,239 @@
+function normalizeText(value, fallback = '') {
+  return String(value ?? fallback).trim() || fallback;
+}
+
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+const RISK_SCORE = Object.freeze({ stable: 0, strained: 1, critical: 2 });
+
+function getRiskScore(riskLevel) {
+  return RISK_SCORE[normalizeText(riskLevel, 'strained')] ?? 1;
+}
+
+function getSelectedRisk(climateOverlay, regionId) {
+  const comparison = climateOverlay?.selectedClimateImpactComparison;
+
+  if (comparison?.current?.riskLevel) {
+    return comparison.current.riskLevel;
+  }
+
+  const region = (climateOverlay?.regions ?? []).find((candidate) => candidate.regionId === regionId);
+  return region?.strategicImpact ?? null;
+}
+
+function getSelectedAnomaly(climateOverlay, regionId) {
+  const comparison = climateOverlay?.selectedClimateImpactComparison;
+
+  if (comparison?.current) {
+    return comparison.current.anomaly ?? null;
+  }
+
+  const region = (climateOverlay?.regions ?? []).find((candidate) => candidate.regionId === regionId);
+  return region?.anomaly ?? null;
+}
+
+function buildDelta(delta) {
+  return {
+    deltaId: delta.deltaId,
+    tone: delta.tone,
+    label: delta.label,
+    value: delta.value,
+    reason: delta.reason,
+    regionId: delta.regionId,
+    forecast: delta.forecast ?? null,
+    realized: delta.realized ?? null,
+  };
+}
+
+function buildRiskDelta({ regionId, currentRisk, previousRisk, currentAnomaly, previousAnomaly }) {
+  if (!currentRisk && !previousRisk) {
+    return null;
+  }
+
+  const currentScore = getRiskScore(currentRisk ?? previousRisk);
+  const previousScore = getRiskScore(previousRisk ?? currentRisk);
+  const riskDelta = currentScore - previousScore;
+
+  if (riskDelta !== 0) {
+    return buildDelta({
+      deltaId: `${regionId}:climate:risk`,
+      tone: riskDelta < 0 ? 'improved' : 'worse',
+      label: riskDelta < 0 ? 'Risque climat réduit' : 'Risque climat accru',
+      value: `${previousRisk ?? 'inconnu'} → ${currentRisk ?? 'inconnu'}`,
+      reason: riskDelta < 0
+        ? 'Le dernier tour a fait baisser la pression climat visible.'
+        : 'Le dernier tour a renforcé la pression climat ou catastrophe.',
+      regionId,
+      realized: { previousRiskLevel: previousRisk ?? null, currentRiskLevel: currentRisk ?? null },
+    });
+  }
+
+  if ((currentAnomaly ?? null) !== (previousAnomaly ?? null)) {
+    return buildDelta({
+      deltaId: `${regionId}:climate:anomaly`,
+      tone: currentAnomaly ? 'worse' : 'improved',
+      label: currentAnomaly ? 'Anomalie apparue' : 'Anomalie résorbée',
+      value: currentAnomaly ? `${currentAnomaly}` : `${previousAnomaly} terminée`,
+      reason: currentAnomaly
+        ? 'Un signal météo impose de relire les choix de mitigation.'
+        : 'Le signal météo précédent ne pèse plus sur la province.',
+      regionId,
+      realized: { previousAnomaly: previousAnomaly ?? null, currentAnomaly: currentAnomaly ?? null },
+    });
+  }
+
+  return buildDelta({
+    deltaId: `${regionId}:climate:stable`,
+    tone: 'neutral',
+    label: 'Climat stable',
+    value: currentRisk ?? 'stable',
+    reason: 'Aucun changement de risque climat notable ce tour.',
+    regionId,
+    realized: { previousRiskLevel: previousRisk ?? null, currentRiskLevel: currentRisk ?? null },
+  });
+}
+
+function buildRecoveryDelta(regionId, previousForecast, realizedRecoveryByChoiceId) {
+  const forecasts = previousForecast?.forecasts ?? [];
+
+  if (forecasts.length === 0) {
+    return null;
+  }
+
+  const expected = forecasts[0];
+  const realized = realizedRecoveryByChoiceId?.[expected.choiceId] ?? null;
+  const realizedWindowDays = realized?.recoveryWindowDays ?? expected.recoveryWindowDays;
+  const deltaDays = realizedWindowDays - expected.recoveryWindowDays;
+
+  return buildDelta({
+    deltaId: `${regionId}:climate:recovery:${expected.choiceId}`,
+    tone: deltaDays <= 0 ? 'improved' : deltaDays <= 4 ? 'partial' : 'worse',
+    label: deltaDays <= 0 ? 'Récupération engagée' : deltaDays <= 4 ? 'Récupération partielle' : 'Récupération retardée',
+    value: `${expected.label} · prévu ${expected.recoveryWindowDays}j / réalisé ${realizedWindowDays}j`,
+    reason: realized?.summary ?? expected.summary,
+    regionId,
+    forecast: {
+      choiceId: expected.choiceId,
+      recoveryWindowDays: expected.recoveryWindowDays,
+      relapseRisk: expected.relapseRisk,
+      nextCriticalSeason: expected.nextCriticalSeason,
+    },
+    realized: {
+      recoveryWindowDays: realizedWindowDays,
+      relapseRisk: realized?.relapseRisk ?? expected.relapseRisk,
+      status: realized?.status ?? (deltaDays <= 0 ? 'on-track' : 'partial'),
+    },
+  });
+}
+
+function buildUpcomingDelta(regionId, climateOverlay, upcomingSeason) {
+  const timing = climateOverlay?.selectedClimateTimingRecommendation;
+  const preview = climateOverlay?.seasonPreview;
+  const label = normalizeText(upcomingSeason ?? preview?.previewLabel ?? timing?.previewSeason, 'saison suivante');
+
+  if (!timing || timing.state === 'no-selection' || timing.state === 'missing-climate-data') {
+    return null;
+  }
+
+  if (timing.direction === 'riskier' || timing.urgency === 'act-before-preview') {
+    return buildDelta({
+      deltaId: `${regionId}:climate:upcoming-risk`,
+      tone: 'warning',
+      label: 'Saison critique proche',
+      value: label,
+      reason: timing.copy,
+      regionId,
+      forecast: { direction: timing.direction, urgency: timing.urgency },
+    });
+  }
+
+  if (timing.direction === 'safer') {
+    return buildDelta({
+      deltaId: `${regionId}:climate:upcoming-window`,
+      tone: 'improved',
+      label: 'Fenêtre météo favorable',
+      value: label,
+      reason: timing.copy,
+      regionId,
+      forecast: { direction: timing.direction, urgency: timing.urgency },
+    });
+  }
+
+  return null;
+}
+
+function dedupeAndSort(deltas) {
+  const toneRank = { worse: 6, warning: 5, partial: 4, improved: 3, neutral: 1 };
+
+  const deltaPriority = (delta) => delta.deltaId.includes(':risk')
+    ? 20
+    : delta.deltaId.includes(':recovery')
+      ? 15
+      : delta.deltaId.includes(':upcoming')
+        ? 10
+        : 0;
+
+  return [...new Map(deltas.filter(Boolean).map((delta) => [delta.deltaId, delta])).values()]
+    .sort((left, right) => {
+      const priorityComparison = deltaPriority(right) - deltaPriority(left);
+
+      if (priorityComparison !== 0) {
+        return priorityComparison;
+      }
+
+      return (toneRank[right.tone] ?? 0) - (toneRank[left.tone] ?? 0) || left.label.localeCompare(right.label);
+    })
+    .slice(0, 4);
+}
+
+export function buildClimateTurnReportDeltas({
+  turn = 1,
+  selectedRegionId,
+  climateOverlay = null,
+  previousClimateOverlay = null,
+  previousRecoveryForecast = null,
+  realizedRecoveryByChoiceId = {},
+  upcomingSeason = null,
+} = {}) {
+  requireObject(realizedRecoveryByChoiceId, 'ClimateTurnReportDeltas realizedRecoveryByChoiceId');
+
+  const regionId = normalizeText(selectedRegionId ?? climateOverlay?.selectedClimateImpactComparison?.regionId, 'province');
+  const currentRisk = getSelectedRisk(climateOverlay, regionId);
+  const previousRisk = getSelectedRisk(previousClimateOverlay, regionId) ?? previousRecoveryForecast?.summary?.currentRiskLevel ?? null;
+  const currentAnomaly = getSelectedAnomaly(climateOverlay, regionId);
+  const previousAnomaly = getSelectedAnomaly(previousClimateOverlay, regionId);
+  const deltas = dedupeAndSort([
+    buildRiskDelta({ regionId, currentRisk, previousRisk, currentAnomaly, previousAnomaly }),
+    buildRecoveryDelta(regionId, previousRecoveryForecast ?? climateOverlay?.selectedClimateRecoveryForecast, realizedRecoveryByChoiceId),
+    buildUpcomingDelta(regionId, climateOverlay, upcomingSeason),
+  ]);
+
+  if (deltas.length === 0) {
+    return {
+      state: 'quiet',
+      turn,
+      regionId,
+      summary: 'Aucun delta climat/catastrophe visible ce tour.',
+      deltas: [],
+    };
+  }
+
+  const worseCount = deltas.filter((delta) => delta.tone === 'worse' || delta.tone === 'warning').length;
+  const improvedCount = deltas.filter((delta) => delta.tone === 'improved').length;
+  const state = worseCount > 0 ? 'risk' : improvedCount > 0 ? 'recovery' : 'stable';
+  const lead = deltas[0];
+
+  return {
+    state,
+    turn,
+    regionId,
+    summary: `Tour ${turn}: ${lead.label} — ${lead.value}.`,
+    deltas,
+  };
+}

--- a/test/ui/climate/buildClimateTurnReportDeltas.test.js
+++ b/test/ui/climate/buildClimateTurnReportDeltas.test.js
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildClimateMapOverlay } from '../../../src/ui/climate/buildClimateMapOverlay.js';
+import { buildClimateTurnReportDeltas } from '../../../src/ui/climate/buildClimateTurnReportDeltas.js';
+
+function buildOverlay({ risk = 'critical', anomaly = 'drought', previewRisk = 'strained' } = {}) {
+  return buildClimateMapOverlay([
+    {
+      regionId: 'sunreach',
+      season: 'summer',
+      temperatureC: risk === 'stable' ? 20 : 35,
+      precipitationLevel: risk === 'stable' ? 45 : 8,
+      droughtIndex: risk === 'critical' ? 78 : risk === 'strained' ? 38 : 8,
+      anomaly,
+    },
+  ], {
+    selectedRegionId: 'sunreach',
+    seasonLabels: { summer: 'Été', autumn: 'Automne' },
+    seasonPreview: {
+      season: 'autumn',
+      impactsByRegion: {
+        sunreach: { strategicImpact: previewRisk, anomaly: previewRisk === 'stable' ? null : anomaly },
+      },
+    },
+  });
+}
+
+test('buildClimateTurnReportDeltas shows risk reduction and forecast versus realized recovery', () => {
+  const previousOverlay = buildOverlay({ risk: 'critical', anomaly: 'drought', previewRisk: 'critical' });
+  const currentOverlay = buildOverlay({ risk: 'strained', anomaly: null, previewRisk: 'stable' });
+  const report = buildClimateTurnReportDeltas({
+    turn: 7,
+    selectedRegionId: 'sunreach',
+    previousClimateOverlay: previousOverlay,
+    climateOverlay: currentOverlay,
+    previousRecoveryForecast: previousOverlay.selectedClimateRecoveryForecast,
+    realizedRecoveryByChoiceId: {
+      'evacuate-risk-zones': {
+        recoveryWindowDays: 18,
+        relapseRisk: 'low',
+        status: 'on-track',
+        summary: 'Mitigation réalisée plus vite que prévu.',
+      },
+    },
+  });
+
+  assert.equal(report.state, 'recovery');
+  assert.equal(report.summary, 'Tour 7: Risque climat réduit — critical → strained.');
+  assert.deepEqual(report.deltas.map((delta) => [delta.tone, delta.label]), [
+    ['improved', 'Risque climat réduit'],
+    ['improved', 'Récupération engagée'],
+    ['improved', 'Fenêtre météo favorable'],
+  ]);
+  assert.deepEqual(report.deltas.find((delta) => delta.label === 'Récupération engagée').forecast, {
+    choiceId: 'evacuate-risk-zones',
+    recoveryWindowDays: 20,
+    relapseRisk: 'medium',
+    nextCriticalSeason: 'Automne',
+  });
+  assert.deepEqual(report.deltas.find((delta) => delta.label === 'Récupération engagée').realized, {
+    recoveryWindowDays: 18,
+    relapseRisk: 'low',
+    status: 'on-track',
+  });
+});
+
+test('buildClimateTurnReportDeltas warns when risk increases and a critical season approaches', () => {
+  const previousOverlay = buildOverlay({ risk: 'stable', anomaly: null, previewRisk: 'critical' });
+  const currentOverlay = buildOverlay({ risk: 'critical', anomaly: 'drought', previewRisk: 'critical' });
+  const report = buildClimateTurnReportDeltas({
+    turn: 8,
+    selectedRegionId: 'sunreach',
+    previousClimateOverlay: previousOverlay,
+    climateOverlay: currentOverlay,
+    upcomingSeason: 'Automne sec',
+  });
+
+  assert.equal(report.state, 'risk');
+  assert.deepEqual(report.deltas.map((delta) => [delta.tone, delta.label, delta.value]), [
+    ['worse', 'Risque climat accru', 'stable → critical'],
+    ['improved', 'Récupération engagée', 'Évacuer les zones exposées · prévu 20j / réalisé 20j'],
+  ]);
+});
+
+test('buildClimateTurnReportDeltas reports stable quiet state without climate data', () => {
+  assert.deepEqual(buildClimateTurnReportDeltas({ turn: 3, selectedRegionId: 'quiet-field' }), {
+    state: 'quiet',
+    turn: 3,
+    regionId: 'quiet-field',
+    summary: 'Aucun delta climat/catastrophe visible ce tour.',
+    deltas: [],
+  });
+});
+
+test('buildClimateTurnReportDeltas validates realized recovery map', () => {
+  assert.throws(() => buildClimateTurnReportDeltas({ realizedRecoveryByChoiceId: null }), /realizedRecoveryByChoiceId must be an object/);
+});

--- a/test/ui/climate/webClimateTurnReportDeltas.test.js
+++ b/test/ui/climate/webClimateTurnReportDeltas.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable map wires climate recovery and risk deltas into selected province turn report', () => {
+  assert.match(webAppSource, /buildClimateTurnReportDeltas/);
+  assert.match(webAppSource, /function renderProvinceClimateTurnReport/);
+  assert.match(webAppSource, /Rapport climat dernier tour/);
+  assert.match(webAppSource, /Prévu: /);
+  assert.match(webAppSource, /Réalisé: /);
+  assert.match(webAppSource, /renderProvinceClimateTurnReport\(province\)/);
+  assert.match(stylesSource, /\.province-climate-turn-report/);
+  assert.match(stylesSource, /province-climate-turn-report--recovery/);
+  assert.match(stylesSource, /province-climate-turn-report--risk/);
+  assert.match(stylesSource, /province-climate-turn-report__delta--partial/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -18,6 +18,7 @@ import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMa
 import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTimeline.js';
 import { buildCultureConsequenceChips } from '../src/ui/culture/buildCultureConsequenceChips.js';
 import { buildCultureTurnReportDeltas } from '../src/ui/culture/buildCultureTurnReportDeltas.js';
+import { buildClimateTurnReportDeltas } from '../src/ui/climate/buildClimateTurnReportDeltas.js';
 
 const culturePayload = {
   cultures: [
@@ -1147,6 +1148,111 @@ function renderIntrigueTurnReportDeltas(province, intrigueView) {
   `;
 }
 
+function getProvinceClimateRiskLevel(province) {
+  if (province.supplyLevel === 'collapsed' || province.contested) {
+    return 'critical';
+  }
+
+  if (province.supplyLevel === 'disrupted' || province.supplyLevel === 'strained') {
+    return 'strained';
+  }
+
+  return 'stable';
+}
+
+function buildProvinceClimateTurnReport(province) {
+  const currentRiskLevel = getProvinceClimateRiskLevel(province);
+  const previousRiskLevel = currentRiskLevel === 'critical'
+    ? 'strained'
+    : currentRiskLevel === 'strained'
+      ? 'stable'
+      : 'stable';
+  const recoveryChoiceId = currentRiskLevel === 'critical' ? 'evacuate-risk-zones' : 'stockpile-supplies';
+  const recoveryLabel = currentRiskLevel === 'critical' ? 'Évacuer les zones exposées' : 'Stocker des vivres';
+  const recoveryWindowDays = currentRiskLevel === 'critical' ? 18 : 12;
+  const climateOverlay = {
+    selectedClimateImpactComparison: {
+      state: 'ready',
+      regionId: province.provinceId,
+      current: {
+        riskLevel: currentRiskLevel,
+        anomaly: currentRiskLevel === 'stable' ? null : 'seasonal-pressure',
+      },
+    },
+    selectedClimateTimingRecommendation: {
+      state: 'ready',
+      direction: currentRiskLevel === 'stable' ? 'steady' : 'riskier',
+      urgency: currentRiskLevel === 'critical' ? 'act-before-preview' : 'time-sensitive',
+      copy: currentRiskLevel === 'stable'
+        ? 'Le climat reste stable pour le prochain tour.'
+        : 'Le prochain tour peut amplifier la pression climatique locale.',
+    },
+  };
+  const previousClimateOverlay = {
+    selectedClimateImpactComparison: {
+      state: 'ready',
+      regionId: province.provinceId,
+      current: {
+        riskLevel: previousRiskLevel,
+        anomaly: null,
+      },
+    },
+  };
+
+  return buildClimateTurnReportDeltas({
+    turn: state.turn,
+    selectedRegionId: province.provinceId,
+    climateOverlay,
+    previousClimateOverlay,
+    previousRecoveryForecast: currentRiskLevel === 'stable' ? null : {
+      forecasts: [
+        {
+          choiceId: recoveryChoiceId,
+          label: recoveryLabel,
+          recoveryWindowDays,
+          relapseRisk: currentRiskLevel === 'critical' ? 'medium' : 'low',
+          nextCriticalSeason: 'prochain tour',
+          summary: `${recoveryLabel}: prévu ~${recoveryWindowDays}j avant stabilisation.`,
+        },
+      ],
+    },
+    realizedRecoveryByChoiceId: currentRiskLevel === 'stable' ? {} : {
+      [recoveryChoiceId]: {
+        recoveryWindowDays: Math.max(6, recoveryWindowDays - 2),
+        relapseRisk: currentRiskLevel === 'critical' ? 'medium' : 'low',
+        status: 'on-track',
+        summary: 'Réalisation lisible dans le rapport du dernier tour.',
+      },
+    },
+    upcomingSeason: 'prochain tour',
+  });
+}
+
+function renderProvinceClimateTurnReport(province) {
+  const report = buildProvinceClimateTurnReport(province);
+
+  return `
+    <section class="province-climate-turn-report province-climate-turn-report--${report.state}" aria-label="Rapport climat et catastrophes du dernier tour">
+      <div class="province-climate-turn-report__header">
+        <strong>Rapport climat dernier tour</strong>
+        <span>${report.deltas.length > 0 ? `${report.deltas.length} delta${report.deltas.length > 1 ? 's' : ''}` : 'stable'}</span>
+      </div>
+      <p>${report.summary}</p>
+      ${report.deltas.length > 0 ? `
+        <ul class="province-climate-turn-report__list">
+          ${report.deltas.map((delta) => `
+            <li class="province-climate-turn-report__delta province-climate-turn-report__delta--${delta.tone}">
+              <b>${delta.label}</b>
+              <span>${delta.value}</span>
+              <small>${delta.forecast && delta.realized ? `Prévu: ${delta.forecast.recoveryWindowDays}j · Réalisé: ${delta.realized.recoveryWindowDays}j` : delta.reason}</small>
+            </li>
+          `).join('')}
+        </ul>
+      ` : ''}
+    </section>
+  `;
+}
+
 function renderProvinceEconomyTurnReport(province, economyView) {
   const previousChoice = buildProvinceLogisticsChoicePreviewView(province, economyView).options[0] ?? null;
   const report = buildProvinceEconomyTurnReport(province, economyView, { previousChoice });
@@ -1429,6 +1535,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}
       ${renderIntrigueTurnReportDeltas(province, intrigueView)}
+      ${renderProvinceClimateTurnReport(province)}
       <div class="context-summary">
         <strong>Comparaison rapide</strong>
         <p>${comparedProvinceNames.length > 0 ? comparedProvinceNames.join(' vs ') : 'Aucune province comparée pour le moment.'}</p>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2141,6 +2141,67 @@ button { font: inherit; }
   margin: 3px 0 0;
   font-size: 12px;
 }
+.province-climate-turn-report {
+  display: grid;
+  gap: 9px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(22, 78, 99, 0.3), rgba(15, 23, 42, 0.58));
+  border: 1px solid rgba(103, 232, 249, 0.16);
+}
+.province-climate-turn-report__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-climate-turn-report__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-climate-turn-report > p {
+  margin: 0;
+  color: #ccfbf1;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.province-climate-turn-report--recovery { border-color: rgba(74, 222, 128, 0.32); }
+.province-climate-turn-report--risk { border-color: rgba(251, 191, 36, 0.36); }
+.province-climate-turn-report--stable,
+.province-climate-turn-report--quiet { border-color: rgba(148, 163, 184, 0.18); }
+.province-climate-turn-report__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.province-climate-turn-report__delta {
+  display: grid;
+  gap: 3px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.province-climate-turn-report__delta b {
+  color: #ecfeff;
+  font-size: 12px;
+}
+.province-climate-turn-report__delta span,
+.province-climate-turn-report__delta small {
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-climate-turn-report__delta--improved { border-color: rgba(74, 222, 128, 0.26); }
+.province-climate-turn-report__delta--worse,
+.province-climate-turn-report__delta--warning { border-color: rgba(251, 191, 36, 0.34); }
+.province-climate-turn-report__delta--partial { border-color: rgba(56, 189, 248, 0.28); }
+.province-climate-turn-report__delta--neutral { border-color: rgba(148, 163, 184, 0.16); }
 .province-economy-turn-report {
   display: grid;
   gap: 9px;


### PR DESCRIPTION
Epsilon: Implements #477.\n\nSummary:\n- adds buildClimateTurnReportDeltas for compact post-turn climate/catastrophe deltas;\n- distinguishes realized risk/anomaly changes from previous recovery forecasts and realized mitigation outcomes;\n- wires a short selected-province climate turn report into the playable map detail panel;\n- adds compact styling that stays alongside military/economy/culture reports without covering the map.\n\nValidation:\n- npm test -- test/ui/climate/buildClimateTurnReportDeltas.test.js test/ui/climate/webClimateTurnReportDeltas.test.js\n- npm test -- test/ui/climate/buildClimateMapOverlay.test.js\n- npm test (401 passing)\n- node --check src/ui/climate/buildClimateTurnReportDeltas.js\n- node --check web/app.js\n- git diff --check\n\nZeta, peux-tu valider cette PR avant merge ?