### PR TITLE
Alpha: add conflict next-step cues to selected provinces

### DIFF
--- a/test/ui/war/webSelectedProvinceConflictNextAction.test.js
+++ b/test/ui/war/webSelectedProvinceConflictNextAction.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected province panel exposes conflict next-step cues from readiness focus', () => {
+  assert.match(webAppSource, /function buildSelectedProvinceConflictNextAction/);
+  assert.match(webAppSource, /function renderSelectedProvinceConflictNextAction/);
+  assert.match(webAppSource, /buildConflictReadinessWarnings\(shell, intrigueView\)/);
+  assert.match(webAppSource, /directWarning/);
+  assert.match(webAppSource, /neighborWarning/);
+  assert.match(webAppSource, /Prochaine action conflit/);
+  assert.match(webAppSource, /Front concerné/);
+  assert.match(webAppSource, /focus conflit sélectionné/);
+  assert.match(webAppSource, /voisine du focus conflit/);
+  assert.match(webAppSource, /Appuyer \$\{targetProvince\.label\}/);
+  assert.match(webAppSource, /renderSelectedProvinceConflictNextAction\(province, shell, focusContext, intrigueView\)/);
+  assert.match(stylesSource, /\.province-conflict-next-action/);
+  assert.match(stylesSource, /province-conflict-next-action--danger/);
+  assert.match(stylesSource, /province-conflict-next-action--warning/);
+  assert.match(stylesSource, /province-conflict-next-action--ready/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2182,6 +2182,70 @@ function renderConflictReadinessWarnings(shell, intrigueView = null) {
 }
 
 
+function buildSelectedProvinceConflictNextAction(province, shell, focusContext, intrigueView = null) {
+  const warnings = buildConflictReadinessWarnings(shell, intrigueView);
+  const directWarning = warnings.find((warning) => warning.provinceId === province.provinceId) ?? null;
+  const neighborWarning = warnings.find((warning) => province.neighborIds.includes(warning.provinceId)) ?? null;
+  const warning = directWarning ?? neighborWarning;
+
+  if (!warning) {
+    return null;
+  }
+
+  const targetProvince = shell.provinces.find((candidate) => candidate.provinceId === warning.provinceId) ?? province;
+  const relation = directWarning ? 'focus conflit sélectionné' : `voisine du focus conflit ${targetProvince.label}`;
+  const actionQueue = buildSelectedProvinceActionQueue(directWarning ? province : targetProvince, shell, {
+    focusedProvinceId: targetProvince.provinceId,
+    focusedProvince: targetProvince,
+    selectedProvince: province,
+    neighborIds: new Set(targetProvince.neighborIds),
+  }, intrigueView);
+  const nextAction = actionQueue[0] ?? null;
+
+  return {
+    tone: warning.tone,
+    priority: warning.priorityLabel,
+    reason: warning.detail,
+    relation,
+    provinceLabel: province.label,
+    targetLabel: warning.focusTargetLabel,
+    frontLabel: targetProvince.contested ? `Front contesté ${targetProvince.label}` : `Front ${targetProvince.label}`,
+    actionCode: nextAction?.actionCode ?? warning.actionCode,
+    suggestedAction: directWarning
+      ? nextAction?.label ?? warning.actionLabel
+      : `Appuyer ${targetProvince.label}: ${nextAction?.label ?? warning.actionLabel}`,
+  };
+}
+
+function renderSelectedProvinceConflictNextAction(province, shell, focusContext, intrigueView = null) {
+  const nextAction = buildSelectedProvinceConflictNextAction(province, shell, focusContext, intrigueView);
+
+  if (!nextAction) {
+    return '';
+  }
+
+  return `
+    <section class="province-conflict-next-action province-conflict-next-action--${nextAction.tone}" aria-label="Prochaine action conflit">
+      <div class="province-conflict-next-action__header">
+        <div>
+          <span>Prochaine action conflit</span>
+          <strong>${nextAction.priority}</strong>
+        </div>
+        <code>${nextAction.actionCode}</code>
+      </div>
+      <dl class="province-conflict-next-action__facts">
+        <div><dt>Province</dt><dd>${nextAction.provinceLabel}</dd></div>
+        <div><dt>Front concerné</dt><dd>${nextAction.frontLabel}</dd></div>
+        <div><dt>Cible</dt><dd>${nextAction.targetLabel}</dd></div>
+        <div><dt>Relation</dt><dd>${nextAction.relation}</dd></div>
+      </dl>
+      <p>${nextAction.reason}</p>
+      <strong class="province-conflict-next-action__suggestion">${nextAction.suggestedAction}</strong>
+    </section>
+  `;
+}
+
+
 
 function buildIntrigueExposureFocusTarget(province, drillDown, leadWarning, response, mitigated) {
   if (mitigated && drillDown) {
@@ -2408,6 +2472,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       </div>
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
       ${renderConflictOutcomePreview(province, shell)}
+      ${renderSelectedProvinceConflictNextAction(province, shell, focusContext, intrigueView)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView)}
       ${renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -2292,6 +2292,71 @@ button { font: inherit; }
 .province-action-queue__item--ready { border-color: rgba(74, 222, 128, 0.28); }
 .province-action-queue__item--risky { border-color: rgba(251, 191, 36, 0.34); }
 .province-action-queue__item--blocked { border-color: rgba(251, 113, 133, 0.4); }
+.province-conflict-next-action {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.68), rgba(88, 28, 135, 0.22));
+  border: 1px solid rgba(196, 181, 253, 0.24);
+}
+.province-conflict-next-action__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.province-conflict-next-action__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-conflict-next-action__header strong {
+  display: block;
+  margin-top: 3px;
+}
+.province-conflict-next-action__header code {
+  color: #bae6fd;
+  font-size: 11px;
+}
+.province-conflict-next-action__facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin: 0;
+}
+.province-conflict-next-action__facts div {
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.province-conflict-next-action__facts dt {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.province-conflict-next-action__facts dd {
+  margin: 2px 0 0;
+  font-size: 12px;
+}
+.province-conflict-next-action > p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.province-conflict-next-action__suggestion {
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-conflict-next-action--ready { border-color: rgba(74, 222, 128, 0.28); }
+.province-conflict-next-action--warning { border-color: rgba(251, 191, 36, 0.34); }
+.province-conflict-next-action--danger { border-color: rgba(251, 113, 133, 0.4); }
 .military-plan-impact {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
Alpha: Implements #523.

Summary:
- Adds a selected-province "Prochaine action conflit" section driven by existing conflict readiness warnings.
- Shows priority, readable reason, selected/neighbor relation, target/front, and a short suggested action.
- Styles ready/warning/danger states and covers the wiring with a focused UI source test.

Tests:
- npm test

Zeta: PR prête pour revue. Merci de valider avant tout merge.
