### PR TITLE
Delta: add intrigue response confidence levels

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -53,3 +53,17 @@ test('selected intrigue province compares safe responses under fog', () => {
   assert.match(stylesSource, /intrigue-response-choice--warning/);
   assert.match(stylesSource, /intrigue-response-choice--watch/);
 });
+
+test('selected intrigue province adds fog-safe confidence levels to responses', () => {
+  assert.match(webAppSource, /confidence: riskIsHigh \? 'incertain' : 'fiable'/);
+  assert.match(webAppSource, /confidence: heatedOperation \? 'dangereux' : entry\.presenceLevel === 'low' \? 'information-insuffisante' : 'incertain'/);
+  assert.match(webAppSource, /Le brouillard masque encore la source du signal; ne pas inférer une menace réelle/);
+  assert.match(webAppSource, /L’exposition visible rend toute neutralisation directe risquée sans révéler les détails masqués/);
+  assert.match(webAppSource, /Collecter renseignement discret avant infiltration ou basculer en surveillance/);
+  assert.match(webAppSource, /choice\.confidenceLabel/);
+  assert.match(webAppSource, /choice\.confidenceReason/);
+  assert.match(stylesSource, /intrigue-response-choice__confidence--fiable/);
+  assert.match(stylesSource, /intrigue-response-choice__confidence--incertain/);
+  assert.match(stylesSource, /intrigue-response-choice__confidence--dangereux/);
+  assert.match(stylesSource, /intrigue-response-choice__confidence--information-insuffisante/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3473,6 +3473,12 @@ function buildSelectedProvinceIntrigueResponseChoices(entry, selectedCellules, s
       label: 'Surveiller',
       tone: 'watch',
       exposureRisk: 'faible',
+      confidence: riskIsHigh ? 'incertain' : 'fiable',
+      confidenceLabel: riskIsHigh ? 'Confiance incertaine' : 'Confiance fiable',
+      confidenceReason: riskIsHigh
+        ? 'Le signal reste exploitable, mais une pression cachée peut fausser la lecture.'
+        : 'Les signaux visibles suffisent pour observer sans exposer le réseau.',
+      improveConfidence: 'Collecter renseignement ou attendre un tour pour confirmer le signal avant action directe.',
       missingInfo: baseMissingInfo,
       gain: 'Maintient le signal visible sans forcer la révélation du brouillard.',
       summary: 'Surveiller: garder la province en observation et attendre un signal plus net.',
@@ -3483,6 +3489,14 @@ function buildSelectedProvinceIntrigueResponseChoices(entry, selectedCellules, s
       label: 'Infiltrer',
       tone: riskIsHigh ? 'warning' : 'watch',
       exposureRisk: riskIsHigh ? 'modéré' : 'faible à modéré',
+      confidence: heatedOperation ? 'dangereux' : entry.presenceLevel === 'low' ? 'information-insuffisante' : 'incertain',
+      confidenceLabel: heatedOperation ? 'Confiance dangereuse' : entry.presenceLevel === 'low' ? 'Information insuffisante' : 'Confiance incertaine',
+      confidenceReason: heatedOperation
+        ? 'La sécurité cible visible est trop haute pour supposer un contact sûr.'
+        : entry.presenceLevel === 'low'
+          ? 'Le brouillard masque encore la source du signal; ne pas inférer une menace réelle.'
+          : 'Le hotspot est plausible, mais le relais précis reste non confirmé.',
+      improveConfidence: 'Collecter renseignement discret avant infiltration ou basculer en surveillance.',
       missingInfo: exposedCount > 0 ? 'canal sûr pour approcher la cellule exposée' : 'confirmation du hotspot avant contact direct',
       gain: 'Transforme le soupçon en renseignement exploitable sans nommer la cible.',
       summary: 'Collecter renseignement: approcher le réseau sans révéler cellule, relais ou objectif.',
@@ -3496,6 +3510,14 @@ function buildSelectedProvinceIntrigueResponseChoices(entry, selectedCellules, s
       label: exposedCount > 0 ? 'Réduire chaleur' : 'Temporiser',
       tone: exposedCount > 0 ? 'danger' : 'warning',
       exposureRisk: exposedCount > 0 ? 'élevé si action directe' : 'modéré tant que la sécurité cible reste haute',
+      confidence: exposedCount > 0 ? 'dangereux' : 'incertain',
+      confidenceLabel: exposedCount > 0 ? 'Confiance dangereuse' : 'Confiance incertaine',
+      confidenceReason: exposedCount > 0
+        ? 'L’exposition visible rend toute neutralisation directe risquée sans révéler les détails masqués.'
+        : 'Le risque est lisible, mais le relais exact reste couvert par le brouillard.',
+      improveConfidence: exposedCount > 0
+        ? 'Réduire chaleur puis collecter renseignement avant une action nominative.'
+        : 'Temporiser pour laisser baisser la sécurité cible avant de réévaluer.',
       missingInfo: fogHint?.reason ?? baseMissingInfo,
       gain: exposedCount > 0
         ? 'Diminue la pression avant une neutralisation publique ou ciblée.'
@@ -3509,6 +3531,12 @@ function buildSelectedProvinceIntrigueResponseChoices(entry, selectedCellules, s
       label: 'Attendre',
       tone: 'watch',
       exposureRisk: 'très faible',
+      confidence: entry.presenceLevel === 'low' ? 'information-insuffisante' : 'fiable',
+      confidenceLabel: entry.presenceLevel === 'low' ? 'Information insuffisante' : 'Confiance fiable',
+      confidenceReason: entry.presenceLevel === 'low'
+        ? 'Le choix est sûr, mais les données visibles ne suffisent pas à qualifier la menace.'
+        : 'Attendre ne révèle rien et garde les options ouvertes avec les informations actuelles.',
+      improveConfidence: 'Surveiller ou collecter renseignement au prochain tour pour clarifier le signal.',
       missingInfo: baseMissingInfo,
       gain: 'Préserve totalement le brouillard mais reporte le gain de renseignement.',
       summary: 'Surveiller sans escalade: attendre si le tour ne peut pas absorber de chaleur intrigue.',
@@ -4472,9 +4500,11 @@ function renderIntrigueSidePanel(intrigueView) {
                   <article class="intrigue-response-choice intrigue-response-choice--${choice.tone} ${choice.recommended ? 'is-recommended' : ''}" aria-label="${choice.label}: risque d'exposition ${choice.exposureRisk}">
                     <div>
                       <strong>${choice.label}</strong>
+                      <span class="intrigue-response-choice__confidence intrigue-response-choice__confidence--${choice.confidence}">${choice.confidenceLabel}</span>
                       ${choice.recommended ? '<b>prudente</b>' : ''}
                     </div>
                     <p>${choice.summary}</p>
+                    <small>${choice.confidenceReason} ${choice.improveConfidence}</small>
                     <dl>
                       <div><dt>Exposition</dt><dd>${choice.exposureRisk}</dd></div>
                       <div><dt>Info manquante</dt><dd>${choice.missingInfo}</dd></div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3630,11 +3630,43 @@ button { font: inherit; }
   margin: 0;
 }
 .intrigue-response-choice p,
+.intrigue-response-choice small,
 .intrigue-response-choice dt,
 .intrigue-response-choice dd {
   margin: 0;
   color: #cbd5e1;
   line-height: 1.35;
+}
+.intrigue-response-choice small {
+  color: #bfdbfe;
+}
+.intrigue-response-choice__confidence {
+  padding: 3px 7px;
+  border-radius: 999px;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+.intrigue-response-choice__confidence--fiable {
+  color: #bbf7d0;
+  background: rgba(22, 163, 74, 0.12);
+  border-color: rgba(74, 222, 128, 0.24);
+}
+.intrigue-response-choice__confidence--incertain {
+  color: #fde68a;
+  background: rgba(245, 158, 11, 0.12);
+  border-color: rgba(250, 204, 21, 0.26);
+}
+.intrigue-response-choice__confidence--dangereux {
+  color: #fecdd3;
+  background: rgba(225, 29, 72, 0.14);
+  border-color: rgba(251, 113, 133, 0.3);
+}
+.intrigue-response-choice__confidence--information-insuffisante {
+  color: #ddd6fe;
+  background: rgba(124, 58, 237, 0.14);
+  border-color: rgba(167, 139, 250, 0.28);
 }
 .intrigue-response-choice dt {
   color: #a5b4fc;


### PR DESCRIPTION
Delta: Implements #546.

Summary:
- Add confidence levels to each fog-limited intrigue response: reliable, uncertain, dangerous, or insufficient information.
- Explain what remains unknown and which cautious action can improve confidence without revealing hidden threat details.
- Style confidence badges alongside the existing safe response comparison.

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: PR ready for validation before merge.
