### PR TITLE
Delta: Add intrigue planning risk warnings

### DIFF
--- a/test/ui/war/webProvinceIntrigueRiskWarnings.test.js
+++ b/test/ui/war/webProvinceIntrigueRiskWarnings.test.js
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('playable map adds intrigue warnings to selected province action planning', () => {
+  assert.match(webAppSource, /function buildProvinceIntrigueRiskWarnings/);
+  assert.match(webAppSource, /function renderProvinceIntrigueRiskWarnings/);
+  assert.match(webAppSource, /Warnings intrigue planning/);
+  assert.match(webAppSource, /Sabotage probable/);
+  assert.match(webAppSource, /Exposition de cellule/);
+  assert.match(webAppSource, /Cooldown \/ alerte active/);
+  assert.match(webAppSource, /Province vulnérable/);
+  assert.match(webAppSource, /renderProvinceIntrigueRiskWarnings\(province, actionQueue, intrigueView\)/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1385,9 +1385,115 @@ function summarizeTurnResolutionPreview(province, actionQueue) {
   };
 }
 
+
+function findProvinceIntrigueDrillDown(province, intrigueView) {
+  const provinceId = province?.provinceId;
+  const selectedDrillDown = intrigueView?.selectedProvince?.drillDown ?? null;
+
+  if (selectedDrillDown?.locationId === provinceId) {
+    return selectedDrillDown;
+  }
+
+  return (intrigueView?.map?.entries ?? [])
+    .find((entry) => entry.locationId === provinceId)?.drillDown ?? null;
+}
+
+function buildProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView) {
+  const drillDown = findProvinceIntrigueDrillDown(province, intrigueView);
+  const selectedResponse = drillDown?.quickResponses?.find((response) => response.code === drillDown.recommendedResponseCode)
+    ?? drillDown?.quickResponses?.[0]
+    ?? null;
+  const warningCandidates = [];
+  const plannedAction = actionQueue[0] ?? null;
+  const riskyActionCount = actionQueue.filter((entry) => entry.status !== 'ready').length;
+
+  if (!drillDown) {
+    warningCandidates.push({
+      tone: 'masked',
+      priority: 5,
+      label: 'Renseignement incomplet',
+      detail: 'Aucun signal confirmé: garder le plan discret jusqu’au prochain rafraîchissement intrigue.',
+      trigger: plannedAction?.actionCode ?? 'aucune action',
+    });
+  } else {
+    if (drillDown.signalType === 'sabotage' || drillDown.criticality === 'critical') {
+      warningCandidates.push({
+        tone: 'danger',
+        priority: 1,
+        label: 'Sabotage probable',
+        detail: `${drillDown.summary}; éviter de lancer ${plannedAction?.label ?? 'une action longue'} sans contre-mesure.`,
+        trigger: plannedAction?.actionCode ?? drillDown.recommendedResponseCode,
+      });
+    }
+
+    if ((drillDown.reasons ?? []).some((reason) => reason.includes('exposée'))) {
+      warningCandidates.push({
+        tone: 'warning',
+        priority: 2,
+        label: 'Exposition de cellule',
+        detail: 'La file d’actions peut révéler des relais: privilégier infiltration ou containment avant l’ordre principal.',
+        trigger: drillDown.primaryCelluleId ?? 'cellule locale',
+      });
+    }
+
+    if (selectedResponse?.cooldownTurns > 0 || selectedResponse?.escalationProbability === 'élevée') {
+      warningCandidates.push({
+        tone: selectedResponse.escalationProbability === 'élevée' ? 'danger' : 'watch',
+        priority: selectedResponse.escalationProbability === 'élevée' ? 1 : 3,
+        label: 'Cooldown / alerte active',
+        detail: `${selectedResponse.label}: cooldown ${selectedResponse.cooldownTurns} tour${selectedResponse.cooldownTurns > 1 ? 's' : ''}, chaleur +${selectedResponse.heatGenerated}, escalade ${selectedResponse.escalationProbability}.`,
+        trigger: selectedResponse.code,
+      });
+    }
+  }
+
+  if (province.supplyLevel !== 'stable' || province.loyalty < 50 || riskyActionCount > 0) {
+    warningCandidates.push({
+      tone: riskyActionCount > 0 ? 'warning' : 'watch',
+      priority: riskyActionCount > 0 ? 2 : 4,
+      label: 'Province vulnérable',
+      detail: `${province.label} cumule ${province.supplyLevel} / loyauté ${province.loyalty}; réduire l’empreinte avant d’empiler les ordres.`,
+      trigger: plannedAction?.actionCode ?? 'plan province',
+    });
+  }
+
+  return warningCandidates
+    .sort((left, right) => left.priority - right.priority || left.label.localeCompare(right.label))
+    .slice(0, 3);
+}
+
+function renderProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView) {
+  const warnings = buildProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView);
+
+  if (warnings.length === 0) {
+    return '';
+  }
+
+  return `
+    <section class="province-intrigue-risk-warnings" aria-label="Warnings intrigue du planning de province">
+      <div class="province-intrigue-risk-warnings__header">
+        <strong>Warnings intrigue planning</strong>
+        <span>${warnings.length} signal${warnings.length > 1 ? 's' : ''}</span>
+      </div>
+      <div class="province-intrigue-risk-warning-list">
+        ${warnings.map((warning) => `
+          <article class="province-intrigue-risk-warning province-intrigue-risk-warning--${warning.tone}">
+            <div>
+              <strong>${warning.label}</strong>
+              <code>${warning.trigger}</code>
+            </div>
+            <p>${warning.detail}</p>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const resolution = summarizeTurnResolutionPreview(province, actionQueue);
+  const intrigueWarnings = renderProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView);
 
   return `
     <section class="province-action-queue" aria-label="File d’actions préparées pour la province sélectionnée">
@@ -1422,6 +1528,7 @@ function renderSelectedProvinceActionQueue(province, shell, focusContext, intrig
         `).join('')}
       </ol>
     </section>
+    ${intrigueWarnings}
   `;
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -4634,3 +4634,50 @@ button { font: inherit; }
   margin-top: 3px;
   color: var(--muted);
 }
+
+
+.province-intrigue-risk-warnings {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(168, 85, 247, 0.18);
+}
+.province-intrigue-risk-warnings__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-risk-warnings__header span {
+  color: var(--muted);
+}
+.province-intrigue-risk-warning-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+.province-intrigue-risk-warning {
+  padding: 9px 10px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.28);
+  border-left: 3px solid rgba(148, 163, 184, 0.46);
+}
+.province-intrigue-risk-warning--danger { border-left-color: rgba(248, 113, 113, 0.8); }
+.province-intrigue-risk-warning--warning { border-left-color: rgba(250, 204, 21, 0.76); }
+.province-intrigue-risk-warning--watch { border-left-color: rgba(96, 165, 250, 0.7); }
+.province-intrigue-risk-warning--masked { border-left-color: rgba(148, 163, 184, 0.52); }
+.province-intrigue-risk-warning div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-risk-warning code {
+  color: #c4b5fd;
+  font-size: 0.72rem;
+}
+.province-intrigue-risk-warning p {
+  margin: 5px 0 0;
+  color: var(--muted);
+}


### PR DESCRIPTION
Delta: Closes #486.

Summary:
- add selected-province intrigue risk warnings tied to the action planning queue;
- cover sabotage probable, cell exposure, cooldown/alert, vulnerable province, and masked-intelligence cases;
- render compact priority warnings near the province action queue without adding map overlay clutter.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/war/webProvinceIntrigueRiskWarnings.test.js
- npm test (408 passing)

Delta: Ready for Zeta validation before merge.