### PR TITLE
Epsilon: forecast climate risk reduction

### DIFF
--- a/test/ui/climate/webClimateRiskReductionForecast.test.js
+++ b/test/ui/climate/webClimateRiskReductionForecast.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected province panel forecasts climate risk reduction after queued mitigation', () => {
+  assert.match(webAppSource, /function getProjectedClimateRiskAfterMitigation/);
+  assert.match(webAppSource, /function buildProvinceClimateRiskReductionForecast/);
+  assert.match(webAppSource, /function renderProvinceClimateRiskReductionForecast/);
+  assert.match(webAppSource, /Prévision de réduction du risque climatique après mitigation en file/);
+  assert.match(webAppSource, /Réduction risque projetée/);
+  assert.match(webAppSource, /currentRisk/);
+  assert.match(webAppSource, /projectedRisk/);
+  assert.match(webAppSource, /criticalDeadline/);
+  assert.match(webAppSource, /queuedAction/);
+  assert.match(webAppSource, /remainingCascades/);
+  assert.match(webAppSource, /Aucune mitigation climat décisive en file/);
+  assert.match(webAppSource, /surveillance résiduelle/);
+  assert.match(webAppSource, /renderProvinceClimateRiskReductionForecast\(province, shell\)/);
+
+  assert.match(stylesSource, /\.province-climate-risk-forecast/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast--empty/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast--unchanged/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast--reduced/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__meter/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__residuals/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1494,6 +1494,86 @@ function buildProvinceClimateMitigationPriorities(province, report = buildProvin
     .slice(0, 3);
 }
 
+function getProjectedClimateRiskAfterMitigation(currentRiskLevel, hasQueuedMitigation) {
+  if (!hasQueuedMitigation) {
+    return currentRiskLevel;
+  }
+
+  if (currentRiskLevel === 'critical') {
+    return 'strained';
+  }
+
+  if (currentRiskLevel === 'strained') {
+    return 'stable';
+  }
+
+  return 'stable';
+}
+
+function buildProvinceClimateRiskReductionForecast(province, shell, report = buildProvinceClimateTurnReport(province)) {
+  const priorities = buildProvinceClimateMitigationPriorities(province, report);
+  const queuedMitigation = priorities.find((priority) => priority.outcomeChange) ?? null;
+  const currentRisk = getProvinceClimateRiskLevel(province);
+  const projectedRisk = getProjectedClimateRiskAfterMitigation(currentRisk, Boolean(queuedMitigation));
+  const cues = buildProvinceClimateCountdownCues(province, report);
+  const criticalDeadline = queuedMitigation?.deadline ?? cues.find((cue) => cue.level !== 'stable')?.countdown ?? 'Aucune échéance critique';
+  const remainingCascades = buildProvinceClimateCascadePreview(province, shell, report)
+    .filter((cascade) => !queuedMitigation || !cascade.changesThisTurn)
+    .slice(0, 2);
+
+  if (!queuedMitigation) {
+    return {
+      state: 'empty',
+      currentRisk,
+      projectedRisk,
+      criticalDeadline,
+      queuedAction: null,
+      summary: 'Aucune mitigation climat décisive en file: la réduction de risque projetée reste inchangée.',
+      remainingCascades,
+    };
+  }
+
+  return {
+    state: projectedRisk === currentRisk ? 'unchanged' : 'reduced',
+    currentRisk,
+    projectedRisk,
+    criticalDeadline,
+    queuedAction: queuedMitigation.option,
+    summary: `${queuedMitigation.option} projette ${currentRisk} → ${projectedRisk} avant ${criticalDeadline}.`,
+    remainingCascades: remainingCascades.length > 0 ? remainingCascades : [{
+      type: 'surveillance résiduelle',
+      scope: 'Aucune cascade probable restante',
+      avoidedImpact: 'La mitigation couvre les cascades régionales lisibles; garder seulement une veille climat.',
+      changesThisTurn: false,
+      priority: 6,
+    }],
+  };
+}
+
+function renderProvinceClimateRiskReductionForecast(province, shell) {
+  const forecast = buildProvinceClimateRiskReductionForecast(province, shell);
+
+  return `
+    <section class="province-climate-risk-forecast province-climate-risk-forecast--${forecast.state}" aria-label="Prévision de réduction du risque climatique après mitigation en file">
+      <div class="province-climate-risk-forecast__header">
+        <strong>Réduction risque projetée</strong>
+        <span>${forecast.criticalDeadline}</span>
+      </div>
+      <div class="province-climate-risk-forecast__meter">
+        <b>${forecast.currentRisk}</b>
+        <i aria-hidden="true">→</i>
+        <b>${forecast.projectedRisk}</b>
+      </div>
+      <p>${forecast.summary}</p>
+      <div class="province-climate-risk-forecast__residuals">
+        ${forecast.remainingCascades.map((cascade) => `
+          <small><b>${cascade.type}</b> · ${cascade.scope}</small>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function buildProvinceClimateCascadePreview(province, shell, report = buildProvinceClimateTurnReport(province)) {
   const priorities = buildProvinceClimateMitigationPriorities(province, report);
   const decisivePriority = priorities.find((priority) => priority.outcomeChange) ?? null;
@@ -3013,6 +3093,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderIntrigueTurnReportDeltas(province, intrigueView)}
       ${renderProvinceClimateCountdownCues(province)}
       ${renderProvinceClimateMitigationPriorities(province)}
+      ${renderProvinceClimateRiskReductionForecast(province, shell)}
       ${renderProvinceClimateCascadePreview(province, shell)}
       ${renderProvinceClimateTurnReport(province)}
       <div class="context-summary">

--- a/web/styles.css
+++ b/web/styles.css
@@ -3239,6 +3239,62 @@ button { font: inherit; }
   line-height: 1.35;
 }
 
+.province-climate-risk-forecast {
+  display: grid;
+  gap: 9px;
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(20, 83, 45, 0.24), rgba(15, 23, 42, 0.58));
+  border: 1px solid rgba(74, 222, 128, 0.18);
+}
+.province-climate-risk-forecast--empty { border-color: rgba(148, 163, 184, 0.18); }
+.province-climate-risk-forecast--unchanged { border-color: rgba(251, 191, 36, 0.26); }
+.province-climate-risk-forecast--reduced { border-color: rgba(74, 222, 128, 0.34); }
+.province-climate-risk-forecast__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-climate-risk-forecast__header span {
+  color: #bbf7d0;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-climate-risk-forecast__meter {
+  display: inline-flex;
+  width: fit-content;
+  gap: 8px;
+  align-items: center;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-climate-risk-forecast__meter b {
+  color: #ecfeff;
+}
+.province-climate-risk-forecast__meter i {
+  color: #86efac;
+  font-style: normal;
+}
+.province-climate-risk-forecast p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-climate-risk-forecast__residuals {
+  display: grid;
+  gap: 3px;
+}
+.province-climate-risk-forecast__residuals small {
+  color: #bae6fd;
+  line-height: 1.35;
+}
+
 .province-climate-cascade-preview {
   display: grid;
   gap: 9px;


### PR DESCRIPTION
Epsilon:

## Summary
- Adds a selected-province forecast for climate risk reduction after queued decisive mitigation.
- Shows current risk, projected risk, critical deadline, and residual cascade notes.
- Provides a clear empty state when no decisive mitigation is queued, while reusing existing countdown, mitigation, and cascade data.

## Testing
- npm test -- test/ui/climate/webClimateRiskReductionForecast.test.js test/ui/climate/webClimateCascadePreview.test.js
- node --check web/app.js
- npm test

Fixes loo469/historia#557