### PR TITLE
Epsilon: compare climate mitigation priorities

### DIFF
--- a/test/ui/climate/webClimateMitigationPriorities.test.js
+++ b/test/ui/climate/webClimateMitigationPriorities.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected province panel compares climate mitigation priorities before deadlines', () => {
+  assert.match(webAppSource, /function buildProvinceClimateMitigationPriorities/);
+  assert.match(webAppSource, /function renderProvinceClimateMitigationPriorities/);
+  assert.match(webAppSource, /Comparaison des priorités de mitigation climat/);
+  assert.match(webAppSource, /Priorités mitigation climat/);
+  assert.match(webAppSource, /buildProvinceClimateCountdownCues\(province, report\)/);
+  assert.match(webAppSource, /Évacuer \/ mitiger/);
+  assert.match(webAppSource, /Préparer réserves/);
+  assert.match(webAppSource, /Déplacer ressources \/ réparation/);
+  assert.match(webAppSource, /Observation \/ attente/);
+  assert.match(webAppSource, /deadline/);
+  assert.match(webAppSource, /avoidedImpact/);
+  assert.match(webAppSource, /tradeoff/);
+  assert.match(webAppSource, /outcomeChange/);
+  assert.match(webAppSource, /renderProvinceClimateMitigationPriorities\(province\)/);
+
+  assert.match(stylesSource, /\.province-climate-mitigation-priorities/);
+  assert.match(stylesSource, /\.province-climate-mitigation-priority-list/);
+  assert.match(stylesSource, /\.province-climate-mitigation-priority\.is-decisive/);
+  assert.match(stylesSource, /\.province-climate-mitigation-priority\.is-observation/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1392,6 +1392,95 @@ function buildProvinceClimateCountdownCues(province, report = buildProvinceClima
     .slice(0, 3);
 }
 
+function buildProvinceClimateMitigationPriorities(province, report = buildProvinceClimateTurnReport(province)) {
+  const cues = buildProvinceClimateCountdownCues(province, report);
+  const primaryCue = cues[0] ?? null;
+  const riskLevel = getProvinceClimateRiskLevel(province);
+  const hazard = province.hazards?.[0] ?? null;
+  const immediate = primaryCue?.level === 'immediate';
+  const nextTurn = primaryCue?.level === 'next-turn';
+  const watch = primaryCue?.level === 'watch';
+  const mitigationContext = hazard
+    ? `${hazard.type} ${hazard.riskLevel ?? 'visible'}`
+    : report.deltas[0]?.label ?? primaryCue?.label ?? 'climat stable';
+  const priorities = [];
+
+  if (immediate || riskLevel === 'critical') {
+    priorities.push({
+      option: province.supplyLevel === 'collapsed' || province.contested ? 'Évacuer / mitiger' : 'Renforcer stabilité',
+      deadline: primaryCue?.countdown ?? 'Immédiat',
+      avoidedImpact: `Évite que ${mitigationContext} bloque le plan province ce tour.`,
+      tradeoff: province.supplyLevel === 'collapsed' ? 'Coût: abandon temporaire de rendement local.' : 'Coût: consommer une action de stabilisation.',
+      outcomeChange: true,
+      priority: 1,
+    });
+  }
+
+  if (immediate || nextTurn || riskLevel === 'strained') {
+    priorities.push({
+      option: 'Préparer réserves',
+      deadline: nextTurn ? 'Prochain tour' : primaryCue?.countdown ?? 'Surveiller',
+      avoidedImpact: `Réduit l’exposition avant ${primaryCue?.label ?? 'la prochaine saison à risque'}.`,
+      tradeoff: 'Coût: détourner ressources et logistique du plan principal.',
+      outcomeChange: immediate || nextTurn,
+      priority: 2,
+    });
+  }
+
+  if (immediate || watch || province.loyalty < 55) {
+    priorities.push({
+      option: 'Déplacer ressources / réparation',
+      deadline: watch ? 'Surveiller' : 'Ce tour',
+      avoidedImpact: 'Contient les pertes de stabilité et accélère la récupération visible.',
+      tradeoff: 'Compromis: retarde une action économique ou militaire concurrente.',
+      outcomeChange: immediate || riskLevel !== 'stable',
+      priority: 3,
+    });
+  }
+
+  priorities.push({
+    option: watch || riskLevel === 'stable' ? 'Observation / attente' : 'Observation active',
+    deadline: primaryCue?.countdown ?? 'Stable',
+    avoidedImpact: riskLevel === 'stable'
+      ? 'Confirme qu’aucune mitigation immédiate ne change le résultat.'
+      : 'Garde le risque lisible si aucune ressource ne peut être engagée.',
+    tradeoff: riskLevel === 'stable' ? 'Coût: aucun, mais pas de réduction proactive.' : 'Compromis: accepte le risque résiduel jusqu’au prochain signal.',
+    outcomeChange: false,
+    priority: 4,
+  });
+
+  return priorities
+    .sort((left, right) => Number(right.outcomeChange) - Number(left.outcomeChange) || left.priority - right.priority)
+    .slice(0, 3);
+}
+
+function renderProvinceClimateMitigationPriorities(province) {
+  const report = buildProvinceClimateTurnReport(province);
+  const priorities = buildProvinceClimateMitigationPriorities(province, report);
+  const decisiveCount = priorities.filter((priority) => priority.outcomeChange).length;
+
+  return `
+    <section class="province-climate-mitigation-priorities" aria-label="Comparaison des priorités de mitigation climat">
+      <div class="province-climate-mitigation-priorities__header">
+        <strong>Priorités mitigation climat</strong>
+        <span>${decisiveCount} change${decisiveCount > 1 ? 'nt' : ''} le résultat</span>
+      </div>
+      <div class="province-climate-mitigation-priority-list">
+        ${priorities.map((priority, index) => `
+          <article class="province-climate-mitigation-priority ${priority.outcomeChange ? 'is-decisive' : 'is-observation'}">
+            <div>
+              <b>${index + 1}. ${priority.option}</b>
+              <code>${priority.deadline}</code>
+            </div>
+            <p>${priority.avoidedImpact}</p>
+            <small>${priority.tradeoff}</small>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderProvinceClimateCountdownCues(province) {
   const report = buildProvinceClimateTurnReport(province);
   const cues = buildProvinceClimateCountdownCues(province, report);
@@ -2644,6 +2733,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}
       ${renderIntrigueTurnReportDeltas(province, intrigueView)}
       ${renderProvinceClimateCountdownCues(province)}
+      ${renderProvinceClimateMitigationPriorities(province)}
       ${renderProvinceClimateTurnReport(province)}
       <div class="context-summary">
         <strong>Comparaison rapide</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3028,6 +3028,65 @@ button { font: inherit; }
   line-height: 1.35;
 }
 
+.province-climate-mitigation-priorities {
+  display: grid;
+  gap: 9px;
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(12, 74, 110, 0.32), rgba(15, 23, 42, 0.58));
+  border: 1px solid rgba(103, 232, 249, 0.18);
+}
+.province-climate-mitigation-priorities__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-climate-mitigation-priorities__header span {
+  color: #bae6fd;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-climate-mitigation-priority-list {
+  display: grid;
+  gap: 7px;
+}
+.province-climate-mitigation-priority {
+  display: grid;
+  gap: 4px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-climate-mitigation-priority.is-decisive { border-color: rgba(251, 191, 36, 0.36); }
+.province-climate-mitigation-priority.is-observation { border-color: rgba(96, 165, 250, 0.24); }
+.province-climate-mitigation-priority div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.province-climate-mitigation-priority b {
+  color: #ecfeff;
+}
+.province-climate-mitigation-priority code {
+  color: #fde68a;
+  font-size: 0.72rem;
+}
+.province-climate-mitigation-priority p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-climate-mitigation-priority small {
+  color: #bae6fd;
+  line-height: 1.35;
+}
+
 .province-climate-turn-report {
   display: grid;
   gap: 9px;


### PR DESCRIPTION
Epsilon:

## Summary
- Adds a compact mitigation-priority comparison to the selected province climate panel.
- Reuses existing climate countdown cues, province hazards, risk level, and turn-report deltas to compare deadline, avoided impact, and main tradeoff.
- Highlights which mitigation options change the result this turn versus observation/waiting.

## Testing
- npm test -- test/ui/climate/webClimateMitigationPriorities.test.js test/ui/climate/webClimateRiskCountdownCues.test.js
- node --check web/app.js
- npm test

Fixes loo469/historia#537