### PR TITLE
Beta: surface logistics blockers on map focus

### DIFF
--- a/src/ui/economy/buildEconomyReadinessWarnings.js
+++ b/src/ui/economy/buildEconomyReadinessWarnings.js
@@ -25,6 +25,7 @@ function buildPlanWarning(province, plan, budgetStatus) {
   const route = plan.routeNames?.[0] ?? 'route locale';
   const hubName = plan.hubName ?? null;
   const status = plan.status === 'blocked' ? 'blocked' : plan.status === 'risky' ? 'risky' : budgetStatus;
+  const blockerLabel = status === 'blocked' && budgetStatus === 'blocked' ? 'budget' : resource.label;
 
   return {
     tone: getWarningTone(status),
@@ -33,9 +34,14 @@ function buildPlanWarning(province, plan, budgetStatus) {
     provinceLabel: province.label ?? province.provinceId,
     label: status === 'blocked' ? 'Blocage budget' : status === 'risky' ? 'Compromis logistique' : 'Capacité sécurisée',
     detail: `${province.label ?? province.provinceId}: ${plan.logisticsAction} sollicite ${resource.quantity} ${resource.label} via ${route}; ${plan.surplusOrShortage}.`,
+    mapSummary: `${blockerLabel}: ${plan.surplusOrShortage}`,
+    nextTurnEffect: plan.effect ?? (status === 'blocked'
+      ? `${resource.label}: action impossible sans stock ou relais avant le prochain tour.`
+      : `${resource.label}: risque de pénurie ou surcharge au prochain tour.`),
     routeName: route,
     hubName,
     resourceLabel: resource.label,
+    blockerLabel,
     focusTarget: {
       kind: status === 'blocked' ? 'hub' : 'route',
       provinceId: province.provinceId,
@@ -59,9 +65,12 @@ function buildChoiceWarning(province, choice) {
     provinceLabel: province.label ?? province.provinceId,
     label: choice.tone === 'high' ? 'Route sous stress' : 'Route surveillée',
     detail: `${province.label ?? province.provinceId}: ${route} garde un risque ${choice.residualRisk ?? 0} sur ${resource}.`,
+    mapSummary: `logistique: ${resource} sous stress`,
+    nextTurnEffect: `${route}: risque ${choice.residualRisk ?? 0}, prévoir relais ou reroutage au prochain tour.`,
     routeName: route,
     hubName: choice.affectedCity ?? null,
     resourceLabel: resource,
+    blockerLabel: 'logistique',
     focusTarget: {
       kind: 'route',
       provinceId: province.provinceId,

--- a/test/ui/economy/buildEconomyReadinessWarnings.test.js
+++ b/test/ui/economy/buildEconomyReadinessWarnings.test.js
@@ -49,6 +49,9 @@ test('buildEconomyReadinessWarnings ranks blocked economy budgets first', () => 
   assert.equal(report.warnings[0].provinceLabel, 'Porte du Fleuve');
   assert.match(report.warnings[0].detail, /Ember Line/);
   assert.match(report.warnings[0].detail, /Outils/);
+  assert.equal(report.warnings[0].blockerLabel, 'budget');
+  assert.match(report.warnings[0].mapSummary, /manquantes/);
+  assert.match(report.warnings[0].nextTurnEffect, /action impossible/);
   assert.deepEqual(report.warnings[0].focusTarget, {
     kind: 'hub',
     provinceId: 'river-gate',
@@ -81,6 +84,9 @@ test('buildEconomyReadinessWarnings falls back to high logistics route stress', 
   assert.match(report.warnings[0].detail, /Iron Road/);
   assert.equal(report.warnings[0].focusTarget.kind, 'route');
   assert.equal(report.warnings[0].focusTarget.hubName, 'Iron Hub');
+  assert.equal(report.warnings[0].blockerLabel, 'logistique');
+  assert.match(report.warnings[0].mapSummary, /Outils sous stress/);
+  assert.match(report.warnings[0].nextTurnEffect, /prochain tour/);
 });
 
 test('buildEconomyReadinessWarnings returns compact ready state without warnings', () => {

--- a/test/ui/economy/webEconomyReadinessWarnings.test.js
+++ b/test/ui/economy/webEconomyReadinessWarnings.test.js
@@ -14,6 +14,9 @@ test('playable map wires economy readiness warnings into end-turn summary', () =
   assert.match(webAppSource, /logisticsByProvinceId/);
   assert.match(webAppSource, /function getEconomyReadinessFocusTarget/);
   assert.match(webAppSource, /data-economy-readiness-focus/);
+  assert.match(webAppSource, /data-readiness-tone=\"\$\{warning\.status === 'blocked' \? 'danger' : 'warning'\}\"/);
+  assert.match(webAppSource, /has-economy-blocker--\$\{routeBlocker\.tone\}/);
+  assert.match(webAppSource, /has-economy-blocker--\$\{cityBlocker\.tone\}/);
   assert.match(webAppSource, /data-blocker-label/);
   assert.match(webAppSource, /data-next-turn-effect/);
   assert.match(webAppSource, /economyReadinessFocus/);
@@ -25,6 +28,11 @@ test('playable map wires economy readiness warnings into end-turn summary', () =
   assert.match(stylesSource, /economy-readiness-warning--critical/);
   assert.match(stylesSource, /economy-readiness-warnings--risky/);
   assert.match(stylesSource, /has-economy-blocker/);
+  assert.match(stylesSource, /economy-route-group\.has-economy-blocker/);
+  assert.match(stylesSource, /economy-route-group\.has-economy-blocker--danger/);
+  assert.match(stylesSource, /economy-route-group\.has-economy-blocker--critical/);
+  assert.match(stylesSource, /economy-blocker-badge--critical/);
+  assert.match(stylesSource, /economy-city-group\.has-economy-blocker--critical/);
   assert.match(stylesSource, /economy-blocker-badge/);
   assert.match(stylesSource, /\.economy-readiness-warning button/);
 });

--- a/test/ui/economy/webEconomyReadinessWarnings.test.js
+++ b/test/ui/economy/webEconomyReadinessWarnings.test.js
@@ -14,10 +14,17 @@ test('playable map wires economy readiness warnings into end-turn summary', () =
   assert.match(webAppSource, /logisticsByProvinceId/);
   assert.match(webAppSource, /function getEconomyReadinessFocusTarget/);
   assert.match(webAppSource, /data-economy-readiness-focus/);
+  assert.match(webAppSource, /data-blocker-label/);
+  assert.match(webAppSource, /data-next-turn-effect/);
+  assert.match(webAppSource, /economyReadinessFocus/);
+  assert.match(webAppSource, /renderEconomyBlockerRouteBadge/);
+  assert.match(webAppSource, /renderEconomyBlockerCityBadge/);
   assert.match(webAppSource, /state\.activeOverlaySlot = 'economy-overlay'/);
   assert.match(webAppSource, /renderEconomyReadinessWarnings\(shell, economyView, focusContext, intrigueView\)/);
   assert.match(stylesSource, /\.economy-readiness-warnings/);
   assert.match(stylesSource, /economy-readiness-warning--critical/);
   assert.match(stylesSource, /economy-readiness-warnings--risky/);
+  assert.match(stylesSource, /has-economy-blocker/);
+  assert.match(stylesSource, /economy-blocker-badge/);
   assert.match(stylesSource, /\.economy-readiness-warning button/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -393,6 +393,7 @@ const state = {
   hoveredProvinceId: null,
   readinessFocusProvinceId: null,
   readinessFocusTone: null,
+  economyReadinessFocus: null,
   activeOverlaySlot: 'culture-overlay',
   popupProvinceId: 'river-gate',
   hoveredCityId: 'river-gate-city',
@@ -444,6 +445,7 @@ function applyMapScenario(scenario) {
   state.hoveredProvinceId = null;
   state.readinessFocusProvinceId = null;
   state.readinessFocusTone = null;
+  state.economyReadinessFocus = null;
   state.hoveredRouteId = null;
   state.selectedRouteId = null;
   state.economyFilters = {
@@ -679,11 +681,13 @@ function renderProvinceCard(province, focusContext) {
   const isFocused = province.selectionState.focused;
   const isHovered = province.selectionState.hovered;
   const readinessTone = state.readinessFocusProvinceId === province.provinceId ? state.readinessFocusTone : null;
+  const economyBlocker = state.economyReadinessFocus?.provinceId === province.provinceId ? state.economyReadinessFocus : null;
   const isReadinessHighlight = Boolean(readinessTone);
   const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && !isReadinessHighlight && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince || state.readinessFocusProvinceId);
   const tacticalState = province.contested ? 'front contesté' : province.occupied ? 'occupation' : 'contrôle stable';
   const readinessLabel = readinessTone === 'danger' ? 'menace immédiate' : readinessTone === 'warning' ? 'préparation insuffisante' : readinessTone === 'ready' ? 'opportunité tactique' : null;
-  const selectionSignal = isReadinessHighlight ? 'ALERTE' : isSelected ? 'ACTIF' : isHovered ? 'SURVOL' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
+  const economyBlockerLabel = economyBlocker ? `${economyBlocker.blocker}: ${economyBlocker.summary}` : null;
+  const selectionSignal = economyBlocker ? 'BLOCAGE' : isReadinessHighlight ? 'ALERTE' : isSelected ? 'ACTIF' : isHovered ? 'SURVOL' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
   const classes = [
     'province-node',
     isSelected ? 'is-selected' : '',
@@ -691,6 +695,8 @@ function renderProvinceCard(province, focusContext) {
     isHovered ? 'is-hovered' : '',
     isNeighbor ? 'is-neighbor' : '',
     isReadinessHighlight ? 'is-readiness-highlight' : '',
+    economyBlocker ? 'has-economy-blocker' : '',
+    economyBlocker ? `has-economy-blocker--${economyBlocker.tone}` : '',
     readinessTone ? `is-readiness-${readinessTone}` : '',
     isMuted ? 'is-muted' : '',
     province.contested ? 'is-contested' : '',
@@ -704,15 +710,18 @@ function renderProvinceCard(province, focusContext) {
       data-province-id="${province.provinceId}"
       data-tactical-state="${readinessLabel ?? tacticalState}"
       data-readiness-highlight="${readinessTone ?? ''}"
+      data-economy-blocker="${economyBlockerLabel ?? ''}"
+      title="${economyBlocker ? `${economyBlocker.summary} — ${economyBlocker.effect}` : province.label}"
       style="left:${layout.x}%;top:${layout.y}%;width:${layout.w}%;height:${layout.h}%;--province-fill:${province.style.fill};--province-border:${province.style.border};--province-shape:${getProvinceShape(province.provinceId)};"
       aria-pressed="${province.selectionState.selected}"
-      aria-label="${province.label}, ${readinessLabel ? `cible préparation conflit: ${readinessLabel}` : tacticalState}, approvisionnement ${province.supplyTone}, loyauté ${province.loyalty}"
+      aria-label="${province.label}, ${economyBlocker ? `blocage économie/logistique: ${economyBlocker.summary}, ${economyBlocker.effect}` : readinessLabel ? `cible préparation conflit: ${readinessLabel}` : tacticalState}, approvisionnement ${province.supplyTone}, loyauté ${province.loyalty}"
     >
       <span class="province-node__terrain"></span>
       <span class="province-node__focus-rail"></span>
       <span class="province-node__signal">${selectionSignal}</span>
       <span class="province-node__name">${province.label}</span>
       <span class="province-node__meta">${province.supplyTone} · loyauté ${province.loyalty}</span>
+      ${economyBlocker ? `<span class="province-node__economy-blocker"><b>${economyBlocker.blocker}</b>${economyBlocker.summary}<small>${economyBlocker.effect}</small></span>` : ''}
       <span class="province-node__badges">${badges}</span>
       ${isNeighbor ? '<span class="province-node__link">Voisine directe</span>' : ''}
     </button>
@@ -1692,6 +1701,10 @@ function renderEconomyReadinessWarnings(shell, economyView, focusContext, intrig
                   data-province-id="${target.provinceId}"
                   data-route-id="${target.routeId}"
                   data-city-id="${target.cityId}"
+                  data-readiness-tone="${warning.status === 'blocked' ? 'danger' : 'warning'}"
+                  data-blocker-label="${warning.blockerLabel}"
+                  data-map-summary="${warning.mapSummary}"
+                  data-next-turn-effect="${warning.nextTurnEffect}"
                 >Voir ${target.label}</button>
               </li>
             `;
@@ -2604,6 +2617,31 @@ function renderRouteStressBadge(route, stress, visual) {
     <g class="economy-route-stress economy-route-stress--${stress.tone}" aria-label="${stress.headline}: ${stress.summary}">
       <rect x="${midpoint.x - 9.4}" y="${midpoint.y - 8.6}" width="18.8" height="4.4" rx="2.2" />
       <text x="${midpoint.x}" y="${midpoint.y - 5.55}" text-anchor="middle">${stress.headline}</text>
+    </g>
+  `;
+}
+
+function renderEconomyBlockerRouteBadge(blocker, visual) {
+  const midpoint = getQuadraticPoint(visual.origin, visual.control, visual.destination, 0.5);
+
+  return `
+    <g class="economy-blocker-badge economy-blocker-badge--${blocker.tone}" aria-label="${blocker.summary}: ${blocker.effect}">
+      <rect x="${midpoint.x - 10.8}" y="${midpoint.y - 9.2}" width="21.6" height="5.2" rx="2.6" />
+      <text x="${midpoint.x}" y="${midpoint.y - 5.55}" text-anchor="middle">${blocker.blocker}</text>
+    </g>
+  `;
+}
+
+function renderEconomyBlockerCityBadge(blocker, position) {
+  const labelDx = Number.isFinite(position.labelDx) ? position.labelDx / 5 : 0;
+  const labelDy = Number.isFinite(position.labelDy) ? position.labelDy / 5 : 0;
+  const x = position.x + labelDx;
+  const y = position.y + labelDy - 7.2;
+
+  return `
+    <g class="economy-blocker-city-badge economy-blocker-city-badge--${blocker.tone}" aria-label="${blocker.summary}: ${blocker.effect}">
+      <circle cx="${x}%" cy="${y}%" r="2.45" />
+      <text x="${x}%" y="calc(${y}% + 1px)" text-anchor="middle">!</text>
     </g>
   `;
 }
@@ -3626,6 +3664,7 @@ function renderEconomyMapOverlay(economyView) {
     `;
   }).join('');
 
+  const economyBlockerFocus = state.economyReadinessFocus;
   const routeLines = economyView.overlay.routes.map((route, index) => {
     const origin = cityLayoutsById[route.originCityId];
     const destination = cityLayoutsById[route.destinationCityId];
@@ -3646,18 +3685,19 @@ function renderEconomyMapOverlay(economyView) {
     const routeFiltered = filters.criticalRoutes && !emphasizeRoute;
     const showRouteLabel = !routeFiltered && (emphasizeRoute || tensionClass === 'has-medium-tension');
     const routeFocused = state.hoveredRouteId === route.routeId || state.selectedRouteId === route.routeId;
+    const routeBlocker = economyBlockerFocus?.routeId === route.routeId ? economyBlockerFocus : null;
     const stress = getRouteStressSummary(route, tensionByCityId, cityNameById);
 
     return `
-      <g class="economy-route-group ${visual.classes} ${tensionClass} ${emphasizeRoute ? 'is-emphasized' : 'is-muted'} ${routeFiltered ? 'is-filtered' : ''} ${routeFocused ? 'is-focused' : ''}" data-route-id="${route.routeId}" aria-label="${routeFiltered ? 'Route secondaire atténuée par filtre' : 'Route économie visible'}: ${stress.summary}">
-        <title>${route.routeName}: ${stress.headline} — ${stress.summary}</title>
+      <g class="economy-route-group ${visual.classes} ${tensionClass} ${emphasizeRoute ? 'is-emphasized' : 'is-muted'} ${routeFiltered ? 'is-filtered' : ''} ${routeFocused ? 'is-focused' : ''} ${routeBlocker ? `has-economy-blocker has-economy-blocker--${routeBlocker.tone}` : ''}" data-route-id="${route.routeId}" aria-label="${routeFiltered ? 'Route secondaire atténuée par filtre' : 'Route économie visible'}: ${routeBlocker ? `${routeBlocker.summary}. ${routeBlocker.effect}` : stress.summary}">
+        <title>${route.routeName}: ${routeBlocker ? `${routeBlocker.summary} — ${routeBlocker.effect}` : `${stress.headline} — ${stress.summary}`}</title>
         <path class="economy-route-hitbox" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__halo" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__casing" d="${visual.pathD}" pathLength="100" />
         <path class="economy-route__line" d="${visual.pathD}" pathLength="100" marker-end="url(#${visual.markerId})" />
         <path class="economy-route__flow" d="${visual.pathD}" pathLength="100" />
         ${renderRouteHudMarkers(route, visual, { compact: !emphasizeRoute || routeFiltered })}
-        ${routeFocused ? renderRouteStressBadge(route, stress, visual) : ''}
+        ${routeBlocker ? renderEconomyBlockerRouteBadge(routeBlocker, visual) : routeFocused ? renderRouteStressBadge(route, stress, visual) : ''}
         ${showRouteLabel ? `<text class="economy-route__label" text-anchor="middle">
           <textPath href="#route-label-${route.routeId}" startOffset="50%">${route.routeName}</textPath>
         </text>` : ''}
@@ -3676,19 +3716,21 @@ function renderEconomyMapOverlay(economyView) {
     const tension = tensionByCityId[city.cityId]?.tensionLevel ?? 'low';
     const isHub = city.tradeRouteIds.length >= 2 || city.resources.totalStock >= 16;
     const isSelected = state.selectedCityId === city.cityId || state.hoveredCityId === city.cityId;
-    const expandResources = isSelected || tension === 'high';
+    const cityBlocker = economyBlockerFocus?.cityId === city.cityId ? economyBlockerFocus : null;
+    const expandResources = isSelected || tension === 'high' || Boolean(cityBlocker);
     const keepResourceWarning = tension === 'high';
     const showResources = keepResourceWarning || (filters.resourceMarkers && (expandResources || city.capital || isHub));
     const showCityLabels = filters.cityLabels && (isSelected || city.capital || isHub || tension !== 'low');
 
     return `
-      <g class="economy-city-group ${isSelected ? 'is-selected' : ''} ${city.capital ? 'is-capital' : ''} ${isHub ? 'is-hub' : ''} is-${tension}-tension ${!filters.resourceMarkers && showResources ? 'has-forced-resource-warning' : ''}" data-city-id="${city.cityId}">
+      <g class="economy-city-group ${isSelected ? 'is-selected' : ''} ${city.capital ? 'is-capital' : ''} ${isHub ? 'is-hub' : ''} is-${tension}-tension ${cityBlocker ? `has-economy-blocker has-economy-blocker--${cityBlocker.tone}` : ''} ${!filters.resourceMarkers && showResources ? 'has-forced-resource-warning' : ''}" data-city-id="${city.cityId}">
         <circle class="economy-city-tension-ring" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 9.2}" />
         ${city.capital ? `<circle class="economy-city-capital-ring" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 10.8}" />` : ''}
         ${isHub ? `<rect class="economy-city-hub-frame" x="calc(${position.x}% - ${city.marker.size * 7.4}px)" y="calc(${position.y}% - ${city.marker.size * 7.4}px)" width="${city.marker.size * 14.8}" height="${city.marker.size * 14.8}" rx="${city.marker.size * 3.2}" ry="${city.marker.size * 3.2}" />` : ''}
         <circle class="economy-city economy-city--${city.marker.tone}" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 6.6}" />
         ${city.capital ? `<text class="economy-city-glyph" x="${position.x}%" y="calc(${position.y}% + 1px)" text-anchor="middle">★</text>` : isHub ? `<text class="economy-city-glyph" x="${position.x}%" y="calc(${position.y}% + 1px)" text-anchor="middle">◆</text>` : ''}
         ${showResources ? renderResourceHudBadges(city, position, { expanded: expandResources && filters.resourceMarkers }) : ''}
+        ${cityBlocker ? renderEconomyBlockerCityBadge(cityBlocker, position) : ''}
         <circle class="economy-city-hitbox" cx="${position.x}%" cy="${position.y}%" r="${city.marker.size * 12}" />
         <text class="economy-city-label ${showCityLabels ? '' : 'economy-city-label--sr'}" x="${position.x}%" y="calc(${position.y}% - 14px)" text-anchor="middle">${city.cityName}</text>
         <text class="economy-city-resource ${showCityLabels ? '' : 'economy-city-resource--sr'}" x="${position.x}%" y="calc(${position.y}% + 18px)" text-anchor="middle">${city.resources.primaryResourceId ?? 'stock vide'}</text>
@@ -5018,10 +5060,22 @@ function render() {
       const provinceId = element.dataset.provinceId;
       const routeId = element.dataset.routeId;
       const cityId = element.dataset.cityId;
+      const readinessTone = element.dataset.readinessTone ?? 'warning';
       state.activeOverlaySlot = 'economy-overlay';
       state.selectedProvinceId = provinceId;
       state.focusedProvinceId = provinceId;
       state.popupProvinceId = provinceId;
+      state.readinessFocusProvinceId = provinceId;
+      state.readinessFocusTone = readinessTone;
+      state.economyReadinessFocus = {
+        provinceId,
+        routeId,
+        cityId,
+        tone: readinessTone,
+        blocker: element.dataset.blockerLabel ?? 'logistique',
+        summary: element.dataset.mapSummary ?? 'contrainte économie/logistique',
+        effect: element.dataset.nextTurnEffect ?? 'Effet à surveiller au prochain tour.',
+      };
 
       if (routeId) {
         state.selectedRouteId = routeId;

--- a/web/styles.css
+++ b/web/styles.css
@@ -370,7 +370,8 @@ button { font: inherit; }
   border-width: 2px;
   box-shadow: inset 0 0 0 1px rgba(248, 250, 252, 0.14), 0 0 0 3px rgba(251, 191, 36, 0.12);
 }
-.province-node.has-economy-blocker--danger::before { border-color: rgba(251, 113, 133, 0.82); }
+.province-node.has-economy-blocker--danger::before,
+.province-node.has-economy-blocker--critical::before { border-color: rgba(251, 113, 133, 0.82); }
 .province-node.has-economy-blocker--warning::before { border-color: rgba(251, 191, 36, 0.76); }
 .province-node__economy-blocker {
   position: relative;
@@ -399,14 +400,24 @@ button { font: inherit; }
   font-size: 9px;
 }
 .economy-route.has-economy-blocker .economy-route__halo,
-.economy-route.has-economy-blocker .economy-route__line {
+.economy-route.has-economy-blocker .economy-route__line,
+.economy-route-group.has-economy-blocker .economy-route__halo,
+.economy-route-group.has-economy-blocker .economy-route__line {
   opacity: 1;
   filter: drop-shadow(0 0 9px rgba(251, 191, 36, 0.42));
 }
 .economy-route.has-economy-blocker--danger .economy-route__halo,
-.economy-route.has-economy-blocker--danger .economy-route__line { stroke: rgba(251, 113, 133, 0.95); }
+.economy-route.has-economy-blocker--danger .economy-route__line,
+.economy-route.has-economy-blocker--critical .economy-route__halo,
+.economy-route.has-economy-blocker--critical .economy-route__line,
+.economy-route-group.has-economy-blocker--danger .economy-route__halo,
+.economy-route-group.has-economy-blocker--danger .economy-route__line,
+.economy-route-group.has-economy-blocker--critical .economy-route__halo,
+.economy-route-group.has-economy-blocker--critical .economy-route__line { stroke: rgba(251, 113, 133, 0.95); }
 .economy-route.has-economy-blocker--warning .economy-route__halo,
-.economy-route.has-economy-blocker--warning .economy-route__line { stroke: rgba(251, 191, 36, 0.95); }
+.economy-route.has-economy-blocker--warning .economy-route__line,
+.economy-route-group.has-economy-blocker--warning .economy-route__halo,
+.economy-route-group.has-economy-blocker--warning .economy-route__line { stroke: rgba(251, 191, 36, 0.95); }
 .economy-blocker-badge,
 .economy-blocker-city-badge { pointer-events: none; filter: drop-shadow(0 0 7px rgba(8, 15, 28, 0.8)); }
 .economy-blocker-badge rect,
@@ -416,7 +427,9 @@ button { font: inherit; }
   stroke-width: 0.48;
 }
 .economy-blocker-badge--danger rect,
-.economy-blocker-city-badge--danger circle { stroke: rgba(251, 113, 133, 0.88); }
+.economy-blocker-badge--critical rect,
+.economy-blocker-city-badge--danger circle,
+.economy-blocker-city-badge--critical circle { stroke: rgba(251, 113, 133, 0.88); }
 .economy-blocker-badge text,
 .economy-blocker-city-badge text {
   fill: #fef3c7;
@@ -430,7 +443,8 @@ button { font: inherit; }
   stroke: rgba(251, 191, 36, 0.94);
   filter: drop-shadow(0 0 8px rgba(251, 191, 36, 0.42));
 }
-.economy-city-group.has-economy-blocker--danger .economy-city-tension-ring {
+.economy-city-group.has-economy-blocker--danger .economy-city-tension-ring,
+.economy-city-group.has-economy-blocker--critical .economy-city-tension-ring {
   stroke: rgba(251, 113, 133, 0.96);
 }
 .culture-turn-report {

--- a/web/styles.css
+++ b/web/styles.css
@@ -357,6 +357,82 @@ button { font: inherit; }
 .economy-readiness-warning--warning { border-color: rgba(251, 191, 36, 0.3); }
 .economy-readiness-warnings--ready,
 .economy-readiness-warning--stable { border-color: rgba(74, 222, 128, 0.24); }
+.economy-readiness-warning small {
+  color: #bfdbfe;
+  font-size: 11px;
+  line-height: 1.25;
+}
+.province-node.has-economy-blocker {
+  z-index: 8;
+  filter: drop-shadow(0 0 18px rgba(251, 191, 36, 0.32));
+}
+.province-node.has-economy-blocker::before {
+  border-width: 2px;
+  box-shadow: inset 0 0 0 1px rgba(248, 250, 252, 0.14), 0 0 0 3px rgba(251, 191, 36, 0.12);
+}
+.province-node.has-economy-blocker--danger::before { border-color: rgba(251, 113, 133, 0.82); }
+.province-node.has-economy-blocker--warning::before { border-color: rgba(251, 191, 36, 0.76); }
+.province-node__economy-blocker {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 2px;
+  max-width: 24ch;
+  margin-top: 6px;
+  padding: 6px 7px;
+  border-radius: 10px;
+  background: rgba(8, 15, 28, 0.76);
+  border: 1px solid rgba(251, 191, 36, 0.34);
+  color: #fde68a;
+  font-size: 10px;
+  line-height: 1.25;
+  letter-spacing: 0.04em;
+}
+.province-node__economy-blocker b {
+  color: #f8fafc;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.province-node__economy-blocker small {
+  color: #bfdbfe;
+  font-size: 9px;
+}
+.economy-route.has-economy-blocker .economy-route__halo,
+.economy-route.has-economy-blocker .economy-route__line {
+  opacity: 1;
+  filter: drop-shadow(0 0 9px rgba(251, 191, 36, 0.42));
+}
+.economy-route.has-economy-blocker--danger .economy-route__halo,
+.economy-route.has-economy-blocker--danger .economy-route__line { stroke: rgba(251, 113, 133, 0.95); }
+.economy-route.has-economy-blocker--warning .economy-route__halo,
+.economy-route.has-economy-blocker--warning .economy-route__line { stroke: rgba(251, 191, 36, 0.95); }
+.economy-blocker-badge,
+.economy-blocker-city-badge { pointer-events: none; filter: drop-shadow(0 0 7px rgba(8, 15, 28, 0.8)); }
+.economy-blocker-badge rect,
+.economy-blocker-city-badge circle {
+  fill: rgba(8, 15, 28, 0.9);
+  stroke: rgba(251, 191, 36, 0.8);
+  stroke-width: 0.48;
+}
+.economy-blocker-badge--danger rect,
+.economy-blocker-city-badge--danger circle { stroke: rgba(251, 113, 133, 0.88); }
+.economy-blocker-badge text,
+.economy-blocker-city-badge text {
+  fill: #fef3c7;
+  font-size: 1.75px;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.economy-blocker-city-badge text { font-size: 3.4px; }
+.economy-city-group.has-economy-blocker .economy-city-tension-ring {
+  stroke: rgba(251, 191, 36, 0.94);
+  filter: drop-shadow(0 0 8px rgba(251, 191, 36, 0.42));
+}
+.economy-city-group.has-economy-blocker--danger .economy-city-tension-ring {
+  stroke: rgba(251, 113, 133, 0.96);
+}
 .culture-turn-report {
   margin-top: 12px;
   max-width: 58ch;


### PR DESCRIPTION
Beta: Implements #514.

## Summary
- adds blocker labels, compact map summaries, and next-turn effects to economy readiness warnings
- carries selected economy readiness warnings onto province, route, and hub map affordances
- adds compact blocker badges/styles and coverage for the new wiring

## Tests
- npm test

Zeta: ready for validation before merge.