### PR TITLE
Beta: prioritize downstream logistics recovery

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -458,12 +458,58 @@ function buildChoiceForRoute(route, localCity, localTension, resourceLabelById, 
   };
 }
 
+
+function getDelayTurns(delay) {
+  const match = String(delay ?? '').match(/\d+/);
+  return match ? Number(match[0]) : 1;
+}
+
+function buildRecoveryPriorityActions(routeChoices) {
+  const candidates = routeChoices
+    .flatMap((option) => option.recoveryChoices.slice(0, 2).map((choice) => {
+      const shortagesAvoided = choice.downstreamShortages.filter((shortage) => shortage.status === 'résolue').length;
+      const displacedShortages = choice.downstreamShortages.filter((shortage) => shortage.status === 'déplacée').length;
+      const aggravatedShortages = choice.downstreamShortages.filter((shortage) => shortage.status === 'aggravée').length;
+      const delayTurns = getDelayTurns(option.delay);
+      const structural = choice.bottleneck.tone === 'high' || choice.bottleneck.type === 'capacity' || choice.bottleneck.type === 'damage';
+      const impactScore = shortagesAvoided * 40 + displacedShortages * 18 - aggravatedShortages * 32 + (structural ? 26 : 8) - delayTurns * 4 + (option.recommended ? 12 : 0);
+      const tradeoff = delayTurns <= 1 && !structural
+        ? 'rapide mais limitée'
+        : structural
+          ? 'plus lente mais structurante'
+          : 'équilibrée';
+
+      return {
+        actionId: `${option.routeId}:${choice.choiceId}`,
+        action: `${choice.label} · ${option.routes[0]}`,
+        route: option.routes[0],
+        resource: option.resources[0],
+        tone: impactScore >= 40 ? 'high' : impactScore >= 18 ? 'medium' : 'low',
+        delay: option.delay,
+        impact: choice.benefit,
+        reason: `${choice.bottleneck.label}; ${choice.downstreamShortages[0]?.detail ?? 'aucune pénurie aval claire'}`,
+        shortagesAvoided,
+        downstreamStatus: choice.downstreamShortages[0]?.status ?? 'inconnue',
+        tradeoff,
+        impactScore,
+      };
+    }))
+    .sort((left, right) => right.impactScore - left.impactScore || left.delay.localeCompare(right.delay) || left.action.localeCompare(right.action))
+    .slice(0, 3)
+    .map((candidate, index) => ({
+      ...candidate,
+      recommended: index === 0,
+    }));
+
+  return candidates;
+}
+
 export function buildProvinceLogisticsChoicePreview(province, economyView, options = {}) {
   const normalizedOptions = requireObject(options, 'ProvinceLogisticsChoicePreview options');
   const resourceLabelById = requireObject(normalizedOptions.resourceLabelById ?? {}, 'ProvinceLogisticsChoicePreview resourceLabelById');
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -496,6 +542,8 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       timelineSummary: 'Aucune action route/logistique en file: timeline vide.',
       downstreamStatus: 'neutre',
       downstreamSummary: 'Aucune pénurie aval claire détectée.',
+      priorityActions: [],
+      prioritySummary: 'Aucune action logistique prioritaire disponible.',
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
       options: [],
@@ -504,6 +552,8 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
 
   const recommended = routeChoices[0];
   const hasBlocker = routeChoices.some((choice) => choice.tone === 'high' || choice.tone === 'medium');
+  const priorityActions = buildRecoveryPriorityActions(routeChoices);
+  const recommendedPriority = priorityActions[0] ?? null;
 
   return {
     recommendedOptionId: recommended.optionId,
@@ -516,6 +566,10 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
     downstreamSummary: hasBlocker
       ? `${recommended.recoveryChoices[0].downstreamShortages[0]?.status ?? 'inconnue'}: ${recommended.recoveryChoices[0].downstreamShortages[0]?.detail ?? 'Aucune pénurie aval claire détectée.'}`
       : 'Aucune pénurie aval claire détectée.',
+    priorityActions,
+    prioritySummary: recommendedPriority
+      ? `${recommendedPriority.action} recommandée: ${recommendedPriority.reason} (${recommendedPriority.tradeoff}, ${recommendedPriority.delay}).`
+      : 'Aucune action logistique prioritaire disponible.',
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker
       ? `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.cause} ${recommended.recoveryChoices[0].label} est prioritaire car ${recommended.recoveryChoices[0].benefit}`

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -77,6 +77,11 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.timelineSummary, /goulot/);
   assert.match(preview.downstreamSummary, /manquer|pression|pénurie|aval/);
   assert.ok(['aggravée', 'déplacée', 'résolue', 'inconnue'].includes(preview.downstreamStatus));
+  assert.ok(preview.priorityActions.length >= 2);
+  assert.equal(preview.priorityActions[0].recommended, true);
+  assert.match(preview.prioritySummary, /recommandée/);
+  assert.ok(preview.priorityActions.some((action) => /rapide mais limitée|plus lente mais structurante|équilibrée/.test(action.tradeoff)));
+  assert.ok(preview.priorityActions.every((action) => action.impact.length > 0 && action.reason.length > 0 && action.delay.length > 0));
   assert.ok(preview.options[0].recoveryChoices.length >= 2);
   assert.equal(preview.options[0].recoveryChoices[0].recommended, true);
   assert.match(preview.options[0].recoveryChoices[0].benefit, /Outils|River Gate|Ember Line/);
@@ -111,6 +116,8 @@ test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and i
   assert.ok(option.recoveryChoices.every((choice) => choice.bottleneck && choice.bottleneck.detail.length > 0));
   assert.ok(option.recoveryChoices.every((choice) => Array.isArray(choice.downstreamShortages)));
   assert.ok(option.recoveryChoices.some((choice) => choice.downstreamShortages.some((shortage) => ['aggravée', 'déplacée', 'résolue', 'inconnue'].includes(shortage.status))));
+  assert.ok(preview.priorityActions.every((action) => ['high', 'medium', 'low'].includes(action.tone)));
+  assert.ok(preview.priorityActions.some((action) => action.downstreamStatus === 'aggravée' || action.shortagesAvoided >= 0));
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
@@ -122,6 +129,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.equal(preview.timelineStatus, 'empty');
   assert.equal(preview.downstreamStatus, 'neutre');
   assert.match(preview.downstreamSummary, /Aucune pénurie aval/);
+  assert.deepEqual(preview.priorityActions, []);
+  assert.match(preview.prioritySummary, /Aucune action logistique prioritaire/);
   assert.match(preview.timelineSummary, /timeline vide/);
   assert.match(preview.summary, /Logistique stable/);
 });
@@ -143,6 +152,8 @@ test('buildProvinceLogisticsChoicePreview exposes stable local route causes', ()
   assert.match(preview.options[0].cause, /River Gate/);
   assert.equal(preview.options[0].recoveryChoices[0].bottleneck.type, 'none');
   assert.match(preview.options[0].recoveryChoices[0].bottleneck.detail, /Aucun ralentisseur/);
+  assert.ok(preview.priorityActions.length >= 1);
+  assert.equal(preview.priorityActions[0].recommended, true);
   assert.equal(preview.options[0].recoveryChoices[0].downstreamShortages[0].status, 'résolue');
   assert.match(preview.options[0].recoveryChoices[0].downstreamShortages[0].detail, /aucune pénurie aval/i);
 });

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -19,6 +19,11 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /choice\.rationale/);
   assert.match(webAppSource, /province-logistics-timeline-summary/);
   assert.match(webAppSource, /province-logistics-downstream-summary/);
+  assert.match(webAppSource, /province-logistics-priority-summary/);
+  assert.match(webAppSource, /Priorité aval/);
+  assert.match(webAppSource, /preview\.priorityActions/);
+  assert.match(webAppSource, /action\.tradeoff/);
+  assert.match(webAppSource, /pénurie/);
   assert.match(webAppSource, /Pénuries aval/);
   assert.match(webAppSource, /choice\.downstreamShortages/);
   assert.match(webAppSource, /shortage\.detail/);
@@ -44,6 +49,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-bottleneck--low/);
   assert.match(stylesSource, /province-logistics-timeline-summary--queued/);
   assert.match(stylesSource, /province-logistics-downstream-summary--aggravée/);
+  assert.match(stylesSource, /province-logistics-priority-summary/);
+  assert.match(stylesSource, /province-logistics-priority-list/);
+  assert.match(stylesSource, /province-logistics-priority--high/);
   assert.match(stylesSource, /province-logistics-downstream-summary--résolue/);
   assert.match(stylesSource, /province-logistics-downstream-shortage--high/);
   assert.match(stylesSource, /province-logistics-timeline-summary--empty/);

--- a/web/app.js
+++ b/web/app.js
@@ -1214,6 +1214,25 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
         <b>Pénuries aval</b>
         <span>${preview.downstreamSummary ?? 'Aucune pénurie aval claire détectée.'}</span>
       </div>
+      <div class="province-logistics-priority-summary" aria-label="Priorisation aval des actions logistiques">
+        <b>Priorité aval</b>
+        <span>${preview.prioritySummary ?? 'Aucune action logistique prioritaire disponible.'}</span>
+      </div>
+      ${preview.priorityActions.length > 0 ? `
+        <div class="province-logistics-priority-list">
+          ${preview.priorityActions.map((action) => `
+            <article class="province-logistics-priority province-logistics-priority--${action.tone} ${action.recommended ? 'is-recommended' : ''}">
+              <div>
+                <strong>${action.action}</strong>
+                <span>${action.recommended ? 'meilleure première action' : action.tradeoff}</span>
+              </div>
+              <p>${action.impact}</p>
+              <small>${action.shortagesAvoided} pénurie${action.shortagesAvoided > 1 ? 's' : ''} évitée${action.shortagesAvoided > 1 ? 's' : ''} · ${action.downstreamStatus} · délai ${action.delay}</small>
+              <small>${action.reason}</small>
+            </article>
+          `).join('')}
+        </div>
+      ` : ''}
       ${preview.options.length > 0 ? `
         <div class="province-logistics-choice-list">
           ${preview.options.map((option) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -3167,6 +3167,64 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.province-logistics-priority-summary {
+  display: grid;
+  gap: 4px;
+  margin: 8px 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(8, 15, 28, 0.46);
+  border: 1px solid rgba(125, 211, 252, 0.22);
+}
+.province-logistics-priority-summary b {
+  color: #bfdbfe;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.province-logistics-priority-summary span {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-logistics-priority-list {
+  display: grid;
+  gap: 7px;
+}
+.province-logistics-priority {
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-logistics-priority.is-recommended {
+  background: rgba(12, 74, 110, 0.26);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.16);
+}
+.province-logistics-priority--high { border-color: rgba(251, 113, 133, 0.34); }
+.province-logistics-priority--medium { border-color: rgba(245, 158, 11, 0.3); }
+.province-logistics-priority--low { border-color: rgba(74, 222, 128, 0.22); }
+.province-logistics-priority div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.province-logistics-priority strong { color: #f8fafc; font-size: 12px; }
+.province-logistics-priority span,
+.province-logistics-priority small {
+  color: #bfdbfe;
+  font-size: 11px;
+  line-height: 1.3;
+}
+.province-logistics-priority p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
 .province-logistics-cause-summary--high { border-color: rgba(251, 113, 133, 0.38); }
 .province-logistics-cause-summary--medium { border-color: rgba(245, 158, 11, 0.34); }
 .province-logistics-cause-summary--stable,


### PR DESCRIPTION
Beta: Implements #584.

## Summary
- derives 2-3 prioritized logistics recovery actions from existing recovery choices, bottlenecks, delays, and downstream shortage forecasts
- marks the recommended first action with reason, impact, avoided shortages, delay, and rapid-vs-structural tradeoff copy
- renders the priority summary/list in the province logistics panel while preserving the existing downstream shortage details

## Tests
- npm test
- npm test -- --test-reporter=spec test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.