### PR TITLE
Gamma: recommend culture urgency actions

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -72,6 +72,60 @@ function buildFallbackUrgency(hint, focusTarget) {
   };
 }
 
+
+function buildRecommendedAction(hint, focusTarget, urgency, actionLabel) {
+  const timing = urgency.timingLabel ?? urgency.window;
+  const source = urgency.sourceLabel ?? focusTarget.label;
+
+  if (hint.status === 'missing') {
+    return {
+      code: 'accept-risk',
+      label: 'Ignorer avec risque assumé',
+      summary: `Ignorer ${focusTarget.label} si ${hint.cultureName} peut attendre; ${timing}.`,
+      timing,
+      source,
+    };
+  }
+
+  if (hint.tone === 'research') {
+    return {
+      code: 'accelerate-research',
+      label: 'Accélérer la recherche',
+      summary: `Accélérer ${source} après ${actionLabel}; fenêtre ${timing}.`,
+      timing,
+      source,
+    };
+  }
+
+  if (hint.tone === 'event' || hint.tone === 'opportunity') {
+    return {
+      code: 'follow-event',
+      label: 'Suivre l’événement',
+      summary: `Suivre ${source} depuis ${focusTarget.regionId ?? hint.regionId}; fenêtre ${timing}.`,
+      timing,
+      source,
+    };
+  }
+
+  if (hint.tone === 'discovery') {
+    return {
+      code: 'protect-site',
+      label: 'Protéger le site',
+      summary: `Protéger ${focusTarget.label} pour exploiter ${source}; fenêtre ${timing}.`,
+      timing,
+      source,
+    };
+  }
+
+  return {
+    code: 'watch-window',
+    label: 'Surveiller la fenêtre',
+    summary: `Surveiller ${focusTarget.label}: ${source}; fenêtre ${timing}.`,
+    timing,
+    source,
+  };
+}
+
 function summarizeHint(hint, actionLabel, urgency) {
   const provinceCopy = hint.regionId ? ` (${hint.regionId})` : '';
   const urgencyCopy = ` ${urgency.label.toLowerCase()} · ${urgency.window}.`;
@@ -99,6 +153,7 @@ function buildReminder(hint, actionLabel) {
     ...focusTarget,
     urgency,
   };
+  const recommendedAction = buildRecommendedAction(hint, focusTargetWithUrgency, urgency, actionLabel);
 
   return {
     reminderId: `${hint.status}:${hint.tone}:${hint.regionId}:${hint.label}:${actionLabel}`,
@@ -112,6 +167,8 @@ function buildReminder(hint, actionLabel) {
     urgency,
     urgencyCopy: `${urgency.label} · ${urgency.window}`,
     reasonCopy: urgency.reason ?? `${urgency.sourceLabel ?? focusTarget.label} · ${urgency.timingLabel ?? urgency.window}`,
+    recommendedAction,
+    actionCopy: `${recommendedAction.label} · ${recommendedAction.timing}`,
     focusTarget: focusTargetWithUrgency,
     focusCopy: `${focusTarget.type}: ${focusTarget.label}`,
   };

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -73,6 +73,12 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
     ['possible', 'Recherche à suivre', 'Recherche culture (river-gate): garder en vue avant de clore le tour. nouveau signal · maintenant.', 'marker: Compact d’Aurora', 'Nouveau signal · maintenant'],
     ['missing', 'Condition à combler', 'Condition manquante (shared-bay): Ligues des Forges manque encore un signal exploitable. à préparer · stable.', 'province: Province liée', 'À préparer · stable'],
   ]);
+  assert.deepEqual(report.reminders.map((reminder) => [reminder.recommendedAction.code, reminder.recommendedAction.label, reminder.recommendedAction.timing]), [
+    ['follow-event', 'Suivre l’événement', 'ce tour'],
+    ['accelerate-research', 'Accélérer la recherche', 'maintenant'],
+    ['accept-risk', 'Ignorer avec risque assumé', 'stable'],
+  ]);
+  assert.equal(report.reminders[0].recommendedAction.summary, 'Suivre Ouverture des archives depuis river-gate; fenêtre ce tour.');
   assert.deepEqual(report.reminders[0].urgency, {
     level: 'soon',
     label: 'Expire bientôt',

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -10,5 +10,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /culture-opportunity-reminder__reason/);
   assert.match(webAppSource, /reminder\.reasonCopy/);
   assert.match(webAppSource, /aria-label="Voir \$\{reminder\.focusCopy\}: \$\{reminder\.urgency\?\.detail/);
+  assert.match(webAppSource, /culture-opportunity-reminder__action/);
+  assert.match(webAppSource, /reminder\.recommendedAction\?\.summary/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__reason/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__action/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -949,6 +949,7 @@ function renderCultureOpportunityReminders(report) {
               <em class="culture-opportunity-reminder__urgency culture-opportunity-reminder__urgency--${reminder.urgency?.level ?? 'stable'}">${reminder.urgencyCopy ?? 'Fenêtre stable · stable'}</em>
               <small class="culture-opportunity-reminder__reason">${reminder.reasonCopy ?? reminder.urgency?.detail ?? reminder.summary}</small>
               <p>${reminder.summary}</p>
+              <p class="culture-opportunity-reminder__action"><b>${reminder.recommendedAction?.label ?? 'Surveiller la fenêtre'}</b> · ${reminder.recommendedAction?.summary ?? reminder.actionCopy ?? reminder.summary}</p>
               <button type="button" data-culture-focus-region="${reminder.focusTarget.regionId}" data-culture-focus-type="${reminder.focusTarget.type}" data-culture-focus-id="${reminder.focusTarget.id}" aria-label="Voir ${reminder.focusCopy}: ${reminder.urgency?.detail ?? reminder.summary}">
                 Voir ${reminder.focusCopy}
               </button>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2564,6 +2564,15 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.culture-opportunity-reminder__action {
+  margin-top: 6px !important;
+  padding: 6px 7px;
+  border-radius: 10px;
+  background: rgba(14, 165, 233, 0.08);
+  border: 1px solid rgba(125, 211, 252, 0.14);
+  color: #dbeafe !important;
+}
+.culture-opportunity-reminder__action b { color: #bfdbfe; }
 .culture-opportunity-reminder button {
   margin-top: 7px;
   padding: 5px 8px;


### PR DESCRIPTION
Gamma: PR prête pour validation.

Scope #535:
- transforme les urgences culturelles en prochaine action compacte (suivre événement, accélérer recherche, protéger site, ignorer avec risque assumé);
- conserve le lien province / focus target / source timeline ou recherche via les raisons déjà présentes;
- ajoute le rendu actionnable dans le panneau carte sans nouveau gros composant;
- renforce les tests de dérivation et de rendu web.

Tests:
- `npm test`
- `node --check web/app.js`
- `node --check src/ui/culture/buildCultureOpportunityReminders.js`
- `git diff --check`

Zeta, peux-tu valider cette PR avant tout merge ?

Closes #535