### PR TITLE
Beta: show downstream logistics shortages

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -282,6 +282,67 @@ function buildRecoveryTimeline(choice, route, localCity, mainResource, localTens
   ];
 }
 
+
+function buildDownstreamShortages(choice, route, localCity, localTension, mainResource) {
+  const pressureEffects = choice.neighborEffects.filter((effect) => effect.tone !== 'low').slice(0, 2);
+
+  if (pressureEffects.length > 0) {
+    return pressureEffects.map((effect) => {
+      const aggravated = choice.choiceId === 'stockpile' || choice.bottleneck.type === 'capacity';
+      const displaced = effect.label === 'congestion déplacée' || choice.choiceId === 'reroute' || choice.bottleneck.type === 'neighbor-dependency';
+      const status = aggravated ? 'aggravée' : displaced ? 'déplacée' : 'inconnue';
+
+      return {
+        target: effect.target,
+        route: effect.route,
+        resource: mainResource.label,
+        status,
+        tone: aggravated ? 'high' : 'medium',
+        detail: status === 'aggravée'
+          ? `${effect.target} risque de manquer de ${mainResource.label}: ${effect.label} maintient la pression aval.`
+          : status === 'déplacée'
+            ? `${effect.target} récupère une partie de la pression de ${localCity.cityName}; ${effect.route} reste à surveiller.`
+            : `${effect.target} manque de signal clair: ${effect.detail}`,
+      };
+    });
+  }
+
+  if (localTension !== 'low') {
+    const resolved = choice.choiceId === 'stockpile' || choice.choiceId === 'economic-priority';
+
+    return [{
+      target: localCity.cityName,
+      route: route.routeName,
+      resource: mainResource.label,
+      status: resolved ? 'résolue' : 'inconnue',
+      tone: resolved ? 'low' : 'medium',
+      detail: resolved
+        ? `${mainResource.label} couvert localement; aucune pénurie aval nette détectée.`
+        : `${localCity.cityName} reste sous tension: confirmer le stock aval après l'action.`,
+    }];
+  }
+
+  if (choice.bottleneck.type === 'none') {
+    return [{
+      target: localCity.cityName,
+      route: route.routeName,
+      resource: mainResource.label,
+      status: 'résolue',
+      tone: 'low',
+      detail: `${mainResource.label} reste couvert; aucune pénurie aval claire détectée.`,
+    }];
+  }
+
+  return [{
+    target: localCity.cityName,
+    route: route.routeName,
+    resource: mainResource.label,
+    status: 'inconnue',
+    tone: 'medium',
+    detail: `Données aval insuffisantes: vérifier ${mainResource.label} après ${choice.label}.`,
+  }];
+}
+
 function buildRecoveryChoices(route, localCity, localTension, mainResource, routeCause, neighborContexts = []) {
   const choices = [
     {
@@ -331,14 +392,17 @@ function buildRecoveryChoices(route, localCity, localTension, mainResource, rout
 
   return rankedChoices.map((choice, index) => {
     const neighborEffects = neighborContexts.map((neighbor) => getNeighborEffect(choice.choiceId, route, localCity, neighbor, mainResource));
+    const bottleneck = inferRecoveryBottleneck({ ...choice, neighborEffects }, route, localCity, localTension);
+    const enrichedChoice = { ...choice, neighborEffects, bottleneck };
 
     return {
       ...choice,
       recommended: index === 0,
       comparison: index === 0 ? 'meilleur levier immédiat' : `moins urgent: ${topChoice.blocker} prioritaire`,
       neighborEffects,
-      bottleneck: inferRecoveryBottleneck({ ...choice, neighborEffects }, route, localCity, localTension),
-      timeline: buildRecoveryTimeline({ ...choice, neighborEffects }, route, localCity, mainResource, localTension),
+      bottleneck,
+      timeline: buildRecoveryTimeline(enrichedChoice, route, localCity, mainResource, localTension),
+      downstreamShortages: buildDownstreamShortages(enrichedChoice, route, localCity, localTension, mainResource),
     };
   });
 }
@@ -399,7 +463,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const resourceLabelById = requireObject(normalizedOptions.resourceLabelById ?? {}, 'ProvinceLogisticsChoicePreview resourceLabelById');
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -430,6 +494,8 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       recommendedOptionId: null,
       timelineStatus: 'empty',
       timelineSummary: 'Aucune action route/logistique en file: timeline vide.',
+      downstreamStatus: 'neutre',
+      downstreamSummary: 'Aucune pénurie aval claire détectée.',
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
       options: [],
@@ -446,6 +512,10 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
     timelineSummary: hasBlocker
       ? `${recommended.recoveryChoices[0].label}: amélioration visible au prochain tour; goulot ${recommended.recoveryChoices[0].bottleneck.label}. ${recommended.recoveryChoices[0].timeline[2].detail}`
       : 'Aucune action route/logistique en file: timeline vide.',
+    downstreamStatus: hasBlocker ? recommended.recoveryChoices[0].downstreamShortages[0]?.status ?? 'inconnue' : 'neutre',
+    downstreamSummary: hasBlocker
+      ? `${recommended.recoveryChoices[0].downstreamShortages[0]?.status ?? 'inconnue'}: ${recommended.recoveryChoices[0].downstreamShortages[0]?.detail ?? 'Aucune pénurie aval claire détectée.'}`
+      : 'Aucune pénurie aval claire détectée.',
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker
       ? `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.cause} ${recommended.recoveryChoices[0].label} est prioritaire car ${recommended.recoveryChoices[0].benefit}`

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -75,6 +75,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.timelineStatus, 'queued');
   assert.match(preview.timelineSummary, /prochain tour/);
   assert.match(preview.timelineSummary, /goulot/);
+  assert.match(preview.downstreamSummary, /manquer|pression|pénurie|aval/);
+  assert.ok(['aggravée', 'déplacée', 'résolue', 'inconnue'].includes(preview.downstreamStatus));
   assert.ok(preview.options[0].recoveryChoices.length >= 2);
   assert.equal(preview.options[0].recoveryChoices[0].recommended, true);
   assert.match(preview.options[0].recoveryChoices[0].benefit, /Outils|River Gate|Ember Line/);
@@ -88,6 +90,9 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.options[0].recoveryChoices[0].bottleneck.type, 'capacity');
   assert.equal(preview.options[0].recoveryChoices[0].bottleneck.label, 'capacité saturée');
   assert.equal(preview.options[0].recoveryChoices[0].timeline[2].bottleneck.label, 'capacité saturée');
+  assert.ok(preview.options[0].recoveryChoices[0].downstreamShortages.length >= 1);
+  assert.equal(preview.options[0].recoveryChoices[0].downstreamShortages[0].status, 'aggravée');
+  assert.match(preview.options[0].recoveryChoices[0].downstreamShortages[0].detail, /Outils|pression aval|manquer/);
 });
 
 test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and impact labels', () => {
@@ -104,6 +109,8 @@ test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and i
   assert.ok(option.recoveryChoices.every((choice) => Array.isArray(choice.neighborEffects)));
   assert.ok(option.recoveryChoices.some((choice) => choice.neighborEffects.some((effect) => effect.target === 'Iron Plain')));
   assert.ok(option.recoveryChoices.every((choice) => choice.bottleneck && choice.bottleneck.detail.length > 0));
+  assert.ok(option.recoveryChoices.every((choice) => Array.isArray(choice.downstreamShortages)));
+  assert.ok(option.recoveryChoices.some((choice) => choice.downstreamShortages.some((shortage) => ['aggravée', 'déplacée', 'résolue', 'inconnue'].includes(shortage.status))));
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
@@ -113,6 +120,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.deepEqual(preview.options, []);
   assert.equal(preview.status, 'stable');
   assert.equal(preview.timelineStatus, 'empty');
+  assert.equal(preview.downstreamStatus, 'neutre');
+  assert.match(preview.downstreamSummary, /Aucune pénurie aval/);
   assert.match(preview.timelineSummary, /timeline vide/);
   assert.match(preview.summary, /Logistique stable/);
 });
@@ -134,6 +143,8 @@ test('buildProvinceLogisticsChoicePreview exposes stable local route causes', ()
   assert.match(preview.options[0].cause, /River Gate/);
   assert.equal(preview.options[0].recoveryChoices[0].bottleneck.type, 'none');
   assert.match(preview.options[0].recoveryChoices[0].bottleneck.detail, /Aucun ralentisseur/);
+  assert.equal(preview.options[0].recoveryChoices[0].downstreamShortages[0].status, 'résolue');
+  assert.match(preview.options[0].recoveryChoices[0].downstreamShortages[0].detail, /aucune pénurie aval/i);
 });
 
 test('buildProvinceLogisticsChoicePreview validates options', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -18,6 +18,10 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Goulot/);
   assert.match(webAppSource, /choice\.rationale/);
   assert.match(webAppSource, /province-logistics-timeline-summary/);
+  assert.match(webAppSource, /province-logistics-downstream-summary/);
+  assert.match(webAppSource, /Pénuries aval/);
+  assert.match(webAppSource, /choice\.downstreamShortages/);
+  assert.match(webAppSource, /shortage\.detail/);
   assert.match(webAppSource, /Timeline récupération/);
   assert.match(webAppSource, /province-logistics-recovery-timeline/);
   assert.match(webAppSource, /choice\.timeline/);
@@ -39,6 +43,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-bottleneck--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck--low/);
   assert.match(stylesSource, /province-logistics-timeline-summary--queued/);
+  assert.match(stylesSource, /province-logistics-downstream-summary--aggravée/);
+  assert.match(stylesSource, /province-logistics-downstream-summary--résolue/);
+  assert.match(stylesSource, /province-logistics-downstream-shortage--high/);
   assert.match(stylesSource, /province-logistics-timeline-summary--empty/);
   assert.match(stylesSource, /province-logistics-recovery-timeline__step--medium/);
   assert.match(stylesSource, /province-logistics-neighbor-effect--medium/);

--- a/web/app.js
+++ b/web/app.js
@@ -1209,6 +1209,10 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
         <b>Timeline récupération</b>
         <span>${preview.timelineSummary ?? 'Aucune action route/logistique en file.'}</span>
       </div>
+      <div class="province-logistics-downstream-summary province-logistics-downstream-summary--${preview.downstreamStatus ?? 'neutre'}">
+        <b>Pénuries aval</b>
+        <span>${preview.downstreamSummary ?? 'Aucune pénurie aval claire détectée.'}</span>
+      </div>
       ${preview.options.length > 0 ? `
         <div class="province-logistics-choice-list">
           ${preview.options.map((option) => `
@@ -1229,6 +1233,17 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                   <p>${choice.benefit}</p>
                   <small>Contrainte: ${choice.blocker} · ${choice.rationale}</small>
                   <small class="province-logistics-bottleneck province-logistics-bottleneck--${choice.bottleneck.tone}">Goulot: ${choice.bottleneck.label} · ${choice.bottleneck.detail}</small>
+                  ${choice.downstreamShortages.length > 0 ? `
+                    <ul class="province-logistics-downstream-shortages" aria-label="Pénuries aval prévues">
+                      ${choice.downstreamShortages.map((shortage) => `
+                        <li class="province-logistics-downstream-shortage province-logistics-downstream-shortage--${shortage.tone}">
+                          <b>${shortage.status}</b>
+                          <span>${shortage.target} · ${shortage.resource}</span>
+                          <small>${shortage.detail}</small>
+                        </li>
+                      `).join('')}
+                    </ul>
+                  ` : ''}
                   ${choice.timeline.length > 0 ? `
                     <ol class="province-logistics-recovery-timeline" aria-label="Timeline de récupération logistique">
                       ${choice.timeline.map((step) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -3069,13 +3069,29 @@ button { font: inherit; }
 }
 .province-logistics-timeline-summary--queued { border-color: rgba(125, 211, 252, 0.28); }
 .province-logistics-timeline-summary--empty { border-color: rgba(74, 222, 128, 0.18); }
-.province-logistics-timeline-summary b {
+.province-logistics-downstream-summary {
+  display: grid;
+  gap: 4px;
+  margin: 8px 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(8, 15, 28, 0.46);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.province-logistics-downstream-summary--aggravée { border-color: rgba(251, 113, 133, 0.36); }
+.province-logistics-downstream-summary--déplacée,
+.province-logistics-downstream-summary--inconnue { border-color: rgba(245, 158, 11, 0.32); }
+.province-logistics-downstream-summary--résolue,
+.province-logistics-downstream-summary--neutre { border-color: rgba(74, 222, 128, 0.2); }
+.province-logistics-timeline-summary b,
+.province-logistics-downstream-summary b {
   color: #bfdbfe;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
-.province-logistics-timeline-summary span {
+.province-logistics-timeline-summary span,
+.province-logistics-downstream-summary span {
   color: #dbeafe;
   font-size: 12px;
   line-height: 1.35;
@@ -3156,6 +3172,31 @@ button { font: inherit; }
 .province-logistics-bottleneck--high { border-color: rgba(251, 113, 133, 0.36); color: #fecdd3; }
 .province-logistics-bottleneck--medium { border-color: rgba(245, 158, 11, 0.32); color: #fde68a; }
 .province-logistics-bottleneck--low { border-color: rgba(74, 222, 128, 0.22); color: #bbf7d0; }
+.province-logistics-downstream-shortages {
+  display: grid;
+  gap: 5px;
+  margin: 5px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.province-logistics-downstream-shortage {
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  border-radius: 9px;
+  background: rgba(15, 23, 42, 0.48);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.province-logistics-downstream-shortage--high { border-color: rgba(251, 113, 133, 0.34); }
+.province-logistics-downstream-shortage--medium { border-color: rgba(245, 158, 11, 0.3); }
+.province-logistics-downstream-shortage--low { border-color: rgba(74, 222, 128, 0.2); }
+.province-logistics-downstream-shortage b { color: #fde68a; font-size: 11px; }
+.province-logistics-downstream-shortage span,
+.province-logistics-downstream-shortage small {
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.3;
+}
 .province-logistics-recovery-timeline {
   display: grid;
   gap: 5px;


### PR DESCRIPTION
Beta: Implements #574.

## Summary
- derives compact downstream shortage forecasts from existing recovery choices, neighbor effects, and bottlenecks
- distinguishes resolved, displaced, aggravated, unknown, and neutral shortage states without adding a simulation subsystem
- renders downstream shortage summary/details in the existing province logistics panel with focused tests

## Tests
- npm test
- npm test -- --test-reporter=spec test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.