### PR TITLE
Beta: show route logistics causes in province detail

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -35,9 +35,59 @@ function getMainResource(route, resourceLabelById) {
   };
 }
 
+function getRouteCause(route, localCity, localTension, mainResource) {
+  if (!route.active) {
+    return {
+      label: 'route inactive',
+      detail: `${route.routeName}: route interrompue vers ${localCity.cityName}, ${mainResource.label} doit attendre une réparation.`,
+    };
+  }
+
+  if (route.riskLevel >= 70) {
+    return {
+      label: 'risque élevé',
+      detail: `${route.routeName}: risque ${route.riskLevel} autour de ${localCity.cityName}, escorte requise pour sécuriser ${mainResource.label}.`,
+    };
+  }
+
+  if (localTension === 'high') {
+    return {
+      label: 'stock critique',
+      detail: `${localCity.cityName}: stock critique, ${route.routeName} doit prioriser ${mainResource.label}.`,
+    };
+  }
+
+  if (route.totalCapacity >= 9) {
+    return {
+      label: 'capacité insuffisante',
+      detail: `${route.routeName}: capacité ${route.totalCapacity} saturée, relais nécessaire avant surcharge de ${localCity.cityName}.`,
+    };
+  }
+
+  if (route.riskLevel >= 55) {
+    return {
+      label: 'risque élevé',
+      detail: `${route.routeName}: risque ${route.riskLevel} sur ${mainResource.label}, convoi à sécuriser.`,
+    };
+  }
+
+  if (localTension === 'medium') {
+    return {
+      label: 'stock sous tension',
+      detail: `${localCity.cityName}: stock sous tension, ${route.routeName} reste à surveiller.`,
+    };
+  }
+
+  return {
+    label: 'logistique stable',
+    detail: `${route.routeName}: logistique stable vers ${localCity.cityName}, ${mainResource.label} couvert.`,
+  };
+}
+
 function buildChoiceForRoute(route, localCity, localTension, resourceLabelById) {
   const mainResource = getMainResource(route, resourceLabelById);
   const tone = getRouteTone(route, localTension);
+  const routeCause = getRouteCause(route, localCity, localTension, mainResource);
   const overloaded = route.totalCapacity >= 9;
   const risky = route.riskLevel >= 55;
   const inactive = !route.active;
@@ -74,6 +124,8 @@ function buildChoiceForRoute(route, localCity, localTension, resourceLabelById) 
     routes: [route.routeName],
     resources: [mainResource.label],
     affectedCity: localCity.cityName,
+    causeLabel: routeCause.label,
+    cause: routeCause.detail,
     residualRisk,
     impact,
     score: (TONE_RANK[tone] ?? 0) * 100 + route.riskLevel + route.totalCapacity + (localTension === 'high' ? 20 : localTension === 'medium' ? 10 : 0),
@@ -85,7 +137,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const resourceLabelById = requireObject(normalizedOptions.resourceLabelById ?? {}, 'ProvinceLogisticsChoicePreview resourceLabelById');
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -114,15 +166,21 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   if (routeChoices.length === 0) {
     return {
       recommendedOptionId: null,
-      summary: 'Aucun reroutage utile: aucune route liée à la province sélectionnée.',
+      status: 'stable',
+      summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
       options: [],
     };
   }
 
   const recommended = routeChoices[0];
+  const hasBlocker = routeChoices.some((choice) => choice.tone === 'high' || choice.tone === 'medium');
+
   return {
     recommendedOptionId: recommended.optionId,
-    summary: `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.impact}`,
+    status: hasBlocker ? recommended.tone : 'stable',
+    summary: hasBlocker
+      ? `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.cause}`
+      : `Logistique stable: ${recommended.routes[0]} et ${recommended.affectedCity} restent couverts.`,
     options: routeChoices,
   };
 }

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -56,6 +56,10 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.options[0].action, 'Sécuriser convoi');
   assert.deepEqual(preview.options[0].resources, ['Outils']);
   assert.match(preview.summary, /Ember Line/);
+  assert.equal(preview.status, 'high');
+  assert.equal(preview.options[0].causeLabel, 'stock critique');
+  assert.match(preview.options[0].cause, /River Gate/);
+  assert.match(preview.options[0].cause, /Ember Line/);
 });
 
 test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and impact labels', () => {
@@ -67,6 +71,7 @@ test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and i
   assert.equal(typeof option.residualRisk, 'number');
   assert.ok(option.impact.includes('tools') || option.impact.includes('ressource'));
   assert.deepEqual(option.routes, ['Ember Line']);
+  assert.ok(option.cause.length > 0);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
@@ -74,7 +79,24 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
 
   assert.equal(preview.recommendedOptionId, null);
   assert.deepEqual(preview.options, []);
-  assert.match(preview.summary, /Aucun reroutage utile/);
+  assert.equal(preview.status, 'stable');
+  assert.match(preview.summary, /Logistique stable/);
+});
+
+test('buildProvinceLogisticsChoicePreview exposes stable local route causes', () => {
+  const stableView = buildEconomyView();
+  stableView.overlay.routes = [stableView.overlay.routes[0]];
+  stableView.comparison.rows = stableView.comparison.rows.map((row) => ({ ...row, tensionLevel: 'low' }));
+
+  const preview = buildProvinceLogisticsChoicePreview(province, stableView, {
+    resourceLabelById: { grain: 'Grain' },
+  });
+
+  assert.equal(preview.status, 'stable');
+  assert.match(preview.summary, /Logistique stable/);
+  assert.equal(preview.options[0].causeLabel, 'logistique stable');
+  assert.match(preview.options[0].cause, /Safe Road/);
+  assert.match(preview.options[0].cause, /River Gate/);
 });
 
 test('buildProvinceLogisticsChoicePreview validates options', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable province detail renders compact logistics route causes', () => {
+  assert.match(webAppSource, /function renderProvinceLogisticsChoicePreview/);
+  assert.match(webAppSource, /province-logistics-cause-summary/);
+  assert.match(webAppSource, /Cause locale/);
+  assert.match(webAppSource, /option\.causeLabel/);
+  assert.match(webAppSource, /option\.cause/);
+  assert.match(webAppSource, /logistique stable/);
+  assert.equal(webAppSource.includes("if (preview.options.length === 0) {\n    return '';\n  }"), false);
+  assert.match(stylesSource, /\.province-logistics-cause-summary/);
+  assert.match(stylesSource, /province-logistics-cause-summary--high/);
+  assert.match(stylesSource, /province-logistics-cause-summary--stable/);
+  assert.match(stylesSource, /province-logistics-choice__cause/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1176,25 +1176,27 @@ function buildProvinceLogisticsChoicePreviewView(province, economyView) {
 function renderProvinceLogisticsChoicePreview(province, economyView) {
   const preview = buildProvinceLogisticsChoicePreviewView(province, economyView);
 
-  if (preview.options.length === 0) {
-    return '';
-  }
-
   return `
     <section class="province-logistics-choice-preview" aria-label="Aperçu reroutage et réparation logistique">
       <div class="province-logistics-choice-preview__header">
         <strong>Aperçu choix logistiques</strong>
-        <span>${preview.options.length} options</span>
+        <span>${preview.options.length > 0 ? `${preview.options.length} options` : 'stable'}</span>
       </div>
       <p>${preview.summary}</p>
-      <div class="province-logistics-choice-list">
-        ${preview.options.map((option) => `
+      <div class="province-logistics-cause-summary province-logistics-cause-summary--${preview.status ?? 'stable'}">
+        <b>Cause locale</b>
+        <span>${preview.options[0]?.cause ?? 'logistique stable'}</span>
+      </div>
+      ${preview.options.length > 0 ? `
+        <div class="province-logistics-choice-list">
+          ${preview.options.map((option) => `
           <article class="province-logistics-choice province-logistics-choice--${option.tone} ${option.recommended ? 'is-recommended' : ''}">
             <div class="province-logistics-choice__title">
               <strong>${option.action}</strong>
               <span>${option.recommended ? 'recommandé' : option.delay}</span>
             </div>
             <p>${option.impact}</p>
+            <small class="province-logistics-choice__cause">${option.causeLabel}: ${option.cause}</small>
             <dl>
               <div><dt>Coût</dt><dd>${option.cost}</dd></div>
               <div><dt>Délai</dt><dd>${option.delay}</dd></div>
@@ -1204,7 +1206,8 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
             </dl>
           </article>
         `).join('')}
-      </div>
+        </div>
+      ` : ''}
     </section>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -2725,6 +2725,30 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.4;
 }
+.province-logistics-cause-summary {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border-radius: 11px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(125, 211, 252, 0.14);
+}
+.province-logistics-cause-summary b {
+  color: #f8fafc;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-logistics-cause-summary span,
+.province-logistics-choice__cause {
+  color: #bfdbfe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-logistics-cause-summary--high { border-color: rgba(251, 113, 133, 0.38); }
+.province-logistics-cause-summary--medium { border-color: rgba(245, 158, 11, 0.34); }
+.province-logistics-cause-summary--stable,
+.province-logistics-cause-summary--low { border-color: rgba(74, 222, 128, 0.24); }
 .province-logistics-choice-list {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Beta: Implements #524.

## Summary
- derives compact route-level logistics causes for province logistics choices
- surfaces the local cause in the selected province detail panel, including stable/no-blocker states
- adds focused derivation and web wiring tests

## Tests
- npm test
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.