### PR TITLE
Epsilon: preview climate mitigation cascades

### DIFF
--- a/test/ui/climate/webClimateCascadePreview.test.js
+++ b/test/ui/climate/webClimateCascadePreview.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected province panel previews regional cascades avoided by climate mitigation', () => {
+  assert.match(webAppSource, /function buildProvinceClimateCascadePreview/);
+  assert.match(webAppSource, /function renderProvinceClimateCascadePreview/);
+  assert.match(webAppSource, /Aperçu des cascades régionales évitées par la mitigation climat/);
+  assert.match(webAppSource, /Cascades évitées/);
+  assert.match(webAppSource, /famine/);
+  assert.match(webAppSource, /route fragilisée/);
+  assert.match(webAppSource, /migration de ressources/);
+  assert.match(webAppSource, /anomalie saisonnière prolongée/);
+  assert.match(webAppSource, /cascade cosmétique/);
+  assert.match(webAppSource, /changesThisTurn/);
+  assert.match(webAppSource, /protectedNeighbors/);
+  assert.match(webAppSource, /resourceDeposits/);
+  assert.match(webAppSource, /renderProvinceClimateCascadePreview\(province, shell\)/);
+
+  assert.match(stylesSource, /\.province-climate-cascade-preview/);
+  assert.match(stylesSource, /\.province-climate-cascade-list/);
+  assert.match(stylesSource, /\.province-climate-cascade\.is-decisive/);
+  assert.match(stylesSource, /\.province-climate-cascade\.is-cosmetic/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1455,6 +1455,106 @@ function buildProvinceClimateMitigationPriorities(province, report = buildProvin
     .slice(0, 3);
 }
 
+function buildProvinceClimateCascadePreview(province, shell, report = buildProvinceClimateTurnReport(province)) {
+  const priorities = buildProvinceClimateMitigationPriorities(province, report);
+  const decisivePriority = priorities.find((priority) => priority.outcomeChange) ?? null;
+  const riskLevel = getProvinceClimateRiskLevel(province);
+  const hazard = province.hazards?.[0] ?? null;
+  const neighborProvinces = province.neighborIds
+    .map((neighborId) => shell.provinces.find((candidate) => candidate.provinceId === neighborId))
+    .filter(Boolean);
+  const protectedNeighbors = neighborProvinces
+    .filter((neighbor) => neighbor.supplyLevel !== 'stable' || neighbor.contested || neighbor.occupied)
+    .slice(0, 3);
+  const localResources = [
+    ...(province.resourceIds ?? []),
+    ...Object.keys(province.resourceDeposits ?? {}),
+  ];
+  const affectedResources = localResources.length > 0 ? localResources.slice(0, 3) : ['réserves locales'];
+  const cascades = [];
+
+  if (riskLevel !== 'stable' || province.supplyLevel === 'collapsed') {
+    cascades.push({
+      type: 'famine',
+      scope: protectedNeighbors.length > 0 ? `Protège aussi ${protectedNeighbors.map((neighbor) => neighbor.label).join(', ')}` : 'Impact local seulement',
+      avoidedImpact: `Évite une rupture de vivres sur ${affectedResources.join(', ')}.`,
+      changesThisTurn: Boolean(decisivePriority),
+      priority: 1,
+    });
+  }
+
+  if (province.contested || province.occupied || protectedNeighbors.length > 0) {
+    cascades.push({
+      type: 'route fragilisée',
+      scope: protectedNeighbors.length > 0 ? `Voisins concernés: ${protectedNeighbors.map((neighbor) => neighbor.label).join(', ')}` : 'Route locale sous pression',
+      avoidedImpact: 'Réduit le risque de propagation vers les connexions frontalières et logistiques.',
+      changesThisTurn: Boolean(decisivePriority),
+      priority: 2,
+    });
+  }
+
+  if (localResources.length > 0 && riskLevel !== 'stable') {
+    cascades.push({
+      type: 'migration de ressources',
+      scope: affectedResources.join(', '),
+      avoidedImpact: 'Garde les ressources dans la province au lieu de les déplacer en urgence.',
+      changesThisTurn: Boolean(decisivePriority),
+      priority: 3,
+    });
+  }
+
+  if (hazard || report.deltas.some((delta) => delta.deltaId.includes(':upcoming') || delta.deltaId.includes(':anomaly'))) {
+    cascades.push({
+      type: 'anomalie saisonnière prolongée',
+      scope: hazard ? `${hazard.type} ${hazard.riskLevel ?? 'visible'}` : 'saison prochaine',
+      avoidedImpact: 'Limite la prolongation qualitative de l’anomalie au prochain tour.',
+      changesThisTurn: Boolean(decisivePriority),
+      priority: 4,
+    });
+  }
+
+  if (cascades.length === 0) {
+    cascades.push({
+      type: 'cascade cosmétique',
+      scope: 'Aucun voisin critique',
+      avoidedImpact: 'La mitigation améliore surtout la lisibilité locale; pas de cascade régionale fiable.',
+      changesThisTurn: false,
+      priority: 5,
+    });
+  }
+
+  return cascades
+    .sort((left, right) => Number(right.changesThisTurn) - Number(left.changesThisTurn) || left.priority - right.priority)
+    .slice(0, 3);
+}
+
+function renderProvinceClimateCascadePreview(province, shell) {
+  const report = buildProvinceClimateTurnReport(province);
+  const cascades = buildProvinceClimateCascadePreview(province, shell, report);
+  const decisiveCount = cascades.filter((cascade) => cascade.changesThisTurn).length;
+
+  return `
+    <section class="province-climate-cascade-preview" aria-label="Aperçu des cascades régionales évitées par la mitigation climat">
+      <div class="province-climate-cascade-preview__header">
+        <strong>Cascades évitées</strong>
+        <span>${decisiveCount > 0 ? `${decisiveCount} change${decisiveCount > 1 ? 'nt' : ''} ce tour` : 'effet local'}</span>
+      </div>
+      <div class="province-climate-cascade-list">
+        ${cascades.map((cascade) => `
+          <article class="province-climate-cascade ${cascade.changesThisTurn ? 'is-decisive' : 'is-cosmetic'}">
+            <div>
+              <b>${cascade.type}</b>
+              <code>${cascade.changesThisTurn ? 'agit ce tour' : 'cosmétique'}</code>
+            </div>
+            <p>${cascade.avoidedImpact}</p>
+            <small>${cascade.scope}</small>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderProvinceClimateMitigationPriorities(province) {
   const report = buildProvinceClimateTurnReport(province);
   const priorities = buildProvinceClimateMitigationPriorities(province, report);
@@ -2735,6 +2835,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderIntrigueTurnReportDeltas(province, intrigueView)}
       ${renderProvinceClimateCountdownCues(province)}
       ${renderProvinceClimateMitigationPriorities(province)}
+      ${renderProvinceClimateCascadePreview(province, shell)}
       ${renderProvinceClimateTurnReport(province)}
       <div class="context-summary">
         <strong>Comparaison rapide</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3096,6 +3096,65 @@ button { font: inherit; }
   line-height: 1.35;
 }
 
+.province-climate-cascade-preview {
+  display: grid;
+  gap: 9px;
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(8, 47, 73, 0.34), rgba(15, 23, 42, 0.58));
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.province-climate-cascade-preview__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-climate-cascade-preview__header span {
+  color: #bae6fd;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-climate-cascade-list {
+  display: grid;
+  gap: 7px;
+}
+.province-climate-cascade {
+  display: grid;
+  gap: 4px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.34);
+  border-left: 3px solid rgba(148, 163, 184, 0.48);
+}
+.province-climate-cascade.is-decisive { border-left-color: rgba(251, 191, 36, 0.82); }
+.province-climate-cascade.is-cosmetic { border-left-color: rgba(96, 165, 250, 0.62); }
+.province-climate-cascade div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.province-climate-cascade b {
+  color: #ecfeff;
+}
+.province-climate-cascade code {
+  color: #fde68a;
+  font-size: 0.72rem;
+}
+.province-climate-cascade p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-climate-cascade small {
+  color: #bae6fd;
+  line-height: 1.35;
+}
+
 .province-climate-turn-report {
   display: grid;
   gap: 9px;


### PR DESCRIPTION
Epsilon:

## Summary
- Adds a selected-province preview of regional cascades avoided by climate mitigation.
- Reuses existing countdown cues, mitigation priorities, hazards, resources, and neighbor province state to classify local-only vs regional protection.
- Surfaces simple qualitative cascades: famine, fragile routes, resource migration, and prolonged seasonal anomaly, with clear this-turn vs cosmetic labels.

## Testing
- npm test -- test/ui/climate/webClimateCascadePreview.test.js test/ui/climate/webClimateMitigationPriorities.test.js
- node --check web/app.js
- npm test

Fixes loo469/historia#547