### PR TITLE
Delta: clarify fog-limited intrigue focus targets

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -9,11 +9,16 @@ test('intrigue end-turn exposure warnings expose fog-aware focus targets', () =>
   assert.match(webAppSource, /function buildIntrigueExposureFocusTarget/);
   assert.match(webAppSource, /data-intrigue-focus-target/);
   assert.match(webAppSource, /focusTarget\.state/);
+  assert.match(webAppSource, /data-intrigue-fog-state/);
   assert.match(webAppSource, /cible confirmée|hotspot confirmé/);
   assert.match(webAppSource, /zone probable/);
-  assert.match(webAppSource, /brouillard préservé/);
-  assert.match(webAppSource, /Information masquée/);
+  assert.match(webAppSource, /Partiellement révélé/);
+  assert.match(webAppSource, /Brouillard préservé: focus limité à la province/);
+  assert.match(webAppSource, /Cible masquée par le brouillard/);
+  assert.match(webAppSource, /sans révéler cellule ou opération/);
   assert.match(stylesSource, /map-intrigue-exposure-summary__item--confirmed/);
   assert.match(stylesSource, /map-intrigue-exposure-summary__item--probable/);
   assert.match(stylesSource, /map-intrigue-exposure-summary__item--masked/);
+  assert.match(stylesSource, /data-intrigue-fog-state="probable"/);
+  assert.match(stylesSource, /data-intrigue-fog-state="masked"/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -2118,6 +2118,11 @@ function buildIntrigueExposureFocusTarget(province, drillDown, leadWarning, resp
         ? `Cellule ${drillDown.primaryCelluleId ?? 'locale'} confirmée`
         : `Hotspot confirmé ${drillDown.locationName}`,
       hint: 'focus confirmé',
+      visibilityLabel: 'Révélé',
+      privacyReason: 'Renseignement confirmé: le focus peut afficher la cible précise.',
+      ariaLabel: response.code === 'exposer'
+        ? `Focaliser cellule confirmée en ${province.label}`
+        : `Focaliser hotspot confirmé en ${province.label}`,
       focusable: true,
     };
   }
@@ -2130,6 +2135,9 @@ function buildIntrigueExposureFocusTarget(province, drillDown, leadWarning, resp
       targetId: drillDown.primaryCelluleId,
       label: `Cellule ${drillDown.primaryCelluleId}`,
       hint: 'cible confirmée',
+      visibilityLabel: 'Révélé',
+      privacyReason: 'Cellule identifiée par le drilldown: aucun brouillard restant sur cette cible.',
+      ariaLabel: `Focaliser cellule confirmée en ${province.label}`,
       focusable: true,
     };
   }
@@ -2142,6 +2150,9 @@ function buildIntrigueExposureFocusTarget(province, drillDown, leadWarning, resp
       targetId: drillDown.locationId,
       label: `Hotspot ${drillDown.locationName}`,
       hint: 'hotspot confirmé',
+      visibilityLabel: 'Révélé',
+      privacyReason: 'Hotspot local confirmé: le focus peut afficher la province sans masquer la source.',
+      ariaLabel: `Focaliser hotspot confirmé en ${province.label}`,
       focusable: true,
     };
   }
@@ -2149,23 +2160,29 @@ function buildIntrigueExposureFocusTarget(province, drillDown, leadWarning, resp
   if (leadWarning?.tone !== 'masked') {
     return {
       state: 'probable',
-      kind: 'province',
+      kind: 'province-fog',
       provinceId: province.provinceId,
       targetId: province.provinceId,
       label: `Zone probable ${province.label}`,
       hint: 'zone probable',
+      visibilityLabel: 'Partiellement révélé',
+      privacyReason: 'Signal agrégé par le brouillard: seules la province et la raison de soupçon sont affichées.',
+      ariaLabel: `Focaliser zone probable sans révéler cellule ou opération en ${province.label}`,
       focusable: true,
     };
   }
 
   return {
     state: 'masked',
-    kind: 'fog',
-    provinceId: null,
-    targetId: null,
-    label: 'Information masquée',
-    hint: 'brouillard préservé',
-    focusable: false,
+    kind: 'province-fog',
+    provinceId: province.provinceId,
+    targetId: province.provinceId,
+    label: `Cible masquée par le brouillard en ${province.label}`,
+    hint: 'voir zone masquée',
+    visibilityLabel: 'Masqué',
+    privacyReason: 'Brouillard préservé: focus limité à la province, cellule et opération restent cachées.',
+    ariaLabel: `Focaliser zone masquée sans révéler cible intrigue en ${province.label}`,
+    focusable: true,
   };
 }
 
@@ -2248,10 +2265,10 @@ function renderMapIntrigueExposureSummary(summary) {
           <li class="map-intrigue-exposure-summary__item map-intrigue-exposure-summary__item--${warning.tone} map-intrigue-exposure-summary__item--${warning.focusTarget.state}">
             <div>
               <b>${warning.provinceLabel}</b>
-              ${warning.focusTarget.focusable ? `<button type="button" data-province-id="${warning.focusTarget.provinceId}" data-intrigue-focus-target="${warning.focusTarget.kind}:${warning.focusTarget.targetId}" aria-label="Focaliser ${warning.focusTarget.label}">${warning.focusTarget.hint}</button>` : `<em>${warning.focusTarget.hint}</em>`}
+              ${warning.focusTarget.focusable ? `<button type="button" data-province-id="${warning.focusTarget.provinceId}" data-intrigue-focus-target="${warning.focusTarget.kind}:${warning.focusTarget.targetId}" data-intrigue-fog-state="${warning.focusTarget.state}" aria-label="${warning.focusTarget.ariaLabel}">${warning.focusTarget.hint}</button>` : `<em>${warning.focusTarget.hint}</em>`}
             </div>
             <span>${warning.risk}</span>
-            <small>${warning.focusTarget.label} · ${warning.trigger} · ${warning.consequence}</small>
+            <small><b>${warning.focusTarget.visibilityLabel}</b> · ${warning.focusTarget.label} · ${warning.trigger} · ${warning.focusTarget.privacyReason} · ${warning.consequence}</small>
           </li>
         `).join('')}
       </ul>

--- a/web/styles.css
+++ b/web/styles.css
@@ -5232,6 +5232,21 @@ button { font: inherit; }
 .map-intrigue-exposure-summary__item button {
   cursor: pointer;
 }
+.map-intrigue-exposure-summary__item button[data-intrigue-fog-state="probable"] {
+  border-color: rgba(250, 204, 21, 0.38);
+  background: rgba(113, 63, 18, 0.22);
+  color: #fde68a;
+}
+.map-intrigue-exposure-summary__item button[data-intrigue-fog-state="masked"] {
+  border-color: rgba(148, 163, 184, 0.34);
+  background: rgba(51, 65, 85, 0.28);
+  color: #cbd5e1;
+}
+.map-intrigue-exposure-summary__item small b {
+  color: #e9d5ff;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
 .map-intrigue-exposure-summary__item button:hover,
 .map-intrigue-exposure-summary__item button:focus-visible {
   border-color: rgba(216, 180, 254, 0.62);


### PR DESCRIPTION
Delta: Implements #516.\n\nSummary:\n- Adds explicit revealed/partially revealed/masked labels for intrigue end-turn focus targets.\n- Keeps fog-limited targets focused only on the province, with non-spoiling privacy reasons for masked/partial signals.\n- Adds fog-state attributes and visual treatment for probable/masked intrigue focus buttons.\n\nValidation:\n- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js\n- node --check web/app.js\n- git diff --check\n- npm test (430 passing)\n\nZeta, please validate before any merge.