### PR TITLE
Beta: show logistics recovery timeline

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -164,6 +164,46 @@ function getNeighborEffect(choiceId, route, localCity, neighbor, mainResource) {
   };
 }
 
+
+function buildRecoveryTimeline(choice, route, localCity, mainResource) {
+  const firstBottleneck = choice.neighborEffects.find((effect) => effect.tone !== 'low') ?? choice.neighborEffects[0] ?? null;
+  const nextTurnLabel = choice.choiceId === 'repair'
+    ? (!route.active ? 'route rouverte' : 'fragilité réduite')
+    : choice.choiceId === 'reroute'
+      ? 'flux redistribué'
+      : choice.choiceId === 'stockpile'
+        ? 'tampon consommé'
+        : 'priorité appliquée';
+  const remainingRisk = choice.choiceId === 'repair'
+    ? Math.max(5, route.riskLevel - (!route.active ? 24 : 16))
+    : choice.choiceId === 'reroute'
+      ? Math.max(5, route.riskLevel - 10)
+      : choice.choiceId === 'stockpile'
+        ? Math.max(5, route.riskLevel - 6)
+        : Math.max(5, route.riskLevel - 8);
+  const riskTone = remainingRisk >= 55 || firstBottleneck?.tone === 'medium' ? 'medium' : 'low';
+
+  return [
+    {
+      step: 'Effet immédiat',
+      tone: choice.tone,
+      detail: `${choice.label}: ${choice.benefit}`,
+    },
+    {
+      step: 'Prochain tour',
+      tone: firstBottleneck?.tone ?? 'low',
+      detail: firstBottleneck
+        ? `${nextTurnLabel}; ${firstBottleneck.label} sur ${firstBottleneck.route} près de ${firstBottleneck.target}.`
+        : `${nextTurnLabel}; aucune route voisine critique détectée.`,
+    },
+    {
+      step: 'Risque restant',
+      tone: riskTone,
+      detail: `Risque estimé ${remainingRisk} sur ${route.routeName}; ${firstBottleneck ? `${firstBottleneck.route} reste le goulot à surveiller.` : `${localCity.cityName} garde ${mainResource.label} sous veille.`}`,
+    },
+  ];
+}
+
 function buildRecoveryChoices(route, localCity, localTension, mainResource, routeCause, neighborContexts = []) {
   const choices = [
     {
@@ -211,12 +251,17 @@ function buildRecoveryChoices(route, localCity, localTension, mainResource, rout
   const rankedChoices = choices.sort((left, right) => right.score - left.score || left.label.localeCompare(right.label));
   const topChoice = rankedChoices[0];
 
-  return rankedChoices.map((choice, index) => ({
-    ...choice,
-    recommended: index === 0,
-    comparison: index === 0 ? 'meilleur levier immédiat' : `moins urgent: ${topChoice.blocker} prioritaire`,
-    neighborEffects: neighborContexts.map((neighbor) => getNeighborEffect(choice.choiceId, route, localCity, neighbor, mainResource)),
-  }));
+  return rankedChoices.map((choice, index) => {
+    const neighborEffects = neighborContexts.map((neighbor) => getNeighborEffect(choice.choiceId, route, localCity, neighbor, mainResource));
+
+    return {
+      ...choice,
+      recommended: index === 0,
+      comparison: index === 0 ? 'meilleur levier immédiat' : `moins urgent: ${topChoice.blocker} prioritaire`,
+      neighborEffects,
+      timeline: buildRecoveryTimeline({ ...choice, neighborEffects }, route, localCity, mainResource),
+    };
+  });
 }
 
 function buildChoiceForRoute(route, localCity, localTension, resourceLabelById, context = {}) {
@@ -275,7 +320,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const resourceLabelById = requireObject(normalizedOptions.resourceLabelById ?? {}, 'ProvinceLogisticsChoicePreview resourceLabelById');
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -304,6 +349,8 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   if (routeChoices.length === 0) {
     return {
       recommendedOptionId: null,
+      timelineStatus: 'empty',
+      timelineSummary: 'Aucune action route/logistique en file: timeline vide.',
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
       options: [],
@@ -316,6 +363,10 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   return {
     recommendedOptionId: recommended.optionId,
     recoveryChoiceCount: recommended.recoveryChoices.length,
+    timelineStatus: hasBlocker ? 'queued' : 'empty',
+    timelineSummary: hasBlocker
+      ? `${recommended.recoveryChoices[0].label}: amélioration visible au prochain tour, risque restant ${recommended.recoveryChoices[0].timeline[2].detail}`
+      : 'Aucune action route/logistique en file: timeline vide.',
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker
       ? `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.cause} ${recommended.recoveryChoices[0].label} est prioritaire car ${recommended.recoveryChoices[0].benefit}`

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -72,6 +72,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.options[0].cause, /River Gate/);
   assert.match(preview.options[0].cause, /Ember Line/);
   assert.equal(preview.recoveryChoiceCount, 4);
+  assert.equal(preview.timelineStatus, 'queued');
+  assert.match(preview.timelineSummary, /prochain tour/);
   assert.ok(preview.options[0].recoveryChoices.length >= 2);
   assert.equal(preview.options[0].recoveryChoices[0].recommended, true);
   assert.match(preview.options[0].recoveryChoices[0].benefit, /Outils|River Gate|Ember Line/);
@@ -80,6 +82,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.ok(preview.options[0].recoveryChoices[0].neighborEffects.length >= 1);
   assert.match(preview.options[0].recoveryChoices[0].neighborEffects[0].detail, /Iron Plain|Hill Hub|voisin|hub|trafic/);
   assert.ok(['congestion déplacée', 'hub soulagé', 'route toujours fragile', 'stockpile consommé', 'hub priorisé', 'effet réseau limité'].includes(preview.options[0].recoveryChoices[0].neighborEffects[0].label));
+  assert.deepEqual(preview.options[0].recoveryChoices[0].timeline.map((step) => step.step), ['Effet immédiat', 'Prochain tour', 'Risque restant']);
+  assert.match(preview.options[0].recoveryChoices[0].timeline[2].detail, /goulot|veille|Risque estimé/);
 });
 
 test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and impact labels', () => {
@@ -103,6 +107,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.equal(preview.recommendedOptionId, null);
   assert.deepEqual(preview.options, []);
   assert.equal(preview.status, 'stable');
+  assert.equal(preview.timelineStatus, 'empty');
+  assert.match(preview.timelineSummary, /timeline vide/);
   assert.match(preview.summary, /Logistique stable/);
 });
 
@@ -116,6 +122,7 @@ test('buildProvinceLogisticsChoicePreview exposes stable local route causes', ()
   });
 
   assert.equal(preview.status, 'stable');
+  assert.equal(preview.timelineStatus, 'empty');
   assert.match(preview.summary, /Logistique stable/);
   assert.equal(preview.options[0].causeLabel, 'logistique stable');
   assert.match(preview.options[0].cause, /Safe Road/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -15,6 +15,11 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /choice\.benefit/);
   assert.match(webAppSource, /choice\.blocker/);
   assert.match(webAppSource, /choice\.rationale/);
+  assert.match(webAppSource, /province-logistics-timeline-summary/);
+  assert.match(webAppSource, /Timeline récupération/);
+  assert.match(webAppSource, /province-logistics-recovery-timeline/);
+  assert.match(webAppSource, /choice\.timeline/);
+  assert.match(webAppSource, /step\.detail/);
   assert.match(webAppSource, /province-logistics-neighbor-effects/);
   assert.match(webAppSource, /effect\.detail/);
   assert.match(webAppSource, /effect\.target/);
@@ -27,6 +32,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-recovery-comparison/);
   assert.match(stylesSource, /province-logistics-recovery--high/);
   assert.match(stylesSource, /province-logistics-recovery--medium/);
+  assert.match(stylesSource, /province-logistics-timeline-summary--queued/);
+  assert.match(stylesSource, /province-logistics-timeline-summary--empty/);
+  assert.match(stylesSource, /province-logistics-recovery-timeline__step--medium/);
   assert.match(stylesSource, /province-logistics-neighbor-effect--medium/);
   assert.match(stylesSource, /province-logistics-neighbor-effect--low/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1191,6 +1191,10 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
         <b>Cause locale</b>
         <span>${preview.options[0]?.cause ?? 'logistique stable'}</span>
       </div>
+      <div class="province-logistics-timeline-summary province-logistics-timeline-summary--${preview.timelineStatus ?? 'empty'}">
+        <b>Timeline récupération</b>
+        <span>${preview.timelineSummary ?? 'Aucune action route/logistique en file.'}</span>
+      </div>
       ${preview.options.length > 0 ? `
         <div class="province-logistics-choice-list">
           ${preview.options.map((option) => `
@@ -1210,6 +1214,16 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                   </div>
                   <p>${choice.benefit}</p>
                   <small>Contrainte: ${choice.blocker} · ${choice.rationale}</small>
+                  ${choice.timeline.length > 0 ? `
+                    <ol class="province-logistics-recovery-timeline" aria-label="Timeline de récupération logistique">
+                      ${choice.timeline.map((step) => `
+                        <li class="province-logistics-recovery-timeline__step province-logistics-recovery-timeline__step--${step.tone}">
+                          <b>${step.step}</b>
+                          <span>${step.detail}</span>
+                        </li>
+                      `).join('')}
+                    </ol>
+                  ` : ''}
                   ${choice.neighborEffects.length > 0 ? `
                     <ul class="province-logistics-neighbor-effects" aria-label="Effets voisins attendus">
                       ${choice.neighborEffects.map((effect) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -2930,6 +2930,28 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.province-logistics-timeline-summary {
+  display: grid;
+  gap: 4px;
+  margin: 8px 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(8, 15, 28, 0.46);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.province-logistics-timeline-summary--queued { border-color: rgba(125, 211, 252, 0.28); }
+.province-logistics-timeline-summary--empty { border-color: rgba(74, 222, 128, 0.18); }
+.province-logistics-timeline-summary b {
+  color: #bfdbfe;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.province-logistics-timeline-summary span {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
 .province-logistics-cause-summary--high { border-color: rgba(251, 113, 133, 0.38); }
 .province-logistics-cause-summary--medium { border-color: rgba(245, 158, 11, 0.34); }
 .province-logistics-cause-summary--stable,
@@ -2994,6 +3016,33 @@ button { font: inherit; }
   color: #dbeafe;
   font-size: 12px;
   line-height: 1.35;
+}
+.province-logistics-recovery-timeline {
+  display: grid;
+  gap: 5px;
+  margin: 5px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.province-logistics-recovery-timeline__step {
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  border-radius: 9px;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.province-logistics-recovery-timeline__step--high { border-color: rgba(251, 113, 133, 0.34); }
+.province-logistics-recovery-timeline__step--medium { border-color: rgba(245, 158, 11, 0.3); }
+.province-logistics-recovery-timeline__step--low { border-color: rgba(74, 222, 128, 0.2); }
+.province-logistics-recovery-timeline__step b {
+  color: #f8fafc;
+  font-size: 11px;
+}
+.province-logistics-recovery-timeline__step span {
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.3;
 }
 .province-logistics-neighbor-effects {
   display: grid;


### PR DESCRIPTION
Beta: Implements #554.

## Summary
- adds a compact recovery timeline for route logistics choices: immediate effect, next turn, remaining risk
- keeps neighboring bottlenecks visible in the timeline when adjacent routes remain fragile or congested
- exposes an explicit empty timeline state when no route/logistics action is queued and updates focused UI tests

## Tests
- npm test
- npm test -- --test-reporter=spec test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.