### PR TITLE
Alpha: highlight front stability drivers

### DIFF
--- a/test/ui/war/webProjectedFrontStabilityDrivers.test.js
+++ b/test/ui/war/webProjectedFrontStabilityDrivers.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('projected front stability forecast explains the top change drivers', () => {
+  assert.match(webAppSource, /function buildFrontStabilityDrivers/);
+  assert.match(webAppSource, /drivers = buildFrontStabilityDrivers/);
+  assert.match(webAppSource, /Pourquoi ça change/);
+  assert.match(webAppSource, /Facteurs de variation de stabilité/);
+  assert.match(webAppSource, /Pression/);
+  assert.match(webAppSource, /Appui/);
+  assert.match(webAppSource, /Fatigue \/ supply/);
+  assert.match(webAppSource, /Moral/);
+  assert.match(webAppSource, /Front voisin/);
+  assert.match(webAppSource, /Terrain/);
+  assert.match(webAppSource, /drivers\.slice\(0, 3\)/);
+  assert.match(stylesSource, /\.projected-front-stability__drivers/);
+  assert.match(stylesSource, /\.projected-front-stability__driver/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2764,6 +2764,41 @@ function renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigue
   `;
 }
 
+function buildFrontStabilityDrivers(province, outcome, queuedAction, sensitiveNeighbor) {
+  const drivers = [];
+
+  if (province.contested || outcome.tone === 'danger') {
+    drivers.push({ label: 'Pression', value: province.contested ? 'front contesté actif' : outcome.summary });
+  }
+
+  if (queuedAction) {
+    drivers.push({
+      label: 'Appui',
+      value: queuedAction.status === 'ready'
+        ? `${queuedAction.label}: action prête à stabiliser le front.`
+        : queuedAction.status === 'risky'
+          ? `${queuedAction.label}: effet dépendant du timing et du contrôle.`
+          : `${queuedAction.label}: bloqueur encore présent avant résolution.`,
+    });
+  }
+
+  if (['collapsed', 'disrupted', 'strained'].includes(province.supplyLevel)) {
+    drivers.push({ label: 'Fatigue / supply', value: `Ravitaillement ${province.supplyLevel}: la projection reste fragile.` });
+  } else if (province.loyalty < 55) {
+    drivers.push({ label: 'Moral', value: `Loyauté ${province.loyalty}: attention à l’attrition locale.` });
+  }
+
+  if (sensitiveNeighbor) {
+    drivers.push({ label: 'Front voisin', value: `${sensitiveNeighbor.label} peut propager la pression si l’action échoue.` });
+  }
+
+  if (drivers.length === 0) {
+    drivers.push({ label: 'Terrain', value: 'Aucun signal critique: stabilité surtout portée par la position locale.' });
+  }
+
+  return drivers.slice(0, 3);
+}
+
 function buildProjectedFrontStability(province, shell, actionQueue) {
   const outcome = buildConflictOutcomePreview(province, shell);
   const queuedAction = actionQueue.find((entry) => entry.status === 'ready') ?? actionQueue[0] ?? null;
@@ -2772,6 +2807,7 @@ function buildProjectedFrontStability(province, shell, actionQueue) {
     .filter((neighbor) => neighbor && neighbor.controllingFactionId !== province.controllingFactionId);
   const sensitiveNeighbor = hostileNeighbors
     .sort((left, right) => (right.strategicValue - left.strategicValue) || left.label.localeCompare(right.label))[0] ?? null;
+  const drivers = buildFrontStabilityDrivers(province, outcome, queuedAction, sensitiveNeighbor);
 
   if (!queuedAction) {
     return {
@@ -2784,6 +2820,7 @@ function buildProjectedFrontStability(province, shell, actionQueue) {
         { label: 'Risque restant', value: outcome.summary },
         { label: 'Voisine sensible', value: sensitiveNeighbor?.label ?? 'aucune menace adjacente prioritaire' },
       ],
+      drivers,
     };
   }
 
@@ -2812,6 +2849,7 @@ function buildProjectedFrontStability(province, shell, actionQueue) {
       { label: 'Risque restant', value: residualRisk },
       { label: 'Voisine sensible', value: sensitiveNeighbor ? `${sensitiveNeighbor.label} · valeur ${sensitiveNeighbor.strategicValue}` : 'aucune menace adjacente prioritaire' },
     ],
+    drivers,
   };
 }
 
@@ -2834,6 +2872,15 @@ function renderProjectedFrontStability(province, shell, focusContext, intrigueVi
           <article class="projected-front-stability__line">
             <span>${line.label}</span>
             <strong>${line.value}</strong>
+          </article>
+        `).join('')}
+      </div>
+      <div class="projected-front-stability__drivers" aria-label="Facteurs de variation de stabilité">
+        <span>Pourquoi ça change</span>
+        ${projection.drivers.map((driver) => `
+          <article class="projected-front-stability__driver">
+            <strong>${driver.label}</strong>
+            <p>${driver.value}</p>
           </article>
         `).join('')}
       </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2561,6 +2561,33 @@ button { font: inherit; }
   margin-top: 4px;
   font-size: 12px;
 }
+.projected-front-stability__drivers {
+  display: grid;
+  gap: 7px;
+  padding-top: 2px;
+}
+.projected-front-stability__drivers > span {
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.projected-front-stability__driver {
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.projected-front-stability__driver strong {
+  display: block;
+  font-size: 12px;
+}
+.projected-front-stability__driver p {
+  margin: 3px 0 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
 .projected-front-stability--ready { border-color: rgba(74, 222, 128, 0.28); }
 .projected-front-stability--warning { border-color: rgba(251, 191, 36, 0.34); }
 .projected-front-stability--danger { border-color: rgba(251, 113, 133, 0.4); }


### PR DESCRIPTION
Alpha: Implements #563.

Summary:
- Adds compact “Pourquoi ça change” drivers to the projected front stability forecast.
- Surfaces up to three concrete causes from existing signals: pressure, support/action status, fatigue/supply, morale, neighboring front, or a neutral terrain fallback.
- Keeps missing/neutral data graceful without noisy placeholders.

Tests:
- npm test

Zeta: PR prête pour revue. Merci de valider avant tout merge.
