### PR TITLE
Gamma: Add culture reminder focus targets

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -52,6 +52,13 @@ function summarizeHint(hint, actionLabel) {
 }
 
 function buildReminder(hint, actionLabel) {
+  const focusTarget = hint.focusTarget ?? {
+    type: 'province',
+    id: hint.regionId,
+    regionId: hint.regionId,
+    label: 'Province liée',
+  };
+
   return {
     reminderId: `${hint.status}:${hint.tone}:${hint.regionId}:${hint.label}:${actionLabel}`,
     tone: reminderTone(hint),
@@ -61,6 +68,8 @@ function buildReminder(hint, actionLabel) {
     provinceId: hint.regionId,
     cultureName: hint.cultureName,
     actionLabel,
+    focusTarget,
+    focusCopy: `${focusTarget.type}: ${focusTarget.label}`,
   };
 }
 

--- a/src/ui/culture/buildCultureUnlockHints.js
+++ b/src/ui/culture/buildCultureUnlockHints.js
@@ -4,7 +4,18 @@ function normalizeText(value, fallback = '') {
   return String(value ?? fallback).trim();
 }
 
-function buildHint({ status, tone, label, explanation, regionId, cultureName, sourceId }) {
+function buildFocusTarget({ type = 'province', id, regionId, label }) {
+  const targetId = normalizeText(id, regionId);
+
+  return {
+    type,
+    id: targetId,
+    regionId,
+    label: normalizeText(label, targetId),
+  };
+}
+
+function buildHint({ status, tone, label, explanation, regionId, cultureName, sourceId, focusTarget }) {
   return {
     hintId: `${status}:${regionId}:${cultureName}:${label}:${sourceId ?? 'source'}`,
     status,
@@ -13,6 +24,8 @@ function buildHint({ status, tone, label, explanation, regionId, cultureName, so
     explanation,
     regionId,
     cultureName,
+    sourceId: sourceId ?? null,
+    focusTarget: focusTarget ?? buildFocusTarget({ regionId, label: 'Province liée' }),
   };
 }
 
@@ -48,6 +61,12 @@ function hintsFromTimeline(localTimeline, actionTitle, fallbackRegionId) {
       regionId: normalizeText(item.regionId, fallbackRegionId),
       cultureName: normalizeText(item.cultureName, 'Culture locale'),
       sourceId: item.timelineId,
+      focusTarget: buildFocusTarget({
+        type: 'timeline',
+        id: item.timelineId,
+        regionId: normalizeText(item.regionId, fallbackRegionId),
+        label: normalizeText(item.title, label),
+      }),
     });
   });
 }
@@ -70,6 +89,12 @@ function hintsFromMarker(marker, actionTitle, fallbackRegionId) {
       regionId,
       cultureName,
       sourceId: marker.overlayId,
+      focusTarget: buildFocusTarget({
+        type: 'marker',
+        id: marker.overlayId,
+        regionId,
+        label: cultureName,
+      }),
     }));
   }
 
@@ -82,6 +107,12 @@ function hintsFromMarker(marker, actionTitle, fallbackRegionId) {
       regionId,
       cultureName,
       sourceId: marker.overlayId,
+      focusTarget: buildFocusTarget({
+        type: 'marker',
+        id: marker.overlayId,
+        regionId,
+        label: cultureName,
+      }),
     }));
   }
 
@@ -109,6 +140,12 @@ function hintsFromCluster(cluster, actionTitle, fallbackRegionId) {
       regionId,
       cultureName: normalizeText(strongestEvent.cultureName, cultureName),
       sourceId: strongestEvent.pinId,
+      focusTarget: buildFocusTarget({
+        type: 'cluster',
+        id: cluster.clusterId,
+        regionId,
+        label: strongestEvent.name,
+      }),
     }));
   }
 
@@ -121,6 +158,12 @@ function hintsFromCluster(cluster, actionTitle, fallbackRegionId) {
       regionId,
       cultureName,
       sourceId: cluster.clusterId,
+      focusTarget: buildFocusTarget({
+        type: 'cluster',
+        id: cluster.clusterId,
+        regionId,
+        label: cultureName,
+      }),
     }));
   }
 
@@ -133,6 +176,12 @@ function hintsFromCluster(cluster, actionTitle, fallbackRegionId) {
       regionId,
       cultureName,
       sourceId: cluster.clusterId,
+      focusTarget: buildFocusTarget({
+        type: 'cluster',
+        id: cluster.clusterId,
+        regionId,
+        label: cultureName,
+      }),
     }));
   }
 
@@ -166,5 +215,6 @@ export function buildCultureUnlockHints({
     regionId,
     cultureName: 'Aucun signal',
     sourceId: actionTitle,
+    focusTarget: buildFocusTarget({ regionId, label: 'Province sans unlock' }),
   })];
 }

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { buildCultureOpportunityReminders } from '../../../src/ui/culture/buildCultureOpportunityReminders.js';
 
-test('buildCultureOpportunityReminders prioritizes actionable culture end-turn reminders', () => {
+test('buildCultureOpportunityReminders prioritizes actionable culture end-turn reminders with focus targets', () => {
   const report = buildCultureOpportunityReminders({
     province: { provinceId: 'river-gate', label: 'Porte du Fleuve' },
     actionQueue: [
@@ -21,6 +21,12 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
             explanation: 'tidal-ledgers liée au choix.',
             regionId: 'river-gate',
             cultureName: 'Compact d’Aurora',
+            focusTarget: {
+              type: 'marker',
+              id: 'river-gate:culture-aurora',
+              regionId: 'river-gate',
+              label: 'Compact d’Aurora',
+            },
           },
           {
             status: 'probable',
@@ -29,6 +35,12 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
             explanation: 'Ouverture des archives proche.',
             regionId: 'river-gate',
             cultureName: 'Compact d’Aurora',
+            focusTarget: {
+              type: 'cluster',
+              id: 'river-gate:culture-cluster',
+              regionId: 'river-gate',
+              label: 'Ouverture des archives',
+            },
           },
         ],
       },
@@ -42,6 +54,12 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
             explanation: 'Aucun pin actif.',
             regionId: 'shared-bay',
             cultureName: 'Ligues des Forges',
+            focusTarget: {
+              type: 'province',
+              id: 'shared-bay',
+              regionId: 'shared-bay',
+              label: 'Province liée',
+            },
           },
         ],
       },
@@ -50,11 +68,17 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
 
   assert.equal(report.state, 'active');
   assert.equal(report.summary, 'Porte du Fleuve: 1 opportunité probable, 1 condition à surveiller.');
-  assert.deepEqual(report.reminders.map((reminder) => [reminder.status, reminder.label, reminder.summary]), [
-    ['probable', 'Prochain repère', 'Événement cluster (river-gate): à exploiter après Sécuriser les archives.'],
-    ['possible', 'Recherche à suivre', 'Recherche culture (river-gate): garder en vue avant de clore le tour.'],
-    ['missing', 'Condition à combler', 'Condition manquante (shared-bay): Ligues des Forges manque encore un signal exploitable.'],
+  assert.deepEqual(report.reminders.map((reminder) => [reminder.status, reminder.label, reminder.summary, reminder.focusCopy]), [
+    ['probable', 'Prochain repère', 'Événement cluster (river-gate): à exploiter après Sécuriser les archives.', 'cluster: Ouverture des archives'],
+    ['possible', 'Recherche à suivre', 'Recherche culture (river-gate): garder en vue avant de clore le tour.', 'marker: Compact d’Aurora'],
+    ['missing', 'Condition à combler', 'Condition manquante (shared-bay): Ligues des Forges manque encore un signal exploitable.', 'province: Province liée'],
   ]);
+  assert.deepEqual(report.reminders[0].focusTarget, {
+    type: 'cluster',
+    id: 'river-gate:culture-cluster',
+    regionId: 'river-gate',
+    label: 'Ouverture des archives',
+  });
 });
 
 test('buildCultureOpportunityReminders returns a compact quiet summary without hints', () => {

--- a/test/ui/culture/buildCultureUnlockHints.test.js
+++ b/test/ui/culture/buildCultureUnlockHints.test.js
@@ -63,6 +63,13 @@ test('buildCultureUnlockHints ranks probable, possible, and missing unlock signa
     ['probable', 'Recherche culture', 'research'],
   ]);
   assert.equal(hints[0].explanation, 'Ouverture des archives peut suivre “Préparer la manœuvre”.');
+  assert.deepEqual(hints.map((hint) => hint.focusTarget.type), ['timeline', 'cluster', 'marker']);
+  assert.deepEqual(hints[0].focusTarget, {
+    type: 'timeline',
+    id: 'river-gate:event:archives-open',
+    regionId: 'river-gate',
+    label: 'Ouverture des archives',
+  });
 });
 
 test('buildCultureUnlockHints returns readable missing-condition fallbacks', () => {
@@ -78,6 +85,13 @@ test('buildCultureUnlockHints returns readable missing-condition fallbacks', () 
       explanation: 'Ajoutez découverte, repère ou cluster actif avant d’attendre un gain culturel.',
       regionId: 'quiet-field',
       cultureName: 'Aucun signal',
+      sourceId: 'Garder en observation',
+      focusTarget: {
+        type: 'province',
+        id: 'quiet-field',
+        regionId: 'quiet-field',
+        label: 'Province sans unlock',
+      },
     },
   ]);
 
@@ -98,5 +112,12 @@ test('buildCultureUnlockHints returns readable missing-condition fallbacks', () 
     explanation: 'Cluster visible, mais aucun pin découverte/événement ne justifie encore un unlock.',
     regionId: 'shared-bay',
     cultureName: 'Delta Scribes, Harbor Compact',
+    sourceId: 'shared-bay:culture-cluster',
+    focusTarget: {
+      type: 'cluster',
+      id: 'shared-bay:culture-cluster',
+      regionId: 'shared-bay',
+      label: 'Delta Scribes, Harbor Compact',
+    },
   });
 });

--- a/web/app.js
+++ b/web/app.js
@@ -924,6 +924,9 @@ function renderCultureOpportunityReminders(report) {
               <span>${reminder.label}</span>
               <strong>${reminder.cultureName}</strong>
               <p>${reminder.summary}</p>
+              <button type="button" data-culture-focus-region="${reminder.focusTarget.regionId}" data-culture-focus-type="${reminder.focusTarget.type}" data-culture-focus-id="${reminder.focusTarget.id}">
+                Voir ${reminder.focusCopy}
+              </button>
             </article>
           `).join('')}
         </div>
@@ -4873,6 +4876,18 @@ function render() {
 
     stage.addEventListener('mouseleave', stopDragging);
     stage.addEventListener('mouseup', stopDragging);
+  });
+
+  document.querySelectorAll('[data-culture-focus-region]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const provinceId = element.dataset.cultureFocusRegion;
+      state.selectedProvinceId = provinceId;
+      state.focusedProvinceId = provinceId;
+      state.popupProvinceId = provinceId;
+      state.activeOverlaySlot = 'culture';
+      state.mobilePanelSection = element.dataset.cultureFocusType === 'timeline' ? 'details' : 'overlay';
+      render();
+    });
   });
 
   document.querySelectorAll('[data-popup-action]').forEach((element) => {

--- a/web/styles.css
+++ b/web/styles.css
@@ -2200,6 +2200,18 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.culture-opportunity-reminder button {
+  margin-top: 7px;
+  padding: 5px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  background: rgba(14, 165, 233, 0.1);
+  color: #bae6fd;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+}
+.culture-opportunity-reminder button:hover { border-color: rgba(125, 211, 252, 0.5); }
 .culture-opportunity-reminder--opportunity { border-color: rgba(74, 222, 128, 0.28); }
 .culture-opportunity-reminder--possible { border-color: rgba(56, 189, 248, 0.26); }
 .culture-opportunity-reminder--research { border-color: rgba(34, 211, 238, 0.28); }


### PR DESCRIPTION
Gamma: Closes #505.

## Summary
- add focus targets to culture unlock hints for province, marker, cluster, and timeline sources
- carry those targets into end-turn culture opportunity reminders with compact focus copy
- make reminder cards clickable/focusable toward the related map province/culture overlay target
- update tests for stable target metadata, ordered reminders, and fallbacks

## Validation
- `node --check src/ui/culture/buildCultureUnlockHints.js`
- `node --check src/ui/culture/buildCultureOpportunityReminders.js`
- `node --check web/app.js`
- `git diff --check`
- `npm test` (426 passing)

Gamma: Ready for Zeta validation before merge.
