### PR TITLE
Epsilon: Add climate preparedness focus targets

### DIFF
--- a/test/ui/climate/webClimatePreparednessFocusTargets.test.js
+++ b/test/ui/climate/webClimatePreparednessFocusTargets.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('climate preparedness warnings expose focusable map targets', () => {
+  assert.match(webAppSource, /focusTarget: \{/);
+  assert.match(webAppSource, /hazard-zone/);
+  assert.match(webAppSource, /critical-season/);
+  assert.match(webAppSource, /mitigation/);
+  assert.match(webAppSource, /data-climate-preparedness-focus="true"/);
+  assert.match(webAppSource, /data-climate-focus-type/);
+  assert.match(webAppSource, /data-climate-focus-id/);
+  assert.match(webAppSource, /Focaliser \$\{warning\.focusTarget\.label\}/);
+  assert.match(webAppSource, /state\.activeOverlaySlot = 'climate-overlay'/);
+  assert.match(webAppSource, /state\.mobilePanelSection = element\.dataset\.climateFocusType === 'mitigation' \? 'details' : 'overlay'/);
+  assert.match(webAppSource, /centerMapOnProvince\(provinceId, viewport\)/);
+  assert.match(stylesSource, /\.map-climate-preparedness__item button/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1426,16 +1426,35 @@ function buildMapClimatePreparednessSummary(shell, focusContext, intrigueView = 
         return null;
       }
 
+      const selectedBlocker = urgentBlocker ?? mitigation;
+      const focusType = urgentBlocker
+        ? urgentBlocker.tone === 'delayed'
+          ? 'critical-season'
+          : 'hazard-zone'
+        : 'mitigation';
+
       return {
         provinceId: province.provinceId,
         provinceLabel: province.label,
-        tone: urgentBlocker?.tone ?? 'safe',
-        status: urgentBlocker?.status ?? mitigation.status,
-        label: urgentBlocker?.label ?? mitigation.label,
-        hazard: urgentBlocker?.hazard ?? mitigation.hazard,
-        action: urgentBlocker?.trigger ?? mitigation.trigger,
-        detail: urgentBlocker?.detail ?? mitigation.detail,
-        priority: urgentBlocker?.priority ?? 4,
+        tone: selectedBlocker.tone,
+        status: selectedBlocker.status,
+        label: selectedBlocker.label,
+        hazard: selectedBlocker.hazard,
+        action: selectedBlocker.trigger,
+        detail: selectedBlocker.detail,
+        priority: selectedBlocker.priority ?? 4,
+        focusTarget: {
+          type: focusType,
+          provinceId: province.provinceId,
+          targetId: `${province.provinceId}:${focusType}`,
+          label: focusType === 'critical-season'
+            ? `Saison critique · ${selectedBlocker.hazard}`
+            : focusType === 'mitigation'
+              ? `Mitigation · ${selectedBlocker.hazard}`
+              : `Zone de danger · ${selectedBlocker.hazard}`,
+          reason: selectedBlocker.detail,
+          mitigation: selectedBlocker.label.includes('Mitigation') ? selectedBlocker.hazard : selectedBlocker.action,
+        },
       };
     })
     .filter(Boolean)
@@ -1480,6 +1499,14 @@ function renderMapClimatePreparednessSummary(summary) {
             <b>${warning.provinceLabel}</b>
             <span>${warning.status}: ${warning.hazard}</span>
             <small>${warning.action} · ${warning.label}</small>
+            <button
+              type="button"
+              data-climate-preparedness-focus="true"
+              data-province-id="${warning.focusTarget.provinceId}"
+              data-climate-focus-type="${warning.focusTarget.type}"
+              data-climate-focus-id="${warning.focusTarget.targetId}"
+              aria-label="Focaliser ${warning.focusTarget.label}: ${warning.focusTarget.reason}"
+            >Voir ${warning.focusTarget.label}</button>
           </li>
         `).join('')}
       </ul>
@@ -4809,6 +4836,21 @@ function render() {
         state.selectedCityId = cityId;
         state.hoveredCityId = cityId;
       }
+
+      const viewport = document.querySelector('.map-viewport');
+      centerMapOnProvince(provinceId, viewport);
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-climate-preparedness-focus]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const provinceId = element.dataset.provinceId;
+      state.activeOverlaySlot = 'climate-overlay';
+      state.selectedProvinceId = provinceId;
+      state.focusedProvinceId = provinceId;
+      state.popupProvinceId = provinceId;
+      state.mobilePanelSection = element.dataset.climateFocusType === 'mitigation' ? 'details' : 'overlay';
 
       const viewport = document.querySelector('.map-viewport');
       centerMapOnProvince(provinceId, viewport);

--- a/web/styles.css
+++ b/web/styles.css
@@ -139,6 +139,25 @@ button { font: inherit; }
 .map-climate-preparedness__item--risky { border-left-color: rgba(250, 204, 21, 0.78); }
 .map-climate-preparedness__item--delayed { border-left-color: rgba(56, 189, 248, 0.72); }
 .map-climate-preparedness__item--safe { border-left-color: rgba(74, 222, 128, 0.72); }
+
+.map-climate-preparedness__item button {
+  justify-self: start;
+  margin-top: 4px;
+  border: 1px solid rgba(103, 232, 249, 0.24);
+  background: rgba(8, 47, 73, 0.44);
+  color: #cffafe;
+  border-radius: 999px;
+  padding: 4px 9px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+}
+.map-climate-preparedness__item button:hover,
+.map-climate-preparedness__item button:focus-visible {
+  border-color: rgba(165, 243, 252, 0.72);
+  background: rgba(14, 116, 144, 0.42);
+}
+
 .map-climate-preparedness__item span,
 .map-climate-preparedness__item small {
   color: var(--muted);


### PR DESCRIPTION
Epsilon: Implements #507.

Summary:
- adds focus targets to climate preparedness warnings for hazard zones, critical seasons, and mitigation entries;
- adds “Voir …” actions that switch to the climate overlay, select/focus the target province, open the relevant mobile panel, and center the map;
- carries target reason/mitigation metadata from existing hazard blockers and preparedness warnings;
- keeps controls compact so the end-turn summary stays readable on small maps.

Validation:
- `npm test -- test/ui/climate/webClimatePreparednessFocusTargets.test.js test/ui/climate/webClimatePreparednessSummary.test.js` → 2 pass
- `npm test` → 428 pass
- `node --check web/app.js` → OK
- `git diff --check` → OK

Zeta, peux-tu valider cette PR avant merge ?
