### PR TITLE
Beta: identify logistics forecast bottlenecks

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -165,7 +165,82 @@ function getNeighborEffect(choiceId, route, localCity, neighbor, mainResource) {
 }
 
 
-function buildRecoveryTimeline(choice, route, localCity, mainResource) {
+
+function inferRecoveryBottleneck(choice, route, localCity, localTension) {
+  const neighborBottleneck = choice.neighborEffects.find((effect) => effect.tone !== 'low') ?? null;
+
+  if (!route.active) {
+    return {
+      type: 'damage',
+      label: 'dégâts route',
+      detail: `${route.routeName} reste interrompue: réparation nécessaire avant gain visible.`,
+      tone: 'high',
+    };
+  }
+
+  if (route.totalCapacity >= 9) {
+    return {
+      type: 'capacity',
+      label: 'capacité saturée',
+      detail: `${route.routeName} porte ${route.totalCapacity} charges: le débit limite la récupération.`,
+      tone: 'high',
+    };
+  }
+
+  if (localTension === 'high') {
+    return {
+      type: 'unrest',
+      label: 'stock critique',
+      detail: `${localCity.cityName} absorbe le stock disponible avant que le réseau se normalise.`,
+      tone: 'high',
+    };
+  }
+
+  if (route.riskLevel >= 70) {
+    return {
+      type: 'climate-pressure',
+      label: 'pression risque',
+      detail: `Risque ${route.riskLevel} autour de ${route.routeName}: sécurisation lente avant stabilisation.`,
+      tone: 'high',
+    };
+  }
+
+  if (route.riskLevel >= 55) {
+    return {
+      type: 'distance',
+      label: 'trajet exposé',
+      detail: `${route.routeName} reste long ou exposé: escorte requise pour raccourcir le délai.`,
+      tone: 'medium',
+    };
+  }
+
+  if (neighborBottleneck) {
+    return {
+      type: 'neighbor-dependency',
+      label: 'dépendance voisine',
+      detail: `${neighborBottleneck.route} près de ${neighborBottleneck.target} peut encore retarder le gain.`,
+      tone: neighborBottleneck.tone,
+    };
+  }
+
+  if (localTension === 'medium') {
+    return {
+      type: 'unrest',
+      label: 'stock sous tension',
+      detail: `${localCity.cityName} demande un tampon local avant amélioration nette.`,
+      tone: 'medium',
+    };
+  }
+
+  return {
+    type: 'none',
+    label: 'aucun goulot clair',
+    detail: 'Aucun ralentisseur dominant détecté pour cette projection.',
+    tone: 'low',
+  };
+}
+
+function buildRecoveryTimeline(choice, route, localCity, mainResource, localTension) {
   const firstBottleneck = choice.neighborEffects.find((effect) => effect.tone !== 'low') ?? choice.neighborEffects[0] ?? null;
   const nextTurnLabel = choice.choiceId === 'repair'
     ? (!route.active ? 'route rouverte' : 'fragilité réduite')
@@ -182,6 +257,7 @@ function buildRecoveryTimeline(choice, route, localCity, mainResource) {
         ? Math.max(5, route.riskLevel - 6)
         : Math.max(5, route.riskLevel - 8);
   const riskTone = remainingRisk >= 55 || firstBottleneck?.tone === 'medium' ? 'medium' : 'low';
+  const bottleneck = inferRecoveryBottleneck(choice, route, localCity, localTension);
 
   return [
     {
@@ -195,11 +271,13 @@ function buildRecoveryTimeline(choice, route, localCity, mainResource) {
       detail: firstBottleneck
         ? `${nextTurnLabel}; ${firstBottleneck.label} sur ${firstBottleneck.route} près de ${firstBottleneck.target}.`
         : `${nextTurnLabel}; aucune route voisine critique détectée.`,
+      bottleneck: bottleneck.type === 'neighbor-dependency' ? bottleneck : null,
     },
     {
       step: 'Risque restant',
       tone: riskTone,
       detail: `Risque estimé ${remainingRisk} sur ${route.routeName}; ${firstBottleneck ? `${firstBottleneck.route} reste le goulot à surveiller.` : `${localCity.cityName} garde ${mainResource.label} sous veille.`}`,
+      bottleneck,
     },
   ];
 }
@@ -259,7 +337,8 @@ function buildRecoveryChoices(route, localCity, localTension, mainResource, rout
       recommended: index === 0,
       comparison: index === 0 ? 'meilleur levier immédiat' : `moins urgent: ${topChoice.blocker} prioritaire`,
       neighborEffects,
-      timeline: buildRecoveryTimeline({ ...choice, neighborEffects }, route, localCity, mainResource),
+      bottleneck: inferRecoveryBottleneck({ ...choice, neighborEffects }, route, localCity, localTension),
+      timeline: buildRecoveryTimeline({ ...choice, neighborEffects }, route, localCity, mainResource, localTension),
     };
   });
 }
@@ -365,7 +444,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
     recoveryChoiceCount: recommended.recoveryChoices.length,
     timelineStatus: hasBlocker ? 'queued' : 'empty',
     timelineSummary: hasBlocker
-      ? `${recommended.recoveryChoices[0].label}: amélioration visible au prochain tour, risque restant ${recommended.recoveryChoices[0].timeline[2].detail}`
+      ? `${recommended.recoveryChoices[0].label}: amélioration visible au prochain tour; goulot ${recommended.recoveryChoices[0].bottleneck.label}. ${recommended.recoveryChoices[0].timeline[2].detail}`
       : 'Aucune action route/logistique en file: timeline vide.',
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -74,6 +74,7 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.recoveryChoiceCount, 4);
   assert.equal(preview.timelineStatus, 'queued');
   assert.match(preview.timelineSummary, /prochain tour/);
+  assert.match(preview.timelineSummary, /goulot/);
   assert.ok(preview.options[0].recoveryChoices.length >= 2);
   assert.equal(preview.options[0].recoveryChoices[0].recommended, true);
   assert.match(preview.options[0].recoveryChoices[0].benefit, /Outils|River Gate|Ember Line/);
@@ -84,6 +85,9 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.ok(['congestion déplacée', 'hub soulagé', 'route toujours fragile', 'stockpile consommé', 'hub priorisé', 'effet réseau limité'].includes(preview.options[0].recoveryChoices[0].neighborEffects[0].label));
   assert.deepEqual(preview.options[0].recoveryChoices[0].timeline.map((step) => step.step), ['Effet immédiat', 'Prochain tour', 'Risque restant']);
   assert.match(preview.options[0].recoveryChoices[0].timeline[2].detail, /goulot|veille|Risque estimé/);
+  assert.equal(preview.options[0].recoveryChoices[0].bottleneck.type, 'capacity');
+  assert.equal(preview.options[0].recoveryChoices[0].bottleneck.label, 'capacité saturée');
+  assert.equal(preview.options[0].recoveryChoices[0].timeline[2].bottleneck.label, 'capacité saturée');
 });
 
 test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and impact labels', () => {
@@ -99,6 +103,7 @@ test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and i
   assert.deepEqual(option.recoveryChoices.map((choice) => choice.choiceId).sort(), ['economic-priority', 'repair', 'reroute', 'stockpile']);
   assert.ok(option.recoveryChoices.every((choice) => Array.isArray(choice.neighborEffects)));
   assert.ok(option.recoveryChoices.some((choice) => choice.neighborEffects.some((effect) => effect.target === 'Iron Plain')));
+  assert.ok(option.recoveryChoices.every((choice) => choice.bottleneck && choice.bottleneck.detail.length > 0));
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
@@ -127,6 +132,8 @@ test('buildProvinceLogisticsChoicePreview exposes stable local route causes', ()
   assert.equal(preview.options[0].causeLabel, 'logistique stable');
   assert.match(preview.options[0].cause, /Safe Road/);
   assert.match(preview.options[0].cause, /River Gate/);
+  assert.equal(preview.options[0].recoveryChoices[0].bottleneck.type, 'none');
+  assert.match(preview.options[0].recoveryChoices[0].bottleneck.detail, /Aucun ralentisseur/);
 });
 
 test('buildProvinceLogisticsChoicePreview validates options', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -14,12 +14,15 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /province-logistics-recovery-comparison/);
   assert.match(webAppSource, /choice\.benefit/);
   assert.match(webAppSource, /choice\.blocker/);
+  assert.match(webAppSource, /choice\.bottleneck/);
+  assert.match(webAppSource, /Goulot/);
   assert.match(webAppSource, /choice\.rationale/);
   assert.match(webAppSource, /province-logistics-timeline-summary/);
   assert.match(webAppSource, /Timeline récupération/);
   assert.match(webAppSource, /province-logistics-recovery-timeline/);
   assert.match(webAppSource, /choice\.timeline/);
   assert.match(webAppSource, /step\.detail/);
+  assert.match(webAppSource, /step\.bottleneck/);
   assert.match(webAppSource, /province-logistics-neighbor-effects/);
   assert.match(webAppSource, /effect\.detail/);
   assert.match(webAppSource, /effect\.target/);
@@ -32,6 +35,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-recovery-comparison/);
   assert.match(stylesSource, /province-logistics-recovery--high/);
   assert.match(stylesSource, /province-logistics-recovery--medium/);
+  assert.match(stylesSource, /province-logistics-bottleneck--high/);
+  assert.match(stylesSource, /province-logistics-bottleneck--medium/);
+  assert.match(stylesSource, /province-logistics-bottleneck--low/);
   assert.match(stylesSource, /province-logistics-timeline-summary--queued/);
   assert.match(stylesSource, /province-logistics-timeline-summary--empty/);
   assert.match(stylesSource, /province-logistics-recovery-timeline__step--medium/);

--- a/web/app.js
+++ b/web/app.js
@@ -1227,12 +1227,14 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                   </div>
                   <p>${choice.benefit}</p>
                   <small>Contrainte: ${choice.blocker} · ${choice.rationale}</small>
+                  <small class="province-logistics-bottleneck province-logistics-bottleneck--${choice.bottleneck.tone}">Goulot: ${choice.bottleneck.label} · ${choice.bottleneck.detail}</small>
                   ${choice.timeline.length > 0 ? `
                     <ol class="province-logistics-recovery-timeline" aria-label="Timeline de récupération logistique">
                       ${choice.timeline.map((step) => `
                         <li class="province-logistics-recovery-timeline__step province-logistics-recovery-timeline__step--${step.tone}">
                           <b>${step.step}</b>
                           <span>${step.detail}</span>
+                          ${step.bottleneck ? `<small>Goulot: ${step.bottleneck.label}</small>` : ''}
                         </li>
                       `).join('')}
                     </ol>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3106,6 +3106,17 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.province-logistics-bottleneck {
+  display: inline-block;
+  margin-top: 3px;
+  padding: 4px 6px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.56);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-logistics-bottleneck--high { border-color: rgba(251, 113, 133, 0.36); color: #fecdd3; }
+.province-logistics-bottleneck--medium { border-color: rgba(245, 158, 11, 0.32); color: #fde68a; }
+.province-logistics-bottleneck--low { border-color: rgba(74, 222, 128, 0.22); color: #bbf7d0; }
 .province-logistics-recovery-timeline {
   display: grid;
   gap: 5px;
@@ -3128,11 +3139,13 @@ button { font: inherit; }
   color: #f8fafc;
   font-size: 11px;
 }
-.province-logistics-recovery-timeline__step span {
+.province-logistics-recovery-timeline__step span,
+.province-logistics-recovery-timeline__step small {
   color: #cbd5e1;
   font-size: 11px;
   line-height: 1.3;
 }
+.province-logistics-recovery-timeline__step small { color: #fde68a; }
 .province-logistics-neighbor-effects {
   display: grid;
   gap: 5px;


### PR DESCRIPTION
Beta: Implements #564.

## Summary
- infers the primary logistics recovery bottleneck for route forecasts (capacity, damage, stock/unrest pressure, exposed route risk, neighbor dependency, or none)
- adds short bottleneck copy to recovery summaries and timeline steps without introducing a new simulation subsystem
- renders compact bottleneck badges in the province logistics panel and updates focused tests

## Tests
- npm test
- npm test -- --test-reporter=spec test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.