### PR TITLE
Beta: compare logistics recovery choices

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -84,6 +84,61 @@ function getRouteCause(route, localCity, localTension, mainResource) {
   };
 }
 
+
+function buildRecoveryChoices(route, localCity, localTension, mainResource, routeCause) {
+  const choices = [
+    {
+      choiceId: 'reroute',
+      label: 'Reroute',
+      tone: route.totalCapacity >= 9 || route.riskLevel >= 55 ? 'high' : 'medium',
+      benefit: route.totalCapacity >= 9
+        ? `Désature ${route.routeName} en répartissant ${mainResource.label} vers un relais voisin.`
+        : `Contourne le risque ${route.riskLevel} et garde ${localCity.cityName} alimentée.`,
+      blocker: route.totalCapacity >= 9 ? 'relais disponible' : 'route alternative sûre',
+      rationale: `Répond à la cause: ${routeCause.label}.`,
+      score: (route.totalCapacity >= 9 ? 34 : 22) + (route.riskLevel >= 55 ? 12 : 0),
+    },
+    {
+      choiceId: 'repair',
+      label: 'Repair',
+      tone: !route.active ? 'high' : route.riskLevel >= 70 ? 'medium' : 'low',
+      benefit: !route.active
+        ? `Rouvre ${route.routeName} et restaure le flux de ${mainResource.label}.`
+        : `Stabilise les points faibles de ${route.routeName} avant le prochain tour.`,
+      blocker: !route.active ? 'équipe et stock outil' : 'fenêtre de maintenance',
+      rationale: `Répond à la cause: ${routeCause.label}.`,
+      score: (!route.active ? 44 : 14) + (route.riskLevel >= 70 ? 10 : 0),
+    },
+    {
+      choiceId: 'stockpile',
+      label: 'Stockpile',
+      tone: localTension !== 'low' ? 'high' : 'low',
+      benefit: `Ajoute un tampon local à ${localCity.cityName} pour absorber la tension sur ${mainResource.label}.`,
+      blocker: 'stock disponible',
+      rationale: `Répond à la cause: ${routeCause.label}.`,
+      score: (localTension === 'high' ? 42 : localTension === 'medium' ? 28 : 8) + mainResource.capacity,
+    },
+    {
+      choiceId: 'economic-priority',
+      label: 'Priorité économie',
+      tone: route.riskLevel >= 55 || route.totalCapacity >= 9 ? 'medium' : 'low',
+      benefit: `Réserve ordres et budget pour ${mainResource.label} au lieu de disperser les flux.`,
+      blocker: 'ordre économie disponible',
+      rationale: `Répond à la cause: ${routeCause.label}.`,
+      score: 16 + (route.riskLevel >= 55 ? 12 : 0) + (route.totalCapacity >= 9 ? 10 : 0),
+    },
+  ];
+
+  const rankedChoices = choices.sort((left, right) => right.score - left.score || left.label.localeCompare(right.label));
+  const topChoice = rankedChoices[0];
+
+  return rankedChoices.map((choice, index) => ({
+    ...choice,
+    recommended: index === 0,
+    comparison: index === 0 ? 'meilleur levier immédiat' : `moins urgent: ${topChoice.blocker} prioritaire`,
+  }));
+}
+
 function buildChoiceForRoute(route, localCity, localTension, resourceLabelById) {
   const mainResource = getMainResource(route, resourceLabelById);
   const tone = getRouteTone(route, localTension);
@@ -114,6 +169,7 @@ function buildChoiceForRoute(route, localCity, localTension, resourceLabelById) 
     : tone === 'medium'
       ? `Soulage ${mainResource.label} sans masquer le risque résiduel.`
       : `Maintient ${localCity.cityName} stable avec surveillance légère.`;
+  const recoveryChoices = buildRecoveryChoices(route, localCity, localTension, mainResource, routeCause);
 
   return {
     routeId: route.routeId,
@@ -126,6 +182,7 @@ function buildChoiceForRoute(route, localCity, localTension, resourceLabelById) 
     affectedCity: localCity.cityName,
     causeLabel: routeCause.label,
     cause: routeCause.detail,
+    recoveryChoices,
     residualRisk,
     impact,
     score: (TONE_RANK[tone] ?? 0) * 100 + route.riskLevel + route.totalCapacity + (localTension === 'high' ? 20 : localTension === 'medium' ? 10 : 0),
@@ -177,9 +234,10 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
 
   return {
     recommendedOptionId: recommended.optionId,
+    recoveryChoiceCount: recommended.recoveryChoices.length,
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker
-      ? `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.cause}`
+      ? `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.cause} ${recommended.recoveryChoices[0].label} est prioritaire car ${recommended.recoveryChoices[0].benefit}`
       : `Logistique stable: ${recommended.routes[0]} et ${recommended.affectedCity} restent couverts.`,
     options: routeChoices,
   };

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -60,6 +60,12 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.options[0].causeLabel, 'stock critique');
   assert.match(preview.options[0].cause, /River Gate/);
   assert.match(preview.options[0].cause, /Ember Line/);
+  assert.equal(preview.recoveryChoiceCount, 4);
+  assert.ok(preview.options[0].recoveryChoices.length >= 2);
+  assert.equal(preview.options[0].recoveryChoices[0].recommended, true);
+  assert.match(preview.options[0].recoveryChoices[0].benefit, /Outils|River Gate|Ember Line/);
+  assert.ok(preview.options[0].recoveryChoices[0].blocker.length > 0);
+  assert.match(preview.options[0].recoveryChoices[1].comparison, /moins urgent/);
 });
 
 test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and impact labels', () => {
@@ -72,6 +78,7 @@ test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and i
   assert.ok(option.impact.includes('tools') || option.impact.includes('ressource'));
   assert.deepEqual(option.routes, ['Ember Line']);
   assert.ok(option.cause.length > 0);
+  assert.deepEqual(option.recoveryChoices.map((choice) => choice.choiceId).sort(), ['economic-priority', 'repair', 'reroute', 'stockpile']);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -11,10 +11,17 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Cause locale/);
   assert.match(webAppSource, /option\.causeLabel/);
   assert.match(webAppSource, /option\.cause/);
+  assert.match(webAppSource, /province-logistics-recovery-comparison/);
+  assert.match(webAppSource, /choice\.benefit/);
+  assert.match(webAppSource, /choice\.blocker/);
+  assert.match(webAppSource, /choice\.rationale/);
   assert.match(webAppSource, /logistique stable/);
   assert.equal(webAppSource.includes("if (preview.options.length === 0) {\n    return '';\n  }"), false);
   assert.match(stylesSource, /\.province-logistics-cause-summary/);
   assert.match(stylesSource, /province-logistics-cause-summary--high/);
   assert.match(stylesSource, /province-logistics-cause-summary--stable/);
   assert.match(stylesSource, /province-logistics-choice__cause/);
+  assert.match(stylesSource, /province-logistics-recovery-comparison/);
+  assert.match(stylesSource, /province-logistics-recovery--high/);
+  assert.match(stylesSource, /province-logistics-recovery--medium/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1199,6 +1199,18 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
             </div>
             <p>${option.impact}</p>
             <small class="province-logistics-choice__cause">${option.causeLabel}: ${option.cause}</small>
+            <div class="province-logistics-recovery-comparison" aria-label="Comparaison des corrections logistiques">
+              ${option.recoveryChoices.slice(0, 3).map((choice) => `
+                <article class="province-logistics-recovery province-logistics-recovery--${choice.tone} ${choice.recommended ? 'is-recommended' : ''}">
+                  <div>
+                    <strong>${choice.label}</strong>
+                    <span>${choice.comparison}</span>
+                  </div>
+                  <p>${choice.benefit}</p>
+                  <small>Contrainte: ${choice.blocker} · ${choice.rationale}</small>
+                </article>
+              `).join('')}
+            </div>
             <dl>
               <div><dt>Coût</dt><dd>${option.cost}</dd></div>
               <div><dt>Délai</dt><dd>${option.delay}</dd></div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2843,6 +2843,45 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.38;
 }
+.province-logistics-recovery-comparison {
+  display: grid;
+  gap: 6px;
+  margin-top: 8px;
+}
+.province-logistics-recovery {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border-radius: 11px;
+  background: rgba(8, 15, 28, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-logistics-recovery.is-recommended {
+  background: rgba(12, 74, 110, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.14);
+}
+.province-logistics-recovery--high { border-color: rgba(251, 113, 133, 0.38); }
+.province-logistics-recovery--medium { border-color: rgba(245, 158, 11, 0.34); }
+.province-logistics-recovery--low { border-color: rgba(74, 222, 128, 0.24); }
+.province-logistics-recovery div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.province-logistics-recovery strong { color: #f8fafc; font-size: 12px; }
+.province-logistics-recovery span,
+.province-logistics-recovery small {
+  color: #bfdbfe;
+  font-size: 11px;
+  line-height: 1.3;
+}
+.province-logistics-recovery p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
 .province-logistics-choice dl {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Beta: Implements #534.

## Summary
- derives ranked recovery choices for each province logistics route option (reroute, repair, stockpile, economic priority)
- links each correction to the route-level cause with benefit, blocker, urgency comparison, and matching tones
- renders the compact comparison in the province detail logistics panel with focused tests

## Tests
- npm test
- npm test -- --test-reporter=spec test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.