### PR TITLE
Gamma: explain culture urgency reasons

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -111,6 +111,7 @@ function buildReminder(hint, actionLabel) {
     actionLabel,
     urgency,
     urgencyCopy: `${urgency.label} · ${urgency.window}`,
+    reasonCopy: urgency.reason ?? `${urgency.sourceLabel ?? focusTarget.label} · ${urgency.timingLabel ?? urgency.window}`,
     focusTarget: focusTargetWithUrgency,
     focusCopy: `${focusTarget.type}: ${focusTarget.label}`,
   };

--- a/src/ui/culture/buildCultureUnlockHints.js
+++ b/src/ui/culture/buildCultureUnlockHints.js
@@ -15,22 +15,33 @@ function buildFocusTarget({ type = 'province', id, regionId, label }) {
   };
 }
 
-function buildUrgency({ status, tone, focusTarget }) {
+function buildUrgency({ status, tone, focusTarget, sourceLabel, timingLabel }) {
+  const normalizedSource = normalizeText(sourceLabel, focusTarget.label);
+  const normalizedTiming = normalizeText(timingLabel, 'timing local stable');
+
   if (status === 'probable') {
     return {
       level: 'soon',
       label: 'Expire bientôt',
       window: 'ce tour',
-      detail: `${focusTarget.label}: fenêtre courte, à traiter avant de clore le tour.`,
+      sourceLabel: normalizedSource,
+      timingLabel: normalizedTiming,
+      reason: `${normalizedSource} · ${normalizedTiming}`,
+      detail: `${focusTarget.label}: fenêtre courte, liée à ${normalizedSource} (${normalizedTiming}).`,
     };
   }
 
   if (status === 'possible') {
+    const isFreshSignal = tone === 'research' || tone === 'discovery';
+
     return {
-      level: tone === 'research' || tone === 'discovery' ? 'new' : 'stable',
-      label: tone === 'research' || tone === 'discovery' ? 'Nouveau signal' : 'Fenêtre stable',
-      window: tone === 'research' || tone === 'discovery' ? 'maintenant' : '2+ tours',
-      detail: `${focusTarget.label}: opportunité disponible sans urgence immédiate.`,
+      level: isFreshSignal ? 'new' : 'stable',
+      label: isFreshSignal ? 'Nouveau signal' : 'Fenêtre stable',
+      window: isFreshSignal ? 'maintenant' : '2+ tours',
+      sourceLabel: normalizedSource,
+      timingLabel: normalizedTiming,
+      reason: `${normalizedSource} · ${normalizedTiming}`,
+      detail: `${focusTarget.label}: opportunité disponible via ${normalizedSource} (${normalizedTiming}).`,
     };
   }
 
@@ -38,13 +49,22 @@ function buildUrgency({ status, tone, focusTarget }) {
     level: 'stable',
     label: 'À préparer',
     window: 'stable',
-    detail: `${focusTarget.label}: signal incomplet, aucune expiration active.`,
+    sourceLabel: normalizedSource,
+    timingLabel: normalizedTiming,
+    reason: `${normalizedSource} · ${normalizedTiming}`,
+    detail: `${focusTarget.label}: signal incomplet autour de ${normalizedSource} (${normalizedTiming}).`,
   };
 }
 
-function buildHint({ status, tone, label, explanation, regionId, cultureName, sourceId, focusTarget }) {
+function buildHint({ status, tone, label, explanation, regionId, cultureName, sourceId, focusTarget, urgencySource, timingLabel }) {
   const normalizedFocusTarget = focusTarget ?? buildFocusTarget({ regionId, label: 'Province liée' });
-  const urgency = buildUrgency({ status, tone, focusTarget: normalizedFocusTarget });
+  const urgency = buildUrgency({
+    status,
+    tone,
+    focusTarget: normalizedFocusTarget,
+    sourceLabel: urgencySource,
+    timingLabel,
+  });
 
   return {
     hintId: `${status}:${regionId}:${cultureName}:${label}:${sourceId ?? 'source'}`,
@@ -58,7 +78,7 @@ function buildHint({ status, tone, label, explanation, regionId, cultureName, so
     urgency,
     focusTarget: {
       ...normalizedFocusTarget,
-      urgency,
+      urgency: { ...urgency },
     },
   };
 }
@@ -95,6 +115,8 @@ function hintsFromTimeline(localTimeline, actionTitle, fallbackRegionId) {
       regionId: normalizeText(item.regionId, fallbackRegionId),
       cultureName: normalizeText(item.cultureName, 'Culture locale'),
       sourceId: item.timelineId,
+      urgencySource: `${item.kind === 'event' ? 'Événement' : 'Découverte'}: ${normalizeText(item.title, label)}`,
+      timingLabel: item.date ? `chronologie locale ${item.date}` : 'chronologie locale maintenant',
       focusTarget: buildFocusTarget({
         type: 'timeline',
         id: item.timelineId,
@@ -123,6 +145,10 @@ function hintsFromMarker(marker, actionTitle, fallbackRegionId) {
       regionId,
       cultureName,
       sourceId: marker.overlayId,
+      urgencySource: (marker.unlockedResearchIds ?? []).length > 0
+        ? `Recherche: ${(marker.unlockedResearchIds ?? []).slice(0, 2).join(', ')}`
+        : `Recherche active: ${marker.activeResearchCount}`,
+      timingLabel: (marker.unlockedResearchIds ?? []).length > 0 ? 'débloquée maintenant' : 'progression locale en cours',
       focusTarget: buildFocusTarget({
         type: 'marker',
         id: marker.overlayId,
@@ -141,6 +167,8 @@ function hintsFromMarker(marker, actionTitle, fallbackRegionId) {
       regionId,
       cultureName,
       sourceId: marker.overlayId,
+      urgencySource: `Découverte: ${marker.discoveries.slice(0, 2).join(', ')}`,
+      timingLabel: 'disponible sur la carte locale',
       focusTarget: buildFocusTarget({
         type: 'marker',
         id: marker.overlayId,
@@ -174,6 +202,8 @@ function hintsFromCluster(cluster, actionTitle, fallbackRegionId) {
       regionId,
       cultureName: normalizeText(strongestEvent.cultureName, cultureName),
       sourceId: strongestEvent.pinId,
+      urgencySource: `Événement: ${strongestEvent.name}`,
+      timingLabel: (strongestEvent.importance ?? 0) >= 4 ? 'priorité du tour' : 'fenêtre locale stable',
       focusTarget: buildFocusTarget({
         type: 'cluster',
         id: cluster.clusterId,
@@ -192,6 +222,8 @@ function hintsFromCluster(cluster, actionTitle, fallbackRegionId) {
       regionId,
       cultureName,
       sourceId: cluster.clusterId,
+      urgencySource: `Découverte: ${discoveryPins.slice(0, 2).map((pin) => pin.name).join(', ')}`,
+      timingLabel: 'voisinage culturel disponible',
       focusTarget: buildFocusTarget({
         type: 'cluster',
         id: cluster.clusterId,
@@ -210,6 +242,8 @@ function hintsFromCluster(cluster, actionTitle, fallbackRegionId) {
       regionId,
       cultureName,
       sourceId: cluster.clusterId,
+      urgencySource: `Cluster: ${cultureName}`,
+      timingLabel: 'signal incomplet stable',
       focusTarget: buildFocusTarget({
         type: 'cluster',
         id: cluster.clusterId,
@@ -249,6 +283,8 @@ export function buildCultureUnlockHints({
     regionId,
     cultureName: 'Aucun signal',
     sourceId: actionTitle,
+    urgencySource: `Plan: ${actionTitle}`,
+    timingLabel: 'aucun signal local actif',
     focusTarget: buildFocusTarget({ regionId, label: 'Province sans unlock' }),
   })];
 }

--- a/test/ui/culture/buildCultureUnlockHints.test.js
+++ b/test/ui/culture/buildCultureUnlockHints.test.js
@@ -66,6 +66,7 @@ test('buildCultureUnlockHints ranks probable, possible, and missing unlock signa
   assert.deepEqual(hints.map((hint) => hint.focusTarget.type), ['timeline', 'cluster', 'marker']);
   assert.equal(hints[0].urgency.label, 'Expire bientôt');
   assert.equal(hints[0].urgency.window, 'ce tour');
+  assert.equal(hints[0].urgency.reason, 'Événement: Ouverture des archives · chronologie locale maintenant');
   assert.deepEqual(hints[0].focusTarget, {
     type: 'timeline',
     id: 'river-gate:event:archives-open',
@@ -75,7 +76,10 @@ test('buildCultureUnlockHints ranks probable, possible, and missing unlock signa
       level: 'soon',
       label: 'Expire bientôt',
       window: 'ce tour',
-      detail: 'Ouverture des archives: fenêtre courte, à traiter avant de clore le tour.',
+      sourceLabel: 'Événement: Ouverture des archives',
+      timingLabel: 'chronologie locale maintenant',
+      reason: 'Événement: Ouverture des archives · chronologie locale maintenant',
+      detail: 'Ouverture des archives: fenêtre courte, liée à Événement: Ouverture des archives (chronologie locale maintenant).',
     },
   });
 });
@@ -98,7 +102,10 @@ test('buildCultureUnlockHints returns readable missing-condition fallbacks', () 
         level: 'stable',
         label: 'À préparer',
         window: 'stable',
-        detail: 'Province sans unlock: signal incomplet, aucune expiration active.',
+        sourceLabel: 'Plan: Garder en observation',
+        timingLabel: 'aucun signal local actif',
+        reason: 'Plan: Garder en observation · aucun signal local actif',
+        detail: 'Province sans unlock: signal incomplet autour de Plan: Garder en observation (aucun signal local actif).',
       },
       focusTarget: {
         type: 'province',
@@ -109,7 +116,10 @@ test('buildCultureUnlockHints returns readable missing-condition fallbacks', () 
           level: 'stable',
           label: 'À préparer',
           window: 'stable',
-          detail: 'Province sans unlock: signal incomplet, aucune expiration active.',
+          sourceLabel: 'Plan: Garder en observation',
+        timingLabel: 'aucun signal local actif',
+        reason: 'Plan: Garder en observation · aucun signal local actif',
+        detail: 'Province sans unlock: signal incomplet autour de Plan: Garder en observation (aucun signal local actif).',
         },
       },
     },
@@ -137,7 +147,10 @@ test('buildCultureUnlockHints returns readable missing-condition fallbacks', () 
       level: 'stable',
       label: 'À préparer',
       window: 'stable',
-      detail: 'Delta Scribes, Harbor Compact: signal incomplet, aucune expiration active.',
+      sourceLabel: 'Cluster: Delta Scribes, Harbor Compact',
+      timingLabel: 'signal incomplet stable',
+      reason: 'Cluster: Delta Scribes, Harbor Compact · signal incomplet stable',
+      detail: 'Delta Scribes, Harbor Compact: signal incomplet autour de Cluster: Delta Scribes, Harbor Compact (signal incomplet stable).',
     },
     focusTarget: {
       type: 'cluster',
@@ -148,7 +161,10 @@ test('buildCultureUnlockHints returns readable missing-condition fallbacks', () 
         level: 'stable',
         label: 'À préparer',
         window: 'stable',
-        detail: 'Delta Scribes, Harbor Compact: signal incomplet, aucune expiration active.',
+        sourceLabel: 'Cluster: Delta Scribes, Harbor Compact',
+      timingLabel: 'signal incomplet stable',
+      reason: 'Cluster: Delta Scribes, Harbor Compact · signal incomplet stable',
+      detail: 'Delta Scribes, Harbor Compact: signal incomplet autour de Cluster: Delta Scribes, Harbor Compact (signal incomplet stable).',
       },
     },
   });

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('culture urgency badges render compact local timeline reasons', () => {
+  assert.match(webAppSource, /hint\.urgency\?\.reason/);
+  assert.match(webAppSource, /culture-opportunity-reminder__reason/);
+  assert.match(webAppSource, /reminder\.reasonCopy/);
+  assert.match(webAppSource, /aria-label="Voir \$\{reminder\.focusCopy\}: \$\{reminder\.urgency\?\.detail/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__reason/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -909,6 +909,7 @@ function renderCultureUnlockHints(hints) {
           <b>${hint.status}</b>
           <small>${hint.label} · ${hint.cultureName}</small>
           <em>${hint.urgency?.label ?? 'Fenêtre stable'} · ${hint.urgency?.window ?? 'stable'}</em>
+          <small>${hint.urgency?.reason ?? hint.urgency?.detail ?? hint.explanation}</small>
         </span>
       `).join('')}
     </div>
@@ -946,6 +947,7 @@ function renderCultureOpportunityReminders(report) {
               <span>${reminder.label}</span>
               <strong>${reminder.cultureName}</strong>
               <em class="culture-opportunity-reminder__urgency culture-opportunity-reminder__urgency--${reminder.urgency?.level ?? 'stable'}">${reminder.urgencyCopy ?? 'Fenêtre stable · stable'}</em>
+              <small class="culture-opportunity-reminder__reason">${reminder.reasonCopy ?? reminder.urgency?.detail ?? reminder.summary}</small>
               <p>${reminder.summary}</p>
               <button type="button" data-culture-focus-region="${reminder.focusTarget.regionId}" data-culture-focus-type="${reminder.focusTarget.type}" data-culture-focus-id="${reminder.focusTarget.id}" aria-label="Voir ${reminder.focusCopy}: ${reminder.urgency?.detail ?? reminder.summary}">
                 Voir ${reminder.focusCopy}

--- a/web/styles.css
+++ b/web/styles.css
@@ -2418,6 +2418,13 @@ button { font: inherit; }
 .culture-opportunity-reminder__urgency--soon { border-color: rgba(74, 222, 128, 0.36); color: #bbf7d0; }
 .culture-opportunity-reminder__urgency--new { border-color: rgba(56, 189, 248, 0.34); color: #bae6fd; }
 .culture-opportunity-reminder__urgency--stable { border-color: rgba(251, 191, 36, 0.22); color: #fde68a; }
+.culture-opportunity-reminder__reason {
+  display: block;
+  margin-bottom: 5px;
+  color: #bae6fd;
+  font-size: 11px;
+  line-height: 1.25;
+}
 .culture-opportunity-reminder p {
   margin: 0;
   color: var(--muted);


### PR DESCRIPTION
Gamma: PR prête pour validation.

Scope #525:
- ajoute une raison compacte aux badges d’urgence culture (source événement/découverte/recherche + timing local);
- propage cette raison aux focus targets et aux rappels culture de fin de tour;
- affiche le “pourquoi maintenant” dans les chips et le panneau sélectionné sans nouveau gros composant;
- renforce les tests de dérivation et de rendu web.

Tests:
- `npm test`
- `node --check web/app.js`
- `git diff --check`

Zeta, peux-tu valider cette PR avant tout merge ?

Closes #525