### PR TITLE
Alpha: Make conflict readiness warnings focusable

### DIFF
--- a/test/ui/war/webFocusableConflictReadinessWarnings.test.js
+++ b/test/ui/war/webFocusableConflictReadinessWarnings.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('conflict readiness warnings expose focusable map targets', () => {
+  assert.match(webAppSource, /focusTargetLabel/);
+  assert.match(webAppSource, /priorityLabel/);
+  assert.match(webAppSource, /severityRank/);
+  assert.match(webAppSource, /expectedImpact/);
+  assert.match(webAppSource, /left\.severityRank - right\.severityRank/);
+  assert.match(webAppSource, /data-readiness-focus/);
+  assert.match(webAppSource, /data-province-id="\$\{warning\.provinceId\}"/);
+  assert.match(webAppSource, /aria-label="Focaliser \$\{warning\.focusTargetLabel\}/);
+  assert.match(webAppSource, /Priorité critique/);
+  assert.match(webAppSource, /À vérifier/);
+  assert.match(webAppSource, /Couvert/);
+  assert.match(stylesSource, /\.conflict-readiness-warning:hover/);
+  assert.match(stylesSource, /\.conflict-readiness-warning:focus-visible/);
+  assert.match(stylesSource, /cursor: pointer/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1990,13 +1990,18 @@ function buildConflictReadinessWarnings(shell, intrigueView = null) {
       const plannedAction = actionQueue[0] ?? null;
       const score = (outcome.tone === 'danger' ? 40 : outcome.tone === 'warning' ? 24 : 8) + (blockedCount * 8) + (riskyCount * 4) + (province.contested ? 6 : 0);
 
+      const tone = blockedCount > 0 || outcome.tone === 'danger' ? 'danger' : riskyCount > 0 || outcome.tone === 'warning' ? 'warning' : 'ready';
+
       return {
         provinceId: province.provinceId,
         provinceLabel: province.label,
+        focusTargetLabel: province.contested ? 'front contesté' : `province ${province.label}`,
         actionCode: plannedAction?.actionCode ?? 'WAR-HOLD',
         actionLabel: plannedAction?.label ?? 'Aucune action planifiée',
-        tone: blockedCount > 0 || outcome.tone === 'danger' ? 'danger' : riskyCount > 0 || outcome.tone === 'warning' ? 'warning' : 'ready',
-        score,
+        tone,
+        severityRank: tone === 'danger' ? 1 : tone === 'warning' ? 2 : 3,
+        expectedImpact: score,
+        priorityLabel: tone === 'danger' ? 'Priorité critique' : tone === 'warning' ? 'À vérifier' : 'Couvert',
         detail: outcome.tone === 'danger'
           ? `${outcome.title}: défense et ravitaillement restent mal couverts.`
           : outcome.tone === 'warning'
@@ -2004,7 +2009,7 @@ function buildConflictReadinessWarnings(shell, intrigueView = null) {
             : `${outcome.title}: couverture suffisante avant fin de tour.`,
       };
     })
-    .sort((left, right) => right.score - left.score || left.provinceLabel.localeCompare(right.provinceLabel))
+    .sort((left, right) => left.severityRank - right.severityRank || right.expectedImpact - left.expectedImpact || left.provinceLabel.localeCompare(right.provinceLabel))
     .slice(0, 3);
 }
 
@@ -2019,13 +2024,14 @@ function renderConflictReadinessWarnings(shell, intrigueView = null) {
       </div>
       <div class="conflict-readiness-summary__list">
         ${warnings.map((warning) => `
-          <article class="conflict-readiness-warning conflict-readiness-warning--${warning.tone}">
+          <button class="conflict-readiness-warning conflict-readiness-warning--${warning.tone}" type="button" data-province-id="${warning.provinceId}" data-readiness-focus="${warning.provinceId}" aria-label="Focaliser ${warning.focusTargetLabel}: ${warning.priorityLabel}">
             <div>
               <strong>${warning.provinceLabel}</strong>
-              <span>${warning.actionCode} · ${warning.actionLabel}</span>
+              <span>${warning.priorityLabel} · ${warning.focusTargetLabel}</span>
             </div>
+            <small>${warning.actionCode} · ${warning.actionLabel}</small>
             <p>${warning.detail}</p>
-          </article>
+          </button>
         `).join('')}
       </div>
     </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -198,10 +198,19 @@ button { font: inherit; }
 .conflict-readiness-warning {
   display: grid;
   gap: 5px;
+  width: 100%;
   padding: 8px;
   border-radius: 12px;
   background: rgba(2, 6, 23, 0.38);
   border: 1px solid rgba(148, 163, 184, 0.14);
+  text-align: left;
+  cursor: pointer;
+}
+.conflict-readiness-warning:hover,
+.conflict-readiness-warning:focus-visible {
+  border-color: rgba(125, 211, 252, 0.5);
+  box-shadow: 0 0 0 2px rgba(125, 211, 252, 0.16);
+  outline: none;
 }
 .conflict-readiness-warning div {
   display: flex;
@@ -213,6 +222,7 @@ button { font: inherit; }
   color: #f8fafc;
 }
 .conflict-readiness-warning span,
+.conflict-readiness-warning small,
 .conflict-readiness-warning p {
   color: var(--muted);
   font-size: 12px;


### PR DESCRIPTION
Alpha: Closes #503.

## Summary
- makes conflict-readiness warnings in the map end-turn summary directly focusable
- adds focus target, priority label, status, and stable severity/impact sorting for each warning
- turns each warning into an accessible map-target button wired through the existing province focus/selection handlers
- adds hover/focus-visible affordances while keeping the summary compact and mobile-friendly
- adds a deterministic web smoke test for focusable readiness targets and sorting metadata

## Verification
- npm test
- npm run preview:map -- /tmp/historia-focusable-conflict-readiness-preview.html
- node --test test/ui/war/webFocusableConflictReadinessWarnings.test.js
- node --check web/app.js
- git diff --check
