### PR TITLE
Delta: project queued intrigue detection risk

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -67,3 +67,17 @@ test('selected intrigue province adds fog-safe confidence levels to responses', 
   assert.match(stylesSource, /intrigue-response-choice__confidence--dangereux/);
   assert.match(stylesSource, /intrigue-response-choice__confidence--information-insuffisante/);
 });
+
+test('queued province intrigue responses project detection risk without breaking fog', () => {
+  assert.match(webAppSource, /function buildQueuedIntrigueDetectionRiskProjection/);
+  assert.match(webAppSource, /function renderQueuedIntrigueDetectionRiskProjection/);
+  assert.match(webAppSource, /Projection détection intrigue/);
+  assert.match(webAppSource, /Aucune réponse intrigue en file/);
+  assert.match(webAppSource, /queuez une réponse intrigue pour estimer la tendance sans lever le brouillard/);
+  assert.match(webAppSource, /Projection prudente: source, cellule et objectif exacts restent masqués par le brouillard/);
+  assert.match(webAppSource, /Basé sur les opérations visibles; les relais non confirmés restent masqués/);
+  assert.match(webAppSource, /Projection détection \$\{visibleBaseRisk\} → \$\{afterRisk\}/);
+  assert.match(stylesSource, /province-intrigue-detection-projection/);
+  assert.match(stylesSource, /province-intrigue-detection-projection--mitigated/);
+  assert.match(stylesSource, /province-intrigue-detection-projection--masked/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2226,6 +2226,86 @@ function buildProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView) 
     .slice(0, 3);
 }
 
+function buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView) {
+  const drillDown = findProvinceIntrigueDrillDown(province, intrigueView);
+  const response = drillDown?.quickResponses?.find((candidate) => candidate.code === drillDown.recommendedResponseCode)
+    ?? drillDown?.quickResponses?.[0]
+    ?? null;
+  const queuedIntrigueAction = actionQueue.find((entry) => entry.label.includes('Signal local') || entry.label.includes('Signal prioritaire')) ?? null;
+
+  if (!queuedIntrigueAction || !drillDown || !response) {
+    return {
+      empty: true,
+      tone: 'masked',
+      label: 'Aucune réponse intrigue en file',
+      summary: 'Aucune projection de détection: queuez une réponse intrigue pour estimer la tendance sans lever le brouillard.',
+      confidence: 'information limitée',
+      beforeLabel: '—',
+      afterLabel: '—',
+      deltaLabel: 'stable',
+      fogLimit: 'Le brouillard conserve les cellules, relais et objectifs masqués.',
+    };
+  }
+
+  const localOperations = (intrigueView?.panels?.operations ?? []).filter((operation) => operation.locationId === province.provinceId);
+  const visibleBaseRisk = localOperations.length > 0
+    ? Math.max(...localOperations.map((operation) => operation.detectionRisk))
+    : drillDown.riskBand === 'high'
+      ? 62
+      : drillDown.riskBand === 'medium'
+        ? 42
+        : 24;
+  const responseDeltaByCode = {
+    contenir: -Math.max(6, Math.round(response.heatGenerated / 2)),
+    surveiller: Math.max(1, Math.round(response.heatGenerated / 3)),
+    infiltrer: Math.max(4, Math.round(response.heatGenerated / 2)),
+    exposer: Math.max(10, response.heatGenerated),
+  };
+  const rawDelta = responseDeltaByCode[response.code] ?? Math.round(response.heatGenerated / 2);
+  const afterRisk = Math.max(0, Math.min(100, visibleBaseRisk + rawDelta));
+  const confidence = localOperations.length > 0
+    ? 'visible'
+    : drillDown.criticality === 'critical'
+      ? 'partielle'
+      : 'brouillard';
+  const tone = rawDelta < 0 ? 'mitigated' : afterRisk >= 60 ? 'danger' : afterRisk >= 40 ? 'warning' : 'watch';
+  const deltaLabel = rawDelta < 0 ? `${rawDelta}` : `+${rawDelta}`;
+
+  return {
+    empty: false,
+    tone,
+    label: `${response.label}: risque ${deltaLabel}`,
+    summary: `Projection détection ${visibleBaseRisk} → ${afterRisk}: ${response.aftermathSummary ?? response.summary}.`,
+    confidence: confidence === 'visible' ? 'confiance visible' : confidence === 'partielle' ? 'confiance partielle' : 'confiance sous brouillard',
+    beforeLabel: `${visibleBaseRisk}`,
+    afterLabel: `${afterRisk}`,
+    deltaLabel,
+    fogLimit: confidence === 'visible'
+      ? 'Basé sur les opérations visibles; les relais non confirmés restent masqués.'
+      : 'Projection prudente: source, cellule et objectif exacts restent masqués par le brouillard.',
+  };
+}
+
+function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView) {
+  const projection = buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView);
+
+  return `
+    <section class="province-intrigue-detection-projection province-intrigue-detection-projection--${projection.tone}" aria-label="Projection du risque de détection intrigue">
+      <div class="province-intrigue-detection-projection__header">
+        <strong>Projection détection intrigue</strong>
+        <span>${projection.confidence}</span>
+      </div>
+      <p>${projection.summary}</p>
+      <div class="province-intrigue-detection-projection__scale">
+        <span>Avant <b>${projection.beforeLabel}</b></span>
+        <span>Après <b>${projection.afterLabel}</b></span>
+        <span>Tendance <b>${projection.deltaLabel}</b></span>
+      </div>
+      <small>${projection.fogLimit}</small>
+    </section>
+  `;
+}
+
 function renderProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView) {
   const warnings = buildProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView);
 
@@ -2378,6 +2458,7 @@ function renderSelectedProvinceActionQueue(province, shell, focusContext, intrig
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const resolution = summarizeTurnResolutionPreview(province, actionQueue);
   const intrigueWarnings = renderProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView);
+  const intrigueDetectionProjection = renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView);
   const climateHazardBlockers = renderProvinceClimateHazardBlockers(province, actionQueue);
 
   return `
@@ -2413,6 +2494,7 @@ function renderSelectedProvinceActionQueue(province, shell, focusContext, intrig
         `).join('')}
       </ol>
     </section>
+    ${intrigueDetectionProjection}
     ${intrigueWarnings}
     ${climateHazardBlockers}
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -5845,6 +5845,43 @@ button { font: inherit; }
   color: #bae6fd;
 }
 
+.province-intrigue-detection-projection {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(96, 165, 250, 0.18);
+}
+.province-intrigue-detection-projection--danger { border-color: rgba(248, 113, 113, 0.34); }
+.province-intrigue-detection-projection--warning { border-color: rgba(250, 204, 21, 0.3); }
+.province-intrigue-detection-projection--watch { border-color: rgba(96, 165, 250, 0.28); }
+.province-intrigue-detection-projection--mitigated { border-color: rgba(34, 197, 94, 0.32); }
+.province-intrigue-detection-projection--masked { border-color: rgba(148, 163, 184, 0.18); }
+.province-intrigue-detection-projection__header,
+.province-intrigue-detection-projection__scale {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-detection-projection__header span,
+.province-intrigue-detection-projection p,
+.province-intrigue-detection-projection small {
+  color: var(--muted);
+}
+.province-intrigue-detection-projection p {
+  margin: 7px 0;
+}
+.province-intrigue-detection-projection__scale {
+  flex-wrap: wrap;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.28);
+}
+.province-intrigue-detection-projection__scale b {
+  color: #bfdbfe;
+}
+
 .province-intrigue-risk-warnings {
   margin-top: 12px;
   padding: 12px;


### PR DESCRIPTION
Delta: Implements #556.

Summary:
- Adds a fog-aware selected-province detection risk projection for queued intrigue responses.
- Shows before/after/tendency plus projection confidence and empty state.
- Styles the projection states and extends fog-aware UI coverage.

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: Ready for validation before merge.