### PR TITLE
Epsilon: Add climate preparedness turn summary

### DIFF
--- a/test/ui/climate/webClimatePreparednessSummary.test.js
+++ b/test/ui/climate/webClimatePreparednessSummary.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable map adds climate preparedness warnings to the end-turn summary', () => {
+  assert.match(webAppSource, /function buildMapClimatePreparednessSummary/);
+  assert.match(webAppSource, /function renderMapClimatePreparednessSummary/);
+  assert.match(webAppSource, /Préparation climat fin de tour/);
+  assert.match(webAppSource, /reste.*exposée.*au climat avant validation du tour/s);
+  assert.match(webAppSource, /mitigation.*climat confirmée/s);
+  assert.match(webAppSource, /aucun danger résiduel prioritaire/);
+  assert.match(webAppSource, /buildProvinceClimateHazardBlockers\(province, actionQueue\)/);
+  assert.match(webAppSource, /renderMapClimatePreparednessSummary\(climatePreparednessSummary\)/);
+  assert.match(stylesSource, /\.map-climate-preparedness/);
+  assert.match(stylesSource, /map-climate-preparedness--warning/);
+  assert.match(stylesSource, /map-climate-preparedness--mitigated/);
+  assert.match(stylesSource, /map-climate-preparedness__item--blocked/);
+  assert.match(stylesSource, /map-climate-preparedness__item--safe/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1370,6 +1370,79 @@ function renderProvinceClimateHazardBlockers(province, actionQueue) {
   `;
 }
 
+function buildMapClimatePreparednessSummary(shell, focusContext, intrigueView = null) {
+  const warnings = shell.provinces
+    .map((province) => {
+      const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+      const blockers = buildProvinceClimateHazardBlockers(province, actionQueue);
+      const urgentBlocker = blockers.find((blocker) => blocker.tone === 'blocked' || blocker.tone === 'delayed' || blocker.tone === 'risky') ?? null;
+      const mitigation = blockers.find((blocker) => blocker.tone === 'safe' && blocker.label === 'Mitigation efficace') ?? null;
+
+      if (!urgentBlocker && !mitigation) {
+        return null;
+      }
+
+      return {
+        provinceId: province.provinceId,
+        provinceLabel: province.label,
+        tone: urgentBlocker?.tone ?? 'safe',
+        status: urgentBlocker?.status ?? mitigation.status,
+        label: urgentBlocker?.label ?? mitigation.label,
+        hazard: urgentBlocker?.hazard ?? mitigation.hazard,
+        action: urgentBlocker?.trigger ?? mitigation.trigger,
+        detail: urgentBlocker?.detail ?? mitigation.detail,
+        priority: urgentBlocker?.priority ?? 4,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.priority - right.priority || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 4);
+  const exposedCount = warnings.filter((warning) => warning.tone !== 'safe').length;
+  const mitigatedCount = warnings.filter((warning) => warning.tone === 'safe').length;
+
+  return {
+    state: exposedCount > 0 ? 'warning' : mitigatedCount > 0 ? 'mitigated' : 'clear',
+    exposedCount,
+    mitigatedCount,
+    warnings,
+    summary: exposedCount > 0
+      ? `${exposedCount} province${exposedCount > 1 ? 's' : ''} reste${exposedCount > 1 ? 'nt' : ''} exposée${exposedCount > 1 ? 's' : ''} au climat avant validation du tour.`
+      : mitigatedCount > 0
+        ? `${mitigatedCount} mitigation${mitigatedCount > 1 ? 's' : ''} climat confirmée${mitigatedCount > 1 ? 's' : ''}; aucun danger résiduel prioritaire.`
+        : 'Préparation climat claire: aucun danger résiduel prioritaire avant validation du tour.',
+  };
+}
+
+function renderMapClimatePreparednessSummary(summary) {
+  if (summary.warnings.length === 0) {
+    return `
+      <section class="map-climate-preparedness map-climate-preparedness--clear" aria-label="Résumé de préparation climatique de fin de tour">
+        <strong>Préparation climat</strong>
+        <p>${summary.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="map-climate-preparedness map-climate-preparedness--${summary.state}" aria-label="Résumé de préparation climatique de fin de tour">
+      <div class="map-climate-preparedness__header">
+        <strong>Préparation climat fin de tour</strong>
+        <span>${summary.exposedCount} exposée${summary.exposedCount > 1 ? 's' : ''} · ${summary.mitigatedCount} mitigée${summary.mitigatedCount > 1 ? 's' : ''}</span>
+      </div>
+      <p>${summary.summary}</p>
+      <ul class="map-climate-preparedness__list">
+        ${summary.warnings.map((warning) => `
+          <li class="map-climate-preparedness__item map-climate-preparedness__item--${warning.tone}">
+            <b>${warning.provinceLabel}</b>
+            <span>${warning.status}: ${warning.hazard}</span>
+            <small>${warning.action} · ${warning.label}</small>
+          </li>
+        `).join('')}
+      </ul>
+    </section>
+  `;
+}
+
 function renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const logisticsPreview = buildProvinceLogisticsChoicePreviewView(province, economyView);
@@ -4354,6 +4427,7 @@ function render() {
     localTimeline: selectedCultureContext.localTimeline,
     consequenceChips: selectedCultureContext.consequenceChips,
   });
+  const climatePreparednessSummary = buildMapClimatePreparednessSummary(shell, focusContext, intrigueView);
 
   document.querySelector('#app').innerHTML = `
     <main class="shell-root">
@@ -4372,6 +4446,7 @@ function render() {
           </div>
           <p class="turn-summary">${state.lastTurnSummary}</p>
           ${renderConflictReadinessWarnings(shell, intrigueView)}
+          ${renderMapClimatePreparednessSummary(climatePreparednessSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">
               <strong>Variation visible</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -91,6 +91,60 @@ button { font: inherit; }
   margin: 12px 0 0;
   max-width: 52ch;
 }
+
+.map-climate-preparedness {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+  max-width: 68ch;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(8, 47, 73, 0.36), rgba(15, 23, 42, 0.56));
+  border: 1px solid rgba(103, 232, 249, 0.18);
+}
+.map-climate-preparedness--warning { border-color: rgba(251, 191, 36, 0.34); }
+.map-climate-preparedness--mitigated { border-color: rgba(74, 222, 128, 0.28); }
+.map-climate-preparedness--clear { border-color: rgba(148, 163, 184, 0.16); }
+.map-climate-preparedness__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-climate-preparedness__header span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.map-climate-preparedness p {
+  margin: 0;
+  color: #ccfbf1;
+  font-size: 13px;
+}
+.map-climate-preparedness__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.map-climate-preparedness__item {
+  display: grid;
+  gap: 2px;
+  padding: 7px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.3);
+  border-left: 3px solid rgba(148, 163, 184, 0.46);
+}
+.map-climate-preparedness__item--blocked { border-left-color: rgba(248, 113, 113, 0.82); }
+.map-climate-preparedness__item--risky { border-left-color: rgba(250, 204, 21, 0.78); }
+.map-climate-preparedness__item--delayed { border-left-color: rgba(56, 189, 248, 0.72); }
+.map-climate-preparedness__item--safe { border-left-color: rgba(74, 222, 128, 0.72); }
+.map-climate-preparedness__item span,
+.map-climate-preparedness__item small {
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .economy-turn-pulse {
   margin-top: 12px;
   display: inline-flex;


### PR DESCRIPTION
Epsilon: Implements #497.

Summary:
- adds a map end-turn climate preparedness summary near the turn recap;
- reuses existing climate hazard blockers, recovery/mitigation deltas, and action queue data across provinces;
- highlights the most urgent residual climate risks before turn validation and keeps successful mitigation confirmations short;
- styles the summary as a compact panel that does not obscure the map.

Validation:
- `npm test -- test/ui/climate/webClimatePreparednessSummary.test.js test/ui/climate/webClimateHazardBlockers.test.js` → 2 pass
- `npm test` → 417 pass
- `node --check web/app.js` → OK
- `git diff --check` → OK

Zeta, peux-tu valider cette PR avant merge ?
