### PR TITLE
Alpha: Add conflict readiness warnings

### DIFF
--- a/test/ui/war/webConflictReadinessWarnings.test.js
+++ b/test/ui/war/webConflictReadinessWarnings.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('map end-turn summary exposes compact conflict readiness warnings', () => {
+  assert.match(webAppSource, /function buildConflictReadinessWarnings/);
+  assert.match(webAppSource, /function renderConflictReadinessWarnings/);
+  assert.match(webAppSource, /Préparation conflit/);
+  assert.match(webAppSource, /points clés/);
+  assert.match(webAppSource, /défense et ravitaillement restent mal couverts/);
+  assert.match(webAppSource, /confirmer seulement avec appui adjacent/);
+  assert.match(webAppSource, /couverture suffisante avant fin de tour/);
+  assert.match(webAppSource, /renderConflictReadinessWarnings\(shell, intrigueView\)/);
+  assert.match(stylesSource, /\.conflict-readiness-summary/);
+  assert.match(stylesSource, /conflict-readiness-warning--ready/);
+  assert.match(stylesSource, /conflict-readiness-warning--warning/);
+  assert.match(stylesSource, /conflict-readiness-warning--danger/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1821,6 +1821,63 @@ function renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigue
   `;
 }
 
+function buildConflictReadinessWarnings(shell, intrigueView = null) {
+  return shell.provinces
+    .map((province) => {
+      const focusContext = {
+        focusedProvinceId: province.provinceId,
+        focusedProvince: province,
+        neighborIds: new Set(province.neighborIds),
+      };
+      const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+      const outcome = buildConflictOutcomePreview(province, shell);
+      const blockedCount = actionQueue.filter((entry) => entry.status === 'blocked').length;
+      const riskyCount = actionQueue.filter((entry) => entry.status === 'risky').length;
+      const plannedAction = actionQueue[0] ?? null;
+      const score = (outcome.tone === 'danger' ? 40 : outcome.tone === 'warning' ? 24 : 8) + (blockedCount * 8) + (riskyCount * 4) + (province.contested ? 6 : 0);
+
+      return {
+        provinceId: province.provinceId,
+        provinceLabel: province.label,
+        actionCode: plannedAction?.actionCode ?? 'WAR-HOLD',
+        actionLabel: plannedAction?.label ?? 'Aucune action planifiée',
+        tone: blockedCount > 0 || outcome.tone === 'danger' ? 'danger' : riskyCount > 0 || outcome.tone === 'warning' ? 'warning' : 'ready',
+        score,
+        detail: outcome.tone === 'danger'
+          ? `${outcome.title}: défense et ravitaillement restent mal couverts.`
+          : outcome.tone === 'warning'
+            ? `${outcome.title}: confirmer seulement avec appui adjacent.`
+            : `${outcome.title}: couverture suffisante avant fin de tour.`,
+      };
+    })
+    .sort((left, right) => right.score - left.score || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 3);
+}
+
+function renderConflictReadinessWarnings(shell, intrigueView = null) {
+  const warnings = buildConflictReadinessWarnings(shell, intrigueView);
+
+  return `
+    <div class="conflict-readiness-summary" aria-label="Préparation conflit avant fin de tour">
+      <div class="conflict-readiness-summary__header">
+        <strong>Préparation conflit</strong>
+        <span>${warnings.length} points clés</span>
+      </div>
+      <div class="conflict-readiness-summary__list">
+        ${warnings.map((warning) => `
+          <article class="conflict-readiness-warning conflict-readiness-warning--${warning.tone}">
+            <div>
+              <strong>${warning.provinceLabel}</strong>
+              <span>${warning.actionCode} · ${warning.actionLabel}</span>
+            </div>
+            <p>${warning.detail}</p>
+          </article>
+        `).join('')}
+      </div>
+    </div>
+  `;
+}
+
 function renderActiveProvince(shell, economyView = null, intrigueView = null) {
   const focusContext = getFocusContext(shell);
   const province = shell.activeProvince ?? shell.provinces[0] ?? null;
@@ -4314,6 +4371,7 @@ function render() {
             <button type="button" class="turn-button turn-button--secondary" data-open-launcher="true">Changer de carte</button>
           </div>
           <p class="turn-summary">${state.lastTurnSummary}</p>
+          ${renderConflictReadinessWarnings(shell, intrigueView)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">
               <strong>Variation visible</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -111,6 +111,65 @@ button { font: inherit; }
   color: var(--muted);
   font-size: 13px;
 }
+.conflict-readiness-summary {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+  max-width: 62ch;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(251, 191, 36, 0.18);
+}
+.conflict-readiness-summary__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.conflict-readiness-summary__header strong {
+  color: #fde68a;
+  font-size: 13px;
+}
+.conflict-readiness-summary__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.conflict-readiness-summary__list {
+  display: grid;
+  gap: 6px;
+}
+.conflict-readiness-warning {
+  display: grid;
+  gap: 5px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.conflict-readiness-warning div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.conflict-readiness-warning strong {
+  color: #f8fafc;
+}
+.conflict-readiness-warning span,
+.conflict-readiness-warning p {
+  color: var(--muted);
+  font-size: 12px;
+}
+.conflict-readiness-warning p {
+  margin: 0;
+  line-height: 1.35;
+}
+.conflict-readiness-warning--ready { border-color: rgba(74, 222, 128, 0.24); }
+.conflict-readiness-warning--warning { border-color: rgba(251, 191, 36, 0.32); }
+.conflict-readiness-warning--danger { border-color: rgba(251, 113, 133, 0.38); }
 .culture-turn-report {
   margin-top: 12px;
   max-width: 58ch;


### PR DESCRIPTION
Alpha: Closes #493.

## Summary
- adds compact conflict-readiness warnings to the map end-turn/hero summary
- reuses existing province action queue and conflict outcome preview data to rank 2-3 key readiness points
- names the affected provinces and planned actions, distinguishing danger, warning, and ready coverage states
- keeps the section compact in the existing turn recap area without duplicating the selected-province impact panel
- adds a deterministic web smoke test for the warning contract and styles

## Verification
- npm test
- npm run preview:map -- /tmp/historia-conflict-readiness-warnings-preview.html
- node --test test/ui/war/webConflictReadinessWarnings.test.js
- node --check web/app.js
- git diff --check
