### PR TITLE
Gamma: show culture recommendation tradeoffs

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -126,6 +126,55 @@ function buildRecommendedAction(hint, focusTarget, urgency, actionLabel) {
   };
 }
 
+
+function buildActionTradeoff(hint, recommendedAction, focusTarget, urgency) {
+  const window = urgency.timingLabel ?? urgency.window;
+  const source = recommendedAction.source ?? urgency.sourceLabel ?? focusTarget.label;
+
+  if (recommendedAction.code === 'follow-event') {
+    return {
+      benefit: `Protège ${source}`,
+      risk: `Événement ignoré si ${urgency.window === 'ce tour' ? 'ce tour passe' : 'la fenêtre glisse'}`,
+      window,
+      summary: `Gain: repère culturel protégé. Risque: événement ignoré (${window}).`,
+    };
+  }
+
+  if (recommendedAction.code === 'accelerate-research') {
+    return {
+      benefit: `Accélère ${source}`,
+      risk: `Recherche retardée si l’action reste en attente`,
+      window,
+      summary: `Gain: recherche accélérée. Risque: retard culturel (${window}).`,
+    };
+  }
+
+  if (recommendedAction.code === 'protect-site') {
+    return {
+      benefit: `Protège ${focusTarget.label}`,
+      risk: `Site exposé et découverte moins exploitable`,
+      window,
+      summary: `Gain: site protégé. Risque: découverte exposée (${window}).`,
+    };
+  }
+
+  if (recommendedAction.code === 'accept-risk') {
+    return {
+      benefit: `Libère l’action province`,
+      risk: `${hint.cultureName} reste sans signal exploitable`,
+      window,
+      summary: `Gain: action libre. Risque: opportunité culturelle manquée (${window}).`,
+    };
+  }
+
+  return {
+    benefit: `Garde ${focusTarget.label} lisible`,
+    risk: `Fenêtre culturelle moins priorisée`,
+    window,
+    summary: `Gain: fenêtre surveillée. Risque: priorité floue (${window}).`,
+  };
+}
+
 function summarizeHint(hint, actionLabel, urgency) {
   const provinceCopy = hint.regionId ? ` (${hint.regionId})` : '';
   const urgencyCopy = ` ${urgency.label.toLowerCase()} · ${urgency.window}.`;
@@ -154,6 +203,7 @@ function buildReminder(hint, actionLabel) {
     urgency,
   };
   const recommendedAction = buildRecommendedAction(hint, focusTargetWithUrgency, urgency, actionLabel);
+  const tradeoff = buildActionTradeoff(hint, recommendedAction, focusTargetWithUrgency, urgency);
 
   return {
     reminderId: `${hint.status}:${hint.tone}:${hint.regionId}:${hint.label}:${actionLabel}`,
@@ -169,6 +219,8 @@ function buildReminder(hint, actionLabel) {
     reasonCopy: urgency.reason ?? `${urgency.sourceLabel ?? focusTarget.label} · ${urgency.timingLabel ?? urgency.window}`,
     recommendedAction,
     actionCopy: `${recommendedAction.label} · ${recommendedAction.timing}`,
+    tradeoff,
+    tradeoffCopy: `${tradeoff.benefit} · ${tradeoff.risk}`,
     focusTarget: focusTargetWithUrgency,
     focusCopy: `${focusTarget.type}: ${focusTarget.label}`,
   };

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -79,6 +79,12 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
     ['accept-risk', 'Ignorer avec risque assumé', 'stable'],
   ]);
   assert.equal(report.reminders[0].recommendedAction.summary, 'Suivre Ouverture des archives depuis river-gate; fenêtre ce tour.');
+  assert.deepEqual(report.reminders.map((reminder) => [reminder.tradeoff.benefit, reminder.tradeoff.risk, reminder.tradeoff.window]), [
+    ['Protège Ouverture des archives', 'Événement ignoré si ce tour passe', 'ce tour'],
+    ['Accélère Compact d’Aurora', 'Recherche retardée si l’action reste en attente', 'maintenant'],
+    ['Libère l’action province', 'Ligues des Forges reste sans signal exploitable', 'stable'],
+  ]);
+  assert.equal(report.reminders[0].tradeoff.summary, 'Gain: repère culturel protégé. Risque: événement ignoré (ce tour).');
   assert.deepEqual(report.reminders[0].urgency, {
     level: 'soon',
     label: 'Expire bientôt',

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -12,6 +12,9 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /aria-label="Voir \$\{reminder\.focusCopy\}: \$\{reminder\.urgency\?\.detail/);
   assert.match(webAppSource, /culture-opportunity-reminder__action/);
   assert.match(webAppSource, /reminder\.recommendedAction\?\.summary/);
+  assert.match(webAppSource, /culture-opportunity-reminder__tradeoff/);
+  assert.match(webAppSource, /reminder\.tradeoff\?\.summary/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__reason/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__action/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__tradeoff/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -950,6 +950,7 @@ function renderCultureOpportunityReminders(report) {
               <small class="culture-opportunity-reminder__reason">${reminder.reasonCopy ?? reminder.urgency?.detail ?? reminder.summary}</small>
               <p>${reminder.summary}</p>
               <p class="culture-opportunity-reminder__action"><b>${reminder.recommendedAction?.label ?? 'Surveiller la fenêtre'}</b> · ${reminder.recommendedAction?.summary ?? reminder.actionCopy ?? reminder.summary}</p>
+              <p class="culture-opportunity-reminder__tradeoff"><b>Compromis</b> · ${reminder.tradeoff?.summary ?? reminder.tradeoffCopy ?? 'Bénéfice culturel contre risque narratif.'}</p>
               <button type="button" data-culture-focus-region="${reminder.focusTarget.regionId}" data-culture-focus-type="${reminder.focusTarget.type}" data-culture-focus-id="${reminder.focusTarget.id}" aria-label="Voir ${reminder.focusCopy}: ${reminder.urgency?.detail ?? reminder.summary}">
                 Voir ${reminder.focusCopy}
               </button>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2573,6 +2573,15 @@ button { font: inherit; }
   color: #dbeafe !important;
 }
 .culture-opportunity-reminder__action b { color: #bfdbfe; }
+.culture-opportunity-reminder__tradeoff {
+  margin-top: 5px !important;
+  padding: 6px 7px;
+  border-radius: 10px;
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.16);
+  color: #fde68a !important;
+}
+.culture-opportunity-reminder__tradeoff b { color: #fef3c7; }
 .culture-opportunity-reminder button {
   margin-top: 7px;
   padding: 5px 8px;


### PR DESCRIPTION
Gamma: PR prête pour validation.

Scope #545:
- ajoute un aperçu compact des compromis pour chaque recommandation culturelle (bénéfice protégé + coût/risque narratif);
- réutilise les actions, raisons et fenêtres déjà dérivées des timelines/markers/research hooks;
- affiche le compromis dans le panneau carte sans dupliquer badges ou raisons;
- renforce les tests de dérivation et de rendu web.

Tests:
- `npm test`
- `node --check web/app.js`
- `node --check src/ui/culture/buildCultureOpportunityReminders.js`
- `git diff --check`

Zeta, peux-tu valider cette PR avant tout merge ?

Closes #545