### PR TITLE
Alpha: flag residual front risks

### DIFF
--- a/test/ui/war/webCriticalFrontRisks.test.js
+++ b/test/ui/war/webCriticalFrontRisks.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('front stability projection flags critical residual risks from the current queue', () => {
+  assert.match(webAppSource, /function buildCriticalFrontRiskWarnings/);
+  assert.match(webAppSource, /function renderCriticalFrontRiskWarnings/);
+  assert.match(webAppSource, /Risques restants/);
+  assert.match(webAppSource, /Risques critiques restants du front/);
+  assert.match(webAppSource, /Risque acceptable/);
+  assert.match(webAppSource, /Risque à surveiller/);
+  assert.match(webAppSource, /Risque critique avant validation/);
+  assert.match(webAppSource, /Fatigue \/ supply résiduelle/);
+  assert.match(webAppSource, /Pression voisine persistante/);
+  assert.match(webAppSource, /buildProjectedFrontStability\(province, shell, actionQueue\)/);
+  assert.match(webAppSource, /renderCriticalFrontRiskWarnings\(province, shell, focusContext, intrigueView\)/);
+  assert.match(stylesSource, /\.critical-front-risks/);
+  assert.match(stylesSource, /critical-front-risk--critical/);
+  assert.match(stylesSource, /critical-front-risk--watch/);
+  assert.match(stylesSource, /critical-front-risk--covered/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2985,6 +2985,90 @@ function renderProjectedFrontStability(province, shell, focusContext, intrigueVi
   `;
 }
 
+function buildCriticalFrontRiskWarnings(province, projection) {
+  const risks = [];
+  const hasDriver = (label) => projection.drivers.some((driver) => driver.label === label);
+
+  if (projection.tone === 'danger') {
+    risks.push({
+      tone: 'critical',
+      label: 'Risque critique avant validation',
+      summary: 'Le plan laisse une brèche ou une perte de contrôle probable.',
+      driver: projection.drivers[0]?.label ?? 'Projection',
+    });
+  } else if (projection.tone === 'warning') {
+    risks.push({
+      tone: 'watch',
+      label: 'Risque à surveiller',
+      summary: 'La stabilité reste partielle: confirmer l’appui avant fin de tour.',
+      driver: projection.drivers[0]?.label ?? 'Projection',
+    });
+  }
+
+  if (hasDriver('Fatigue / supply')) {
+    risks.push({
+      tone: ['collapsed', 'disrupted'].includes(province.supplyLevel) ? 'critical' : 'watch',
+      label: 'Fatigue / supply résiduelle',
+      summary: `Ravitaillement ${province.supplyLevel}: l’action peut rester difficile à rattraper au tour suivant.`,
+      driver: 'Fatigue / supply',
+    });
+  }
+
+  if (hasDriver('Front voisin')) {
+    risks.push({
+      tone: projection.tone === 'ready' ? 'watch' : 'critical',
+      label: 'Pression voisine persistante',
+      summary: 'Un front adjacent peut propager la pression malgré l’action en file.',
+      driver: 'Front voisin',
+    });
+  }
+
+  if (risks.length === 0) {
+    risks.push({
+      tone: 'covered',
+      label: 'Risque acceptable',
+      summary: 'Le plan couvre correctement le front pour ce tour.',
+      driver: projection.drivers[0]?.label ?? 'Terrain',
+    });
+  }
+
+  const rank = { critical: 1, watch: 2, covered: 3 };
+  return risks
+    .sort((left, right) => rank[left.tone] - rank[right.tone] || left.label.localeCompare(right.label))
+    .slice(0, 3);
+}
+
+function renderCriticalFrontRiskWarnings(province, shell, focusContext, intrigueView = null) {
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const projection = buildProjectedFrontStability(province, shell, actionQueue);
+  const risks = buildCriticalFrontRiskWarnings(province, projection);
+  const leadRisk = risks[0] ?? null;
+
+  return `
+    <section class="critical-front-risks critical-front-risks--${leadRisk?.tone ?? 'covered'}" aria-label="Risques critiques restants du front">
+      <div class="critical-front-risks__header">
+        <div>
+          <span>Risques restants</span>
+          <strong>${leadRisk?.label ?? 'Risque acceptable'}</strong>
+        </div>
+        <small>${risks.length} signal${risks.length > 1 ? 's' : ''}</small>
+      </div>
+      <div class="critical-front-risks__list">
+        ${risks.map((risk) => `
+          <article class="critical-front-risk critical-front-risk--${risk.tone}">
+            <div>
+              <strong>${risk.label}</strong>
+              <code>${risk.driver}</code>
+            </div>
+            <p>${risk.summary}</p>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
+
 
 function buildConflictReadinessWarnings(shell, intrigueView = null) {
   return shell.provinces
@@ -3347,6 +3431,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView)}
       ${renderProjectedFrontStability(province, shell, focusContext, intrigueView)}
+      ${renderCriticalFrontRiskWarnings(province, shell, focusContext, intrigueView)}
       ${renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView)}
       ${renderProvinceEconomyBudgetPreview(province, economyView, shell, focusContext, intrigueView)}
       ${renderResolvedConflictDeltas(province, shell, focusContext, intrigueView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -2592,6 +2592,63 @@ button { font: inherit; }
 .projected-front-stability--warning { border-color: rgba(251, 191, 36, 0.34); }
 .projected-front-stability--danger { border-color: rgba(251, 113, 133, 0.4); }
 .projected-front-stability--neutral { border-color: rgba(148, 163, 184, 0.22); }
+.critical-front-risks {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(127, 29, 29, 0.18));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+.critical-front-risks__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.critical-front-risks__header span,
+.critical-front-risks__header small {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.critical-front-risks__header strong {
+  display: block;
+  margin-top: 3px;
+}
+.critical-front-risks__list {
+  display: grid;
+  gap: 8px;
+}
+.critical-front-risk {
+  padding: 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.critical-front-risk div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.critical-front-risk code {
+  color: #bae6fd;
+  font-size: 11px;
+}
+.critical-front-risk p {
+  margin: 5px 0 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.critical-front-risks--critical,
+.critical-front-risk--critical { border-color: rgba(251, 113, 133, 0.42); }
+.critical-front-risks--watch,
+.critical-front-risk--watch { border-color: rgba(251, 191, 36, 0.34); }
+.critical-front-risks--covered,
+.critical-front-risk--covered { border-color: rgba(74, 222, 128, 0.28); }
 .culture-opportunity-reminders {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
Alpha: Implements #573.

Summary:
- Adds a compact “Risques restants” block for the selected front after the current military queue.
- Reuses projected stability and its existing drivers to classify covered, watch, and critical residual risks.
- Prioritizes up to three short warnings for blocked/risky plans, fatigue/supply, and neighboring pressure, with a calm covered state when the plan is acceptable.

Tests:
- npm test

Zeta: PR prête pour revue. Merci de valider avant tout merge.
