### PR TITLE
Epsilon: flag climate deadline coverage

### DIFF
--- a/test/ui/climate/webClimateRiskReductionForecast.test.js
+++ b/test/ui/climate/webClimateRiskReductionForecast.test.js
@@ -8,6 +8,8 @@ const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta
 test('selected province panel forecasts climate risk reduction after queued mitigation', () => {
   assert.match(webAppSource, /function getProjectedClimateRiskAfterMitigation/);
   assert.match(webAppSource, /function buildClimateMitigationPayoffTradeoff/);
+  assert.match(webAppSource, /function buildClimateMitigationDeadlineCoverage/);
+  assert.match(webAppSource, /function getClimateDeadlineResidualRisk/);
   assert.match(webAppSource, /function buildProvinceClimateRiskReductionForecast/);
   assert.match(webAppSource, /function renderProvinceClimateRiskReductionForecast/);
   assert.match(webAppSource, /Prévision de réduction du risque climatique après mitigation en file/);
@@ -22,6 +24,14 @@ test('selected province panel forecasts climate risk reduction after queued miti
   assert.match(webAppSource, /friction culturelle/);
   assert.match(webAppSource, /exposition militaire/);
   assert.match(webAppSource, /coût d’opportunité/);
+  assert.match(webAppSource, /deadlineCoverage/);
+  assert.match(webAppSource, /Aucune deadline critique active/);
+  assert.match(webAppSource, /juste à temps/);
+  assert.match(webAppSource, /trop tard pour/);
+  assert.match(webAppSource, /Risque résiduel/);
+  assert.match(webAppSource, /récolte: rupture de vivres locale probable/);
+  assert.match(webAppSource, /route: exposition logistique et militaire prolongée/);
+  assert.match(webAppSource, /stabilité: friction locale prolongée/);
   assert.match(webAppSource, /remainingCascades/);
   assert.match(webAppSource, /Aucune mitigation climat décisive en file/);
   assert.match(webAppSource, /surveillance résiduelle/);
@@ -33,5 +43,10 @@ test('selected province panel forecasts climate risk reduction after queued miti
   assert.match(stylesSource, /\.province-climate-risk-forecast--reduced/);
   assert.match(stylesSource, /\.province-climate-risk-forecast__meter/);
   assert.match(stylesSource, /\.province-climate-risk-forecast__payoff/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__deadline/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__deadline--covered/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__deadline--just-in-time/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__deadline--missed/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__deadline--calm/);
   assert.match(stylesSource, /\.province-climate-risk-forecast__residuals/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1557,6 +1557,94 @@ function buildClimateMitigationPayoffTradeoff(province, queuedMitigation, curren
   };
 }
 
+function getClimateMitigationDeadlineRank(deadline) {
+  if (deadline === 'Immédiat' || deadline === 'Ce tour') {
+    return 0;
+  }
+
+  if (deadline === 'Prochain tour') {
+    return 1;
+  }
+
+  if (deadline === 'Surveiller') {
+    return 2;
+  }
+
+  return 3;
+}
+
+function getClimateDeadlineResidualRisk(province, cue, cascades) {
+  const cascade = cascades[0] ?? null;
+
+  if (cascade) {
+    return `${cascade.type}: ${cascade.scope}`;
+  }
+
+  if (province.supplyLevel === 'collapsed') {
+    return 'récolte: rupture de vivres locale probable';
+  }
+
+  if (province.contested || province.occupied) {
+    return 'route: exposition logistique et militaire prolongée';
+  }
+
+  if (province.loyalty < 55) {
+    return 'stabilité: friction locale prolongée';
+  }
+
+  return cue?.label ? `anomalie prolongée: ${cue.label}` : 'anomalie prolongée: surveillance climat requise';
+}
+
+function buildClimateMitigationDeadlineCoverage(province, queuedMitigation, cues, cascades) {
+  const criticalCue = cues.find((cue) => cue.level === 'immediate' || cue.level === 'next-turn') ?? null;
+
+  if (!criticalCue) {
+    return {
+      state: 'calm',
+      label: 'Aucune deadline critique active',
+      detail: 'Le plan peut rester en surveillance sans urgence temporelle confirmée.',
+      residualRisk: null,
+    };
+  }
+
+  if (!queuedMitigation) {
+    return {
+      state: 'missed',
+      label: `${criticalCue.countdown}: aucune mitigation en file`,
+      detail: 'La deadline climat reste non couverte par le plan actuel.',
+      residualRisk: getClimateDeadlineResidualRisk(province, criticalCue, cascades),
+    };
+  }
+
+  const urgencyRank = criticalCue.level === 'immediate' ? 0 : 1;
+  const mitigationRank = getClimateMitigationDeadlineRank(queuedMitigation.deadline);
+
+  if (mitigationRank < urgencyRank) {
+    return {
+      state: 'covered',
+      label: `${queuedMitigation.deadline}: avant ${criticalCue.countdown}`,
+      detail: 'La mitigation arrive avant l’échéance climat visible.',
+      residualRisk: null,
+    };
+  }
+
+  if (mitigationRank === urgencyRank) {
+    return {
+      state: 'just-in-time',
+      label: `${queuedMitigation.deadline}: juste à temps`,
+      detail: 'Le plan couvre l’urgence, mais sans marge si un autre risque se dégrade.',
+      residualRisk: getClimateDeadlineResidualRisk(province, criticalCue, cascades),
+    };
+  }
+
+  return {
+    state: 'missed',
+    label: `${queuedMitigation.deadline}: trop tard pour ${criticalCue.countdown}`,
+    detail: 'La mitigation réduit le risque ensuite, mais ne couvre pas la deadline critique actuelle.',
+    residualRisk: getClimateDeadlineResidualRisk(province, criticalCue, cascades),
+  };
+}
+
 function buildProvinceClimateRiskReductionForecast(province, shell, report = buildProvinceClimateTurnReport(province)) {
   const priorities = buildProvinceClimateMitigationPriorities(province, report);
   const queuedMitigation = priorities.find((priority) => priority.outcomeChange) ?? null;
@@ -1568,6 +1656,7 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
   const remainingCascades = buildProvinceClimateCascadePreview(province, shell, report)
     .filter((cascade) => !queuedMitigation || !cascade.changesThisTurn)
     .slice(0, 2);
+  const deadlineCoverage = buildClimateMitigationDeadlineCoverage(province, queuedMitigation, cues, remainingCascades);
 
   if (!queuedMitigation) {
     return {
@@ -1577,6 +1666,7 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
       criticalDeadline,
       queuedAction: null,
       payoffTradeoff: null,
+      deadlineCoverage,
       summary: 'Aucune mitigation climat décisive en file: la réduction de risque projetée reste inchangée.',
       remainingCascades,
     };
@@ -1589,6 +1679,7 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
     criticalDeadline,
     queuedAction: queuedMitigation.option,
     payoffTradeoff,
+    deadlineCoverage,
     summary: `${queuedMitigation.option} projette ${currentRisk} → ${projectedRisk} avant ${criticalDeadline}.`,
     remainingCascades: remainingCascades.length > 0 ? remainingCascades : [{
       type: 'surveillance résiduelle',
@@ -1621,6 +1712,11 @@ function renderProvinceClimateRiskReductionForecast(province, shell) {
           <small><b>${forecast.payoffTradeoff.tradeoffType}</b> · ${forecast.payoffTradeoff.tradeoff}</small>
         </div>
       ` : ''}
+      <div class="province-climate-risk-forecast__deadline province-climate-risk-forecast__deadline--${forecast.deadlineCoverage.state}">
+        <span><b>Deadline</b> · ${forecast.deadlineCoverage.label}</span>
+        <small>${forecast.deadlineCoverage.detail}</small>
+        ${forecast.deadlineCoverage.residualRisk ? `<small><b>Risque résiduel</b> · ${forecast.deadlineCoverage.residualRisk}</small>` : ''}
+      </div>
       <div class="province-climate-risk-forecast__residuals">
         ${forecast.remainingCascades.map((cascade) => `
           <small><b>${cascade.type}</b> · ${cascade.scope}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3525,6 +3525,30 @@ button { font: inherit; }
   color: #fde68a;
   line-height: 1.35;
 }
+.province-climate-risk-forecast__deadline {
+  display: grid;
+  gap: 3px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+.province-climate-risk-forecast__deadline--covered { border-color: rgba(74, 222, 128, 0.28); }
+.province-climate-risk-forecast__deadline--just-in-time { border-color: rgba(251, 191, 36, 0.34); }
+.province-climate-risk-forecast__deadline--missed { border-color: rgba(248, 113, 113, 0.34); }
+.province-climate-risk-forecast__deadline--calm { border-color: rgba(125, 211, 252, 0.18); }
+.province-climate-risk-forecast__deadline span {
+  color: #e0f2fe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-climate-risk-forecast__deadline small {
+  color: #cbd5e1;
+  line-height: 1.35;
+}
+.province-climate-risk-forecast__deadline b {
+  color: #fef3c7;
+}
 .province-climate-risk-forecast__residuals {
   display: grid;
   gap: 3px;


### PR DESCRIPTION
Epsilon:

## Summary
- Adds deadline coverage status to the selected-province climate risk forecast.
- Indicates whether the queued mitigation arrives before the climate deadline, just in time, too late, or when no critical deadline is active.
- Shows one concise residual risk when the deadline is missed or marginless, reusing countdown cues, cascade previews, and existing province signals.

## Testing
- npm test -- test/ui/climate/webClimateRiskReductionForecast.test.js test/ui/climate/webClimateCascadePreview.test.js
- node --check web/app.js
- npm test

Fixes loo469/historia#577