### PR TITLE
Gamma: Add culture unlock hints

### DIFF
--- a/src/ui/culture/buildCultureUnlockHints.js
+++ b/src/ui/culture/buildCultureUnlockHints.js
@@ -1,0 +1,170 @@
+const STATUS_RANK = Object.freeze({ probable: 3, possible: 2, missing: 1 });
+
+function normalizeText(value, fallback = '') {
+  return String(value ?? fallback).trim();
+}
+
+function buildHint({ status, tone, label, explanation, regionId, cultureName, sourceId }) {
+  return {
+    hintId: `${status}:${regionId}:${cultureName}:${label}:${sourceId ?? 'source'}`,
+    status,
+    tone,
+    label,
+    explanation,
+    regionId,
+    cultureName,
+  };
+}
+
+function dedupeAndSort(hints) {
+  const hintsByKey = new Map();
+
+  for (const hint of hints) {
+    const key = `${hint.status}:${hint.label}:${hint.regionId}:${hint.cultureName}`;
+    const existingHint = hintsByKey.get(key);
+
+    if (!existingHint || STATUS_RANK[hint.status] > STATUS_RANK[existingHint.status]) {
+      hintsByKey.set(key, hint);
+    }
+  }
+
+  return [...hintsByKey.values()]
+    .sort((left, right) => STATUS_RANK[right.status] - STATUS_RANK[left.status] || left.label.localeCompare(right.label))
+    .slice(0, 3);
+}
+
+function hintsFromTimeline(localTimeline, actionTitle, fallbackRegionId) {
+  return (localTimeline?.items ?? []).map((item) => {
+    const status = item.signal === 'opportunity' ? 'probable' : item.signal === 'research' ? 'possible' : 'missing';
+    const label = item.kind === 'event'
+      ? 'Débloque repère'
+      : 'Débloque découverte';
+
+    return buildHint({
+      status,
+      tone: item.signal,
+      label,
+      explanation: `${normalizeText(item.title, label)} peut suivre “${actionTitle}”.`,
+      regionId: normalizeText(item.regionId, fallbackRegionId),
+      cultureName: normalizeText(item.cultureName, 'Culture locale'),
+      sourceId: item.timelineId,
+    });
+  });
+}
+
+function hintsFromMarker(marker, actionTitle, fallbackRegionId) {
+  if (!marker) {
+    return [];
+  }
+
+  const regionId = normalizeText(marker.regionId, fallbackRegionId);
+  const cultureName = normalizeText(marker.cultureName, 'Culture locale');
+  const hints = [];
+
+  if ((marker.unlockedResearchIds ?? []).length > 0 || (marker.activeResearchCount ?? 0) > 0) {
+    hints.push(buildHint({
+      status: (marker.unlockedResearchIds ?? []).length > 0 ? 'probable' : 'possible',
+      tone: 'research',
+      label: 'Recherche culture',
+      explanation: `${(marker.unlockedResearchIds ?? []).slice(0, 2).join(', ') || `${marker.activeResearchCount} recherche active`} liée à “${actionTitle}”.`,
+      regionId,
+      cultureName,
+      sourceId: marker.overlayId,
+    }));
+  }
+
+  if ((marker.discoveries ?? []).length > 0) {
+    hints.push(buildHint({
+      status: 'possible',
+      tone: 'discovery',
+      label: 'Découverte exploitable',
+      explanation: `${marker.discoveries.slice(0, 2).join(', ')} peut nourrir le choix planifié.`,
+      regionId,
+      cultureName,
+      sourceId: marker.overlayId,
+    }));
+  }
+
+  return hints;
+}
+
+function hintsFromCluster(cluster, actionTitle, fallbackRegionId) {
+  if (!cluster) {
+    return [];
+  }
+
+  const regionId = normalizeText(cluster.regionIds?.[0], fallbackRegionId);
+  const cultureName = normalizeText(cluster.summary, 'Cluster culturel');
+  const discoveryPins = (cluster.pins ?? []).filter((pin) => pin.kind === 'discovery');
+  const eventPins = (cluster.pins ?? []).filter((pin) => pin.kind === 'event');
+  const hints = [];
+
+  if (eventPins.length > 0) {
+    const strongestEvent = eventPins.slice().sort((left, right) => (right.importance ?? 0) - (left.importance ?? 0))[0];
+    hints.push(buildHint({
+      status: (strongestEvent.importance ?? 0) >= 4 ? 'probable' : 'possible',
+      tone: 'event',
+      label: 'Événement cluster',
+      explanation: `${strongestEvent.name} peut se rattacher à “${actionTitle}”.`,
+      regionId,
+      cultureName: normalizeText(strongestEvent.cultureName, cultureName),
+      sourceId: strongestEvent.pinId,
+    }));
+  }
+
+  if (discoveryPins.length > 0) {
+    hints.push(buildHint({
+      status: 'possible',
+      tone: 'discovery',
+      label: 'Découverte cluster',
+      explanation: `${discoveryPins.slice(0, 2).map((pin) => pin.name).join(', ')} disponible dans le voisinage.`,
+      regionId,
+      cultureName,
+      sourceId: cluster.clusterId,
+    }));
+  }
+
+  if (hints.length === 0) {
+    hints.push(buildHint({
+      status: 'missing',
+      tone: 'identity',
+      label: 'Condition manquante',
+      explanation: 'Cluster visible, mais aucun pin découverte/événement ne justifie encore un unlock.',
+      regionId,
+      cultureName,
+      sourceId: cluster.clusterId,
+    }));
+  }
+
+  return hints;
+}
+
+export function buildCultureUnlockHints({
+  province = null,
+  action = null,
+  selectedMarker = null,
+  selectedCluster = null,
+  localTimeline = null,
+} = {}) {
+  const regionId = normalizeText(province?.provinceId ?? selectedMarker?.regionId ?? selectedCluster?.regionIds?.[0], 'province');
+  const actionTitle = normalizeText(action?.title, 'action province');
+  const hints = dedupeAndSort([
+    ...hintsFromTimeline(localTimeline, actionTitle, regionId),
+    ...hintsFromMarker(selectedMarker, actionTitle, regionId),
+    ...hintsFromCluster(selectedCluster, actionTitle, regionId),
+  ]);
+
+  if (hints.length > 0) {
+    return hints;
+  }
+
+  return [buildHint({
+    status: 'missing',
+    tone: 'neutral',
+    label: 'Aucun unlock culture',
+    explanation: 'Ajoutez découverte, repère ou cluster actif avant d’attendre un gain culturel.',
+    regionId,
+    cultureName: 'Aucun signal',
+    sourceId: actionTitle,
+  })];
+}

--- a/test/ui/culture/buildCultureUnlockHints.test.js
+++ b/test/ui/culture/buildCultureUnlockHints.test.js
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCultureUnlockHints } from '../../../src/ui/culture/buildCultureUnlockHints.js';
+
+test('buildCultureUnlockHints ranks probable, possible, and missing unlock signals', () => {
+  const hints = buildCultureUnlockHints({
+    province: { provinceId: 'river-gate' },
+    action: { title: 'Préparer la manœuvre' },
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      activeResearchCount: 1,
+      unlockedResearchIds: ['tidal-ledgers'],
+      discoveries: ['archive-routes'],
+    },
+    selectedCluster: {
+      clusterId: 'river-gate:culture-cluster',
+      summary: 'Compact d’Aurora, Ligues des Forges',
+      regionIds: ['river-gate'],
+      pins: [
+        {
+          pinId: 'river-gate:culture-aurora:event:archives-open',
+          kind: 'event',
+          name: 'Ouverture des archives',
+          cultureName: 'Compact d’Aurora',
+          importance: 4,
+        },
+        {
+          pinId: 'river-gate:culture-aurora:discovery:archive-routes',
+          kind: 'discovery',
+          name: 'archive-routes',
+          cultureName: 'Compact d’Aurora',
+        },
+      ],
+    },
+    localTimeline: {
+      items: [
+        {
+          timelineId: 'river-gate:event:archives-open',
+          kind: 'event',
+          signal: 'opportunity',
+          title: 'Ouverture des archives',
+          regionId: 'river-gate',
+          cultureName: 'Compact d’Aurora',
+        },
+        {
+          timelineId: 'river-gate:discovery:archive-routes',
+          kind: 'discovery',
+          signal: 'research',
+          title: 'archive-routes',
+          regionId: 'river-gate',
+          cultureName: 'Compact d’Aurora',
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(hints.map((hint) => [hint.status, hint.label, hint.tone]), [
+    ['probable', 'Débloque repère', 'opportunity'],
+    ['probable', 'Événement cluster', 'event'],
+    ['probable', 'Recherche culture', 'research'],
+  ]);
+  assert.equal(hints[0].explanation, 'Ouverture des archives peut suivre “Préparer la manœuvre”.');
+});
+
+test('buildCultureUnlockHints returns readable missing-condition fallbacks', () => {
+  assert.deepEqual(buildCultureUnlockHints({
+    province: { provinceId: 'quiet-field' },
+    action: { title: 'Garder en observation' },
+  }), [
+    {
+      hintId: 'missing:quiet-field:Aucun signal:Aucun unlock culture:Garder en observation',
+      status: 'missing',
+      tone: 'neutral',
+      label: 'Aucun unlock culture',
+      explanation: 'Ajoutez découverte, repère ou cluster actif avant d’attendre un gain culturel.',
+      regionId: 'quiet-field',
+      cultureName: 'Aucun signal',
+    },
+  ]);
+
+  assert.deepEqual(buildCultureUnlockHints({
+    province: { provinceId: 'shared-bay' },
+    action: { title: 'Stabiliser l’occupation' },
+    selectedCluster: {
+      clusterId: 'shared-bay:culture-cluster',
+      summary: 'Delta Scribes, Harbor Compact',
+      regionIds: ['shared-bay'],
+      pins: [],
+    },
+  })[0], {
+    hintId: 'missing:shared-bay:Delta Scribes, Harbor Compact:Condition manquante:shared-bay:culture-cluster',
+    status: 'missing',
+    tone: 'identity',
+    label: 'Condition manquante',
+    explanation: 'Cluster visible, mais aucun pin découverte/événement ne justifie encore un unlock.',
+    regionId: 'shared-bay',
+    cultureName: 'Delta Scribes, Harbor Compact',
+  });
+});

--- a/web/app.js
+++ b/web/app.js
@@ -18,6 +18,7 @@ import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMa
 import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTimeline.js';
 import { buildCultureConsequenceChips } from '../src/ui/culture/buildCultureConsequenceChips.js';
 import { buildCultureTurnReportDeltas } from '../src/ui/culture/buildCultureTurnReportDeltas.js';
+import { buildCultureUnlockHints } from '../src/ui/culture/buildCultureUnlockHints.js';
 import { buildClimateTurnReportDeltas } from '../src/ui/climate/buildClimateTurnReportDeltas.js';
 
 const culturePayload = {
@@ -876,6 +877,19 @@ function renderCultureTurnReport(report) {
   `;
 }
 
+function renderCultureUnlockHints(hints) {
+  return `
+    <div class="culture-unlock-hints" aria-label="Unlocks culture potentiels">
+      ${hints.map((hint) => `
+        <span class="culture-unlock-hint culture-unlock-hint--${hint.status} culture-unlock-hint--${hint.tone}" title="${hint.explanation}">
+          <b>${hint.status}</b>
+          <small>${hint.label} · ${hint.cultureName}</small>
+        </span>
+      `).join('')}
+    </div>
+  `;
+}
+
 function renderCultureConsequenceChips(chips) {
   return `
     <div class="culture-consequence-chips" aria-label="Conséquences culturelles">
@@ -908,11 +922,19 @@ function renderProvinceActionRecommendations(province, focusContext, intrigueVie
             selectedCluster,
             localTimeline,
           });
+          const unlockHints = buildCultureUnlockHints({
+            province,
+            action: recommendation,
+            selectedMarker,
+            selectedCluster,
+            localTimeline,
+          });
 
           return `
             <article class="province-action-card province-action-card--${recommendation.tone}">
               <strong>${recommendation.title}</strong>
               <p>${recommendation.body}</p>
+              ${renderCultureUnlockHints(unlockHints)}
               ${renderCultureConsequenceChips(cultureChips)}
             </article>
           `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -1713,6 +1713,38 @@ button { font: inherit; }
 .province-action-card--warning { border-color: rgba(251, 191, 36, 0.32); }
 .province-action-card--ready { border-color: rgba(74, 222, 128, 0.28); }
 .province-action-card--info { border-color: rgba(56, 189, 248, 0.3); }
+.culture-unlock-hints {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 9px;
+}
+.culture-unlock-hint {
+  display: inline-grid;
+  gap: 2px;
+  max-width: 100%;
+  padding: 5px 7px;
+  border-radius: 10px;
+  background: rgba(14, 165, 233, 0.08);
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.culture-unlock-hint b {
+  color: #bae6fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+.culture-unlock-hint small {
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.1;
+}
+.culture-unlock-hint--probable { border-color: rgba(74, 222, 128, 0.32); }
+.culture-unlock-hint--probable b { color: #bbf7d0; }
+.culture-unlock-hint--possible { border-color: rgba(56, 189, 248, 0.3); }
+.culture-unlock-hint--missing { border-color: rgba(251, 191, 36, 0.26); }
+.culture-unlock-hint--missing b { color: #fde68a; }
 .culture-consequence-chips {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Gamma: Closes #485.

## Summary
- add a reusable culture unlock hint builder for province action planning
- surface probable/possible/missing culture, discovery, research, and event unlock hints on action cards
- connect hints to selected markers, local timelines, and cluster pins without duplicating the turn report copy
- add deterministic tests for ranked hints and missing-condition fallbacks

## Validation
- `node --check web/app.js`
- `git diff --check`
- `npm test` (409 passing)

Gamma: Ready for Zeta validation before merge.
