### PR TITLE
Gamma: add culture recommendation confidence cues

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -236,6 +236,48 @@ function buildRippleEffects(hint, recommendedAction, focusTarget, urgency) {
   return baseEffects.slice(0, 3);
 }
 
+
+function buildConfidenceCue(hint, recommendedAction, urgency, rippleEffects) {
+  if (hint.status === 'missing') {
+    return {
+      level: 'risky',
+      label: 'Confiance risquée',
+      dissent: 'Signal culturel manquant',
+      summary: `${hint.cultureName}: recommandation à considérer comme pari assumé.`,
+    };
+  }
+
+  if (hint.tone === 'risk' || rippleEffects.some((effect) => effect.tone === 'risky')) {
+    return {
+      level: 'risky',
+      label: 'Confiance risquée',
+      dissent: urgency.sourceLabel ?? recommendedAction.source ?? 'Propagation fragile',
+      summary: `Risque visible: propagation fragile si la file change.`,
+    };
+  }
+
+  if (hint.status === 'possible' || rippleEffects.some((effect) => effect.tone === 'uncertain')) {
+    const dissent = hint.tone === 'research'
+      ? 'Recherche encore partielle'
+      : urgency.window === '2+ tours'
+        ? 'Fenêtre encore lointaine'
+        : 'Effet local à confirmer';
+    return {
+      level: 'mixed',
+      label: 'Confiance mixte',
+      dissent,
+      summary: `${dissent}: garder le signal visible sans sur-prioriser.`,
+    };
+  }
+
+  return {
+    level: 'high',
+    label: 'Confiance haute',
+    dissent: 'Aucune dissidence majeure',
+    summary: `Signal cohérent avec la fenêtre ${urgency.timingLabel ?? urgency.window}.`,
+  };
+}
+
 function summarizeHint(hint, actionLabel, urgency) {
   const provinceCopy = hint.regionId ? ` (${hint.regionId})` : '';
   const urgencyCopy = ` ${urgency.label.toLowerCase()} · ${urgency.window}.`;
@@ -266,6 +308,7 @@ function buildReminder(hint, actionLabel) {
   const recommendedAction = buildRecommendedAction(hint, focusTargetWithUrgency, urgency, actionLabel);
   const tradeoff = buildActionTradeoff(hint, recommendedAction, focusTargetWithUrgency, urgency);
   const rippleEffects = buildRippleEffects(hint, recommendedAction, focusTargetWithUrgency, urgency);
+  const confidenceCue = buildConfidenceCue(hint, recommendedAction, urgency, rippleEffects);
 
   return {
     reminderId: `${hint.status}:${hint.tone}:${hint.regionId}:${hint.label}:${actionLabel}`,
@@ -287,6 +330,8 @@ function buildReminder(hint, actionLabel) {
     rippleCopy: rippleEffects.length > 0
       ? rippleEffects.map((effect) => `${effect.targetLabel}: ${effect.summary}`).join(' | ')
       : 'Aucun effet de propagation culturel en file.',
+    confidenceCue,
+    confidenceCopy: `${confidenceCue.label} · ${confidenceCue.dissent}`,
     focusTarget: focusTargetWithUrgency,
     focusCopy: `${focusTarget.type}: ${focusTarget.label}`,
   };

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -91,6 +91,13 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
     [],
   ]);
   assert.equal(report.reminders[0].rippleCopy, 'Province river-gate: Ouverture des archives stabilise l’opportunité culturelle locale. | Timeline locale: Repère narratif maintenu dans la timeline locale.');
+  assert.deepEqual(report.reminders.map((reminder) => [reminder.confidenceCue.level, reminder.confidenceCue.label, reminder.confidenceCue.dissent]), [
+    ['high', 'Confiance haute', 'Aucune dissidence majeure'],
+    ['mixed', 'Confiance mixte', 'Recherche encore partielle'],
+    ['risky', 'Confiance risquée', 'Signal culturel manquant'],
+  ]);
+  assert.equal(report.reminders[1].confidenceCue.summary, 'Recherche encore partielle: garder le signal visible sans sur-prioriser.');
+  assert.equal(report.reminders[2].confidenceCopy, 'Confiance risquée · Signal culturel manquant');
   assert.deepEqual(report.reminders[0].urgency, {
     level: 'soon',
     label: 'Expire bientôt',

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -16,10 +16,15 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /reminder\.tradeoff\?\.summary/);
   assert.match(webAppSource, /culture-opportunity-reminder__ripples/);
   assert.match(webAppSource, /reminder\.rippleEffects/);
+  assert.match(webAppSource, /culture-opportunity-reminder__confidence/);
+  assert.match(webAppSource, /reminder\.confidenceCue\?\.summary/);
   assert.match(webAppSource, /Aucun effet de propagation culturel en file/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__reason/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__action/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__tradeoff/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__confidence--high/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__confidence--mixed/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__confidence--risky/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--positive/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--uncertain/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--risky/);

--- a/web/app.js
+++ b/web/app.js
@@ -951,6 +951,7 @@ function renderCultureOpportunityReminders(report) {
               <p>${reminder.summary}</p>
               <p class="culture-opportunity-reminder__action"><b>${reminder.recommendedAction?.label ?? 'Surveiller la fenêtre'}</b> · ${reminder.recommendedAction?.summary ?? reminder.actionCopy ?? reminder.summary}</p>
               <p class="culture-opportunity-reminder__tradeoff"><b>Compromis</b> · ${reminder.tradeoff?.summary ?? reminder.tradeoffCopy ?? 'Bénéfice culturel contre risque narratif.'}</p>
+              <p class="culture-opportunity-reminder__confidence culture-opportunity-reminder__confidence--${reminder.confidenceCue?.level ?? 'mixed'}"><b>${reminder.confidenceCue?.label ?? 'Confiance mixte'}</b> · ${reminder.confidenceCue?.summary ?? reminder.confidenceCopy ?? 'Effet culturel à confirmer.'}</p>
               <div class="culture-opportunity-reminder__ripples" aria-label="Effets de propagation culturelle">
                 <b>Propagation</b>
                 ${(reminder.rippleEffects ?? []).length > 0 ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -2667,6 +2667,18 @@ button { font: inherit; }
   color: #fde68a !important;
 }
 .culture-opportunity-reminder__tradeoff b { color: #fef3c7; }
+.culture-opportunity-reminder__confidence {
+  margin-top: 5px !important;
+  padding: 6px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.48);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: #e2e8f0 !important;
+}
+.culture-opportunity-reminder__confidence b { color: #f8fafc; }
+.culture-opportunity-reminder__confidence--high { border-color: rgba(74, 222, 128, 0.32); background: rgba(22, 163, 74, 0.09); }
+.culture-opportunity-reminder__confidence--mixed { border-color: rgba(56, 189, 248, 0.32); background: rgba(14, 165, 233, 0.08); }
+.culture-opportunity-reminder__confidence--risky { border-color: rgba(251, 191, 36, 0.34); background: rgba(217, 119, 6, 0.08); }
 .culture-opportunity-reminder__ripples {
   display: grid;
   gap: 5px;


### PR DESCRIPTION
Gamma: PR prête pour validation.

Scope #565:
- ajoute un cue compact de confiance aux recommandations culturelles (haute, mixte, risquée);
- expose une source courte de dissidence/incertitude quand le signal est partiel, fragile ou manquant;
- conserve les compromis et effets de propagation existants, sans rapport détaillé supplémentaire;
- met à jour les tests de dérivation et de rendu web.

Tests:
- `npm test`
- `npm test -- test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js`
- `node --check web/app.js`
- `node --check src/ui/culture/buildCultureOpportunityReminders.js`
- `git diff --check`

Zeta, peux-tu valider cette PR avant tout merge ?

Closes #565