### PR TITLE
Alpha: Add military plan impact summary

### DIFF
--- a/test/ui/war/webMilitaryPlanImpactSummary.test.js
+++ b/test/ui/war/webMilitaryPlanImpactSummary.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable map exposes military plan impact summary for queued province actions', () => {
+  assert.match(webAppSource, /function buildMilitaryPlanImpactSummary/);
+  assert.match(webAppSource, /function renderMilitaryPlanImpactSummary/);
+  assert.match(webAppSource, /Impact du plan/);
+  assert.match(webAppSource, /mis à jour avec la file/);
+  assert.match(webAppSource, /Fronts \/ provinces/);
+  assert.match(webAppSource, /Pression attendue/);
+  assert.match(webAppSource, /Contrôle probable/);
+  assert.match(webAppSource, /Risque ravitaillement/);
+  assert.match(webAppSource, /Aucune action militaire en file/);
+  assert.match(webAppSource, /renderMilitaryPlanImpactSummary\(province, shell, focusContext, intrigueView\)/);
+  assert.match(stylesSource, /\.military-plan-impact/);
+  assert.match(stylesSource, /military-plan-impact__metrics/);
+  assert.match(stylesSource, /military-plan-impact--ready/);
+  assert.match(stylesSource, /military-plan-impact--warning/);
+  assert.match(stylesSource, /military-plan-impact--danger/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1489,6 +1489,62 @@ function renderResolvedConflictDeltas(province, shell, focusContext, intrigueVie
   `;
 }
 
+function buildMilitaryPlanImpactSummary(province, shell, actionQueue) {
+  const outcome = buildConflictOutcomePreview(province, shell);
+  const affectedProvinceLabels = [province.label, ...province.neighborIds
+    .map((provinceId) => shell.provinces.find((candidate) => candidate.provinceId === provinceId)?.label)
+    .filter(Boolean)]
+    .slice(0, 4);
+  const readyActions = actionQueue.filter((entry) => entry.status === 'ready');
+  const riskyActions = actionQueue.filter((entry) => entry.status === 'risky');
+  const blockedActions = actionQueue.filter((entry) => entry.status === 'blocked');
+  const supplyRisk = province.supplyLevel === 'collapsed' || province.supplyLevel === 'disrupted'
+    ? 'routage fragile'
+    : province.supplyLevel === 'strained'
+      ? 'ravitaillement à surveiller'
+      : 'ravitaillement stable';
+
+  return {
+    turn: state.turn,
+    tone: blockedActions.length > 0 ? 'danger' : riskyActions.length > readyActions.length ? 'warning' : 'ready',
+    summary: actionQueue.length === 0
+      ? 'Aucune action militaire en file: le plan de tour ne modifie pas encore la carte.'
+      : `${actionQueue.length} action${actionQueue.length > 1 ? 's' : ''} en file: ${readyActions.length} prête${readyActions.length > 1 ? 's' : ''}, ${riskyActions.length} risquée${riskyActions.length > 1 ? 's' : ''}, ${blockedActions.length} bloquée${blockedActions.length > 1 ? 's' : ''}.`,
+    metrics: [
+      { label: 'Fronts / provinces', value: affectedProvinceLabels.join(', ') || province.label },
+      { label: 'Pression attendue', value: outcome.tone === 'success' ? 'pression en baisse' : outcome.tone === 'danger' ? 'pression en hausse' : 'pression contestée' },
+      { label: 'Contrôle probable', value: outcome.tone === 'success' ? 'contrôle consolidé' : outcome.tone === 'danger' ? 'contrôle menacé' : 'contrôle disputé' },
+      { label: 'Risque ravitaillement', value: supplyRisk },
+    ],
+  };
+}
+
+function renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView = null) {
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const impact = buildMilitaryPlanImpactSummary(province, shell, actionQueue);
+
+  return `
+    <section class="military-plan-impact military-plan-impact--${impact.tone}" aria-label="Impact du plan militaire en file">
+      <div class="military-plan-impact__header">
+        <div>
+          <span>Impact du plan</span>
+          <strong>Tour ${impact.turn}</strong>
+        </div>
+        <small>mis à jour avec la file</small>
+      </div>
+      <p>${impact.summary}</p>
+      <div class="military-plan-impact__metrics">
+        ${impact.metrics.map((metric) => `
+          <article class="military-plan-impact__metric">
+            <span>${metric.label}</span>
+            <strong>${metric.value}</strong>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderActiveProvince(shell, economyView = null, intrigueView = null) {
   const focusContext = getFocusContext(shell);
   const province = shell.activeProvince ?? shell.provinces[0] ?? null;
@@ -1533,6 +1589,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
+      ${renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView)}
       ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}
       ${renderIntrigueTurnReportDeltas(province, intrigueView)}
       ${renderProvinceClimateTurnReport(province)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -1883,6 +1883,61 @@ button { font: inherit; }
 .province-action-queue__item--ready { border-color: rgba(74, 222, 128, 0.28); }
 .province-action-queue__item--risky { border-color: rgba(251, 191, 36, 0.34); }
 .province-action-queue__item--blocked { border-color: rgba(251, 113, 133, 0.4); }
+.military-plan-impact {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(17, 24, 39, 0.72), rgba(8, 15, 28, 0.58));
+  border: 1px solid rgba(94, 234, 212, 0.2);
+}
+.military-plan-impact__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.military-plan-impact__header span,
+.military-plan-impact__header small {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.military-plan-impact__header strong {
+  display: block;
+  margin-top: 3px;
+}
+.military-plan-impact > p {
+  margin: 0;
+  color: #ccfbf1;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.military-plan-impact__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.military-plan-impact__metric {
+  padding: 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.44);
+  border: 1px solid rgba(148, 163, 184, 0.13);
+}
+.military-plan-impact__metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+.military-plan-impact__metric strong {
+  font-size: 12px;
+}
+.military-plan-impact--ready { border-color: rgba(45, 212, 191, 0.32); }
+.military-plan-impact--warning { border-color: rgba(251, 191, 36, 0.34); }
+.military-plan-impact--danger { border-color: rgba(251, 113, 133, 0.4); }
 .resolved-conflict-deltas {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
Alpha: Closes #483.

## Summary
- adds a selected-province “Impact du plan” summary derived from the queued Alpha military actions
- surfaces affected fronts/provinces, expected pressure, probable control, and supply risk before turn validation
- ties the summary to current turn and action queue state so it updates with queue/turn rerenders
- keeps the new HUD section inside the existing tactical province panel without covering the map
- adds a deterministic web smoke test for the summary contract and styles

## Verification
- npm test
- npm run preview:map -- /tmp/historia-military-plan-impact-preview.html
- node --test test/ui/war/webMilitaryPlanImpactSummary.test.js
- node --check web/app.js
- git diff --check
