### PR TITLE
Alpha: compare military response options

### DIFF
--- a/test/ui/war/webMilitaryResponseOptions.test.js
+++ b/test/ui/war/webMilitaryResponseOptions.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected conflict provinces compare compact military response options', () => {
+  assert.match(webAppSource, /function buildMilitaryResponseOptions/);
+  assert.match(webAppSource, /function renderMilitaryResponseOptions/);
+  assert.match(webAppSource, /buildSelectedProvinceActionQueue\(province, shell, focusContext, intrigueView\)/);
+  assert.match(webAppSource, /buildConflictReadinessWarnings\(shell, intrigueView\)/);
+  assert.match(webAppSource, /Réponses militaires/);
+  assert.match(webAppSource, /Comparer avant d’engager/);
+  assert.match(webAppSource, /Option prioritaire/);
+  assert.match(webAppSource, /Option prudente/);
+  assert.match(webAppSource, /Option de réserve/);
+  assert.match(webAppSource, /Coût \/ risque/);
+  assert.match(webAppSource, /Effet prochain tour/);
+  assert.match(webAppSource, /Raison locale/);
+  assert.match(webAppSource, /renderMilitaryResponseOptions\(province, shell, focusContext, intrigueView\)/);
+  assert.match(stylesSource, /\.military-response-options/);
+  assert.match(stylesSource, /\.military-response-options__grid/);
+  assert.match(stylesSource, /military-response-option--blocked/);
+  assert.match(stylesSource, /military-response-option--risky/);
+  assert.match(stylesSource, /military-response-option--ready/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2052,6 +2052,69 @@ function renderProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView)
   `;
 }
 
+function buildMilitaryResponseOptions(province, shell, focusContext, intrigueView = null) {
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const outcome = buildConflictOutcomePreview(province, shell);
+  const readinessWarning = buildConflictReadinessWarnings(shell, intrigueView)
+    .find((warning) => warning.provinceId === province.provinceId || province.neighborIds.includes(warning.provinceId)) ?? null;
+  const localReason = readinessWarning?.provinceId === province.provinceId
+    ? readinessWarning.detail
+    : readinessWarning
+      ? `Voisinage sous tension: ${readinessWarning.focusTargetLabel}.`
+      : outcome.summary;
+
+  if (outcome.tone === 'success' && !readinessWarning && actionQueue.every((entry) => entry.status === 'ready')) {
+    return [];
+  }
+
+  return actionQueue.slice(0, 3).map((entry, index) => ({
+    ...entry,
+    optionLabel: index === 0 ? 'Option prioritaire' : index === 1 ? 'Option prudente' : 'Option de réserve',
+    localReason: index === 0
+      ? localReason
+      : entry.status === 'ready'
+        ? `Appui local disponible: ${province.supplyLevel}, loyauté ${province.loyalty}.`
+        : entry.mainRisk,
+    expectedNextTurn: entry.expectedResult,
+  }));
+}
+
+function renderMilitaryResponseOptions(province, shell, focusContext, intrigueView = null) {
+  const options = buildMilitaryResponseOptions(province, shell, focusContext, intrigueView);
+
+  if (options.length === 0) {
+    return '';
+  }
+
+  return `
+    <section class="military-response-options" aria-label="Comparaison des réponses militaires">
+      <div class="military-response-options__header">
+        <div>
+          <span>Réponses militaires</span>
+          <strong>Comparer avant d’engager</strong>
+        </div>
+        <small>${options.length} option${options.length > 1 ? 's' : ''}</small>
+      </div>
+      <div class="military-response-options__grid">
+        ${options.map((option) => `
+          <article class="military-response-option military-response-option--${option.status}">
+            <div class="military-response-option__title">
+              <span>${option.optionLabel}</span>
+              <code>${option.actionCode}</code>
+            </div>
+            <strong>${option.label}</strong>
+            <dl>
+              <div><dt>Coût / risque</dt><dd>${option.orderCost} · ${option.mainRisk}</dd></div>
+              <div><dt>Effet prochain tour</dt><dd>${option.expectedNextTurn}</dd></div>
+              <div><dt>Raison locale</dt><dd>${option.localReason}</dd></div>
+            </dl>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const resolution = summarizeTurnResolutionPreview(province, actionQueue);
@@ -2573,6 +2636,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceConflictNextAction(province, shell, focusContext, intrigueView)}
+      ${renderMilitaryResponseOptions(province, shell, focusContext, intrigueView)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView)}
       ${renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -2357,6 +2357,74 @@ button { font: inherit; }
 .province-conflict-next-action--ready { border-color: rgba(74, 222, 128, 0.28); }
 .province-conflict-next-action--warning { border-color: rgba(251, 191, 36, 0.34); }
 .province-conflict-next-action--danger { border-color: rgba(251, 113, 133, 0.4); }
+.military-response-options {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(49, 46, 129, 0.26));
+  border: 1px solid rgba(125, 211, 252, 0.2);
+}
+.military-response-options__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.military-response-options__header span,
+.military-response-options__header small,
+.military-response-option__title span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.military-response-options__header strong {
+  display: block;
+  margin-top: 3px;
+}
+.military-response-options__grid {
+  display: grid;
+  gap: 8px;
+}
+.military-response-option {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.44);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.military-response-option__title {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.military-response-option__title code {
+  color: #bae6fd;
+  font-size: 11px;
+}
+.military-response-option dl {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+.military-response-option dt {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.military-response-option dd {
+  margin: 2px 0 0;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.military-response-option--ready { border-color: rgba(74, 222, 128, 0.28); }
+.military-response-option--risky { border-color: rgba(251, 191, 36, 0.34); }
+.military-response-option--blocked { border-color: rgba(251, 113, 133, 0.4); }
 .military-plan-impact {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
Alpha: Implements #533.

Summary:
- Adds a compact "Réponses militaires" comparison to selected conflict provinces.
- Reuses action queue, conflict outcome, and readiness warning data for cost/risk, expected next-turn effect, and local rationale.
- Keeps the comparison inside the existing province panel without duplicating the readiness warning block.

Tests:
- npm test

Zeta: PR prête pour revue. Merci de valider avant tout merge.
