### PR TITLE
Epsilon: compare climate mitigation payoff tradeoffs

### DIFF
--- a/test/ui/climate/webClimateRiskReductionForecast.test.js
+++ b/test/ui/climate/webClimateRiskReductionForecast.test.js
@@ -7,6 +7,7 @@ const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta
 
 test('selected province panel forecasts climate risk reduction after queued mitigation', () => {
   assert.match(webAppSource, /function getProjectedClimateRiskAfterMitigation/);
+  assert.match(webAppSource, /function buildClimateMitigationPayoffTradeoff/);
   assert.match(webAppSource, /function buildProvinceClimateRiskReductionForecast/);
   assert.match(webAppSource, /function renderProvinceClimateRiskReductionForecast/);
   assert.match(webAppSource, /Prévision de réduction du risque climatique après mitigation en file/);
@@ -15,6 +16,12 @@ test('selected province panel forecasts climate risk reduction after queued miti
   assert.match(webAppSource, /projectedRisk/);
   assert.match(webAppSource, /criticalDeadline/);
   assert.match(webAppSource, /queuedAction/);
+  assert.match(webAppSource, /payoffTradeoff/);
+  assert.match(webAppSource, /Bénéfice attendu: risque/);
+  assert.match(webAppSource, /pression économie\/logistique/);
+  assert.match(webAppSource, /friction culturelle/);
+  assert.match(webAppSource, /exposition militaire/);
+  assert.match(webAppSource, /coût d’opportunité/);
   assert.match(webAppSource, /remainingCascades/);
   assert.match(webAppSource, /Aucune mitigation climat décisive en file/);
   assert.match(webAppSource, /surveillance résiduelle/);
@@ -25,5 +32,6 @@ test('selected province panel forecasts climate risk reduction after queued miti
   assert.match(stylesSource, /\.province-climate-risk-forecast--unchanged/);
   assert.match(stylesSource, /\.province-climate-risk-forecast--reduced/);
   assert.match(stylesSource, /\.province-climate-risk-forecast__meter/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__payoff/);
   assert.match(stylesSource, /\.province-climate-risk-forecast__residuals/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1510,6 +1510,34 @@ function getProjectedClimateRiskAfterMitigation(currentRiskLevel, hasQueuedMitig
   return 'stable';
 }
 
+function buildClimateMitigationPayoffTradeoff(province, queuedMitigation, currentRisk, projectedRisk) {
+  if (!queuedMitigation) {
+    return null;
+  }
+
+  const tradeoffType = province.contested || province.occupied
+    ? 'exposition militaire'
+    : province.loyalty < 55
+      ? 'friction culturelle'
+      : queuedMitigation.tradeoff.includes('logistique') || queuedMitigation.tradeoff.includes('ressources')
+        ? 'pression économie/logistique'
+        : queuedMitigation.deadline === 'Ce tour' || queuedMitigation.deadline === 'Immédiat'
+          ? 'temps'
+          : queuedMitigation.tradeoff.includes('retarde') || queuedMitigation.tradeoff.includes('Compromis')
+            ? 'coût d’opportunité'
+            : null;
+
+  if (!tradeoffType) {
+    return null;
+  }
+
+  return {
+    benefit: `Bénéfice attendu: risque ${currentRisk} → ${projectedRisk}.`,
+    tradeoffType,
+    tradeoff: queuedMitigation.tradeoff,
+  };
+}
+
 function buildProvinceClimateRiskReductionForecast(province, shell, report = buildProvinceClimateTurnReport(province)) {
   const priorities = buildProvinceClimateMitigationPriorities(province, report);
   const queuedMitigation = priorities.find((priority) => priority.outcomeChange) ?? null;
@@ -1517,6 +1545,7 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
   const projectedRisk = getProjectedClimateRiskAfterMitigation(currentRisk, Boolean(queuedMitigation));
   const cues = buildProvinceClimateCountdownCues(province, report);
   const criticalDeadline = queuedMitigation?.deadline ?? cues.find((cue) => cue.level !== 'stable')?.countdown ?? 'Aucune échéance critique';
+  const payoffTradeoff = buildClimateMitigationPayoffTradeoff(province, queuedMitigation, currentRisk, projectedRisk);
   const remainingCascades = buildProvinceClimateCascadePreview(province, shell, report)
     .filter((cascade) => !queuedMitigation || !cascade.changesThisTurn)
     .slice(0, 2);
@@ -1528,6 +1557,7 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
       projectedRisk,
       criticalDeadline,
       queuedAction: null,
+      payoffTradeoff: null,
       summary: 'Aucune mitigation climat décisive en file: la réduction de risque projetée reste inchangée.',
       remainingCascades,
     };
@@ -1539,6 +1569,7 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
     projectedRisk,
     criticalDeadline,
     queuedAction: queuedMitigation.option,
+    payoffTradeoff,
     summary: `${queuedMitigation.option} projette ${currentRisk} → ${projectedRisk} avant ${criticalDeadline}.`,
     remainingCascades: remainingCascades.length > 0 ? remainingCascades : [{
       type: 'surveillance résiduelle',
@@ -1565,6 +1596,12 @@ function renderProvinceClimateRiskReductionForecast(province, shell) {
         <b>${forecast.projectedRisk}</b>
       </div>
       <p>${forecast.summary}</p>
+      ${forecast.payoffTradeoff ? `
+        <div class="province-climate-risk-forecast__payoff">
+          <span>${forecast.payoffTradeoff.benefit}</span>
+          <small><b>${forecast.payoffTradeoff.tradeoffType}</b> · ${forecast.payoffTradeoff.tradeoff}</small>
+        </div>
+      ` : ''}
       <div class="province-climate-risk-forecast__residuals">
         ${forecast.remainingCascades.map((cascade) => `
           <small><b>${cascade.type}</b> · ${cascade.scope}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3344,6 +3344,23 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.province-climate-risk-forecast__payoff {
+  display: grid;
+  gap: 4px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.32);
+  border: 1px solid rgba(74, 222, 128, 0.2);
+}
+.province-climate-risk-forecast__payoff span {
+  color: #dcfce7;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-climate-risk-forecast__payoff small {
+  color: #fde68a;
+  line-height: 1.35;
+}
 .province-climate-risk-forecast__residuals {
   display: grid;
   gap: 3px;


### PR DESCRIPTION
Epsilon:

## Summary
- Adds a payoff-vs-tradeoff comparison to the selected-province climate risk forecast when mitigation data supports it.
- Reuses the queued mitigation forecast to show expected risk reduction alongside one likely drawback category: time, economy/logistics pressure, cultural friction, military exposure, or opportunity cost.
- Keeps the empty/no-confident-tradeoff path quiet so no drawback is shown without support.

## Testing
- npm test -- test/ui/climate/webClimateRiskReductionForecast.test.js test/ui/climate/webClimateCascadePreview.test.js
- node --check web/app.js
- npm test

Fixes loo469/historia#567