### PR TITLE
Alpha: show military option blockers

### DIFF
--- a/test/ui/war/webMilitaryOptionBlockers.test.js
+++ b/test/ui/war/webMilitaryOptionBlockers.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('military response options expose compact feasibility blockers before queuing', () => {
+  assert.match(webAppSource, /function buildMilitaryOptionFeasibility/);
+  assert.match(webAppSource, /feasibility: buildMilitaryOptionFeasibility/);
+  assert.match(webAppSource, /prêt/);
+  assert.match(webAppSource, /risqué/);
+  assert.match(webAppSource, /bloqué/);
+  assert.match(webAppSource, /dépendant/);
+  assert.match(webAppSource, /Ravitaillement insuffisant/);
+  assert.match(webAppSource, /Pression de front trop forte/);
+  assert.match(webAppSource, /Moral local fragile/);
+  assert.match(webAppSource, /Province voisine sous pression/);
+  assert.match(webAppSource, /Information manquante/);
+  assert.match(webAppSource, /Bloqueur principal/);
+  assert.match(webAppSource, /option\.feasibility\.unlockAction/);
+  assert.match(stylesSource, /\.military-response-option__feasibility/);
+  assert.match(stylesSource, /military-response-option__feasibility--dependent/);
+  assert.match(stylesSource, /military-response-option--dependent/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2254,6 +2254,56 @@ function renderProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView)
   `;
 }
 
+function buildMilitaryOptionFeasibility(entry, province, readinessWarning, outcome) {
+  const neighborPressure = readinessWarning && readinessWarning.provinceId !== province.provinceId;
+
+  if (entry.status === 'blocked') {
+    const blocker = ['disrupted', 'collapsed'].includes(province.supplyLevel)
+      ? 'Ravitaillement insuffisant'
+      : province.contested || outcome.tone === 'danger'
+        ? 'Pression de front trop forte'
+        : province.loyalty < 45
+          ? 'Moral local fragile'
+          : 'Information manquante';
+
+    return {
+      state: 'bloqué',
+      tone: 'blocked',
+      blocker,
+      detail: entry.mainRisk,
+      unlockAction: blocker === 'Ravitaillement insuffisant'
+        ? 'Sécuriser une route ou un convoi avant de confirmer.'
+        : blocker === 'Pression de front trop forte'
+          ? 'Ajouter un appui adjacent ou renforcer la garnison.'
+          : blocker === 'Moral local fragile'
+            ? 'Stabiliser loyauté et ordre public avant l’action.'
+            : 'Lancer reconnaissance ou attendre un signal confirmé.',
+    };
+  }
+
+  if (entry.status === 'risky') {
+    return {
+      state: neighborPressure ? 'dépendant' : 'risqué',
+      tone: neighborPressure ? 'dependent' : 'risky',
+      blocker: neighborPressure ? 'Province voisine sous pression' : 'Délai / contrôle à confirmer',
+      detail: neighborPressure ? readinessWarning.focusTargetLabel : entry.mainRisk,
+      unlockAction: neighborPressure
+        ? `Traiter ${readinessWarning.provinceLabel} ou déplacer un appui voisin.`
+        : 'Vérifier réserve, timing et contrôle avant de queue l’ordre.',
+    };
+  }
+
+  return {
+    state: readinessWarning?.tone === 'warning' ? 'dépendant' : 'prêt',
+    tone: readinessWarning?.tone === 'warning' ? 'dependent' : 'ready',
+    blocker: readinessWarning?.tone === 'warning' ? 'Préparation voisine à surveiller' : 'Aucun bloqueur immédiat',
+    detail: readinessWarning?.tone === 'warning' ? readinessWarning.focusTargetLabel : `Ravitaillement ${province.supplyLevel}, loyauté ${province.loyalty}.`,
+    unlockAction: readinessWarning?.tone === 'warning'
+      ? 'Confirmer l’appui adjacent avant engagement.'
+      : 'Peut être queue maintenant si l’ordre reste prioritaire.',
+  };
+}
+
 function buildMilitaryResponseOptions(province, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const outcome = buildConflictOutcomePreview(province, shell);
@@ -2272,6 +2322,7 @@ function buildMilitaryResponseOptions(province, shell, focusContext, intrigueVie
   return actionQueue.slice(0, 3).map((entry, index) => ({
     ...entry,
     optionLabel: index === 0 ? 'Option prioritaire' : index === 1 ? 'Option prudente' : 'Option de réserve',
+    feasibility: buildMilitaryOptionFeasibility(entry, province, readinessWarning, outcome),
     localReason: index === 0
       ? localReason
       : entry.status === 'ready'
@@ -2299,16 +2350,22 @@ function renderMilitaryResponseOptions(province, shell, focusContext, intrigueVi
       </div>
       <div class="military-response-options__grid">
         ${options.map((option) => `
-          <article class="military-response-option military-response-option--${option.status}">
+          <article class="military-response-option military-response-option--${option.status} military-response-option--${option.feasibility.tone}">
             <div class="military-response-option__title">
               <span>${option.optionLabel}</span>
               <code>${option.actionCode}</code>
             </div>
             <strong>${option.label}</strong>
+            <div class="military-response-option__feasibility military-response-option__feasibility--${option.feasibility.tone}">
+              <span>${option.feasibility.state}</span>
+              <strong>${option.feasibility.blocker}</strong>
+              <small>${option.feasibility.unlockAction}</small>
+            </div>
             <dl>
               <div><dt>Coût / risque</dt><dd>${option.orderCost} · ${option.mainRisk}</dd></div>
               <div><dt>Effet prochain tour</dt><dd>${option.expectedNextTurn}</dd></div>
               <div><dt>Raison locale</dt><dd>${option.localReason}</dd></div>
+              <div><dt>Bloqueur principal</dt><dd>${option.feasibility.detail}</dd></div>
             </dl>
           </article>
         `).join('')}

--- a/web/styles.css
+++ b/web/styles.css
@@ -2406,6 +2406,32 @@ button { font: inherit; }
   color: #bae6fd;
   font-size: 11px;
 }
+.military-response-option__feasibility {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.military-response-option__feasibility span {
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.military-response-option__feasibility strong {
+  font-size: 12px;
+}
+.military-response-option__feasibility small {
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.military-response-option__feasibility--ready { border-color: rgba(74, 222, 128, 0.28); }
+.military-response-option__feasibility--dependent { border-color: rgba(125, 211, 252, 0.32); }
+.military-response-option__feasibility--risky { border-color: rgba(251, 191, 36, 0.34); }
+.military-response-option__feasibility--blocked { border-color: rgba(251, 113, 133, 0.4); }
 .military-response-option dl {
   display: grid;
   gap: 6px;
@@ -2423,6 +2449,7 @@ button { font: inherit; }
   line-height: 1.35;
 }
 .military-response-option--ready { border-color: rgba(74, 222, 128, 0.28); }
+.military-response-option--dependent { border-color: rgba(125, 211, 252, 0.32); }
 .military-response-option--risky { border-color: rgba(251, 191, 36, 0.34); }
 .military-response-option--blocked { border-color: rgba(251, 113, 133, 0.4); }
 .military-plan-impact {


### PR DESCRIPTION
Alpha: Implements #543.

Summary:
- Adds compact feasibility indicators to each military response option: prêt, risqué, bloqué, or dépendant.
- Explains the principal blocker using existing readiness/outcome/province data (supply, front pressure, morale, neighbor pressure, or missing information).
- Shows a minimal unlock action before the player queues the option, without adding a new combat system.

Tests:
- npm test

Zeta: PR prête pour revue. Merci de valider avant tout merge.
