### PR TITLE
Delta: Add intrigue exposure end-turn summary

### DIFF
--- a/test/ui/intrigue/webIntrigueExposureEndTurnSummary.test.js
+++ b/test/ui/intrigue/webIntrigueExposureEndTurnSummary.test.js
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('map end-turn summary exposes intrigue exposure warnings and mitigations', () => {
+  assert.match(webAppSource, /function buildMapIntrigueExposureSummary/);
+  assert.match(webAppSource, /function renderMapIntrigueExposureSummary/);
+  assert.match(webAppSource, /Intrigue fin de tour/);
+  assert.match(webAppSource, /risque.*intrigue.*actif/s);
+  assert.match(webAppSource, /Exposition réduite/);
+  assert.match(webAppSource, /renderMapIntrigueExposureSummary\(intrigueExposureSummary\)/);
+  assert.match(stylesSource, /\.map-intrigue-exposure-summary/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1991,6 +1991,91 @@ function renderConflictReadinessWarnings(shell, intrigueView = null) {
   `;
 }
 
+
+function buildMapIntrigueExposureSummary(shell, intrigueView = null) {
+  const warnings = shell.provinces
+    .map((province) => {
+      const focusContext = {
+        focusedProvinceId: province.provinceId,
+        focusedProvince: province,
+        neighborIds: new Set(province.neighborIds),
+      };
+      const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+      const localWarnings = buildProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView);
+      const lead = localWarnings[0] ?? null;
+      const drillDown = findProvinceIntrigueDrillDown(province, intrigueView);
+      const response = drillDown?.quickResponses?.find((candidate) => candidate.code === drillDown.recommendedResponseCode)
+        ?? drillDown?.quickResponses?.[0]
+        ?? null;
+
+      if (!lead && !response) {
+        return null;
+      }
+
+      const mitigated = response && ['contenir', 'exposer'].includes(response.code) && response.escalationProbability !== 'élevée';
+
+      return {
+        provinceId: province.provinceId,
+        provinceLabel: province.label,
+        tone: mitigated ? 'mitigated' : lead?.tone ?? 'masked',
+        label: mitigated ? 'Exposition réduite' : lead.label,
+        risk: mitigated ? response.label : lead.label,
+        consequence: mitigated
+          ? `${response.label}: ${response.aftermathSummary ?? response.summary}`
+          : lead.detail,
+        trigger: mitigated ? response.code : lead.trigger,
+        priority: mitigated ? 4 : lead.priority,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.priority - right.priority || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 4);
+  const residualCount = warnings.filter((warning) => warning.tone !== 'mitigated').length;
+  const mitigatedCount = warnings.filter((warning) => warning.tone === 'mitigated').length;
+
+  return {
+    state: residualCount > 0 ? 'warning' : mitigatedCount > 0 ? 'mitigated' : 'clear',
+    residualCount,
+    mitigatedCount,
+    warnings,
+    summary: residualCount > 0
+      ? `${residualCount} risque${residualCount > 1 ? 's' : ''} intrigue reste${residualCount > 1 ? 'nt' : ''} actif${residualCount > 1 ? 's' : ''} avant fin de tour.`
+      : mitigatedCount > 0
+        ? `${mitigatedCount} exposition${mitigatedCount > 1 ? 's' : ''} intrigue fortement réduite${mitigatedCount > 1 ? 's' : ''} par le plan actuel.`
+        : 'Récap intrigue clair: aucun hotspot ou cooldown critique laissé ouvert.',
+  };
+}
+
+function renderMapIntrigueExposureSummary(summary) {
+  if (summary.warnings.length === 0) {
+    return `
+      <section class="map-intrigue-exposure-summary map-intrigue-exposure-summary--clear" aria-label="Résumé intrigue de fin de tour">
+        <strong>Intrigue fin de tour</strong>
+        <p>${summary.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="map-intrigue-exposure-summary map-intrigue-exposure-summary--${summary.state}" aria-label="Résumé intrigue de fin de tour">
+      <div class="map-intrigue-exposure-summary__header">
+        <strong>Intrigue fin de tour</strong>
+        <span>${summary.residualCount} résiduel${summary.residualCount > 1 ? 's' : ''} · ${summary.mitigatedCount} réduit${summary.mitigatedCount > 1 ? 's' : ''}</span>
+      </div>
+      <p>${summary.summary}</p>
+      <ul class="map-intrigue-exposure-summary__list">
+        ${summary.warnings.map((warning) => `
+          <li class="map-intrigue-exposure-summary__item map-intrigue-exposure-summary__item--${warning.tone}">
+            <b>${warning.provinceLabel}</b>
+            <span>${warning.risk}</span>
+            <small>${warning.trigger} · ${warning.consequence}</small>
+          </li>
+        `).join('')}
+      </ul>
+    </section>
+  `;
+}
+
 function renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const cultureContext = getSelectedCultureContext(province.provinceId);
@@ -4482,6 +4567,7 @@ function render() {
     consequenceChips: selectedCultureContext.consequenceChips,
   });
   const climatePreparednessSummary = buildMapClimatePreparednessSummary(shell, focusContext, intrigueView);
+  const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
     <main class="shell-root">
@@ -4501,6 +4587,7 @@ function render() {
           <p class="turn-summary">${state.lastTurnSummary}</p>
           ${renderConflictReadinessWarnings(shell, intrigueView)}
           ${renderMapClimatePreparednessSummary(climatePreparednessSummary)}
+          ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">
               <strong>Variation visible</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -5010,3 +5010,54 @@ button { font: inherit; }
   margin: 5px 0 0;
   color: var(--muted);
 }
+
+
+.map-intrigue-exposure-summary {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(168, 85, 247, 0.2);
+}
+.map-intrigue-exposure-summary--warning { border-color: rgba(248, 113, 113, 0.34); }
+.map-intrigue-exposure-summary--mitigated { border-color: rgba(34, 197, 94, 0.32); }
+.map-intrigue-exposure-summary--clear { border-color: rgba(148, 163, 184, 0.16); }
+.map-intrigue-exposure-summary__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.map-intrigue-exposure-summary p,
+.map-intrigue-exposure-summary__header span {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+.map-intrigue-exposure-summary__list {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.map-intrigue-exposure-summary__item {
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.28);
+  border-left: 3px solid rgba(148, 163, 184, 0.46);
+}
+.map-intrigue-exposure-summary__item--danger,
+.map-intrigue-exposure-summary__item--warning { border-left-color: rgba(248, 113, 113, 0.76); }
+.map-intrigue-exposure-summary__item--watch { border-left-color: rgba(96, 165, 250, 0.7); }
+.map-intrigue-exposure-summary__item--mitigated { border-left-color: rgba(34, 197, 94, 0.72); }
+.map-intrigue-exposure-summary__item--masked { border-left-color: rgba(148, 163, 184, 0.52); }
+.map-intrigue-exposure-summary__item b,
+.map-intrigue-exposure-summary__item span,
+.map-intrigue-exposure-summary__item small {
+  display: block;
+}
+.map-intrigue-exposure-summary__item span,
+.map-intrigue-exposure-summary__item small {
+  margin-top: 3px;
+  color: var(--muted);
+}


### PR DESCRIPTION
Delta: Closes #496.

Summary:
- add a compact intrigue end-turn exposure summary to the map hero;
- reuse existing hotspot, quick response/aftermath, and province planning warning signals;
- distinguish residual intrigue risks from mitigated exposure confirmations without adding overlay clutter.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/intrigue/webIntrigueExposureEndTurnSummary.test.js
- npm test (421 passing)

Delta: Ready for Zeta validation before merge.