### PR TITLE
Gamma: show culture inaction costs

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -237,6 +237,65 @@ function buildRippleEffects(hint, recommendedAction, focusTarget, urgency) {
 }
 
 
+
+function buildInactionCost(hint, recommendedAction, focusTarget, urgency) {
+  const window = urgency.timingLabel ?? urgency.window;
+  const source = recommendedAction.source ?? urgency.sourceLabel ?? focusTarget.label;
+  const isUrgent = urgency.level === 'soon' || urgency.window === 'ce tour' || hint.status === 'probable';
+
+  if (!isUrgent) {
+    return {
+      level: 'low',
+      label: 'Inaction tolérée',
+      source,
+      summary: 'Pas de perte culturelle claire si la recommandation attend.',
+    };
+  }
+
+  if (recommendedAction.code === 'follow-event') {
+    return {
+      level: 'closing',
+      label: 'Se ferme ce tour',
+      source,
+      summary: `${source} risque de sortir de la timeline locale sans action (${window}).`,
+    };
+  }
+
+  if (recommendedAction.code === 'accelerate-research') {
+    return {
+      level: 'degrades',
+      label: 'Recherche ralentie',
+      source,
+      summary: `${source} reste bloquée et perd son avance culturelle (${window}).`,
+    };
+  }
+
+  if (recommendedAction.code === 'protect-site') {
+    return {
+      level: 'degrades',
+      label: 'Site exposé',
+      source: focusTarget.label,
+      summary: `${focusTarget.label} peut se dégrader avant d’être exploité (${window}).`,
+    };
+  }
+
+  if (hint.tone === 'risk') {
+    return {
+      level: 'risky',
+      label: 'Tension culturelle',
+      source,
+      summary: `${hint.cultureName} garde une tension active si rien n’est mis en file (${window}).`,
+    };
+  }
+
+  return {
+    level: 'blocked',
+    label: 'Signal bloqué',
+    source,
+    summary: `${source} reste bloqué si aucune action culturelle n’est planifiée (${window}).`,
+  };
+}
+
 function buildConfidenceCue(hint, recommendedAction, urgency, rippleEffects) {
   if (hint.status === 'missing') {
     return {
@@ -309,6 +368,7 @@ function buildReminder(hint, actionLabel) {
   const tradeoff = buildActionTradeoff(hint, recommendedAction, focusTargetWithUrgency, urgency);
   const rippleEffects = buildRippleEffects(hint, recommendedAction, focusTargetWithUrgency, urgency);
   const confidenceCue = buildConfidenceCue(hint, recommendedAction, urgency, rippleEffects);
+  const inactionCost = buildInactionCost(hint, recommendedAction, focusTargetWithUrgency, urgency);
 
   return {
     reminderId: `${hint.status}:${hint.tone}:${hint.regionId}:${hint.label}:${actionLabel}`,
@@ -332,6 +392,8 @@ function buildReminder(hint, actionLabel) {
       : 'Aucun effet de propagation culturel en file.',
     confidenceCue,
     confidenceCopy: `${confidenceCue.label} · ${confidenceCue.dissent}`,
+    inactionCost,
+    inactionCopy: `${inactionCost.label} · ${inactionCost.summary}`,
     focusTarget: focusTargetWithUrgency,
     focusCopy: `${focusTarget.type}: ${focusTarget.label}`,
   };

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -98,6 +98,13 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
   ]);
   assert.equal(report.reminders[1].confidenceCue.summary, 'Recherche encore partielle: garder le signal visible sans sur-prioriser.');
   assert.equal(report.reminders[2].confidenceCopy, 'Confiance risquée · Signal culturel manquant');
+  assert.deepEqual(report.reminders.map((reminder) => [reminder.inactionCost.level, reminder.inactionCost.label]), [
+    ['closing', 'Se ferme ce tour'],
+    ['low', 'Inaction tolérée'],
+    ['low', 'Inaction tolérée'],
+  ]);
+  assert.equal(report.reminders[0].inactionCost.summary, 'Ouverture des archives risque de sortir de la timeline locale sans action (ce tour).');
+  assert.equal(report.reminders[1].inactionCopy, 'Inaction tolérée · Pas de perte culturelle claire si la recommandation attend.');
   assert.deepEqual(report.reminders[0].urgency, {
     level: 'soon',
     label: 'Expire bientôt',

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -18,6 +18,9 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /reminder\.rippleEffects/);
   assert.match(webAppSource, /culture-opportunity-reminder__confidence/);
   assert.match(webAppSource, /reminder\.confidenceCue\?\.summary/);
+  assert.match(webAppSource, /culture-opportunity-reminder__inaction/);
+  assert.match(webAppSource, /reminder\.inactionCost\?\.summary/);
+  assert.match(webAppSource, /Pas de perte culturelle claire/);
   assert.match(webAppSource, /Aucun effet de propagation culturel en file/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__reason/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__action/);
@@ -25,6 +28,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-opportunity-reminder__confidence--high/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__confidence--mixed/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__confidence--risky/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__inaction--closing/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__inaction--low/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--positive/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--uncertain/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--risky/);

--- a/web/app.js
+++ b/web/app.js
@@ -952,6 +952,7 @@ function renderCultureOpportunityReminders(report) {
               <p class="culture-opportunity-reminder__action"><b>${reminder.recommendedAction?.label ?? 'Surveiller la fenêtre'}</b> · ${reminder.recommendedAction?.summary ?? reminder.actionCopy ?? reminder.summary}</p>
               <p class="culture-opportunity-reminder__tradeoff"><b>Compromis</b> · ${reminder.tradeoff?.summary ?? reminder.tradeoffCopy ?? 'Bénéfice culturel contre risque narratif.'}</p>
               <p class="culture-opportunity-reminder__confidence culture-opportunity-reminder__confidence--${reminder.confidenceCue?.level ?? 'mixed'}"><b>${reminder.confidenceCue?.label ?? 'Confiance mixte'}</b> · ${reminder.confidenceCue?.summary ?? reminder.confidenceCopy ?? 'Effet culturel à confirmer.'}</p>
+              <p class="culture-opportunity-reminder__inaction culture-opportunity-reminder__inaction--${reminder.inactionCost?.level ?? 'low'}"><b>Inaction</b> · ${reminder.inactionCost?.summary ?? reminder.inactionCopy ?? 'Pas de perte culturelle claire si la recommandation attend.'}</p>
               <div class="culture-opportunity-reminder__ripples" aria-label="Effets de propagation culturelle">
                 <b>Propagation</b>
                 ${(reminder.rippleEffects ?? []).length > 0 ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -2706,6 +2706,20 @@ button { font: inherit; }
 .culture-opportunity-reminder__confidence--high { border-color: rgba(74, 222, 128, 0.32); background: rgba(22, 163, 74, 0.09); }
 .culture-opportunity-reminder__confidence--mixed { border-color: rgba(56, 189, 248, 0.32); background: rgba(14, 165, 233, 0.08); }
 .culture-opportunity-reminder__confidence--risky { border-color: rgba(251, 191, 36, 0.34); background: rgba(217, 119, 6, 0.08); }
+.culture-opportunity-reminder__inaction {
+  margin-top: 5px !important;
+  padding: 6px 7px;
+  border-radius: 10px;
+  background: rgba(30, 41, 59, 0.44);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: #cbd5e1 !important;
+}
+.culture-opportunity-reminder__inaction b { color: #f8fafc; }
+.culture-opportunity-reminder__inaction--closing { border-color: rgba(248, 113, 113, 0.36); background: rgba(127, 29, 29, 0.14); color: #fecaca !important; }
+.culture-opportunity-reminder__inaction--degrades,
+.culture-opportunity-reminder__inaction--risky,
+.culture-opportunity-reminder__inaction--blocked { border-color: rgba(251, 191, 36, 0.34); background: rgba(120, 53, 15, 0.12); color: #fde68a !important; }
+.culture-opportunity-reminder__inaction--low { border-color: rgba(148, 163, 184, 0.14); opacity: 0.82; }
 .culture-opportunity-reminder__ripples {
   display: grid;
   gap: 5px;


### PR DESCRIPTION
Gamma: PR prête pour validation.

Scope #575:
- ajoute un aperçu court du coût d’inaction pour les recommandations culturelles urgentes;
- relie le coût aux sources existantes: timeline/event, recherche, site, tension ou signal bloqué;
- garde un état discret quand l’inaction n’a pas de conséquence claire;
- conserve les compromis, propagation et confiance/dissidence déjà affichés.

Tests:
- `npm test`
- `npm test -- test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js`
- `node --check web/app.js`
- `node --check src/ui/culture/buildCultureOpportunityReminders.js`
- `git diff --check`

Zeta, peux-tu valider cette PR avant tout merge ?

Closes #575