### PR TITLE
Gamma: Add culture opportunity reminders

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -1,0 +1,119 @@
+const STATUS_RANK = Object.freeze({ probable: 3, possible: 2, missing: 1 });
+const TONE_RANK = Object.freeze({ event: 5, opportunity: 5, risk: 4, research: 3, discovery: 2, identity: 1, neutral: 0 });
+
+function normalizeText(value, fallback = '') {
+  return String(value ?? fallback).trim();
+}
+
+function reminderTone(hint) {
+  if (hint.status === 'missing') {
+    return 'warning';
+  }
+
+  if (hint.tone === 'risk') {
+    return 'risk';
+  }
+
+  if (hint.tone === 'research') {
+    return 'research';
+  }
+
+  return hint.status === 'probable' ? 'opportunity' : 'possible';
+}
+
+function reminderLabel(hint) {
+  if (hint.status === 'probable') {
+    return hint.tone === 'event' || hint.tone === 'opportunity'
+      ? 'Prochain repère'
+      : 'Déblocage probable';
+  }
+
+  if (hint.status === 'possible') {
+    return hint.tone === 'research'
+      ? 'Recherche à suivre'
+      : 'Piste possible';
+  }
+
+  return 'Condition à combler';
+}
+
+function summarizeHint(hint, actionLabel) {
+  const provinceCopy = hint.regionId ? ` (${hint.regionId})` : '';
+
+  if (hint.status === 'probable') {
+    return `${hint.label}${provinceCopy}: à exploiter après ${actionLabel}.`;
+  }
+
+  if (hint.status === 'possible') {
+    return `${hint.label}${provinceCopy}: garder en vue avant de clore le tour.`;
+  }
+
+  return `${hint.label}${provinceCopy}: ${hint.cultureName} manque encore un signal exploitable.`;
+}
+
+function buildReminder(hint, actionLabel) {
+  return {
+    reminderId: `${hint.status}:${hint.tone}:${hint.regionId}:${hint.label}:${actionLabel}`,
+    tone: reminderTone(hint),
+    status: hint.status,
+    label: reminderLabel(hint),
+    summary: summarizeHint(hint, actionLabel),
+    provinceId: hint.regionId,
+    cultureName: hint.cultureName,
+    actionLabel,
+  };
+}
+
+function dedupeAndSort(reminders) {
+  const remindersByKey = new Map();
+
+  for (const reminder of reminders) {
+    const key = `${reminder.status}:${reminder.label}:${reminder.provinceId}:${reminder.cultureName}`;
+    const existingReminder = remindersByKey.get(key);
+
+    if (!existingReminder || STATUS_RANK[reminder.status] > STATUS_RANK[existingReminder.status]) {
+      remindersByKey.set(key, reminder);
+    }
+  }
+
+  return [...remindersByKey.values()]
+    .sort((left, right) => STATUS_RANK[right.status] - STATUS_RANK[left.status]
+      || TONE_RANK[right.tone] - TONE_RANK[left.tone]
+      || left.label.localeCompare(right.label))
+    .slice(0, 3);
+}
+
+export function buildCultureOpportunityReminders({
+  province = null,
+  actionQueue = [],
+  unlockHintsByAction = [],
+} = {}) {
+  const actionLabels = actionQueue.length > 0
+    ? actionQueue.map((entry) => normalizeText(entry.label, entry.actionCode ?? 'action planifiée'))
+    : ['plan actuel'];
+  const hints = unlockHintsByAction.flatMap((entry, index) => {
+    const actionLabel = normalizeText(entry.action?.label ?? entry.action?.title, actionLabels[index] ?? actionLabels[0]);
+    return (entry.hints ?? []).map((hint) => buildReminder(hint, actionLabel));
+  });
+  const reminders = dedupeAndSort(hints);
+  const provinceLabel = normalizeText(province?.label, province?.provinceId ?? 'province');
+
+  if (reminders.length === 0) {
+    return {
+      state: 'quiet',
+      provinceLabel,
+      summary: `${provinceLabel}: aucune opportunité culturelle nouvelle dans le plan de fin de tour.`,
+      reminders: [],
+    };
+  }
+
+  const probableCount = reminders.filter((reminder) => reminder.status === 'probable').length;
+  const missingCount = reminders.filter((reminder) => reminder.status === 'missing').length;
+
+  return {
+    state: 'active',
+    provinceLabel,
+    summary: `${provinceLabel}: ${probableCount} opportunité${probableCount > 1 ? 's' : ''} probable${probableCount > 1 ? 's' : ''}, ${missingCount} condition${missingCount > 1 ? 's' : ''} à surveiller.`,
+    reminders,
+  };
+}

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCultureOpportunityReminders } from '../../../src/ui/culture/buildCultureOpportunityReminders.js';
+
+test('buildCultureOpportunityReminders prioritizes actionable culture end-turn reminders', () => {
+  const report = buildCultureOpportunityReminders({
+    province: { provinceId: 'river-gate', label: 'Porte du Fleuve' },
+    actionQueue: [
+      { actionCode: 'SECURE', label: 'Sécuriser les archives' },
+      { actionCode: 'WATCH', label: 'Observer le delta' },
+    ],
+    unlockHintsByAction: [
+      {
+        action: { label: 'Sécuriser les archives' },
+        hints: [
+          {
+            status: 'possible',
+            tone: 'research',
+            label: 'Recherche culture',
+            explanation: 'tidal-ledgers liée au choix.',
+            regionId: 'river-gate',
+            cultureName: 'Compact d’Aurora',
+          },
+          {
+            status: 'probable',
+            tone: 'event',
+            label: 'Événement cluster',
+            explanation: 'Ouverture des archives proche.',
+            regionId: 'river-gate',
+            cultureName: 'Compact d’Aurora',
+          },
+        ],
+      },
+      {
+        action: { label: 'Observer le delta' },
+        hints: [
+          {
+            status: 'missing',
+            tone: 'identity',
+            label: 'Condition manquante',
+            explanation: 'Aucun pin actif.',
+            regionId: 'shared-bay',
+            cultureName: 'Ligues des Forges',
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(report.state, 'active');
+  assert.equal(report.summary, 'Porte du Fleuve: 1 opportunité probable, 1 condition à surveiller.');
+  assert.deepEqual(report.reminders.map((reminder) => [reminder.status, reminder.label, reminder.summary]), [
+    ['probable', 'Prochain repère', 'Événement cluster (river-gate): à exploiter après Sécuriser les archives.'],
+    ['possible', 'Recherche à suivre', 'Recherche culture (river-gate): garder en vue avant de clore le tour.'],
+    ['missing', 'Condition à combler', 'Condition manquante (shared-bay): Ligues des Forges manque encore un signal exploitable.'],
+  ]);
+});
+
+test('buildCultureOpportunityReminders returns a compact quiet summary without hints', () => {
+  assert.deepEqual(buildCultureOpportunityReminders({
+    province: { provinceId: 'quiet-field', label: 'Champ Calme' },
+    actionQueue: [],
+    unlockHintsByAction: [],
+  }), {
+    state: 'quiet',
+    provinceLabel: 'Champ Calme',
+    summary: 'Champ Calme: aucune opportunité culturelle nouvelle dans le plan de fin de tour.',
+    reminders: [],
+  });
+});

--- a/web/app.js
+++ b/web/app.js
@@ -20,6 +20,7 @@ import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTi
 import { buildCultureConsequenceChips } from '../src/ui/culture/buildCultureConsequenceChips.js';
 import { buildCultureTurnReportDeltas } from '../src/ui/culture/buildCultureTurnReportDeltas.js';
 import { buildCultureUnlockHints } from '../src/ui/culture/buildCultureUnlockHints.js';
+import { buildCultureOpportunityReminders } from '../src/ui/culture/buildCultureOpportunityReminders.js';
 import { buildClimateTurnReportDeltas } from '../src/ui/climate/buildClimateTurnReportDeltas.js';
 
 const culturePayload = {
@@ -888,6 +889,45 @@ function renderCultureUnlockHints(hints) {
         </span>
       `).join('')}
     </div>
+  `;
+}
+
+function buildCultureUnlockHintsForActions(province, actions, cultureContext) {
+  return actions.map((action) => ({
+    action,
+    hints: buildCultureUnlockHints({
+      province,
+      action: { title: action.title, label: action.label },
+      selectedMarker: cultureContext.selectedMarker,
+      selectedCluster: cultureContext.selectedCluster,
+      localTimeline: cultureContext.localTimeline,
+    }),
+  }));
+}
+
+function renderCultureOpportunityReminders(report) {
+  return `
+    <section class="culture-opportunity-reminders culture-opportunity-reminders--${report.state}" aria-label="Rappels culturels de fin de tour">
+      <div class="culture-opportunity-reminders__header">
+        <div>
+          <span>Rappels culture fin de tour</span>
+          <strong>${report.provinceLabel}</strong>
+        </div>
+        <small>${report.reminders.length} signal${report.reminders.length > 1 ? 's' : ''}</small>
+      </div>
+      <p>${report.summary}</p>
+      ${report.reminders.length > 0 ? `
+        <div class="culture-opportunity-reminder-list">
+          ${report.reminders.map((reminder) => `
+            <article class="culture-opportunity-reminder culture-opportunity-reminder--${reminder.tone}">
+              <span>${reminder.label}</span>
+              <strong>${reminder.cultureName}</strong>
+              <p>${reminder.summary}</p>
+            </article>
+          `).join('')}
+        </div>
+      ` : ''}
+    </section>
   `;
 }
 
@@ -1878,6 +1918,19 @@ function renderConflictReadinessWarnings(shell, intrigueView = null) {
   `;
 }
 
+function renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView = null) {
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const cultureContext = getSelectedCultureContext(province.provinceId);
+  const unlockHintsByAction = buildCultureUnlockHintsForActions(province, actionQueue, cultureContext);
+  const report = buildCultureOpportunityReminders({
+    province,
+    actionQueue,
+    unlockHintsByAction,
+  });
+
+  return renderCultureOpportunityReminders(report);
+}
+
 function renderActiveProvince(shell, economyView = null, intrigueView = null) {
   const focusContext = getFocusContext(shell);
   const province = shell.activeProvince ?? shell.provinces[0] ?? null;
@@ -1923,6 +1976,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView)}
+      ${renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView)}
       ${renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView)}
       ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}
       ${renderIntrigueTurnReportDeltas(province, intrigueView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -2029,6 +2029,71 @@ button { font: inherit; }
 .military-plan-impact--ready { border-color: rgba(45, 212, 191, 0.32); }
 .military-plan-impact--warning { border-color: rgba(251, 191, 36, 0.34); }
 .military-plan-impact--danger { border-color: rgba(251, 113, 133, 0.4); }
+.culture-opportunity-reminders {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.68), rgba(15, 23, 42, 0.54));
+  border: 1px solid rgba(34, 211, 238, 0.2);
+}
+.culture-opportunity-reminders__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.culture-opportunity-reminders__header span,
+.culture-opportunity-reminders__header small {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-opportunity-reminders__header strong { display: block; margin-top: 3px; }
+.culture-opportunity-reminders > p {
+  margin: 0;
+  color: #cffafe;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.culture-opportunity-reminder-list {
+  display: grid;
+  gap: 7px;
+}
+.culture-opportunity-reminder {
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.13);
+}
+.culture-opportunity-reminder span {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  margin-bottom: 3px;
+  text-transform: uppercase;
+}
+.culture-opportunity-reminder strong {
+  display: block;
+  color: #f8fafc;
+  font-size: 12px;
+  margin-bottom: 3px;
+}
+.culture-opportunity-reminder p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.culture-opportunity-reminder--opportunity { border-color: rgba(74, 222, 128, 0.28); }
+.culture-opportunity-reminder--possible { border-color: rgba(56, 189, 248, 0.26); }
+.culture-opportunity-reminder--research { border-color: rgba(34, 211, 238, 0.28); }
+.culture-opportunity-reminder--risk,
+.culture-opportunity-reminder--warning { border-color: rgba(251, 191, 36, 0.3); }
+.culture-opportunity-reminders--quiet { border-color: rgba(148, 163, 184, 0.16); }
 .province-economy-budget-preview {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
Gamma: Closes #495.

## Summary
- add a reusable culture opportunity reminder builder for map end-turn summaries
- summarize probable, possible, and missing culture opportunities from existing unlock hints after planned provincial actions
- surface compact province/culture reminders in the selected province recap without copying planning hint text verbatim
- add deterministic tests for prioritized reminders and quiet-state copy

## Validation
- `node --check web/app.js`
- `git diff --check`
- `npm test` (418 passing)

Gamma: Ready for Zeta validation before merge.
