### PR TITLE
Gamma: preview culture ripple effects

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -175,6 +175,67 @@ function buildActionTradeoff(hint, recommendedAction, focusTarget, urgency) {
   };
 }
 
+
+function buildRippleEffects(hint, recommendedAction, focusTarget, urgency) {
+  if (hint.status === 'missing') {
+    return [];
+  }
+
+  const source = recommendedAction.source ?? urgency.sourceLabel ?? focusTarget.label;
+  const regionId = focusTarget.regionId ?? hint.regionId;
+  const baseEffects = [{
+    targetId: regionId,
+    targetLabel: `Province ${regionId}`,
+    cultureName: hint.cultureName,
+    tone: urgency.level === 'soon' ? 'positive' : 'uncertain',
+    summary: urgency.level === 'soon'
+      ? `${source} stabilise l’opportunité culturelle locale.`
+      : `${source} garde la fenêtre culturelle ouverte.`,
+  }];
+
+  if (recommendedAction.code === 'accelerate-research') {
+    baseEffects.push({
+      targetId: `${regionId}:research`,
+      targetLabel: 'Recherche locale',
+      cultureName: hint.cultureName,
+      tone: 'positive',
+      summary: `Progression de recherche plus lisible au prochain choix.`,
+    });
+  }
+
+  if (recommendedAction.code === 'protect-site') {
+    baseEffects.push({
+      targetId: `${regionId}:site`,
+      targetLabel: focusTarget.label,
+      cultureName: hint.cultureName,
+      tone: 'uncertain',
+      summary: `Site protégé, mais diffusion encore dépendante du prochain tour.`,
+    });
+  }
+
+  if (recommendedAction.code === 'follow-event') {
+    baseEffects.push({
+      targetId: `${regionId}:timeline`,
+      targetLabel: 'Timeline locale',
+      cultureName: hint.cultureName,
+      tone: urgency.level === 'soon' ? 'positive' : 'uncertain',
+      summary: `Repère narratif maintenu dans la timeline locale.`,
+    });
+  }
+
+  if (hint.tone === 'risk') {
+    baseEffects.push({
+      targetId: `${regionId}:risk`,
+      targetLabel: 'Voisinage culturel',
+      cultureName: hint.cultureName,
+      tone: 'risky',
+      summary: `Propagation fragile si l’action est repoussée.`,
+    });
+  }
+
+  return baseEffects.slice(0, 3);
+}
+
 function summarizeHint(hint, actionLabel, urgency) {
   const provinceCopy = hint.regionId ? ` (${hint.regionId})` : '';
   const urgencyCopy = ` ${urgency.label.toLowerCase()} · ${urgency.window}.`;
@@ -204,6 +265,7 @@ function buildReminder(hint, actionLabel) {
   };
   const recommendedAction = buildRecommendedAction(hint, focusTargetWithUrgency, urgency, actionLabel);
   const tradeoff = buildActionTradeoff(hint, recommendedAction, focusTargetWithUrgency, urgency);
+  const rippleEffects = buildRippleEffects(hint, recommendedAction, focusTargetWithUrgency, urgency);
 
   return {
     reminderId: `${hint.status}:${hint.tone}:${hint.regionId}:${hint.label}:${actionLabel}`,
@@ -221,6 +283,10 @@ function buildReminder(hint, actionLabel) {
     actionCopy: `${recommendedAction.label} · ${recommendedAction.timing}`,
     tradeoff,
     tradeoffCopy: `${tradeoff.benefit} · ${tradeoff.risk}`,
+    rippleEffects,
+    rippleCopy: rippleEffects.length > 0
+      ? rippleEffects.map((effect) => `${effect.targetLabel}: ${effect.summary}`).join(' | ')
+      : 'Aucun effet de propagation culturel en file.',
     focusTarget: focusTargetWithUrgency,
     focusCopy: `${focusTarget.type}: ${focusTarget.label}`,
   };

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -85,6 +85,12 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
     ['Libère l’action province', 'Ligues des Forges reste sans signal exploitable', 'stable'],
   ]);
   assert.equal(report.reminders[0].tradeoff.summary, 'Gain: repère culturel protégé. Risque: événement ignoré (ce tour).');
+  assert.deepEqual(report.reminders.map((reminder) => reminder.rippleEffects.map((effect) => [effect.targetLabel, effect.tone])), [
+    [['Province river-gate', 'positive'], ['Timeline locale', 'positive']],
+    [['Province river-gate', 'uncertain'], ['Recherche locale', 'positive']],
+    [],
+  ]);
+  assert.equal(report.reminders[0].rippleCopy, 'Province river-gate: Ouverture des archives stabilise l’opportunité culturelle locale. | Timeline locale: Repère narratif maintenu dans la timeline locale.');
   assert.deepEqual(report.reminders[0].urgency, {
     level: 'soon',
     label: 'Expire bientôt',

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -14,7 +14,13 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /reminder\.recommendedAction\?\.summary/);
   assert.match(webAppSource, /culture-opportunity-reminder__tradeoff/);
   assert.match(webAppSource, /reminder\.tradeoff\?\.summary/);
+  assert.match(webAppSource, /culture-opportunity-reminder__ripples/);
+  assert.match(webAppSource, /reminder\.rippleEffects/);
+  assert.match(webAppSource, /Aucun effet de propagation culturel en file/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__reason/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__action/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__tradeoff/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--positive/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--uncertain/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--risky/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -951,6 +951,19 @@ function renderCultureOpportunityReminders(report) {
               <p>${reminder.summary}</p>
               <p class="culture-opportunity-reminder__action"><b>${reminder.recommendedAction?.label ?? 'Surveiller la fenêtre'}</b> · ${reminder.recommendedAction?.summary ?? reminder.actionCopy ?? reminder.summary}</p>
               <p class="culture-opportunity-reminder__tradeoff"><b>Compromis</b> · ${reminder.tradeoff?.summary ?? reminder.tradeoffCopy ?? 'Bénéfice culturel contre risque narratif.'}</p>
+              <div class="culture-opportunity-reminder__ripples" aria-label="Effets de propagation culturelle">
+                <b>Propagation</b>
+                ${(reminder.rippleEffects ?? []).length > 0 ? `
+                  <ul>
+                    ${reminder.rippleEffects.slice(0, 3).map((effect) => `
+                      <li class="culture-opportunity-reminder__ripple culture-opportunity-reminder__ripple--${effect.tone}">
+                        <span>${effect.targetLabel}</span>
+                        <small>${effect.cultureName} · ${effect.summary}</small>
+                      </li>
+                    `).join('')}
+                  </ul>
+                ` : '<small>Aucun effet de propagation culturel en file.</small>'}
+              </div>
               <button type="button" data-culture-focus-region="${reminder.focusTarget.regionId}" data-culture-focus-type="${reminder.focusTarget.type}" data-culture-focus-id="${reminder.focusTarget.id}" aria-label="Voir ${reminder.focusCopy}: ${reminder.urgency?.detail ?? reminder.summary}">
                 Voir ${reminder.focusCopy}
               </button>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2609,6 +2609,37 @@ button { font: inherit; }
   color: #fde68a !important;
 }
 .culture-opportunity-reminder__tradeoff b { color: #fef3c7; }
+.culture-opportunity-reminder__ripples {
+  display: grid;
+  gap: 5px;
+  margin-top: 6px;
+  padding: 7px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.44);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.culture-opportunity-reminder__ripples > b {
+  color: #cffafe;
+  font-size: 11px;
+}
+.culture-opportunity-reminder__ripples ul {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.culture-opportunity-reminder__ripple {
+  display: grid;
+  gap: 2px;
+  padding-left: 7px;
+  border-left: 2px solid rgba(148, 163, 184, 0.24);
+}
+.culture-opportunity-reminder__ripple span { color: #f8fafc; font-size: 11px; }
+.culture-opportunity-reminder__ripple small { color: var(--muted); font-size: 11px; }
+.culture-opportunity-reminder__ripple--positive { border-left-color: rgba(74, 222, 128, 0.62); }
+.culture-opportunity-reminder__ripple--uncertain { border-left-color: rgba(56, 189, 248, 0.56); }
+.culture-opportunity-reminder__ripple--risky { border-left-color: rgba(251, 191, 36, 0.62); }
 .culture-opportunity-reminder button {
   margin-top: 7px;
   padding: 5px 8px;


### PR DESCRIPTION
Gamma: PR prête pour validation.

Scope #555:
- ajoute un aperçu de propagation culturelle attendu pour les recommandations culturelles en file;
- distingue les effets positifs, incertains et risqués avec micro-copie compacte;
- conserve les compromis/recommandations existants et ajoute un état vide quand aucune propagation n’est applicable;
- renforce les tests de dérivation et de rendu web.

Tests:
- `npm test`
- `node --check web/app.js`
- `node --check src/ui/culture/buildCultureOpportunityReminders.js`
- `git diff --check`

Zeta, peux-tu valider cette PR avant tout merge ?

Closes #555