### PR TITLE
Delta: suggest safe intrigue fallbacks

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -97,3 +97,21 @@ test('queued intrigue detection projection explains fog-safe exposure sources', 
   assert.match(stylesSource, /province-intrigue-detection-source--danger/);
   assert.match(stylesSource, /province-intrigue-detection-source--mitigated/);
 });
+
+test('risky queued intrigue responses suggest fog-safe fallback actions', () => {
+  assert.match(webAppSource, /function buildSafeIntrigueFallbackAction/);
+  assert.match(webAppSource, /Alternative intrigue sûre/);
+  assert.match(webAppSource, /Fallback prudent/);
+  assert.match(webAppSource, /Aucune alternative sûre connue/);
+  assert.match(webAppSource, /Réduire chaleur/);
+  assert.match(webAppSource, /Collecter renseignement/);
+  assert.match(webAppSource, /Temporiser/);
+  assert.match(webAppSource, /Contenir/);
+  assert.match(webAppSource, /Surveiller/);
+  assert.match(webAppSource, /Protège les canaux visibles avant toute révélation publique, sans nommer cellule ou cible/);
+  assert.match(webAppSource, /Clarifie le signal et teste la couverture avant un contact plus exposé/);
+  assert.match(webAppSource, /Réduit la fenêtre d’exposition sans dévoiler la menace réelle/);
+  assert.match(stylesSource, /province-intrigue-detection-fallback/);
+  assert.match(stylesSource, /province-intrigue-detection-fallback--ready/);
+  assert.match(stylesSource, /province-intrigue-detection-fallback--empty/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2472,6 +2472,64 @@ function buildIntrigueExposureSourceBreakdown(province, drillDown, response, loc
   return sources.slice(0, 3);
 }
 
+function buildSafeIntrigueFallbackAction(province, drillDown, response, projectionTone, confidence, rawDelta) {
+  if (!drillDown || !response) {
+    return {
+      empty: true,
+      action: 'Aucune alternative sûre connue',
+      detail: 'Attendre un signal confirmé avant de choisir une réponse intrigue.',
+    };
+  }
+
+  const riskyProjection = ['danger', 'warning'].includes(projectionTone) || ['partielle', 'brouillard'].includes(confidence) || rawDelta >= 8;
+
+  if (!riskyProjection) {
+    return {
+      empty: true,
+      action: 'Aucune alternative sûre connue',
+      detail: 'La réponse en file reste lisible; garder le plan actuel ou surveiller sans escalade.',
+    };
+  }
+
+  if (response.code === 'exposer') {
+    return {
+      empty: false,
+      action: 'Réduire chaleur',
+      detail: 'Protège les canaux visibles avant toute révélation publique, sans nommer cellule ou cible.',
+    };
+  }
+
+  if (response.code === 'infiltrer') {
+    return {
+      empty: false,
+      action: 'Collecter renseignement',
+      detail: 'Clarifie le signal et teste la couverture avant un contact plus exposé.',
+    };
+  }
+
+  if (response.code === 'contenir' && projectionTone === 'danger') {
+    return {
+      empty: false,
+      action: 'Temporiser',
+      detail: 'Préserve la marge de sécurité si le brouillard rend la contention trop visible.',
+    };
+  }
+
+  if (drillDown.criticality === 'critical' || drillDown.riskBand === 'high') {
+    return {
+      empty: false,
+      action: 'Contenir',
+      detail: 'Réduit la fenêtre d’exposition sans dévoiler la menace réelle.',
+    };
+  }
+
+  return {
+    empty: false,
+    action: 'Surveiller',
+    detail: 'Garde la province sous observation et clarifie le prochain signal sans ajouter de chaleur.',
+  };
+}
+
 function buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView) {
   const drillDown = findProvinceIntrigueDrillDown(province, intrigueView);
   const response = drillDown?.quickResponses?.find((candidate) => candidate.code === drillDown.recommendedResponseCode)
@@ -2491,6 +2549,7 @@ function buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intri
       deltaLabel: 'stable',
       fogLimit: 'Le brouillard conserve les cellules, relais et objectifs masqués.',
       sources: buildIntrigueExposureSourceBreakdown(province, drillDown, response, []),
+      fallback: buildSafeIntrigueFallbackAction(province, drillDown, response, 'masked', 'brouillard', 0),
     };
   }
 
@@ -2518,6 +2577,7 @@ function buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intri
   const tone = rawDelta < 0 ? 'mitigated' : afterRisk >= 60 ? 'danger' : afterRisk >= 40 ? 'warning' : 'watch';
   const deltaLabel = rawDelta < 0 ? `${rawDelta}` : `+${rawDelta}`;
   const sources = buildIntrigueExposureSourceBreakdown(province, drillDown, response, localOperations);
+  const fallback = buildSafeIntrigueFallbackAction(province, drillDown, response, tone, confidence, rawDelta);
 
   return {
     empty: false,
@@ -2532,6 +2592,7 @@ function buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intri
       ? 'Basé sur les opérations visibles; les relais non confirmés restent masqués.'
       : 'Projection prudente: source, cellule et objectif exacts restent masqués par le brouillard.',
     sources,
+    fallback,
   };
 }
 
@@ -2557,6 +2618,11 @@ function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intr
             <span>${source.detail}</span>
           </article>
         `).join('')}
+      </div>
+      <div class="province-intrigue-detection-fallback province-intrigue-detection-fallback--${projection.fallback.empty ? 'empty' : 'ready'}" aria-label="Alternative intrigue sûre">
+        <span>Fallback prudent</span>
+        <strong>${projection.fallback.action}</strong>
+        <small>${projection.fallback.detail}</small>
       </div>
       <small>${projection.fogLimit}</small>
     </section>

--- a/web/styles.css
+++ b/web/styles.css
@@ -6280,6 +6280,32 @@ button { font: inherit; }
   margin-top: 2px;
   color: var(--muted);
 }
+.province-intrigue-detection-fallback {
+  display: grid;
+  gap: 3px;
+  margin: 8px 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(8, 47, 73, 0.24);
+  border: 1px solid rgba(125, 211, 252, 0.22);
+}
+.province-intrigue-detection-fallback--ready {
+  border-color: rgba(34, 197, 94, 0.28);
+  background: rgba(20, 83, 45, 0.2);
+}
+.province-intrigue-detection-fallback--empty {
+  border-color: rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.28);
+}
+.province-intrigue-detection-fallback span {
+  color: #bae6fd;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.province-intrigue-detection-fallback small {
+  color: var(--muted);
+}
 
 .province-intrigue-risk-warnings {
   margin-top: 12px;


### PR DESCRIPTION
Delta: Implements #576.

Summary:
- Adds a fog-safe fallback action to queued intrigue detection projections when risk or confidence is unsafe.
- Suggests existing cautious actions: surveiller, réduire chaleur, collecter renseignement, temporiser, or contenir.
- Includes an explicit empty fallback state and compact styling.

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: Ready for validation before merge.