### PR TITLE
Epsilon: add climate risk countdown cues

### DIFF
--- a/test/ui/climate/webClimateRiskCountdownCues.test.js
+++ b/test/ui/climate/webClimateRiskCountdownCues.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected province panel exposes climate risk countdown cues', () => {
+  assert.match(webAppSource, /function buildProvinceClimateCountdownCues/);
+  assert.match(webAppSource, /function renderProvinceClimateCountdownCues/);
+  assert.match(webAppSource, /Compte à rebours des risques climat de province/);
+  assert.match(webAppSource, /Urgence climat/);
+  assert.match(webAppSource, /Immédiat/);
+  assert.match(webAppSource, /Prochain tour/);
+  assert.match(webAppSource, /Surveiller/);
+  assert.match(webAppSource, /Stable/);
+  assert.match(webAppSource, /Évacuer \/ mitiger/);
+  assert.match(webAppSource, /Préparer réserves/);
+  assert.match(webAppSource, /Renforcer stabilité/);
+  assert.match(webAppSource, /province\.hazards/);
+  assert.match(webAppSource, /Température\/précipitations/);
+  assert.match(webAppSource, /renderProvinceClimateCountdownCues\(province\)/);
+
+  assert.match(stylesSource, /\.province-climate-countdown/);
+  assert.match(stylesSource, /\.province-climate-countdown__cue--immediate/);
+  assert.match(stylesSource, /\.province-climate-countdown__cue--next-turn/);
+  assert.match(stylesSource, /\.province-climate-countdown__cue--watch/);
+  assert.match(stylesSource, /\.province-climate-countdown__cue--stable/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1318,6 +1318,89 @@ function buildProvinceClimateTurnReport(province) {
   });
 }
 
+function buildProvinceClimateCountdownCues(province, report = buildProvinceClimateTurnReport(province)) {
+  const hazard = province.hazards?.[0] ?? null;
+  const hazardRisk = hazard?.riskLevel ?? null;
+  const riskDelta = report.deltas.find((delta) => delta.deltaId.includes(':risk') || delta.deltaId.includes(':anomaly')) ?? null;
+  const upcomingDelta = report.deltas.find((delta) => delta.deltaId.includes(':upcoming')) ?? null;
+  const recoveryDelta = report.deltas.find((delta) => delta.deltaId.includes(':recovery')) ?? null;
+  const cues = [];
+
+  if (report.state === 'risk' || hazardRisk === 'high' || getProvinceClimateRiskLevel(province) === 'critical') {
+    cues.push({
+      level: 'immediate',
+      countdown: 'Immédiat',
+      label: riskDelta?.label ?? (hazard ? `Catastrophe ${hazard.type}` : 'Risque climat critique'),
+      detail: riskDelta?.reason ?? `${province.label} cumule instabilité, sévérité locale et exposition climatique visible.`,
+      action: province.supplyLevel === 'collapsed' || province.contested ? 'Évacuer / mitiger' : 'Renforcer stabilité',
+      priority: 1,
+    });
+  }
+
+  if (upcomingDelta) {
+    cues.push({
+      level: 'next-turn',
+      countdown: 'Prochain tour',
+      label: 'Saison à risque',
+      detail: upcomingDelta.reason,
+      action: 'Préparer réserves',
+      priority: 2,
+    });
+  }
+
+  if (recoveryDelta || hazardRisk === 'moderate' || getProvinceClimateRiskLevel(province) === 'strained') {
+    cues.push({
+      level: 'watch',
+      countdown: 'Surveiller',
+      label: recoveryDelta?.label ?? (hazard ? `Aléa ${hazard.type}` : 'Pression climat'),
+      detail: recoveryDelta?.reason ?? 'Température/précipitations et sévérité restent à confirmer avant validation du tour.',
+      action: recoveryDelta?.tone === 'improved' ? 'Conserver mitigation' : 'Surveiller',
+      priority: 3,
+    });
+  }
+
+  if (cues.length === 0) {
+    cues.push({
+      level: 'stable',
+      countdown: 'Stable',
+      label: 'Climat stable',
+      detail: 'Aucune catastrophe, anomalie ou dérive température/précipitations prioritaire visible.',
+      action: 'Surveiller',
+      priority: 4,
+    });
+  }
+
+  return cues
+    .sort((left, right) => left.priority - right.priority || left.label.localeCompare(right.label))
+    .slice(0, 3);
+}
+
+function renderProvinceClimateCountdownCues(province) {
+  const report = buildProvinceClimateTurnReport(province);
+  const cues = buildProvinceClimateCountdownCues(province, report);
+
+  return `
+    <section class="province-climate-countdown" aria-label="Compte à rebours des risques climat de province">
+      <div class="province-climate-countdown__header">
+        <strong>Urgence climat</strong>
+        <span>${cues[0]?.countdown ?? 'Stable'}</span>
+      </div>
+      <div class="province-climate-countdown__list">
+        ${cues.map((cue) => `
+          <article class="province-climate-countdown__cue province-climate-countdown__cue--${cue.level}">
+            <div>
+              <b>${cue.countdown}</b>
+              <code>${cue.action}</code>
+            </div>
+            <strong>${cue.label}</strong>
+            <p>${cue.detail}</p>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderProvinceClimateTurnReport(province) {
   const report = buildProvinceClimateTurnReport(province);
 
@@ -2414,6 +2497,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView)}
       ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}
       ${renderIntrigueTurnReportDeltas(province, intrigueView)}
+      ${renderProvinceClimateCountdownCues(province)}
       ${renderProvinceClimateTurnReport(province)}
       <div class="context-summary">
         <strong>Comparaison rapide</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2767,6 +2767,64 @@ button { font: inherit; }
   margin: 3px 0 0;
   font-size: 12px;
 }
+.province-climate-countdown {
+  display: grid;
+  gap: 9px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(14, 116, 144, 0.28), rgba(15, 23, 42, 0.58));
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.province-climate-countdown__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-climate-countdown__header span {
+  color: #fde68a;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-climate-countdown__list {
+  display: grid;
+  gap: 7px;
+}
+.province-climate-countdown__cue {
+  display: grid;
+  gap: 4px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.34);
+  border-left: 3px solid rgba(148, 163, 184, 0.48);
+}
+.province-climate-countdown__cue--immediate { border-left-color: rgba(248, 113, 113, 0.86); }
+.province-climate-countdown__cue--next-turn { border-left-color: rgba(251, 191, 36, 0.78); }
+.province-climate-countdown__cue--watch { border-left-color: rgba(56, 189, 248, 0.72); }
+.province-climate-countdown__cue--stable { border-left-color: rgba(74, 222, 128, 0.68); }
+.province-climate-countdown__cue div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-climate-countdown__cue code {
+  color: #a5f3fc;
+  font-size: 0.72rem;
+}
+.province-climate-countdown__cue strong,
+.province-climate-countdown__cue b {
+  color: #ecfeff;
+}
+.province-climate-countdown__cue p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
 .province-climate-turn-report {
   display: grid;
   gap: 9px;


### PR DESCRIPTION
Epsilon:

## Summary
- Adds selected-province climate countdown cues for immediate, next-turn, watch, and stable risk states.
- Reuses existing province hazards, climate risk/stability, and climate turn-report deltas to keep the panel scoped and readable.
- Shows short recommended actions such as preparing reserves, reinforcing stability, watching, or evacuating/mitigating.

## Testing
- node --check web/app.js
- npm test -- test/ui/climate/webClimateRiskCountdownCues.test.js test/ui/climate/webClimateTurnReportDeltas.test.js
- npm test

Fixes loo469/historia#527