### PR TITLE
Epsilon: Add climate hazard action blockers

### DIFF
--- a/test/ui/climate/webClimateHazardBlockers.test.js
+++ b/test/ui/climate/webClimateHazardBlockers.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable map adds climate hazard blockers to selected province action planning', () => {
+  assert.match(webAppSource, /function buildProvinceClimateHazardBlockers/);
+  assert.match(webAppSource, /function renderProvinceClimateHazardBlockers/);
+  assert.match(webAppSource, /Blockers climat planning/);
+  assert.match(webAppSource, /Hazard climat bloquant/);
+  assert.match(webAppSource, /Saison à risque court terme/);
+  assert.match(webAppSource, /Mitigation efficace/);
+  assert.match(webAppSource, /Aucun blocker climat/);
+  assert.match(webAppSource, /sûre/);
+  assert.match(webAppSource, /risquée/);
+  assert.match(webAppSource, /retardée/);
+  assert.match(webAppSource, /déconseillée/);
+  assert.match(webAppSource, /renderProvinceClimateHazardBlockers\(province, actionQueue\)/);
+  assert.match(stylesSource, /\.province-climate-hazard-blockers/);
+  assert.match(stylesSource, /province-climate-hazard-blocker--blocked/);
+  assert.match(stylesSource, /province-climate-hazard-blocker--risky/);
+  assert.match(stylesSource, /province-climate-hazard-blocker--delayed/);
+  assert.match(stylesSource, /province-climate-hazard-blocker--safe/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1276,6 +1276,100 @@ function renderProvinceClimateTurnReport(province) {
   `;
 }
 
+function buildProvinceClimateHazardBlockers(province, actionQueue) {
+  const report = buildProvinceClimateTurnReport(province);
+  const plannedAction = actionQueue[0] ?? null;
+  const riskDelta = report.deltas.find((delta) => delta.deltaId.includes(':risk') || delta.deltaId.includes(':anomaly'));
+  const recoveryDelta = report.deltas.find((delta) => delta.deltaId.includes(':recovery'));
+  const upcomingDelta = report.deltas.find((delta) => delta.deltaId.includes(':upcoming'));
+  const blockers = [];
+
+  if (report.state === 'risk') {
+    blockers.push({
+      tone: 'blocked',
+      status: 'déconseillée',
+      label: 'Hazard climat bloquant',
+      hazard: riskDelta?.label ?? 'risque climat accru',
+      detail: `${plannedAction?.label ?? 'Action principale'} déconseillée: ${riskDelta?.reason ?? report.summary}`,
+      trigger: plannedAction?.actionCode ?? 'plan province',
+      priority: 1,
+    });
+  }
+
+  if (upcomingDelta) {
+    blockers.push({
+      tone: upcomingDelta.tone === 'improved' ? 'safe' : 'delayed',
+      status: upcomingDelta.tone === 'improved' ? 'sûre' : 'retardée',
+      label: upcomingDelta.tone === 'improved' ? 'Fenêtre climat sûre' : 'Saison à risque court terme',
+      hazard: upcomingDelta.value,
+      detail: upcomingDelta.tone === 'improved'
+        ? `${plannedAction?.label ?? 'Action'} peut être planifiée pendant cette fenêtre: ${upcomingDelta.reason}`
+        : `${plannedAction?.label ?? 'Action'} devrait attendre ou recevoir une mitigation: ${upcomingDelta.reason}`,
+      trigger: plannedAction?.actionCode ?? 'saison suivante',
+      priority: upcomingDelta.tone === 'improved' ? 4 : 2,
+    });
+  }
+
+  if (recoveryDelta) {
+    blockers.push({
+      tone: recoveryDelta.tone === 'worse' ? 'blocked' : recoveryDelta.tone === 'partial' ? 'risky' : 'safe',
+      status: recoveryDelta.tone === 'worse' ? 'déconseillée' : recoveryDelta.tone === 'partial' ? 'risquée' : 'sûre',
+      label: recoveryDelta.tone === 'improved' ? 'Mitigation efficace' : 'Récupération à surveiller',
+      hazard: recoveryDelta.value,
+      detail: recoveryDelta.forecast && recoveryDelta.realized
+        ? `Prévu ${recoveryDelta.forecast.recoveryWindowDays}j / réalisé ${recoveryDelta.realized.recoveryWindowDays}j; garder ce délai dans la file d’actions.`
+        : recoveryDelta.reason,
+      trigger: plannedAction?.actionCode ?? recoveryDelta.deltaId,
+      priority: recoveryDelta.tone === 'improved' ? 3 : 2,
+    });
+  }
+
+  if (report.state === 'stable' || report.state === 'quiet') {
+    blockers.push({
+      tone: 'safe',
+      status: 'sûre',
+      label: 'Aucun blocker climat',
+      hazard: 'saison stable',
+      detail: `${plannedAction?.label ?? 'Action principale'} peut être planifiée sans retard climatique visible.`,
+      trigger: plannedAction?.actionCode ?? 'plan province',
+      priority: 5,
+    });
+  }
+
+  return blockers
+    .sort((left, right) => left.priority - right.priority || left.label.localeCompare(right.label))
+    .slice(0, 3);
+}
+
+function renderProvinceClimateHazardBlockers(province, actionQueue) {
+  const blockers = buildProvinceClimateHazardBlockers(province, actionQueue);
+
+  if (blockers.length === 0) {
+    return '';
+  }
+
+  return `
+    <section class="province-climate-hazard-blockers" aria-label="Blockers climatiques du planning de province">
+      <div class="province-climate-hazard-blockers__header">
+        <strong>Blockers climat planning</strong>
+        <span>${blockers.length} signal${blockers.length > 1 ? 's' : ''}</span>
+      </div>
+      <div class="province-climate-hazard-blocker-list">
+        ${blockers.map((blocker) => `
+          <article class="province-climate-hazard-blocker province-climate-hazard-blocker--${blocker.tone}">
+            <div>
+              <strong>${blocker.label}</strong>
+              <code>${blocker.status}</code>
+            </div>
+            <p>${blocker.detail}</p>
+            <small>Hazard: ${blocker.hazard} · Action: ${blocker.trigger}</small>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const logisticsPreview = buildProvinceLogisticsChoicePreviewView(province, economyView);
@@ -1567,6 +1661,7 @@ function renderSelectedProvinceActionQueue(province, shell, focusContext, intrig
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const resolution = summarizeTurnResolutionPreview(province, actionQueue);
   const intrigueWarnings = renderProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView);
+  const climateHazardBlockers = renderProvinceClimateHazardBlockers(province, actionQueue);
 
   return `
     <section class="province-action-queue" aria-label="File d’actions préparées pour la province sélectionnée">
@@ -1602,6 +1697,7 @@ function renderSelectedProvinceActionQueue(province, shell, focusContext, intrig
       </ol>
     </section>
     ${intrigueWarnings}
+    ${climateHazardBlockers}
   `;
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -4735,6 +4735,58 @@ button { font: inherit; }
 }
 
 
+
+.province-climate-hazard-blockers {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(8, 47, 73, 0.42), rgba(15, 23, 42, 0.58));
+  border: 1px solid rgba(103, 232, 249, 0.2);
+}
+.province-climate-hazard-blockers__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-climate-hazard-blockers__header span {
+  color: var(--muted);
+}
+.province-climate-hazard-blocker-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+.province-climate-hazard-blocker {
+  padding: 9px 10px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.3);
+  border-left: 3px solid rgba(148, 163, 184, 0.46);
+}
+.province-climate-hazard-blocker--blocked { border-left-color: rgba(248, 113, 113, 0.82); }
+.province-climate-hazard-blocker--risky { border-left-color: rgba(250, 204, 21, 0.78); }
+.province-climate-hazard-blocker--delayed { border-left-color: rgba(56, 189, 248, 0.72); }
+.province-climate-hazard-blocker--safe { border-left-color: rgba(74, 222, 128, 0.72); }
+.province-climate-hazard-blocker div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-climate-hazard-blocker code {
+  color: #a5f3fc;
+  font-size: 0.72rem;
+}
+.province-climate-hazard-blocker p {
+  margin: 5px 0 0;
+  color: var(--muted);
+}
+.province-climate-hazard-blocker small {
+  display: block;
+  margin-top: 5px;
+  color: #bae6fd;
+}
+
 .province-intrigue-risk-warnings {
   margin-top: 12px;
   padding: 12px;


### PR DESCRIPTION
Epsilon: Implements #487.

Summary:
- adds climate hazard blockers/warnings to selected province action planning;
- labels planned actions as safe, risky, delayed, or discouraged from current climate risk, upcoming season signals, and recovery/mitigation deltas;
- surfaces the relevant hazard and action trigger beside the existing action queue without changing climate simulation rules;
- adds compact climate blocker styling aligned with the existing intrigue planning warnings.

Validation:
- `npm test -- test/ui/climate/webClimateHazardBlockers.test.js test/ui/climate/webClimateTurnReportDeltas.test.js` → 2 pass
- `npm test` → 416 pass
- `node --check web/app.js` → OK
- `git diff --check` → OK

Zeta, peux-tu valider cette PR avant merge ?
