### PR TITLE
Alpha: explain projected front stability

### DIFF
--- a/test/ui/war/webProjectedFrontStability.test.js
+++ b/test/ui/war/webProjectedFrontStability.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected province panel explains projected front stability after queued military actions', () => {
+  assert.match(webAppSource, /function buildProjectedFrontStability/);
+  assert.match(webAppSource, /function renderProjectedFrontStability/);
+  assert.match(webAppSource, /Projection stabilité front/);
+  assert.match(webAppSource, /Projection front non engagée/);
+  assert.match(webAppSource, /Aucune action militaire en file/);
+  assert.match(webAppSource, /Stabilité attendue/);
+  assert.match(webAppSource, /Risque restant/);
+  assert.match(webAppSource, /Voisine sensible/);
+  assert.match(webAppSource, /sensitiveNeighbor/);
+  assert.match(webAppSource, /projection après validation de l’action en file/);
+  assert.match(webAppSource, /renderProjectedFrontStability\(province, shell, focusContext, intrigueView\)/);
+  assert.match(stylesSource, /\.projected-front-stability/);
+  assert.match(stylesSource, /projected-front-stability--ready/);
+  assert.match(stylesSource, /projected-front-stability--warning/);
+  assert.match(stylesSource, /projected-front-stability--danger/);
+  assert.match(stylesSource, /projected-front-stability--neutral/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2647,6 +2647,84 @@ function renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigue
   `;
 }
 
+function buildProjectedFrontStability(province, shell, actionQueue) {
+  const outcome = buildConflictOutcomePreview(province, shell);
+  const queuedAction = actionQueue.find((entry) => entry.status === 'ready') ?? actionQueue[0] ?? null;
+  const hostileNeighbors = province.neighborIds
+    .map((provinceId) => shell.provinces.find((candidate) => candidate.provinceId === provinceId))
+    .filter((neighbor) => neighbor && neighbor.controllingFactionId !== province.controllingFactionId);
+  const sensitiveNeighbor = hostileNeighbors
+    .sort((left, right) => (right.strategicValue - left.strategicValue) || left.label.localeCompare(right.label))[0] ?? null;
+
+  if (!queuedAction) {
+    return {
+      empty: true,
+      tone: 'neutral',
+      title: 'Projection front non engagée',
+      summary: 'Aucune action militaire en file: la stabilité du front reste inchangée pour ce tour.',
+      lines: [
+        { label: 'Stabilité attendue', value: province.contested ? 'front encore contesté' : 'position maintenue' },
+        { label: 'Risque restant', value: outcome.summary },
+        { label: 'Voisine sensible', value: sensitiveNeighbor?.label ?? 'aucune menace adjacente prioritaire' },
+      ],
+    };
+  }
+
+  const stability = queuedAction.status === 'blocked'
+    ? 'instable après résolution'
+    : queuedAction.status === 'risky'
+      ? 'stabilité partielle'
+      : outcome.tone === 'success'
+        ? 'front stabilisé'
+        : 'front sous contrôle prudent';
+  const residualRisk = queuedAction.status === 'blocked'
+    ? queuedAction.mainRisk
+    : queuedAction.status === 'risky'
+      ? 'risque résiduel si appui ou timing échoue'
+      : outcome.tone === 'danger'
+        ? 'pression ennemie encore élevée'
+        : 'risque contenu au prochain tour';
+
+  return {
+    empty: false,
+    tone: queuedAction.status === 'blocked' ? 'danger' : queuedAction.status === 'risky' ? 'warning' : 'ready',
+    title: queuedAction.label,
+    summary: `${queuedAction.actionCode}: projection après validation de l’action en file.`,
+    lines: [
+      { label: 'Stabilité attendue', value: stability },
+      { label: 'Risque restant', value: residualRisk },
+      { label: 'Voisine sensible', value: sensitiveNeighbor ? `${sensitiveNeighbor.label} · valeur ${sensitiveNeighbor.strategicValue}` : 'aucune menace adjacente prioritaire' },
+    ],
+  };
+}
+
+function renderProjectedFrontStability(province, shell, focusContext, intrigueView = null) {
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const projection = buildProjectedFrontStability(province, shell, actionQueue);
+
+  return `
+    <section class="projected-front-stability projected-front-stability--${projection.tone} ${projection.empty ? 'is-empty' : ''}" aria-label="Projection de stabilité du front après actions en file">
+      <div class="projected-front-stability__header">
+        <div>
+          <span>Projection stabilité front</span>
+          <strong>${projection.title}</strong>
+        </div>
+        <small>${projection.empty ? 'aucune action en file' : 'après action'}</small>
+      </div>
+      <p>${projection.summary}</p>
+      <div class="projected-front-stability__lines">
+        ${projection.lines.map((line) => `
+          <article class="projected-front-stability__line">
+            <span>${line.label}</span>
+            <strong>${line.value}</strong>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
+
 function buildConflictReadinessWarnings(shell, intrigueView = null) {
   return shell.provinces
     .map((province) => {
@@ -3007,6 +3085,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderMilitaryResponseOptions(province, shell, focusContext, intrigueView)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView)}
+      ${renderProjectedFrontStability(province, shell, focusContext, intrigueView)}
       ${renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView)}
       ${renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView)}
       ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -2507,6 +2507,64 @@ button { font: inherit; }
 .military-plan-impact--ready { border-color: rgba(45, 212, 191, 0.32); }
 .military-plan-impact--warning { border-color: rgba(251, 191, 36, 0.34); }
 .military-plan-impact--danger { border-color: rgba(251, 113, 133, 0.4); }
+.projected-front-stability {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(8, 15, 28, 0.74), rgba(30, 64, 175, 0.2));
+  border: 1px solid rgba(96, 165, 250, 0.22);
+}
+.projected-front-stability__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.projected-front-stability__header span,
+.projected-front-stability__header small {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.projected-front-stability__header strong {
+  display: block;
+  margin-top: 3px;
+}
+.projected-front-stability > p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.projected-front-stability__lines {
+  display: grid;
+  gap: 8px;
+}
+.projected-front-stability__line {
+  padding: 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.projected-front-stability__line span {
+  display: block;
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.projected-front-stability__line strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+}
+.projected-front-stability--ready { border-color: rgba(74, 222, 128, 0.28); }
+.projected-front-stability--warning { border-color: rgba(251, 191, 36, 0.34); }
+.projected-front-stability--danger { border-color: rgba(251, 113, 133, 0.4); }
+.projected-front-stability--neutral { border-color: rgba(148, 163, 184, 0.22); }
 .culture-opportunity-reminders {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
Alpha: Implements #553.

Summary:
- Adds a compact projected front stability block to the selected province panel.
- Shows expected stability, residual risk, and the most sensitive neighboring province after queued military actions.
- Provides a useful empty state when no military action is queued, without adding backend or combat-resolution changes.

Tests:
- npm test

Zeta: PR prête pour revue. Merci de valider avant tout merge.
