### PR TITLE
Beta: add economy readiness warnings

### DIFF
--- a/src/ui/economy/buildEconomyReadinessWarnings.js
+++ b/src/ui/economy/buildEconomyReadinessWarnings.js
@@ -1,0 +1,101 @@
+function requireObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object.`);
+  }
+
+  return value;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value;
+}
+
+const STATUS_RANK = Object.freeze({ blocked: 3, risky: 2, ready: 1, empty: 0 });
+
+function getWarningTone(status) {
+  return status === 'blocked' ? 'critical' : status === 'risky' ? 'warning' : 'stable';
+}
+
+function buildPlanWarning(province, plan, budgetStatus) {
+  const resource = plan.consumedResources?.[0] ?? { label: 'ressource', quantity: plan.costUnits ?? 0 };
+  const route = plan.routeNames?.[0] ?? 'route locale';
+  const status = plan.status === 'blocked' ? 'blocked' : plan.status === 'risky' ? 'risky' : budgetStatus;
+
+  return {
+    tone: getWarningTone(status),
+    status,
+    provinceId: province.provinceId,
+    provinceLabel: province.label ?? province.provinceId,
+    label: status === 'blocked' ? 'Blocage budget' : status === 'risky' ? 'Compromis logistique' : 'Capacité sécurisée',
+    detail: `${province.label ?? province.provinceId}: ${plan.logisticsAction} sollicite ${resource.quantity} ${resource.label} via ${route}; ${plan.surplusOrShortage}.`,
+    routeName: route,
+    resourceLabel: resource.label,
+    score: (STATUS_RANK[status] ?? 0) * 100 + (plan.risk ?? 0) + (plan.costUnits ?? 0),
+  };
+}
+
+function buildChoiceWarning(province, choice) {
+  const status = choice.tone === 'high' ? 'risky' : 'ready';
+  const resource = choice.resources?.[0] ?? 'ressource';
+  const route = choice.routes?.[0] ?? 'route locale';
+
+  return {
+    tone: getWarningTone(status),
+    status,
+    provinceId: province.provinceId,
+    provinceLabel: province.label ?? province.provinceId,
+    label: choice.tone === 'high' ? 'Route sous stress' : 'Route surveillée',
+    detail: `${province.label ?? province.provinceId}: ${route} garde un risque ${choice.residualRisk ?? 0} sur ${resource}.`,
+    routeName: route,
+    resourceLabel: resource,
+    score: (choice.tone === 'high' ? 180 : 80) + (choice.residualRisk ?? 0),
+  };
+}
+
+export function buildEconomyReadinessWarnings(provinces, options = {}) {
+  const normalizedProvinces = requireArray(provinces, 'EconomyReadinessWarnings provinces');
+  const normalizedOptions = requireObject(options, 'EconomyReadinessWarnings options');
+  const budgetByProvinceId = requireObject(normalizedOptions.budgetByProvinceId ?? {}, 'EconomyReadinessWarnings budgetByProvinceId');
+  const logisticsByProvinceId = requireObject(normalizedOptions.logisticsByProvinceId ?? {}, 'EconomyReadinessWarnings logisticsByProvinceId');
+  const maxWarnings = Number.isInteger(normalizedOptions.maxWarnings) && normalizedOptions.maxWarnings > 0 ? normalizedOptions.maxWarnings : 3;
+
+  const warnings = normalizedProvinces.flatMap((province) => {
+    const budget = budgetByProvinceId[province.provinceId] ?? null;
+    const logistics = logisticsByProvinceId[province.provinceId] ?? null;
+    const planWarnings = (budget?.plans ?? [])
+      .filter((plan) => ['blocked', 'risky'].includes(plan.status) || budget.status === 'blocked')
+      .map((plan) => buildPlanWarning(province, plan, budget.status));
+
+    if (planWarnings.length > 0) {
+      return planWarnings;
+    }
+
+    const topChoice = logistics?.options?.[0] ?? null;
+    return topChoice && topChoice.tone === 'high' ? [buildChoiceWarning(province, topChoice)] : [];
+  })
+    .sort((left, right) => right.score - left.score || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, maxWarnings);
+
+  if (warnings.length === 0) {
+    return {
+      status: 'ready',
+      summary: 'Capacités économie/logistique lisibles: aucun blocage majeur avant validation du tour.',
+      warnings: [],
+    };
+  }
+
+  const blockedCount = warnings.filter((warning) => warning.status === 'blocked').length;
+  const riskyCount = warnings.filter((warning) => warning.status === 'risky').length;
+
+  return {
+    status: blockedCount > 0 ? 'blocked' : 'risky',
+    summary: blockedCount > 0
+      ? `${blockedCount} blocage${blockedCount > 1 ? 's' : ''} économie/logistique à lever avant fin de tour.`
+      : `${riskyCount} compromis économie/logistique à confirmer avant fin de tour.`,
+    warnings,
+  };
+}

--- a/test/ui/economy/buildEconomyReadinessWarnings.test.js
+++ b/test/ui/economy/buildEconomyReadinessWarnings.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildEconomyReadinessWarnings } from '../../../src/ui/economy/buildEconomyReadinessWarnings.js';
+
+const provinces = [
+  { provinceId: 'river-gate', label: 'Porte du Fleuve' },
+  { provinceId: 'iron-plain', label: 'Plaine de Fer' },
+];
+
+test('buildEconomyReadinessWarnings ranks blocked economy budgets first', () => {
+  const report = buildEconomyReadinessWarnings(provinces, {
+    budgetByProvinceId: {
+      'river-gate': {
+        status: 'blocked',
+        plans: [
+          {
+            status: 'blocked',
+            logisticsAction: 'Réparer route',
+            consumedResources: [{ label: 'Outils', quantity: 4 }],
+            routeNames: ['Ember Line'],
+            surplusOrShortage: '2 unités manquantes',
+            risk: 30,
+            costUnits: 4,
+          },
+        ],
+      },
+      'iron-plain': {
+        status: 'risky',
+        plans: [
+          {
+            status: 'risky',
+            logisticsAction: 'Sécuriser convoi',
+            consumedResources: [{ label: 'Grain', quantity: 3 }],
+            routeNames: ['Iron Road'],
+            surplusOrShortage: '1 unité restante',
+            risk: 58,
+            costUnits: 3,
+          },
+        ],
+      },
+    },
+  });
+
+  assert.equal(report.status, 'blocked');
+  assert.match(report.summary, /blocage/);
+  assert.equal(report.warnings[0].tone, 'critical');
+  assert.equal(report.warnings[0].provinceLabel, 'Porte du Fleuve');
+  assert.match(report.warnings[0].detail, /Ember Line/);
+  assert.match(report.warnings[0].detail, /Outils/);
+});
+
+test('buildEconomyReadinessWarnings falls back to high logistics route stress', () => {
+  const report = buildEconomyReadinessWarnings(provinces, {
+    logisticsByProvinceId: {
+      'iron-plain': {
+        options: [
+          {
+            tone: 'high',
+            routes: ['Iron Road'],
+            resources: ['Outils'],
+            residualRisk: 72,
+          },
+        ],
+      },
+    },
+  });
+
+  assert.equal(report.status, 'risky');
+  assert.equal(report.warnings.length, 1);
+  assert.equal(report.warnings[0].label, 'Route sous stress');
+  assert.match(report.warnings[0].detail, /Iron Road/);
+});
+
+test('buildEconomyReadinessWarnings returns compact ready state without warnings', () => {
+  const report = buildEconomyReadinessWarnings(provinces, {
+    budgetByProvinceId: {
+      'river-gate': { status: 'ready', plans: [{ status: 'ready' }] },
+    },
+  });
+
+  assert.equal(report.status, 'ready');
+  assert.deepEqual(report.warnings, []);
+  assert.match(report.summary, /aucun blocage majeur/);
+});
+
+test('buildEconomyReadinessWarnings validates inputs', () => {
+  assert.throws(() => buildEconomyReadinessWarnings(null), /provinces must be an array/);
+  assert.throws(() => buildEconomyReadinessWarnings(provinces, null), /options must be an object/);
+  assert.throws(() => buildEconomyReadinessWarnings(provinces, { budgetByProvinceId: [] }), /budgetByProvinceId must be an object/);
+});

--- a/test/ui/economy/webEconomyReadinessWarnings.test.js
+++ b/test/ui/economy/webEconomyReadinessWarnings.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable map wires economy readiness warnings into end-turn summary', () => {
+  assert.match(webAppSource, /buildEconomyReadinessWarnings/);
+  assert.match(webAppSource, /function renderEconomyReadinessWarnings/);
+  assert.match(webAppSource, /Readiness économie/);
+  assert.match(webAppSource, /Alertes économie et logistique avant fin de tour/);
+  assert.match(webAppSource, /budgetByProvinceId/);
+  assert.match(webAppSource, /logisticsByProvinceId/);
+  assert.match(webAppSource, /renderEconomyReadinessWarnings\(shell, economyView, focusContext, intrigueView\)/);
+  assert.match(stylesSource, /\.economy-readiness-warnings/);
+  assert.match(stylesSource, /economy-readiness-warning--critical/);
+  assert.match(stylesSource, /economy-readiness-warnings--risky/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -11,6 +11,7 @@ import { buildCityComparisonPanel } from '../src/ui/economy/buildCityComparisonP
 import { buildProvinceLogisticsChoicePreview } from '../src/ui/economy/buildProvinceLogisticsChoicePreview.js';
 import { buildProvinceEconomyTurnReport } from '../src/ui/economy/buildProvinceEconomyTurnReport.js';
 import { buildProvinceEconomyBudgetPreview } from '../src/ui/economy/buildProvinceEconomyBudgetPreview.js';
+import { buildEconomyReadinessWarnings } from '../src/ui/economy/buildEconomyReadinessWarnings.js';
 import { Cellule } from '../src/domain/intrigue/Cellule.js';
 import { OperationClandestine } from '../src/domain/intrigue/OperationClandestine.js';
 import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js';
@@ -1483,13 +1484,18 @@ function renderMapClimatePreparednessSummary(summary) {
   `;
 }
 
-function renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView = null) {
+function buildProvinceEconomyBudgetPreviewView(province, economyView, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const logisticsPreview = buildProvinceLogisticsChoicePreviewView(province, economyView);
-  const budget = buildProvinceEconomyBudgetPreview(province, economyView, {
+
+  return buildProvinceEconomyBudgetPreview(province, economyView, {
     actionQueue,
     logisticsChoices: logisticsPreview.options,
   });
+}
+
+function renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView = null) {
+  const budget = buildProvinceEconomyBudgetPreviewView(province, economyView, shell, focusContext, intrigueView);
 
   if (budget.status === 'empty') {
     return `
@@ -1529,6 +1535,41 @@ function renderProvinceEconomyBudgetPreview(province, economyView, shell, focusC
           </article>
         `).join('')}
       </div>
+    </section>
+  `;
+}
+
+function renderEconomyReadinessWarnings(shell, economyView, focusContext, intrigueView = null) {
+  const provinces = shell.provinces.slice(0, 6);
+  const logisticsByProvinceId = Object.fromEntries(
+    provinces.map((province) => [province.provinceId, buildProvinceLogisticsChoicePreviewView(province, economyView)]),
+  );
+  const budgetByProvinceId = Object.fromEntries(
+    provinces.map((province) => [province.provinceId, buildProvinceEconomyBudgetPreviewView(province, economyView, shell, focusContext, intrigueView)]),
+  );
+  const readiness = buildEconomyReadinessWarnings(provinces, {
+    budgetByProvinceId,
+    logisticsByProvinceId,
+    maxWarnings: 3,
+  });
+
+  return `
+    <section class="economy-readiness-warnings economy-readiness-warnings--${readiness.status}" aria-label="Alertes économie et logistique avant fin de tour">
+      <div class="economy-readiness-warnings__header">
+        <strong>Readiness économie</strong>
+        <span>${readiness.warnings.length > 0 ? `${readiness.warnings.length} alerte${readiness.warnings.length > 1 ? 's' : ''}` : 'sécurisé'}</span>
+      </div>
+      <p>${readiness.summary}</p>
+      ${readiness.warnings.length > 0 ? `
+        <ul class="economy-readiness-warnings__list">
+          ${readiness.warnings.map((warning) => `
+            <li class="economy-readiness-warning economy-readiness-warning--${warning.tone}">
+              <b>${warning.label}</b>
+              <span>${warning.detail}</span>
+            </li>
+          `).join('')}
+        </ul>
+      ` : ''}
     </section>
   `;
 }
@@ -4507,6 +4548,7 @@ function render() {
               <span>${economyView.pulse.city.name}, stock ${economyView.pulse.delta.stockDelta > 0 ? '+' : ''}${economyView.pulse.delta.stockDelta}, stabilité ${economyView.pulse.delta.stabilityDelta > 0 ? '+' : ''}${economyView.pulse.delta.stabilityDelta}, prospérité ${economyView.pulse.delta.prosperityDelta > 0 ? '+' : ''}${economyView.pulse.delta.prosperityDelta}</span>
             </div>
           ` : ''}
+          ${renderEconomyReadinessWarnings(shell, economyView, focusContext, intrigueView)}
           ${renderCultureTurnReport(cultureTurnReport)}
         </div>
         <div class="hero-stats">

--- a/web/styles.css
+++ b/web/styles.css
@@ -224,6 +224,64 @@ button { font: inherit; }
 .conflict-readiness-warning--ready { border-color: rgba(74, 222, 128, 0.24); }
 .conflict-readiness-warning--warning { border-color: rgba(251, 191, 36, 0.32); }
 .conflict-readiness-warning--danger { border-color: rgba(251, 113, 133, 0.38); }
+.economy-readiness-warnings {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+  max-width: 62ch;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.economy-readiness-warnings__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.economy-readiness-warnings__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.economy-readiness-warnings p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.economy-readiness-warnings__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.economy-readiness-warning {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(125, 211, 252, 0.12);
+}
+.economy-readiness-warning b {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.economy-readiness-warning span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.economy-readiness-warnings--blocked,
+.economy-readiness-warning--critical { border-color: rgba(251, 113, 133, 0.34); }
+.economy-readiness-warnings--risky,
+.economy-readiness-warning--warning { border-color: rgba(251, 191, 36, 0.3); }
+.economy-readiness-warnings--ready,
+.economy-readiness-warning--stable { border-color: rgba(74, 222, 128, 0.24); }
 .culture-turn-report {
   margin-top: 12px;
   max-width: 58ch;


### PR DESCRIPTION
Beta: Implements #494.

Scope:
- add a reusable economy/logistics readiness warning builder for end-turn summaries;
- reuse province budget previews and logistics choices to rank blocked/risky constraints;
- surface compact warnings with province, route, resource, surplus/shortage, and critical/compromise tone;
- wire the readiness summary into the map hero/end-turn area without repeating full province details.

Validation:
- node --test test/ui/economy/buildEconomyReadinessWarnings.test.js test/ui/economy/webEconomyReadinessWarnings.test.js
- npm test (422 passing)
- node --check web/app.js
- node --check src/ui/economy/buildEconomyReadinessWarnings.js
- git diff --check origin/main...HEAD
- git diff --check

Ready for Zeta validation before merge.