### PR TITLE
Beta: preview logistics neighbor effects

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -85,7 +85,86 @@ function getRouteCause(route, localCity, localTension, mainResource) {
 }
 
 
-function buildRecoveryChoices(route, localCity, localTension, mainResource, routeCause) {
+function getNeighborContexts(route, localCity, cities, routes, tensionByCityId) {
+  const cityById = new Map(cities.map((city) => [city.cityId, city]));
+  const directNeighbors = route.cityIds
+    .filter((cityId) => cityId !== localCity.cityId)
+    .map((cityId) => ({ city: cityById.get(cityId), route }))
+    .filter((context) => context.city);
+  const hubNeighbors = routes
+    .filter((candidate) => candidate.routeId !== route.routeId && candidate.cityIds.includes(localCity.cityId))
+    .map((candidate) => {
+      const neighborCityId = candidate.cityIds.find((cityId) => cityId !== localCity.cityId);
+      return { city: cityById.get(neighborCityId), route: candidate };
+    })
+    .filter((context) => context.city);
+
+  return [...directNeighbors, ...hubNeighbors]
+    .map((context) => ({
+      ...context,
+      tension: tensionByCityId[context.city.cityId] ?? 'low',
+      score: (context.route.riskLevel ?? 0) + (context.route.totalCapacity ?? 0) + (tensionByCityId[context.city.cityId] === 'high' ? 20 : tensionByCityId[context.city.cityId] === 'medium' ? 10 : 0),
+    }))
+    .sort((left, right) => right.score - left.score || left.city.cityName.localeCompare(right.city.cityName))
+    .slice(0, 2);
+}
+
+function getNeighborEffect(choiceId, route, localCity, neighbor, mainResource) {
+  const routeName = neighbor.route.routeName;
+  const cityName = neighbor.city.cityName;
+
+  if (choiceId === 'reroute') {
+    const displaced = route.totalCapacity >= 9 || neighbor.route.totalCapacity >= 9;
+    return {
+      target: cityName,
+      route: routeName,
+      tone: displaced ? 'medium' : 'low',
+      label: displaced ? 'congestion déplacée' : 'hub soulagé',
+      detail: displaced
+        ? `${cityName} peut récupérer une partie du trafic de ${localCity.cityName}; surveiller ${routeName}.`
+        : `${routeName} partage mieux ${mainResource.label} et soulage le hub proche.`,
+    };
+  }
+
+  if (choiceId === 'repair') {
+    const fragile = !neighbor.route.active || neighbor.route.riskLevel >= 55;
+    return {
+      target: cityName,
+      route: routeName,
+      tone: fragile ? 'medium' : 'low',
+      label: fragile ? 'route toujours fragile' : 'axe stabilisé',
+      detail: fragile
+        ? `${routeName} reste fragile près de ${cityName}; la réparation aide surtout ${localCity.cityName}.`
+        : `${routeName} profite de l'axe réparé sans nouvelle surcharge visible.`,
+    };
+  }
+
+  if (choiceId === 'stockpile') {
+    const strained = neighbor.tension !== 'low';
+    return {
+      target: cityName,
+      route: routeName,
+      tone: strained ? 'medium' : 'low',
+      label: 'stockpile consommé',
+      detail: strained
+        ? `${cityName} reste sous tension: le tampon protège ${localCity.cityName} mais ne diffuse pas assez.`
+        : `${cityName} garde son flux; le stockpile absorbe surtout le choc local.`,
+    };
+  }
+
+  const improvesNetwork = route.riskLevel >= 55 || route.totalCapacity >= 9 || neighbor.tension !== 'low';
+  return {
+    target: cityName,
+    route: routeName,
+    tone: improvesNetwork ? 'medium' : 'low',
+    label: improvesNetwork ? 'hub priorisé' : 'effet réseau limité',
+    detail: improvesNetwork
+      ? `${cityName} bénéficie de la priorité sur ${mainResource.label}, mais ${routeName} reste à suivre.`
+      : `${cityName} reçoit peu d'effet: correction surtout administrative pour ${localCity.cityName}.`,
+  };
+}
+
+function buildRecoveryChoices(route, localCity, localTension, mainResource, routeCause, neighborContexts = []) {
   const choices = [
     {
       choiceId: 'reroute',
@@ -136,10 +215,11 @@ function buildRecoveryChoices(route, localCity, localTension, mainResource, rout
     ...choice,
     recommended: index === 0,
     comparison: index === 0 ? 'meilleur levier immédiat' : `moins urgent: ${topChoice.blocker} prioritaire`,
+    neighborEffects: neighborContexts.map((neighbor) => getNeighborEffect(choice.choiceId, route, localCity, neighbor, mainResource)),
   }));
 }
 
-function buildChoiceForRoute(route, localCity, localTension, resourceLabelById) {
+function buildChoiceForRoute(route, localCity, localTension, resourceLabelById, context = {}) {
   const mainResource = getMainResource(route, resourceLabelById);
   const tone = getRouteTone(route, localTension);
   const routeCause = getRouteCause(route, localCity, localTension, mainResource);
@@ -169,7 +249,8 @@ function buildChoiceForRoute(route, localCity, localTension, resourceLabelById) 
     : tone === 'medium'
       ? `Soulage ${mainResource.label} sans masquer le risque résiduel.`
       : `Maintient ${localCity.cityName} stable avec surveillance légère.`;
-  const recoveryChoices = buildRecoveryChoices(route, localCity, localTension, mainResource, routeCause);
+  const neighborContexts = getNeighborContexts(route, localCity, context.cities ?? [], context.routes ?? [], context.tensionByCityId ?? {});
+  const recoveryChoices = buildRecoveryChoices(route, localCity, localTension, mainResource, routeCause, neighborContexts);
 
   return {
     routeId: route.routeId,
@@ -209,7 +290,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       const localCityId = route.cityIds.find((cityId) => provinceCityIds.has(cityId));
       const localCity = provinceCities.find((city) => city.cityId === localCityId) ?? provinceCities[0];
       const localTension = tensionByCityId[localCity?.cityId] ?? 'low';
-      return localCity ? buildChoiceForRoute(route, localCity, localTension, resourceLabelById) : null;
+      return localCity ? buildChoiceForRoute(route, localCity, localTension, resourceLabelById, { cities, routes, tensionByCityId }) : null;
     })
     .filter(Boolean)
     .sort((left, right) => right.score - left.score || left.action.localeCompare(right.action))

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -12,6 +12,7 @@ function buildEconomyView() {
         { cityId: 'river-city', cityName: 'River Gate', regionId: 'river-gate' },
         { cityId: 'iron-city', cityName: 'Iron Plain', regionId: 'iron-plain' },
         { cityId: 'port-city', cityName: 'Crown Port', regionId: 'crown-heart' },
+        { cityId: 'hill-city', cityName: 'Hill Hub', regionId: 'hill-hub' },
       ],
       routes: [
         {
@@ -32,6 +33,15 @@ function buildEconomyView() {
           totalCapacity: 10,
           resources: [{ resourceId: 'tools', capacity: 6 }],
         },
+        {
+          routeId: 'hill-spur',
+          routeName: 'Hill Spur',
+          cityIds: ['river-city', 'hill-city'],
+          active: true,
+          riskLevel: 46,
+          totalCapacity: 8,
+          resources: [{ resourceId: 'tools', capacity: 3 }],
+        },
       ],
     },
     comparison: {
@@ -39,6 +49,7 @@ function buildEconomyView() {
         { cityId: 'river-city', tensionLevel: 'high' },
         { cityId: 'iron-city', tensionLevel: 'low' },
         { cityId: 'port-city', tensionLevel: 'low' },
+        { cityId: 'hill-city', tensionLevel: 'medium' },
       ],
     },
   };
@@ -49,7 +60,7 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
     resourceLabelById: { grain: 'Grain', tools: 'Outils' },
   });
 
-  assert.equal(preview.options.length, 2);
+  assert.equal(preview.options.length, 3);
   assert.equal(preview.recommendedOptionId, preview.options[0].optionId);
   assert.equal(preview.options[0].routeId, 'ember-line');
   assert.equal(preview.options[0].recommended, true);
@@ -66,6 +77,9 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.options[0].recoveryChoices[0].benefit, /Outils|River Gate|Ember Line/);
   assert.ok(preview.options[0].recoveryChoices[0].blocker.length > 0);
   assert.match(preview.options[0].recoveryChoices[1].comparison, /moins urgent/);
+  assert.ok(preview.options[0].recoveryChoices[0].neighborEffects.length >= 1);
+  assert.match(preview.options[0].recoveryChoices[0].neighborEffects[0].detail, /Iron Plain|Hill Hub|voisin|hub|trafic/);
+  assert.ok(['congestion déplacée', 'hub soulagé', 'route toujours fragile', 'stockpile consommé', 'hub priorisé', 'effet réseau limité'].includes(preview.options[0].recoveryChoices[0].neighborEffects[0].label));
 });
 
 test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and impact labels', () => {
@@ -79,6 +93,8 @@ test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and i
   assert.deepEqual(option.routes, ['Ember Line']);
   assert.ok(option.cause.length > 0);
   assert.deepEqual(option.recoveryChoices.map((choice) => choice.choiceId).sort(), ['economic-priority', 'repair', 'reroute', 'stockpile']);
+  assert.ok(option.recoveryChoices.every((choice) => Array.isArray(choice.neighborEffects)));
+  assert.ok(option.recoveryChoices.some((choice) => choice.neighborEffects.some((effect) => effect.target === 'Iron Plain')));
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -15,6 +15,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /choice\.benefit/);
   assert.match(webAppSource, /choice\.blocker/);
   assert.match(webAppSource, /choice\.rationale/);
+  assert.match(webAppSource, /province-logistics-neighbor-effects/);
+  assert.match(webAppSource, /effect\.detail/);
+  assert.match(webAppSource, /effect\.target/);
   assert.match(webAppSource, /logistique stable/);
   assert.equal(webAppSource.includes("if (preview.options.length === 0) {\n    return '';\n  }"), false);
   assert.match(stylesSource, /\.province-logistics-cause-summary/);
@@ -24,4 +27,6 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-recovery-comparison/);
   assert.match(stylesSource, /province-logistics-recovery--high/);
   assert.match(stylesSource, /province-logistics-recovery--medium/);
+  assert.match(stylesSource, /province-logistics-neighbor-effect--medium/);
+  assert.match(stylesSource, /province-logistics-neighbor-effect--low/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1209,6 +1209,17 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                   </div>
                   <p>${choice.benefit}</p>
                   <small>Contrainte: ${choice.blocker} · ${choice.rationale}</small>
+                  ${choice.neighborEffects.length > 0 ? `
+                    <ul class="province-logistics-neighbor-effects" aria-label="Effets voisins attendus">
+                      ${choice.neighborEffects.map((effect) => `
+                        <li class="province-logistics-neighbor-effect province-logistics-neighbor-effect--${effect.tone}">
+                          <b>${effect.label}</b>
+                          <span>${effect.target} · ${effect.route}</span>
+                          <small>${effect.detail}</small>
+                        </li>
+                      `).join('')}
+                    </ul>
+                  ` : ''}
                 </article>
               `).join('')}
             </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2959,6 +2959,33 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.province-logistics-neighbor-effects {
+  display: grid;
+  gap: 5px;
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.province-logistics-neighbor-effect {
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  border-radius: 9px;
+  background: rgba(15, 23, 42, 0.46);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.province-logistics-neighbor-effect--medium { border-color: rgba(245, 158, 11, 0.3); }
+.province-logistics-neighbor-effect--low { border-color: rgba(74, 222, 128, 0.2); }
+.province-logistics-neighbor-effect b {
+  color: #fde68a;
+  font-size: 11px;
+}
+.province-logistics-neighbor-effect span,
+.province-logistics-neighbor-effect small {
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.3;
+}
 .province-logistics-choice dl {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Beta: Implements #544.

## Summary
- derives qualitative neighbor effects for logistics recovery choices from nearby route/city context
- flags displaced congestion, relieved hubs, consumed stockpiles, and still-fragile routes without adding simulation mechanics
- renders 1-2 neighboring route/province effects inside the existing province logistics panel with focused tests

## Tests
- npm test
- npm test -- --test-reporter=spec test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.