### PR TITLE
Delta: Add fog-aware intrigue focus targets

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('intrigue end-turn exposure warnings expose fog-aware focus targets', () => {
+  assert.match(webAppSource, /function buildIntrigueExposureFocusTarget/);
+  assert.match(webAppSource, /data-intrigue-focus-target/);
+  assert.match(webAppSource, /focusTarget\.state/);
+  assert.match(webAppSource, /cible confirmée|hotspot confirmé/);
+  assert.match(webAppSource, /zone probable/);
+  assert.match(webAppSource, /brouillard préservé/);
+  assert.match(webAppSource, /Information masquée/);
+  assert.match(stylesSource, /map-intrigue-exposure-summary__item--confirmed/);
+  assert.match(stylesSource, /map-intrigue-exposure-summary__item--probable/);
+  assert.match(stylesSource, /map-intrigue-exposure-summary__item--masked/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2065,6 +2065,69 @@ function renderConflictReadinessWarnings(shell, intrigueView = null) {
 }
 
 
+
+function buildIntrigueExposureFocusTarget(province, drillDown, leadWarning, response, mitigated) {
+  if (mitigated && drillDown) {
+    return {
+      state: 'confirmed',
+      kind: response.code === 'exposer' ? 'cellule' : 'hotspot',
+      provinceId: province.provinceId,
+      targetId: response.code === 'exposer' ? drillDown.primaryCelluleId ?? drillDown.locationId : drillDown.locationId,
+      label: response.code === 'exposer'
+        ? `Cellule ${drillDown.primaryCelluleId ?? 'locale'} confirmée`
+        : `Hotspot confirmé ${drillDown.locationName}`,
+      hint: 'focus confirmé',
+      focusable: true,
+    };
+  }
+
+  if (drillDown?.primaryCelluleId) {
+    return {
+      state: 'confirmed',
+      kind: 'cellule',
+      provinceId: province.provinceId,
+      targetId: drillDown.primaryCelluleId,
+      label: `Cellule ${drillDown.primaryCelluleId}`,
+      hint: 'cible confirmée',
+      focusable: true,
+    };
+  }
+
+  if (drillDown?.locationId) {
+    return {
+      state: 'confirmed',
+      kind: 'hotspot',
+      provinceId: province.provinceId,
+      targetId: drillDown.locationId,
+      label: `Hotspot ${drillDown.locationName}`,
+      hint: 'hotspot confirmé',
+      focusable: true,
+    };
+  }
+
+  if (leadWarning?.tone !== 'masked') {
+    return {
+      state: 'probable',
+      kind: 'province',
+      provinceId: province.provinceId,
+      targetId: province.provinceId,
+      label: `Zone probable ${province.label}`,
+      hint: 'zone probable',
+      focusable: true,
+    };
+  }
+
+  return {
+    state: 'masked',
+    kind: 'fog',
+    provinceId: null,
+    targetId: null,
+    label: 'Information masquée',
+    hint: 'brouillard préservé',
+    focusable: false,
+  };
+}
+
 function buildMapIntrigueExposureSummary(shell, intrigueView = null) {
   const warnings = shell.provinces
     .map((province) => {
@@ -2087,6 +2150,8 @@ function buildMapIntrigueExposureSummary(shell, intrigueView = null) {
 
       const mitigated = response && ['contenir', 'exposer'].includes(response.code) && response.escalationProbability !== 'élevée';
 
+      const focusTarget = buildIntrigueExposureFocusTarget(province, drillDown, lead, response, mitigated);
+
       return {
         provinceId: province.provinceId,
         provinceLabel: province.label,
@@ -2098,6 +2163,7 @@ function buildMapIntrigueExposureSummary(shell, intrigueView = null) {
           : lead.detail,
         trigger: mitigated ? response.code : lead.trigger,
         priority: mitigated ? 4 : lead.priority,
+        focusTarget,
       };
     })
     .filter(Boolean)
@@ -2138,10 +2204,13 @@ function renderMapIntrigueExposureSummary(summary) {
       <p>${summary.summary}</p>
       <ul class="map-intrigue-exposure-summary__list">
         ${summary.warnings.map((warning) => `
-          <li class="map-intrigue-exposure-summary__item map-intrigue-exposure-summary__item--${warning.tone}">
-            <b>${warning.provinceLabel}</b>
+          <li class="map-intrigue-exposure-summary__item map-intrigue-exposure-summary__item--${warning.tone} map-intrigue-exposure-summary__item--${warning.focusTarget.state}">
+            <div>
+              <b>${warning.provinceLabel}</b>
+              ${warning.focusTarget.focusable ? `<button type="button" data-province-id="${warning.focusTarget.provinceId}" data-intrigue-focus-target="${warning.focusTarget.kind}:${warning.focusTarget.targetId}" aria-label="Focaliser ${warning.focusTarget.label}">${warning.focusTarget.hint}</button>` : `<em>${warning.focusTarget.hint}</em>`}
+            </div>
             <span>${warning.risk}</span>
-            <small>${warning.trigger} · ${warning.consequence}</small>
+            <small>${warning.focusTarget.label} · ${warning.trigger} · ${warning.consequence}</small>
           </li>
         `).join('')}
       </ul>

--- a/web/styles.css
+++ b/web/styles.css
@@ -5158,3 +5158,31 @@ button { font: inherit; }
   margin-top: 3px;
   color: var(--muted);
 }
+
+.map-intrigue-exposure-summary__item--confirmed { box-shadow: inset 3px 0 0 rgba(34, 197, 94, 0.32); }
+.map-intrigue-exposure-summary__item--probable { box-shadow: inset 3px 0 0 rgba(250, 204, 21, 0.28); }
+.map-intrigue-exposure-summary__item--masked { opacity: 0.86; }
+.map-intrigue-exposure-summary__item div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.map-intrigue-exposure-summary__item button,
+.map-intrigue-exposure-summary__item em {
+  border: 1px solid rgba(167, 139, 250, 0.28);
+  border-radius: 999px;
+  padding: 3px 8px;
+  background: rgba(88, 28, 135, 0.22);
+  color: #ddd6fe;
+  font-size: 0.72rem;
+  font-style: normal;
+}
+.map-intrigue-exposure-summary__item button {
+  cursor: pointer;
+}
+.map-intrigue-exposure-summary__item button:hover,
+.map-intrigue-exposure-summary__item button:focus-visible {
+  border-color: rgba(216, 180, 254, 0.62);
+  outline: none;
+}


### PR DESCRIPTION
Delta: Closes #506.

Summary:
- add fog-aware focus targets to intrigue exposure end-turn warnings;
- distinguish confirmed hotspot/cell targets, probable province zones, and intentionally masked intelligence;
- make focusable targets reuse existing province focus behavior while preserving compact end-turn summary presentation.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js test/ui/intrigue/webIntrigueExposureEndTurnSummary.test.js
- npm test (428 passing)

Delta: Ready for Zeta validation before merge.