### PR TITLE
Delta: compare safe intrigue fog responses

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -37,3 +37,19 @@ test('selected intrigue province detail explains fog reasons with safe action hi
   assert.match(stylesSource, /intrigue-fog-hint--warning/);
   assert.match(stylesSource, /intrigue-fog-hint--watch/);
 });
+
+test('selected intrigue province compares safe responses under fog', () => {
+  assert.match(webAppSource, /function buildSelectedProvinceIntrigueResponseChoices/);
+  assert.match(webAppSource, /Choix sous brouillard/);
+  assert.match(webAppSource, /Agir ou attendre/);
+  assert.match(webAppSource, /risque d'exposition/);
+  assert.match(webAppSource, /Info manquante/);
+  assert.match(webAppSource, /Transforme le soupçon en renseignement exploitable sans nommer la cible/);
+  assert.match(webAppSource, /Surveiller: garder la province en observation/);
+  assert.match(webAppSource, /privilégier une réponse prudente avant toute neutralisation visible/);
+  assert.match(webAppSource, /Surveiller sans escalade: attendre/);
+  assert.match(stylesSource, /intrigue-response-comparison/);
+  assert.match(stylesSource, /intrigue-response-choice--danger/);
+  assert.match(stylesSource, /intrigue-response-choice--warning/);
+  assert.match(stylesSource, /intrigue-response-choice--watch/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3184,6 +3184,73 @@ function buildSelectedProvinceIntrigueFogHint(entry, selectedCellules, selectedO
   };
 }
 
+function buildSelectedProvinceIntrigueResponseChoices(entry, selectedCellules, selectedOperations, fogHint = null) {
+  if (!entry) {
+    return [];
+  }
+
+  const compromisedCount = selectedCellules.filter((cellule) => cellule.statusClass === 'compromised').length;
+  const exposedCount = entry.metrics.exposedCellCount + compromisedCount;
+  const hasActiveOperation = selectedOperations.length > 0;
+  const heatedOperation = selectedOperations.find((operation) => operation.detectionRisk >= 50 || operation.heat >= 50) ?? null;
+  const riskIsHigh = entry.sabotageRiskLevel === 'high' || exposedCount > 0 || Boolean(heatedOperation);
+  const baseMissingInfo = exposedCount > 0
+    ? 'identité de cellule et relais précis masqués'
+    : hasActiveOperation
+      ? 'objectif exact et relais opérationnel masqués'
+      : 'source du signal et loyautés locales inconnues';
+  const choices = [
+    {
+      code: 'surveiller',
+      label: 'Surveiller',
+      tone: 'watch',
+      exposureRisk: 'faible',
+      missingInfo: baseMissingInfo,
+      gain: 'Maintient le signal visible sans forcer la révélation du brouillard.',
+      summary: 'Surveiller: garder la province en observation et attendre un signal plus net.',
+      recommended: !riskIsHigh,
+    },
+    {
+      code: 'infiltrer',
+      label: 'Infiltrer',
+      tone: riskIsHigh ? 'warning' : 'watch',
+      exposureRisk: riskIsHigh ? 'modéré' : 'faible à modéré',
+      missingInfo: exposedCount > 0 ? 'canal sûr pour approcher la cellule exposée' : 'confirmation du hotspot avant contact direct',
+      gain: 'Transforme le soupçon en renseignement exploitable sans nommer la cible.',
+      summary: 'Collecter renseignement: approcher le réseau sans révéler cellule, relais ou objectif.',
+      recommended: !heatedOperation && entry.presenceLevel !== 'low',
+    },
+  ];
+
+  if (riskIsHigh) {
+    choices.push({
+      code: exposedCount > 0 ? 'reduire-chaleur' : 'temporiser',
+      label: exposedCount > 0 ? 'Réduire chaleur' : 'Temporiser',
+      tone: exposedCount > 0 ? 'danger' : 'warning',
+      exposureRisk: exposedCount > 0 ? 'élevé si action directe' : 'modéré tant que la sécurité cible reste haute',
+      missingInfo: fogHint?.reason ?? baseMissingInfo,
+      gain: exposedCount > 0
+        ? 'Diminue la pression avant une neutralisation publique ou ciblée.'
+        : 'Laisse passer la fenêtre risquée tout en gardant le théâtre sous contrôle.',
+      summary: `${exposedCount > 0 ? 'Réduire chaleur' : 'Temporiser'}: privilégier une réponse prudente avant toute neutralisation visible.`,
+      recommended: true,
+    });
+  } else {
+    choices.push({
+      code: 'attendre',
+      label: 'Attendre',
+      tone: 'watch',
+      exposureRisk: 'très faible',
+      missingInfo: baseMissingInfo,
+      gain: 'Préserve totalement le brouillard mais reporte le gain de renseignement.',
+      summary: 'Surveiller sans escalade: attendre si le tour ne peut pas absorber de chaleur intrigue.',
+      recommended: false,
+    });
+  }
+
+  return choices.slice(0, 3);
+}
+
 function getIntrigueViewModel() {
   const liveCellules = intrigueCellules.map(getIntrigueCelluleStateByTurn);
   const liveOperations = intrigueOperations.map(getIntrigueOperationStateByTurn);
@@ -3236,6 +3303,8 @@ function getIntrigueViewModel() {
       ? `${selectedCellules.filter((cellule) => cellule.statusClass === 'compromised').length} cellule${selectedCellules.filter((cellule) => cellule.statusClass === 'compromised').length > 1 ? 's' : ''} compromise${selectedCellules.filter((cellule) => cellule.statusClass === 'compromised').length > 1 ? 's' : ''}`
       : null,
   ].filter(Boolean);
+  const selectedFogHint = buildSelectedProvinceIntrigueFogHint(selectedEntry, selectedCellules, selectedOperations);
+  const selectedResponseChoices = buildSelectedProvinceIntrigueResponseChoices(selectedEntry, selectedCellules, selectedOperations, selectedFogHint);
   const incidents = [
     {
       id: 'incident-locks',
@@ -3284,7 +3353,8 @@ function getIntrigueViewModel() {
       sleeperCellCount: selectedEntry.metrics.sleeperCellCount,
       activeOperationCount: selectedOperations.length,
       drillDown: selectedEntry.drillDown,
-      fogHint: buildSelectedProvinceIntrigueFogHint(selectedEntry, selectedCellules, selectedOperations),
+      fogHint: selectedFogHint,
+      responseChoices: selectedResponseChoices,
       reasons: selectedRiskReasons.length > 0 ? selectedRiskReasons : ['Aucun signal Delta notable'],
       guidance: selectedEntry.sabotageRiskLevel === 'high'
         ? 'Priorite a la surveillance locale, les marqueurs rouges concentrent le risque actif.'
@@ -4122,6 +4192,30 @@ function renderIntrigueSidePanel(intrigueView) {
               <p>${intrigueView.selectedProvince.fogHint.reason}</p>
               <small>${intrigueView.selectedProvince.fogHint.actionHint}</small>
             </aside>
+          ` : ''}
+          ${intrigueView.selectedProvince.responseChoices?.length ? `
+            <section class="intrigue-response-comparison" aria-label="Comparer les réponses intrigue sûres sous brouillard">
+              <div class="intrigue-response-comparison__header">
+                <span>Choix sous brouillard</span>
+                <strong>Agir ou attendre</strong>
+              </div>
+              <div class="intrigue-response-comparison__list">
+                ${intrigueView.selectedProvince.responseChoices.map((choice) => `
+                  <article class="intrigue-response-choice intrigue-response-choice--${choice.tone} ${choice.recommended ? 'is-recommended' : ''}" aria-label="${choice.label}: risque d'exposition ${choice.exposureRisk}">
+                    <div>
+                      <strong>${choice.label}</strong>
+                      ${choice.recommended ? '<b>prudente</b>' : ''}
+                    </div>
+                    <p>${choice.summary}</p>
+                    <dl>
+                      <div><dt>Exposition</dt><dd>${choice.exposureRisk}</dd></div>
+                      <div><dt>Info manquante</dt><dd>${choice.missingInfo}</dd></div>
+                      <div><dt>Gain</dt><dd>${choice.gain}</dd></div>
+                    </dl>
+                  </article>
+                `).join('')}
+              </div>
+            </section>
           ` : ''}
           <div class="intrigue-province-focus__stats">
             <span>${intrigueView.selectedProvince.celluleCount} cellules</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3346,6 +3346,76 @@ button { font: inherit; }
   color: #cbd5e1;
   line-height: 1.35;
 }
+.intrigue-response-comparison {
+  display: grid;
+  gap: 9px;
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 15px;
+  background: rgba(2, 6, 23, 0.3);
+  border: 1px solid rgba(167, 139, 250, 0.16);
+}
+.intrigue-response-comparison__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.intrigue-response-comparison__header span {
+  color: #c4b5fd;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.intrigue-response-comparison__list {
+  display: grid;
+  gap: 8px;
+}
+.intrigue-response-choice {
+  display: grid;
+  gap: 6px;
+  padding: 9px;
+  border-radius: 13px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.intrigue-response-choice--danger { border-color: rgba(251, 113, 133, 0.36); }
+.intrigue-response-choice--warning { border-color: rgba(250, 204, 21, 0.34); }
+.intrigue-response-choice--watch { border-color: rgba(96, 165, 250, 0.26); }
+.intrigue-response-choice.is-recommended { box-shadow: inset 3px 0 0 rgba(196, 181, 253, 0.42); }
+.intrigue-response-choice div,
+.intrigue-response-choice dl,
+.intrigue-response-choice dl div {
+  display: flex;
+  gap: 8px;
+}
+.intrigue-response-choice div,
+.intrigue-response-choice dl {
+  justify-content: space-between;
+  align-items: baseline;
+}
+.intrigue-response-choice dl {
+  flex-wrap: wrap;
+  margin: 0;
+}
+.intrigue-response-choice p,
+.intrigue-response-choice dt,
+.intrigue-response-choice dd {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.35;
+}
+.intrigue-response-choice dt {
+  color: #a5b4fc;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+.intrigue-response-choice dd {
+  max-width: 220px;
+}
+.intrigue-response-choice b {
+  color: #fde68a;
+}
 .intrigue-legend-strip {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Delta: Implements #536.

Summary:
- Add a compact fog-safe comparison of intrigue response choices for the selected province.
- Show exposure risk, missing information, and potential gain for each cautious response.
- Keep recommendations aligned with existing fog hints without revealing hidden cell, relay, or objective details.

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: PR ready for validation before merge.
