### PR TITLE
Delta: add safe intrigue fog hints

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -22,3 +22,18 @@ test('intrigue end-turn exposure warnings expose fog-aware focus targets', () =>
   assert.match(stylesSource, /data-intrigue-fog-state="probable"/);
   assert.match(stylesSource, /data-intrigue-fog-state="masked"/);
 });
+
+test('selected intrigue province detail explains fog reasons with safe action hints', () => {
+  assert.match(webAppSource, /function buildSelectedProvinceIntrigueFogHint/);
+  assert.match(webAppSource, /Cellule exposée signalée/);
+  assert.match(webAppSource, /Sécurité cible élevée/);
+  assert.match(webAppSource, /Renseignement incomplet/);
+  assert.match(webAppSource, /Réduire chaleur/);
+  assert.match(webAppSource, /Collecter renseignement/);
+  assert.match(webAppSource, /Temporiser/);
+  assert.match(webAppSource, /Surveiller sans escalade/);
+  assert.match(webAppSource, /aria-label="\$\{intrigueView\.selectedProvince\.fogHint\.ariaLabel\}"/);
+  assert.match(stylesSource, /intrigue-fog-hint--danger/);
+  assert.match(stylesSource, /intrigue-fog-hint--warning/);
+  assert.match(stylesSource, /intrigue-fog-hint--watch/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3116,6 +3116,59 @@ function buildIntrigueLinks(entries) {
   return [...links.values()];
 }
 
+function buildSelectedProvinceIntrigueFogHint(entry, selectedCellules, selectedOperations) {
+  if (!entry) {
+    return null;
+  }
+
+  const compromisedCount = selectedCellules.filter((cellule) => cellule.statusClass === 'compromised').length;
+  const exposedCount = entry.metrics.exposedCellCount + compromisedCount;
+  const heatedOperation = selectedOperations.find((operation) => operation.detectionRisk >= 50 || operation.heat >= 50) ?? null;
+  const activeSabotage = selectedOperations.find((operation) => operation.type === 'sabotage') ?? null;
+
+  if (exposedCount > 0) {
+    return {
+      tone: 'warning',
+      visibility: 'Partiellement révélé',
+      reason: `Cellule exposée signalée à ${entry.locationName}: les identifiants restent masqués tant que le renseignement local n'est pas consolidé.`,
+      safeAction: 'Réduire chaleur',
+      actionHint: 'Réduire chaleur avant d’exposer la cellule ou déplacer le focus sur une cible nominative.',
+      ariaLabel: `Raison brouillard intrigue pour ${entry.locationName}: cellule exposée, action sûre réduire chaleur`,
+    };
+  }
+
+  if (heatedOperation) {
+    return {
+      tone: 'danger',
+      visibility: 'Masqué',
+      reason: `Sécurité cible élevée à ${entry.locationName}: l'opération est active mais son relais exact reste couvert par le brouillard.`,
+      safeAction: 'Temporiser',
+      actionHint: 'Temporiser et baisser la pression; ne pas révéler cellule, relais ou objectif tant que le risque reste haut.',
+      ariaLabel: `Raison brouillard intrigue pour ${entry.locationName}: sécurité cible élevée, action sûre temporiser`,
+    };
+  }
+
+  if (entry.presenceLevel === 'high' || entry.sabotageRiskLevel === 'medium' || entry.sabotageRiskLevel === 'high' || activeSabotage) {
+    return {
+      tone: entry.sabotageRiskLevel === 'high' ? 'danger' : 'warning',
+      visibility: 'Partiellement révélé',
+      reason: `Renseignement incomplet à ${entry.locationName}: la présence clandestine est lisible, mais les relais précis ne sont pas confirmés.`,
+      safeAction: 'Collecter renseignement',
+      actionHint: 'Collecter renseignement pour confirmer le hotspot avant toute action qui révélerait une cible.',
+      ariaLabel: `Raison brouillard intrigue pour ${entry.locationName}: renseignement incomplet, action sûre collecter renseignement`,
+    };
+  }
+
+  return {
+    tone: 'watch',
+    visibility: 'Surveillance',
+    reason: `Signal faible à ${entry.locationName}: le brouillard masque les détails car aucun risque fort n'est confirmé.`,
+    safeAction: 'Surveiller',
+    actionHint: 'Surveiller sans escalade; garder la province en observation jusqu’à un signal plus net.',
+    ariaLabel: `Raison brouillard intrigue pour ${entry.locationName}: signal faible, action sûre surveiller`,
+  };
+}
+
 function getIntrigueViewModel() {
   const liveCellules = intrigueCellules.map(getIntrigueCelluleStateByTurn);
   const liveOperations = intrigueOperations.map(getIntrigueOperationStateByTurn);
@@ -3216,6 +3269,7 @@ function getIntrigueViewModel() {
       sleeperCellCount: selectedEntry.metrics.sleeperCellCount,
       activeOperationCount: selectedOperations.length,
       drillDown: selectedEntry.drillDown,
+      fogHint: buildSelectedProvinceIntrigueFogHint(selectedEntry, selectedCellules, selectedOperations),
       reasons: selectedRiskReasons.length > 0 ? selectedRiskReasons : ['Aucun signal Delta notable'],
       guidance: selectedEntry.sabotageRiskLevel === 'high'
         ? 'Priorite a la surveillance locale, les marqueurs rouges concentrent le risque actif.'
@@ -4044,6 +4098,16 @@ function renderIntrigueSidePanel(intrigueView) {
             <span>presence ${intrigueView.selectedProvince.presenceLevel} · risque ${intrigueView.selectedProvince.sabotageRiskLevel}</span>
           </div>
           <p>${intrigueView.selectedProvince.guidance}</p>
+          ${intrigueView.selectedProvince.fogHint ? `
+            <aside class="intrigue-fog-hint intrigue-fog-hint--${intrigueView.selectedProvince.fogHint.tone}" aria-label="${intrigueView.selectedProvince.fogHint.ariaLabel}">
+              <div>
+                <span>${intrigueView.selectedProvince.fogHint.visibility}</span>
+                <strong>${intrigueView.selectedProvince.fogHint.safeAction}</strong>
+              </div>
+              <p>${intrigueView.selectedProvince.fogHint.reason}</p>
+              <small>${intrigueView.selectedProvince.fogHint.actionHint}</small>
+            </aside>
+          ` : ''}
           <div class="intrigue-province-focus__stats">
             <span>${intrigueView.selectedProvince.celluleCount} cellules</span>
             <span>${intrigueView.selectedProvince.activeOperationCount} operations</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3250,6 +3250,39 @@ button { font: inherit; }
   border: 1px solid rgba(103, 232, 249, 0.12);
   color: #cbd5e1;
 }
+.intrigue-fog-hint {
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.48);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+.intrigue-fog-hint--danger { border-color: rgba(251, 113, 133, 0.38); }
+.intrigue-fog-hint--warning { border-color: rgba(250, 204, 21, 0.34); }
+.intrigue-fog-hint--watch { border-color: rgba(96, 165, 250, 0.28); }
+.intrigue-fog-hint div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.intrigue-fog-hint span {
+  color: #c4b5fd;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.intrigue-fog-hint strong {
+  color: #fef3c7;
+}
+.intrigue-fog-hint p,
+.intrigue-fog-hint small {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.35;
+}
 .intrigue-legend-strip {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Delta: Implements #526.\n\nSummary:\n- Adds local intrigue fog explanations for selected province detail using existing presence/risk/cell exposure/operation heat data.\n- Adds short safe action hints: collect intelligence, reduce heat, temporize, or monitor.\n- Keeps focus/ARIA text non-spoiling and styles the new fog hint states.\n\nValidation:\n- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js\n- node --check web/app.js\n- git diff --check\n- npm test (434 passing)\n\nZeta, please validate before any merge.