### PR TITLE
Gamma: add culture urgency badges

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -37,18 +37,54 @@ function reminderLabel(hint) {
   return 'Condition à combler';
 }
 
-function summarizeHint(hint, actionLabel) {
-  const provinceCopy = hint.regionId ? ` (${hint.regionId})` : '';
+function buildFallbackUrgency(hint, focusTarget) {
+  if (hint.urgency) {
+    return hint.urgency;
+  }
+
+  if (focusTarget.urgency) {
+    return focusTarget.urgency;
+  }
 
   if (hint.status === 'probable') {
-    return `${hint.label}${provinceCopy}: à exploiter après ${actionLabel}.`;
+    return {
+      level: 'soon',
+      label: 'Expire bientôt',
+      window: 'ce tour',
+      detail: `${focusTarget.label}: fenêtre courte, à traiter avant de clore le tour.`,
+    };
   }
 
   if (hint.status === 'possible') {
-    return `${hint.label}${provinceCopy}: garder en vue avant de clore le tour.`;
+    return {
+      level: hint.tone === 'research' || hint.tone === 'discovery' ? 'new' : 'stable',
+      label: hint.tone === 'research' || hint.tone === 'discovery' ? 'Nouveau signal' : 'Fenêtre stable',
+      window: hint.tone === 'research' || hint.tone === 'discovery' ? 'maintenant' : '2+ tours',
+      detail: `${focusTarget.label}: opportunité disponible sans urgence immédiate.`,
+    };
   }
 
-  return `${hint.label}${provinceCopy}: ${hint.cultureName} manque encore un signal exploitable.`;
+  return {
+    level: 'stable',
+    label: 'À préparer',
+    window: 'stable',
+    detail: `${focusTarget.label}: signal incomplet, aucune expiration active.`,
+  };
+}
+
+function summarizeHint(hint, actionLabel, urgency) {
+  const provinceCopy = hint.regionId ? ` (${hint.regionId})` : '';
+  const urgencyCopy = ` ${urgency.label.toLowerCase()} · ${urgency.window}.`;
+
+  if (hint.status === 'probable') {
+    return `${hint.label}${provinceCopy}: à exploiter après ${actionLabel}.${urgencyCopy}`;
+  }
+
+  if (hint.status === 'possible') {
+    return `${hint.label}${provinceCopy}: garder en vue avant de clore le tour.${urgencyCopy}`;
+  }
+
+  return `${hint.label}${provinceCopy}: ${hint.cultureName} manque encore un signal exploitable.${urgencyCopy}`;
 }
 
 function buildReminder(hint, actionLabel) {
@@ -58,17 +94,24 @@ function buildReminder(hint, actionLabel) {
     regionId: hint.regionId,
     label: 'Province liée',
   };
+  const urgency = buildFallbackUrgency(hint, focusTarget);
+  const focusTargetWithUrgency = {
+    ...focusTarget,
+    urgency,
+  };
 
   return {
     reminderId: `${hint.status}:${hint.tone}:${hint.regionId}:${hint.label}:${actionLabel}`,
     tone: reminderTone(hint),
     status: hint.status,
     label: reminderLabel(hint),
-    summary: summarizeHint(hint, actionLabel),
+    summary: summarizeHint(hint, actionLabel, urgency),
     provinceId: hint.regionId,
     cultureName: hint.cultureName,
     actionLabel,
-    focusTarget,
+    urgency,
+    urgencyCopy: `${urgency.label} · ${urgency.window}`,
+    focusTarget: focusTargetWithUrgency,
     focusCopy: `${focusTarget.type}: ${focusTarget.label}`,
   };
 }

--- a/src/ui/culture/buildCultureUnlockHints.js
+++ b/src/ui/culture/buildCultureUnlockHints.js
@@ -15,7 +15,37 @@ function buildFocusTarget({ type = 'province', id, regionId, label }) {
   };
 }
 
+function buildUrgency({ status, tone, focusTarget }) {
+  if (status === 'probable') {
+    return {
+      level: 'soon',
+      label: 'Expire bientôt',
+      window: 'ce tour',
+      detail: `${focusTarget.label}: fenêtre courte, à traiter avant de clore le tour.`,
+    };
+  }
+
+  if (status === 'possible') {
+    return {
+      level: tone === 'research' || tone === 'discovery' ? 'new' : 'stable',
+      label: tone === 'research' || tone === 'discovery' ? 'Nouveau signal' : 'Fenêtre stable',
+      window: tone === 'research' || tone === 'discovery' ? 'maintenant' : '2+ tours',
+      detail: `${focusTarget.label}: opportunité disponible sans urgence immédiate.`,
+    };
+  }
+
+  return {
+    level: 'stable',
+    label: 'À préparer',
+    window: 'stable',
+    detail: `${focusTarget.label}: signal incomplet, aucune expiration active.`,
+  };
+}
+
 function buildHint({ status, tone, label, explanation, regionId, cultureName, sourceId, focusTarget }) {
+  const normalizedFocusTarget = focusTarget ?? buildFocusTarget({ regionId, label: 'Province liée' });
+  const urgency = buildUrgency({ status, tone, focusTarget: normalizedFocusTarget });
+
   return {
     hintId: `${status}:${regionId}:${cultureName}:${label}:${sourceId ?? 'source'}`,
     status,
@@ -25,7 +55,11 @@ function buildHint({ status, tone, label, explanation, regionId, cultureName, so
     regionId,
     cultureName,
     sourceId: sourceId ?? null,
-    focusTarget: focusTarget ?? buildFocusTarget({ regionId, label: 'Province liée' }),
+    urgency,
+    focusTarget: {
+      ...normalizedFocusTarget,
+      urgency,
+    },
   };
 }
 

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -68,16 +68,28 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
 
   assert.equal(report.state, 'active');
   assert.equal(report.summary, 'Porte du Fleuve: 1 opportunité probable, 1 condition à surveiller.');
-  assert.deepEqual(report.reminders.map((reminder) => [reminder.status, reminder.label, reminder.summary, reminder.focusCopy]), [
-    ['probable', 'Prochain repère', 'Événement cluster (river-gate): à exploiter après Sécuriser les archives.', 'cluster: Ouverture des archives'],
-    ['possible', 'Recherche à suivre', 'Recherche culture (river-gate): garder en vue avant de clore le tour.', 'marker: Compact d’Aurora'],
-    ['missing', 'Condition à combler', 'Condition manquante (shared-bay): Ligues des Forges manque encore un signal exploitable.', 'province: Province liée'],
+  assert.deepEqual(report.reminders.map((reminder) => [reminder.status, reminder.label, reminder.summary, reminder.focusCopy, reminder.urgencyCopy]), [
+    ['probable', 'Prochain repère', 'Événement cluster (river-gate): à exploiter après Sécuriser les archives. expire bientôt · ce tour.', 'cluster: Ouverture des archives', 'Expire bientôt · ce tour'],
+    ['possible', 'Recherche à suivre', 'Recherche culture (river-gate): garder en vue avant de clore le tour. nouveau signal · maintenant.', 'marker: Compact d’Aurora', 'Nouveau signal · maintenant'],
+    ['missing', 'Condition à combler', 'Condition manquante (shared-bay): Ligues des Forges manque encore un signal exploitable. à préparer · stable.', 'province: Province liée', 'À préparer · stable'],
   ]);
+  assert.deepEqual(report.reminders[0].urgency, {
+    level: 'soon',
+    label: 'Expire bientôt',
+    window: 'ce tour',
+    detail: 'Ouverture des archives: fenêtre courte, à traiter avant de clore le tour.',
+  });
   assert.deepEqual(report.reminders[0].focusTarget, {
     type: 'cluster',
     id: 'river-gate:culture-cluster',
     regionId: 'river-gate',
     label: 'Ouverture des archives',
+    urgency: {
+      level: 'soon',
+      label: 'Expire bientôt',
+      window: 'ce tour',
+      detail: 'Ouverture des archives: fenêtre courte, à traiter avant de clore le tour.',
+    },
   });
 });
 

--- a/test/ui/culture/buildCultureUnlockHints.test.js
+++ b/test/ui/culture/buildCultureUnlockHints.test.js
@@ -64,11 +64,19 @@ test('buildCultureUnlockHints ranks probable, possible, and missing unlock signa
   ]);
   assert.equal(hints[0].explanation, 'Ouverture des archives peut suivre “Préparer la manœuvre”.');
   assert.deepEqual(hints.map((hint) => hint.focusTarget.type), ['timeline', 'cluster', 'marker']);
+  assert.equal(hints[0].urgency.label, 'Expire bientôt');
+  assert.equal(hints[0].urgency.window, 'ce tour');
   assert.deepEqual(hints[0].focusTarget, {
     type: 'timeline',
     id: 'river-gate:event:archives-open',
     regionId: 'river-gate',
     label: 'Ouverture des archives',
+    urgency: {
+      level: 'soon',
+      label: 'Expire bientôt',
+      window: 'ce tour',
+      detail: 'Ouverture des archives: fenêtre courte, à traiter avant de clore le tour.',
+    },
   });
 });
 
@@ -86,11 +94,23 @@ test('buildCultureUnlockHints returns readable missing-condition fallbacks', () 
       regionId: 'quiet-field',
       cultureName: 'Aucun signal',
       sourceId: 'Garder en observation',
+      urgency: {
+        level: 'stable',
+        label: 'À préparer',
+        window: 'stable',
+        detail: 'Province sans unlock: signal incomplet, aucune expiration active.',
+      },
       focusTarget: {
         type: 'province',
         id: 'quiet-field',
         regionId: 'quiet-field',
         label: 'Province sans unlock',
+        urgency: {
+          level: 'stable',
+          label: 'À préparer',
+          window: 'stable',
+          detail: 'Province sans unlock: signal incomplet, aucune expiration active.',
+        },
       },
     },
   ]);
@@ -113,11 +133,23 @@ test('buildCultureUnlockHints returns readable missing-condition fallbacks', () 
     regionId: 'shared-bay',
     cultureName: 'Delta Scribes, Harbor Compact',
     sourceId: 'shared-bay:culture-cluster',
+    urgency: {
+      level: 'stable',
+      label: 'À préparer',
+      window: 'stable',
+      detail: 'Delta Scribes, Harbor Compact: signal incomplet, aucune expiration active.',
+    },
     focusTarget: {
       type: 'cluster',
       id: 'shared-bay:culture-cluster',
       regionId: 'shared-bay',
       label: 'Delta Scribes, Harbor Compact',
+      urgency: {
+        level: 'stable',
+        label: 'À préparer',
+        window: 'stable',
+        detail: 'Delta Scribes, Harbor Compact: signal incomplet, aucune expiration active.',
+      },
     },
   });
 });

--- a/web/app.js
+++ b/web/app.js
@@ -896,9 +896,10 @@ function renderCultureUnlockHints(hints) {
   return `
     <div class="culture-unlock-hints" aria-label="Unlocks culture potentiels">
       ${hints.map((hint) => `
-        <span class="culture-unlock-hint culture-unlock-hint--${hint.status} culture-unlock-hint--${hint.tone}" title="${hint.explanation}">
+        <span class="culture-unlock-hint culture-unlock-hint--${hint.status} culture-unlock-hint--${hint.tone} culture-unlock-hint--urgency-${hint.urgency?.level ?? 'stable'}" title="${hint.explanation} ${hint.urgency?.detail ?? ''}">
           <b>${hint.status}</b>
           <small>${hint.label} · ${hint.cultureName}</small>
+          <em>${hint.urgency?.label ?? 'Fenêtre stable'} · ${hint.urgency?.window ?? 'stable'}</em>
         </span>
       `).join('')}
     </div>
@@ -935,8 +936,9 @@ function renderCultureOpportunityReminders(report) {
             <article class="culture-opportunity-reminder culture-opportunity-reminder--${reminder.tone}">
               <span>${reminder.label}</span>
               <strong>${reminder.cultureName}</strong>
+              <em class="culture-opportunity-reminder__urgency culture-opportunity-reminder__urgency--${reminder.urgency?.level ?? 'stable'}">${reminder.urgencyCopy ?? 'Fenêtre stable · stable'}</em>
               <p>${reminder.summary}</p>
-              <button type="button" data-culture-focus-region="${reminder.focusTarget.regionId}" data-culture-focus-type="${reminder.focusTarget.type}" data-culture-focus-id="${reminder.focusTarget.id}">
+              <button type="button" data-culture-focus-region="${reminder.focusTarget.regionId}" data-culture-focus-type="${reminder.focusTarget.type}" data-culture-focus-id="${reminder.focusTarget.id}" aria-label="Voir ${reminder.focusCopy}: ${reminder.urgency?.detail ?? reminder.summary}">
                 Voir ${reminder.focusCopy}
               </button>
             </article>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1984,16 +1984,25 @@ button { font: inherit; }
   line-height: 1;
   text-transform: uppercase;
 }
-.culture-unlock-hint small {
+.culture-unlock-hint small,
+.culture-unlock-hint em {
   color: var(--muted);
   font-size: 10px;
   line-height: 1.1;
+}
+.culture-unlock-hint em {
+  color: #e0f2fe;
+  font-style: normal;
+  font-weight: 700;
 }
 .culture-unlock-hint--probable { border-color: rgba(74, 222, 128, 0.32); }
 .culture-unlock-hint--probable b { color: #bbf7d0; }
 .culture-unlock-hint--possible { border-color: rgba(56, 189, 248, 0.3); }
 .culture-unlock-hint--missing { border-color: rgba(251, 191, 36, 0.26); }
 .culture-unlock-hint--missing b { color: #fde68a; }
+.culture-unlock-hint--urgency-soon { background: rgba(74, 222, 128, 0.1); }
+.culture-unlock-hint--urgency-new { background: rgba(56, 189, 248, 0.1); }
+.culture-unlock-hint--urgency-stable { background: rgba(15, 23, 42, 0.42); }
 .culture-consequence-chips {
   display: flex;
   flex-wrap: wrap;
@@ -2272,6 +2281,24 @@ button { font: inherit; }
   font-size: 12px;
   margin-bottom: 3px;
 }
+.culture-opportunity-reminder__urgency {
+  display: inline-block;
+  width: fit-content;
+  margin-bottom: 5px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: #e0f2fe;
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.culture-opportunity-reminder__urgency--soon { border-color: rgba(74, 222, 128, 0.36); color: #bbf7d0; }
+.culture-opportunity-reminder__urgency--new { border-color: rgba(56, 189, 248, 0.34); color: #bae6fd; }
+.culture-opportunity-reminder__urgency--stable { border-color: rgba(251, 191, 36, 0.22); color: #fde68a; }
 .culture-opportunity-reminder p {
   margin: 0;
   color: var(--muted);


### PR DESCRIPTION
Gamma: PR prête pour validation.

Scope #515:
- ajoute des badges d’urgence aux hints culture focusables (expire bientôt / nouveau signal / à préparer), propagés vers les cibles carte/timeline;
- expose ces fenêtres dans les rappels culture de fin de tour et les boutons focus;
- adapte les styles UI et les tests culture existants.

Tests:
- `npm test`

Zeta, peux-tu valider cette PR avant tout merge ?

Closes #515