### PR TITLE
Beta: add economy budget preview

### DIFF
--- a/src/ui/economy/buildProvinceEconomyBudgetPreview.js
+++ b/src/ui/economy/buildProvinceEconomyBudgetPreview.js
@@ -1,0 +1,142 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function getChoiceCostUnits(choice) {
+  if (choice.action === 'Réparer route') {
+    return 4;
+  }
+
+  if (choice.action === 'Sécuriser convoi') {
+    return 3;
+  }
+
+  if (choice.action === 'Détourner flux') {
+    return 2;
+  }
+
+  if (choice.action === 'Stocker localement') {
+    return 2;
+  }
+
+  return 1;
+}
+
+function getBudgetStatus({ availableStock, costUnits, residualRisk, tensionLevel, actionStatus }) {
+  if (actionStatus === 'blocked' || availableStock < costUnits) {
+    return 'blocked';
+  }
+
+  if (actionStatus === 'risky' || residualRisk >= 55 || tensionLevel === 'high' || availableStock - costUnits <= 2) {
+    return 'risky';
+  }
+
+  return 'ready';
+}
+
+function getStatusTone(status) {
+  return status === 'blocked' ? 'danger' : status === 'risky' ? 'warning' : 'success';
+}
+
+function getResourceStock(city, resourceLabel) {
+  const resourceKey = String(resourceLabel ?? '').toLowerCase();
+  const entry = (city.resources?.entries ?? []).find((candidate) => {
+    const candidateKey = String(candidate.resourceId ?? '').toLowerCase();
+    return candidateKey === resourceKey || resourceKey.includes(candidateKey) || candidateKey.includes(resourceKey);
+  });
+
+  return entry?.quantity ?? city.resources?.totalStock ?? 0;
+}
+
+export function buildProvinceEconomyBudgetPreview(province, economyView, options = {}) {
+  const normalizedOptions = requireObject(options, 'ProvinceEconomyBudgetPreview options');
+  const actionQueue = Array.isArray(normalizedOptions.actionQueue) ? normalizedOptions.actionQueue : [];
+  const logisticsChoices = Array.isArray(normalizedOptions.logisticsChoices) ? normalizedOptions.logisticsChoices : [];
+
+  if (!province || !economyView) {
+    return {
+      status: 'empty',
+      summary: 'Aucun budget économie disponible pour ce plan de province.',
+      totalCost: 0,
+      plans: [],
+    };
+  }
+
+  const cities = economyView.overlay?.cities ?? [];
+  const tensionRows = economyView.comparison?.rows ?? [];
+  const provinceCities = cities.filter((city) => city.regionId === province.provinceId);
+  const fallbackCity = provinceCities[0] ?? null;
+  const tensionByCityId = Object.fromEntries(tensionRows.map((row) => [row.cityId, row.tensionLevel ?? 'low']));
+  const choices = logisticsChoices.length > 0 ? logisticsChoices : [];
+
+  const plans = choices.slice(0, 4).map((choice, index) => {
+    const action = actionQueue[index] ?? actionQueue[0] ?? { label: choice.action, status: 'ready' };
+    const hub = provinceCities.find((city) => city.cityName === choice.affectedCity) ?? fallbackCity;
+    const resourceLabel = choice.resources?.[0] ?? 'réserve locale';
+    const availableStock = hub ? getResourceStock(hub, resourceLabel) : 0;
+    const costUnits = getChoiceCostUnits(choice);
+    const tensionLevel = hub ? tensionByCityId[hub.cityId] ?? 'low' : 'low';
+    const status = getBudgetStatus({
+      availableStock,
+      costUnits,
+      residualRisk: choice.residualRisk ?? 0,
+      tensionLevel,
+      actionStatus: action.status,
+    });
+    const remainingStock = Math.max(0, availableStock - costUnits);
+    const surplusOrShortage = availableStock >= costUnits
+      ? `${remainingStock} unité${remainingStock > 1 ? 's' : ''} restante${remainingStock > 1 ? 's' : ''}`
+      : `${costUnits - availableStock} unité${costUnits - availableStock > 1 ? 's' : ''} manquante${costUnits - availableStock > 1 ? 's' : ''}`;
+
+    return {
+      planId: `${province.provinceId}:budget:${choice.optionId ?? index}`,
+      actionCode: action.actionCode ?? null,
+      actionLabel: action.label ?? choice.action,
+      logisticsAction: choice.action,
+      status,
+      tone: getStatusTone(status),
+      costUnits,
+      consumedResources: [{ label: resourceLabel, quantity: costUnits }],
+      routeNames: choice.routes ?? [],
+      hubName: hub?.cityName ?? choice.affectedCity ?? 'hub local',
+      availableStock,
+      surplusOrShortage,
+      effect: status === 'blocked'
+        ? `${resourceLabel}: budget insuffisant, action impossible sans stock ou relais.`
+        : status === 'risky'
+          ? `${resourceLabel}: action possible mais risque de pénurie/surcharge sur ${hub?.cityName ?? 'le hub'}.`
+          : `${resourceLabel}: coût absorbable, surplus conservé pour le prochain tour.`,
+      risk: choice.residualRisk ?? 0,
+    };
+  });
+
+  if (plans.length === 0) {
+    return {
+      status: 'empty',
+      summary: `Aucun coût économie/logistique à budgéter sur ${province.label ?? province.provinceId}.`,
+      totalCost: 0,
+      plans: [],
+    };
+  }
+
+  const blockedCount = plans.filter((plan) => plan.status === 'blocked').length;
+  const riskyCount = plans.filter((plan) => plan.status === 'risky').length;
+  const totalCost = plans.reduce((sum, plan) => sum + plan.costUnits, 0);
+  const status = blockedCount > 0 ? 'blocked' : riskyCount > 0 ? 'risky' : 'ready';
+  const lead = plans[0];
+
+  return {
+    status,
+    summary: blockedCount > 0
+      ? `${blockedCount} action économie impossible: renforcer les stocks avant de lancer le tour.`
+      : riskyCount > 0
+        ? `${riskyCount} action${riskyCount > 1 ? 's' : ''} à risque: ${lead.logisticsAction} consomme ${lead.costUnits} ${lead.consumedResources[0].label}.`
+        : `Budget soutenable: ${totalCost} unités engagées, ${lead.hubName} conserve un surplus lisible.`,
+    totalCost,
+    plans,
+  };
+}

--- a/test/ui/economy/buildProvinceEconomyBudgetPreview.test.js
+++ b/test/ui/economy/buildProvinceEconomyBudgetPreview.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildProvinceEconomyBudgetPreview } from '../../../src/ui/economy/buildProvinceEconomyBudgetPreview.js';
+
+const province = { provinceId: 'river-gate', label: 'Porte du Fleuve' };
+
+function buildEconomyView(toolStock = 6) {
+  return {
+    overlay: {
+      cities: [
+        {
+          cityId: 'river-city',
+          cityName: 'River Gate',
+          regionId: 'river-gate',
+          resources: {
+            totalStock: toolStock + 2,
+            entries: [
+              { resourceId: 'Outils', quantity: toolStock },
+              { resourceId: 'grain', quantity: 2 },
+            ],
+          },
+        },
+      ],
+    },
+    comparison: {
+      rows: [{ cityId: 'river-city', tensionLevel: 'medium' }],
+    },
+  };
+}
+
+const logisticsChoices = [
+  {
+    optionId: 'choice-1',
+    action: 'Sécuriser convoi',
+    resources: ['Outils'],
+    routes: ['Ember Line'],
+    affectedCity: 'River Gate',
+    residualRisk: 42,
+  },
+];
+
+const actionQueue = [
+  { actionCode: 'WAR-RIVER-GATE-1', label: 'Inspecter les routes', status: 'ready' },
+];
+
+test('buildProvinceEconomyBudgetPreview exposes consumptions, route and hub budget details', () => {
+  const preview = buildProvinceEconomyBudgetPreview(province, buildEconomyView(), { actionQueue, logisticsChoices });
+
+  assert.equal(preview.status, 'ready');
+  assert.equal(preview.totalCost, 3);
+  assert.equal(preview.plans[0].actionCode, 'WAR-RIVER-GATE-1');
+  assert.equal(preview.plans[0].logisticsAction, 'Sécuriser convoi');
+  assert.deepEqual(preview.plans[0].routeNames, ['Ember Line']);
+  assert.equal(preview.plans[0].hubName, 'River Gate');
+  assert.deepEqual(preview.plans[0].consumedResources, [{ label: 'Outils', quantity: 3 }]);
+  assert.match(preview.plans[0].surplusOrShortage, /restante/);
+});
+
+test('buildProvinceEconomyBudgetPreview marks impossible actions when resources are missing', () => {
+  const preview = buildProvinceEconomyBudgetPreview(province, buildEconomyView(1), { actionQueue, logisticsChoices });
+
+  assert.equal(preview.status, 'blocked');
+  assert.equal(preview.plans[0].status, 'blocked');
+  assert.match(preview.summary, /impossible/);
+  assert.match(preview.plans[0].effect, /budget insuffisant/);
+});
+
+test('buildProvinceEconomyBudgetPreview returns an empty state without logistics choices', () => {
+  const preview = buildProvinceEconomyBudgetPreview(province, buildEconomyView(), { actionQueue, logisticsChoices: [] });
+
+  assert.equal(preview.status, 'empty');
+  assert.equal(preview.totalCost, 0);
+  assert.deepEqual(preview.plans, []);
+  assert.match(preview.summary, /Aucun coût économie\/logistique/);
+});
+
+test('buildProvinceEconomyBudgetPreview validates options', () => {
+  assert.throws(() => buildProvinceEconomyBudgetPreview(province, buildEconomyView(), null), /options must be an object/);
+});

--- a/test/ui/economy/webProvinceEconomyBudgetPreview.test.js
+++ b/test/ui/economy/webProvinceEconomyBudgetPreview.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable map wires economy budget preview into province action planning', () => {
+  assert.match(webAppSource, /buildProvinceEconomyBudgetPreview/);
+  assert.match(webAppSource, /function renderProvinceEconomyBudgetPreview/);
+  assert.match(webAppSource, /Budget économie du plan/);
+  assert.match(webAppSource, /logisticsChoices: logisticsPreview\.options/);
+  assert.match(webAppSource, /renderProvinceEconomyBudgetPreview\(province, economyView, shell, focusContext, intrigueView\)/);
+  assert.match(stylesSource, /\.province-economy-budget-preview/);
+  assert.match(stylesSource, /province-economy-budget-card--blocked/);
+  assert.match(stylesSource, /province-economy-budget-preview--risky/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -10,6 +10,7 @@ import { buildCityStockPanel } from '../src/ui/economy/buildCityStockPanel.js';
 import { buildCityComparisonPanel } from '../src/ui/economy/buildCityComparisonPanel.js';
 import { buildProvinceLogisticsChoicePreview } from '../src/ui/economy/buildProvinceLogisticsChoicePreview.js';
 import { buildProvinceEconomyTurnReport } from '../src/ui/economy/buildProvinceEconomyTurnReport.js';
+import { buildProvinceEconomyBudgetPreview } from '../src/ui/economy/buildProvinceEconomyBudgetPreview.js';
 import { Cellule } from '../src/domain/intrigue/Cellule.js';
 import { OperationClandestine } from '../src/domain/intrigue/OperationClandestine.js';
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
@@ -1253,6 +1254,56 @@ function renderProvinceClimateTurnReport(province) {
   `;
 }
 
+function renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView = null) {
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const logisticsPreview = buildProvinceLogisticsChoicePreviewView(province, economyView);
+  const budget = buildProvinceEconomyBudgetPreview(province, economyView, {
+    actionQueue,
+    logisticsChoices: logisticsPreview.options,
+  });
+
+  if (budget.status === 'empty') {
+    return `
+      <section class="province-economy-budget-preview province-economy-budget-preview--empty" aria-label="Aperçu budget économie du plan de province">
+        <div class="province-economy-budget-preview__header">
+          <strong>Budget économie du plan</strong>
+          <span>stable</span>
+        </div>
+        <p>${budget.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="province-economy-budget-preview province-economy-budget-preview--${budget.status}" aria-label="Aperçu budget économie du plan de province">
+      <div class="province-economy-budget-preview__header">
+        <strong>Budget économie du plan</strong>
+        <span>${budget.totalCost} unités</span>
+      </div>
+      <p>${budget.summary}</p>
+      <div class="province-economy-budget-preview__list">
+        ${budget.plans.map((plan) => `
+          <article class="province-economy-budget-card province-economy-budget-card--${plan.status}">
+            <div class="province-economy-budget-card__title">
+              <strong>${plan.logisticsAction}</strong>
+              <span>${plan.status}</span>
+            </div>
+            <p>${plan.effect}</p>
+            <dl>
+              <div><dt>Action</dt><dd>${plan.actionCode ?? plan.actionLabel}</dd></div>
+              <div><dt>Coût</dt><dd>${plan.consumedResources.map((resource) => `${resource.quantity} ${resource.label}`).join(', ')}</dd></div>
+              <div><dt>Route</dt><dd>${plan.routeNames.join(', ') || 'hub local'}</dd></div>
+              <div><dt>Hub</dt><dd>${plan.hubName}</dd></div>
+              <div><dt>Stock</dt><dd>${plan.surplusOrShortage}</dd></div>
+              <div><dt>Risque</dt><dd>${plan.risk}</dd></div>
+            </dl>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderProvinceEconomyTurnReport(province, economyView) {
   const previousChoice = buildProvinceLogisticsChoicePreviewView(province, economyView).options[0] ?? null;
   const report = buildProvinceEconomyTurnReport(province, economyView, { previousChoice });
@@ -1590,6 +1641,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView)}
+      ${renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView)}
       ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}
       ${renderIntrigueTurnReportDeltas(province, intrigueView)}
       ${renderProvinceClimateTurnReport(province)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -1938,6 +1938,73 @@ button { font: inherit; }
 .military-plan-impact--ready { border-color: rgba(45, 212, 191, 0.32); }
 .military-plan-impact--warning { border-color: rgba(251, 191, 36, 0.34); }
 .military-plan-impact--danger { border-color: rgba(251, 113, 133, 0.4); }
+.province-economy-budget-preview {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.64), rgba(8, 47, 73, 0.34));
+  border: 1px solid rgba(56, 189, 248, 0.18);
+}
+.province-economy-budget-preview__header,
+.province-economy-budget-card__title {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-economy-budget-preview__header span,
+.province-economy-budget-card__title span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-economy-budget-preview > p,
+.province-economy-budget-card p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.province-economy-budget-preview__list {
+  display: grid;
+  gap: 8px;
+}
+.province-economy-budget-card {
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-economy-budget-card--ready { border-color: rgba(74, 222, 128, 0.3); }
+.province-economy-budget-card--risky { border-color: rgba(251, 191, 36, 0.36); }
+.province-economy-budget-card--blocked { border-color: rgba(251, 113, 133, 0.42); }
+.province-economy-budget-preview--ready { border-color: rgba(74, 222, 128, 0.26); }
+.province-economy-budget-preview--risky { border-color: rgba(251, 191, 36, 0.32); }
+.province-economy-budget-preview--blocked { border-color: rgba(251, 113, 133, 0.38); }
+.province-economy-budget-preview--empty { border-style: dashed; }
+.province-economy-budget-card dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin: 8px 0 0;
+}
+.province-economy-budget-card dl div {
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(8, 15, 28, 0.42);
+}
+.province-economy-budget-card dt {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.province-economy-budget-card dd {
+  margin: 3px 0 0;
+  font-size: 12px;
+}
 .resolved-conflict-deltas {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
Beta: Implements #484.

Scope:
- add a reusable province economy budget preview builder for logistics/economy planning;
- surface consumed resources, route/hub pressure, shortages/surplus, status ready/risky/blocked;
- wire the preview into province action planning alongside the existing action queue and turn reports;
- keep the feature as UI preview derived from existing economy/logistics data, without new simulation logic.

Validation:
- node --test test/ui/economy/buildProvinceEconomyBudgetPreview.test.js test/ui/economy/webProvinceEconomyBudgetPreview.test.js
- npm test (411 passing)
- node --check web/app.js
- node --check src/ui/economy/buildProvinceEconomyBudgetPreview.js
- git diff --check

Ready for Zeta validation before merge.