### PR TITLE
Beta: add logistics readiness focus targets

### DIFF
--- a/src/ui/economy/buildEconomyReadinessWarnings.js
+++ b/src/ui/economy/buildEconomyReadinessWarnings.js
@@ -23,6 +23,7 @@ function getWarningTone(status) {
 function buildPlanWarning(province, plan, budgetStatus) {
   const resource = plan.consumedResources?.[0] ?? { label: 'ressource', quantity: plan.costUnits ?? 0 };
   const route = plan.routeNames?.[0] ?? 'route locale';
+  const hubName = plan.hubName ?? null;
   const status = plan.status === 'blocked' ? 'blocked' : plan.status === 'risky' ? 'risky' : budgetStatus;
 
   return {
@@ -33,7 +34,15 @@ function buildPlanWarning(province, plan, budgetStatus) {
     label: status === 'blocked' ? 'Blocage budget' : status === 'risky' ? 'Compromis logistique' : 'Capacité sécurisée',
     detail: `${province.label ?? province.provinceId}: ${plan.logisticsAction} sollicite ${resource.quantity} ${resource.label} via ${route}; ${plan.surplusOrShortage}.`,
     routeName: route,
+    hubName,
     resourceLabel: resource.label,
+    focusTarget: {
+      kind: status === 'blocked' ? 'hub' : 'route',
+      provinceId: province.provinceId,
+      routeName: route,
+      hubName,
+      resourceLabel: resource.label,
+    },
     score: (STATUS_RANK[status] ?? 0) * 100 + (plan.risk ?? 0) + (plan.costUnits ?? 0),
   };
 }
@@ -51,7 +60,15 @@ function buildChoiceWarning(province, choice) {
     label: choice.tone === 'high' ? 'Route sous stress' : 'Route surveillée',
     detail: `${province.label ?? province.provinceId}: ${route} garde un risque ${choice.residualRisk ?? 0} sur ${resource}.`,
     routeName: route,
+    hubName: choice.affectedCity ?? null,
     resourceLabel: resource,
+    focusTarget: {
+      kind: 'route',
+      provinceId: province.provinceId,
+      routeName: route,
+      hubName: choice.affectedCity ?? null,
+      resourceLabel: resource,
+    },
     score: (choice.tone === 'high' ? 180 : 80) + (choice.residualRisk ?? 0),
   };
 }

--- a/test/ui/economy/buildEconomyReadinessWarnings.test.js
+++ b/test/ui/economy/buildEconomyReadinessWarnings.test.js
@@ -19,6 +19,7 @@ test('buildEconomyReadinessWarnings ranks blocked economy budgets first', () => 
             logisticsAction: 'Réparer route',
             consumedResources: [{ label: 'Outils', quantity: 4 }],
             routeNames: ['Ember Line'],
+            hubName: 'River Gate',
             surplusOrShortage: '2 unités manquantes',
             risk: 30,
             costUnits: 4,
@@ -48,6 +49,13 @@ test('buildEconomyReadinessWarnings ranks blocked economy budgets first', () => 
   assert.equal(report.warnings[0].provinceLabel, 'Porte du Fleuve');
   assert.match(report.warnings[0].detail, /Ember Line/);
   assert.match(report.warnings[0].detail, /Outils/);
+  assert.deepEqual(report.warnings[0].focusTarget, {
+    kind: 'hub',
+    provinceId: 'river-gate',
+    routeName: 'Ember Line',
+    hubName: 'River Gate',
+    resourceLabel: 'Outils',
+  });
 });
 
 test('buildEconomyReadinessWarnings falls back to high logistics route stress', () => {
@@ -59,6 +67,7 @@ test('buildEconomyReadinessWarnings falls back to high logistics route stress', 
             tone: 'high',
             routes: ['Iron Road'],
             resources: ['Outils'],
+            affectedCity: 'Iron Hub',
             residualRisk: 72,
           },
         ],
@@ -70,6 +79,8 @@ test('buildEconomyReadinessWarnings falls back to high logistics route stress', 
   assert.equal(report.warnings.length, 1);
   assert.equal(report.warnings[0].label, 'Route sous stress');
   assert.match(report.warnings[0].detail, /Iron Road/);
+  assert.equal(report.warnings[0].focusTarget.kind, 'route');
+  assert.equal(report.warnings[0].focusTarget.hubName, 'Iron Hub');
 });
 
 test('buildEconomyReadinessWarnings returns compact ready state without warnings', () => {

--- a/test/ui/economy/webEconomyReadinessWarnings.test.js
+++ b/test/ui/economy/webEconomyReadinessWarnings.test.js
@@ -12,8 +12,12 @@ test('playable map wires economy readiness warnings into end-turn summary', () =
   assert.match(webAppSource, /Alertes économie et logistique avant fin de tour/);
   assert.match(webAppSource, /budgetByProvinceId/);
   assert.match(webAppSource, /logisticsByProvinceId/);
+  assert.match(webAppSource, /function getEconomyReadinessFocusTarget/);
+  assert.match(webAppSource, /data-economy-readiness-focus/);
+  assert.match(webAppSource, /state\.activeOverlaySlot = 'economy-overlay'/);
   assert.match(webAppSource, /renderEconomyReadinessWarnings\(shell, economyView, focusContext, intrigueView\)/);
   assert.match(stylesSource, /\.economy-readiness-warnings/);
   assert.match(stylesSource, /economy-readiness-warning--critical/);
   assert.match(stylesSource, /economy-readiness-warnings--risky/);
+  assert.match(stylesSource, /\.economy-readiness-warning button/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1539,6 +1539,18 @@ function renderProvinceEconomyBudgetPreview(province, economyView, shell, focusC
   `;
 }
 
+function getEconomyReadinessFocusTarget(warning, economyView) {
+  const route = economyView.overlay.routes.find((candidate) => candidate.routeName === warning.focusTarget?.routeName) ?? null;
+  const hub = economyView.overlay.cities.find((candidate) => candidate.cityName === warning.focusTarget?.hubName) ?? null;
+
+  return {
+    provinceId: warning.provinceId,
+    routeId: route?.routeId ?? '',
+    cityId: hub?.cityId ?? '',
+    label: route?.routeName ?? hub?.cityName ?? warning.provinceLabel,
+  };
+}
+
 function renderEconomyReadinessWarnings(shell, economyView, focusContext, intrigueView = null) {
   const provinces = shell.provinces.slice(0, 6);
   const logisticsByProvinceId = Object.fromEntries(
@@ -1562,12 +1574,23 @@ function renderEconomyReadinessWarnings(shell, economyView, focusContext, intrig
       <p>${readiness.summary}</p>
       ${readiness.warnings.length > 0 ? `
         <ul class="economy-readiness-warnings__list">
-          ${readiness.warnings.map((warning) => `
-            <li class="economy-readiness-warning economy-readiness-warning--${warning.tone}">
-              <b>${warning.label}</b>
-              <span>${warning.detail}</span>
-            </li>
-          `).join('')}
+          ${readiness.warnings.map((warning) => {
+            const target = getEconomyReadinessFocusTarget(warning, economyView);
+
+            return `
+              <li class="economy-readiness-warning economy-readiness-warning--${warning.tone}">
+                <b>${warning.label}</b>
+                <span>${warning.detail}</span>
+                <button
+                  type="button"
+                  data-economy-readiness-focus="true"
+                  data-province-id="${target.provinceId}"
+                  data-route-id="${target.routeId}"
+                  data-city-id="${target.cityId}"
+                >Voir ${target.label}</button>
+              </li>
+            `;
+          }).join('')}
         </ul>
       ` : ''}
     </section>
@@ -4754,6 +4777,32 @@ function render() {
     element.addEventListener('click', () => {
       state.selectedRouteId = element.dataset.routeId;
       state.hoveredRouteId = element.dataset.routeId;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-economy-readiness-focus]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const provinceId = element.dataset.provinceId;
+      const routeId = element.dataset.routeId;
+      const cityId = element.dataset.cityId;
+      state.activeOverlaySlot = 'economy-overlay';
+      state.selectedProvinceId = provinceId;
+      state.focusedProvinceId = provinceId;
+      state.popupProvinceId = provinceId;
+
+      if (routeId) {
+        state.selectedRouteId = routeId;
+        state.hoveredRouteId = routeId;
+      }
+
+      if (cityId) {
+        state.selectedCityId = cityId;
+        state.hoveredCityId = cityId;
+      }
+
+      const viewport = document.querySelector('.map-viewport');
+      centerMapOnProvince(provinceId, viewport);
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -276,6 +276,23 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.economy-readiness-warning button {
+  justify-self: start;
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  background: rgba(14, 116, 144, 0.2);
+  color: #bae6fd;
+  border-radius: 999px;
+  padding: 5px 9px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.economy-readiness-warning button:hover {
+  border-color: rgba(186, 230, 253, 0.56);
+  color: #e0f2fe;
+}
 .economy-readiness-warnings--blocked,
 .economy-readiness-warning--critical { border-color: rgba(251, 113, 133, 0.34); }
 .economy-readiness-warnings--risky,


### PR DESCRIPTION
Beta: Implements #504.

Scope:
- add focus target metadata to economy/logistics readiness warnings;
- resolve warning route/hub labels to map route/city/province targets;
- add actionable warning buttons that switch to the economy overlay, select the province, route, and hub, and center the map;
- keep the end-turn summary compact while preserving neutral state behavior.

Validation:
- node --test test/ui/economy/buildEconomyReadinessWarnings.test.js test/ui/economy/webEconomyReadinessWarnings.test.js
- npm test (426 passing)
- node --check web/app.js
- node --check src/ui/economy/buildEconomyReadinessWarnings.js
- git diff --check

Ready for Zeta validation before merge.