### PR TITLE
Alpha: rank front priority provinces

### DIFF
--- a/test/ui/war/webFrontPriorityRanking.test.js
+++ b/test/ui/war/webFrontPriorityRanking.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('map ranks visible front provinces by next military priority', () => {
+  assert.match(webAppSource, /function buildFrontPriorityRanking/);
+  assert.match(webAppSource, /function renderFrontPriorityRanking/);
+  assert.match(webAppSource, /Priorités fronts/);
+  assert.match(webAppSource, /buildCriticalFrontRiskWarnings\(province, projection\)/);
+  assert.match(webAppSource, /buildProjectedFrontStability\(province, shell, actionQueue\)/);
+  assert.match(webAppSource, /blockedCount \* 12/);
+  assert.match(webAppSource, /urgence \$\{urgencyLabel\}/);
+  assert.match(webAppSource, /Passe en premier: cumul risque \/ stabilité le plus élevé/);
+  assert.match(webAppSource, /Après \$\{entries\[index - 1\]\.provinceLabel\}: score/);
+  assert.match(webAppSource, /renderFrontPriorityRanking\(shell, intrigueView\)/);
+  assert.match(stylesSource, /\.front-priority-ranking/);
+  assert.match(stylesSource, /\.front-priority--danger/);
+  assert.match(stylesSource, /\.front-priority--warning/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3248,6 +3248,112 @@ function renderCriticalFrontRiskWarnings(province, shell, focusContext, intrigue
 
 
 
+function buildFrontPriorityRanking(shell, intrigueView = null) {
+  const rankTone = { critical: 'danger', watch: 'warning', covered: 'ready' };
+
+  return shell.provinces
+    .map((province) => {
+      const focusContext = {
+        focusedProvinceId: province.provinceId,
+        focusedProvince: province,
+        neighborIds: new Set(province.neighborIds),
+      };
+      const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+      const projection = buildProjectedFrontStability(province, shell, actionQueue);
+      const risks = buildCriticalFrontRiskWarnings(province, projection);
+      const leadRisk = risks[0] ?? { tone: 'covered', label: 'Risque acceptable', driver: 'Terrain' };
+      const blockedCount = actionQueue.filter((entry) => entry.status === 'blocked').length;
+      const riskyCount = actionQueue.filter((entry) => entry.status === 'risky').length;
+      const criticalCount = risks.filter((risk) => risk.tone === 'critical').length;
+      const watchCount = risks.filter((risk) => risk.tone === 'watch').length;
+      const urgencyLabel = criticalCount > 0 || blockedCount > 0
+        ? 'avant validation'
+        : watchCount > 0 || riskyCount > 0
+          ? 'prochain tour'
+          : 'surveillance légère';
+      const score = (criticalCount * 40)
+        + (watchCount * 18)
+        + (projection.tone === 'danger' ? 28 : projection.tone === 'warning' ? 16 : 4)
+        + (blockedCount * 12)
+        + (riskyCount * 6)
+        + (province.contested ? 8 : 0)
+        + (['collapsed', 'disrupted'].includes(province.supplyLevel) ? 6 : province.supplyLevel === 'strained' ? 3 : 0)
+        + Math.min(province.strategicValue ?? 0, 8);
+      const reasons = [
+        `${leadRisk.label} (${leadRisk.driver})`,
+        projection.lines.find((line) => line.label === 'Stabilité attendue')?.value ?? projection.title,
+      ];
+
+      if (blockedCount > 0) {
+        reasons.push(`${blockedCount} option${blockedCount > 1 ? 's' : ''} bloquée${blockedCount > 1 ? 's' : ''}`);
+      } else if (riskyCount > 0) {
+        reasons.push(`${riskyCount} option${riskyCount > 1 ? 's' : ''} risquée${riskyCount > 1 ? 's' : ''}`);
+      }
+
+      reasons.push(`urgence ${urgencyLabel}`);
+
+      return {
+        provinceId: province.provinceId,
+        provinceLabel: province.label,
+        tone: rankTone[leadRisk.tone] ?? 'ready',
+        score,
+        leadRisk: leadRisk.label,
+        actionCode: actionQueue[0]?.actionCode ?? 'WAR-HOLD',
+        reason: reasons.slice(0, 4).join(' · '),
+        focusTargetLabel: province.contested ? `front contesté ${province.label}` : `province ${province.label}`,
+      };
+    })
+    .filter((entry) => entry.tone !== 'ready' || entry.score >= 18)
+    .sort((left, right) => right.score - left.score || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 3)
+    .map((entry, index, entries) => ({
+      ...entry,
+      rank: index + 1,
+      comparison: index === 0
+        ? 'Passe en premier: cumul risque / stabilité le plus élevé.'
+        : `Après ${entries[index - 1].provinceLabel}: score ${entry.score} contre ${entries[index - 1].score}.`,
+    }));
+}
+
+function renderFrontPriorityRanking(shell, intrigueView = null) {
+  const priorities = buildFrontPriorityRanking(shell, intrigueView);
+
+  if (priorities.length === 0) {
+    return `
+      <section class="front-priority-ranking is-empty" aria-label="Classement des priorités militaires de front">
+        <div class="front-priority-ranking__header">
+          <strong>Priorités fronts</strong>
+          <span>calme</span>
+        </div>
+        <p>Aucun front visible ne demande de priorité militaire immédiate.</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="front-priority-ranking" aria-label="Classement des priorités militaires de front">
+      <div class="front-priority-ranking__header">
+        <strong>Priorités fronts</strong>
+        <span>${priorities.length} provinces à traiter</span>
+      </div>
+      <div class="front-priority-ranking__list">
+        ${priorities.map((priority) => `
+          <button class="front-priority front-priority--${priority.tone}" type="button" data-province-id="${priority.provinceId}" data-readiness-focus="${priority.provinceId}" aria-label="Priorité ${priority.rank}: ${priority.focusTargetLabel}">
+            <div>
+              <strong>#${priority.rank} ${priority.provinceLabel}</strong>
+              <code>${priority.actionCode}</code>
+            </div>
+            <p>${priority.reason}</p>
+            <small>${priority.comparison}</small>
+          </button>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
+
+
 function buildConflictReadinessWarnings(shell, intrigueView = null) {
   return shell.provinces
     .map((province) => {
@@ -6283,6 +6389,7 @@ function render() {
           </div>
           <p class="turn-summary">${state.lastTurnSummary}</p>
           ${renderConflictReadinessWarnings(shell, intrigueView)}
+          ${renderFrontPriorityRanking(shell, intrigueView)}
           ${renderMapClimatePreparednessSummary(climatePreparednessSummary)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -282,6 +282,74 @@ button { font: inherit; }
 .conflict-readiness-warning--ready { border-color: rgba(74, 222, 128, 0.24); }
 .conflict-readiness-warning--warning { border-color: rgba(251, 191, 36, 0.32); }
 .conflict-readiness-warning--danger { border-color: rgba(251, 113, 133, 0.38); }
+.front-priority-ranking {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+  max-width: 62ch;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.front-priority-ranking__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.front-priority-ranking__header strong {
+  color: #bae6fd;
+  font-size: 13px;
+}
+.front-priority-ranking__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.front-priority-ranking p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.front-priority-ranking__list {
+  display: grid;
+  gap: 6px;
+}
+.front-priority {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  text-align: left;
+  cursor: pointer;
+}
+.front-priority:hover,
+.front-priority:focus-visible {
+  border-color: rgba(125, 211, 252, 0.5);
+  box-shadow: 0 0 0 2px rgba(125, 211, 252, 0.16);
+  outline: none;
+}
+.front-priority div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.front-priority strong { color: #f8fafc; }
+.front-priority code { color: #bae6fd; font-size: 11px; }
+.front-priority small {
+  color: var(--muted);
+  font-size: 11px;
+}
+.front-priority--ready { border-color: rgba(74, 222, 128, 0.24); }
+.front-priority--warning { border-color: rgba(251, 191, 36, 0.32); }
+.front-priority--danger { border-color: rgba(251, 113, 133, 0.38); }
 .economy-readiness-warnings {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Alpha: Implements #583.

Summary:
- Adds a compact “Priorités fronts” ranking in the map header for the top 2–3 provinces needing military attention.
- Reuses residual front risks, projected stability, blocked/risky options, contested state, supply, and strategic value to order priorities without adding a new combat model.
- Explains why each province is ranked, including comparison with the previous rank and calm fallback when no front needs immediate action.

Tests:
- npm test

Zeta: PR prête pour revue. Merci de valider avant tout merge.
