### PR TITLE
Epsilon: compare climate intervention windows

### DIFF
--- a/test/ui/climate/webClimateInterventionWindows.test.js
+++ b/test/ui/climate/webClimateInterventionWindows.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('map compares climate intervention windows across regions', () => {
+  assert.match(webAppSource, /function buildMapClimateInterventionWindows/);
+  assert.match(webAppSource, /function renderMapClimateInterventionWindows/);
+  assert.match(webAppSource, /Comparaison des fenêtres d’intervention climatique/);
+  assert.match(webAppSource, /Fenêtres d’intervention climat/);
+  assert.match(webAppSource, /deadlineState/);
+  assert.match(webAppSource, /delayRisk/);
+  assert.match(webAppSource, /Bénéfice immédiat/);
+  assert.match(webAppSource, /Si retard/);
+  assert.match(webAppSource, /Peut attendre sans gros coût visible/);
+  assert.match(webAppSource, /Une seule région climat concernée/);
+  assert.match(webAppSource, /renderMapClimateInterventionWindows\(climateInterventionWindows\)/);
+
+  assert.match(stylesSource, /\.map-climate-windows/);
+  assert.match(stylesSource, /\.map-climate-windows--urgent/);
+  assert.match(stylesSource, /\.map-climate-windows--watch/);
+  assert.match(stylesSource, /\.map-climate-windows--calm/);
+  assert.match(stylesSource, /\.map-climate-windows__item--missed/);
+  assert.match(stylesSource, /\.map-climate-windows__item--just-in-time/);
+  assert.match(stylesSource, /\.map-climate-windows__item--covered/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2132,6 +2132,94 @@ function buildMapClimatePreparednessSummary(shell, focusContext, intrigueView = 
   };
 }
 
+function getClimateInterventionWindowRank(entry) {
+  if (entry.deadlineState === 'missed') return 0;
+  if (entry.deadlineState === 'just-in-time') return 1;
+  if (entry.deadlineState === 'covered') return 2;
+  if (entry.riskLevel === 'critical') return 3;
+  if (entry.riskLevel === 'strained') return 4;
+  return 5;
+}
+
+function buildMapClimateInterventionWindows(shell) {
+  const windows = shell.provinces
+    .map((province) => {
+      const forecast = buildProvinceClimateRiskReductionForecast(province, shell);
+      const primaryCue = buildProvinceClimateCountdownCues(province)[0] ?? null;
+      const riskLevel = getProvinceClimateRiskLevel(province);
+      const residualCascade = forecast.remainingCascades[0] ?? null;
+      const canWait = forecast.deadlineCoverage.state === 'calm' || (riskLevel === 'stable' && primaryCue?.level === 'stable');
+      const deadline = forecast.deadlineCoverage.state === 'calm'
+        ? primaryCue?.countdown ?? 'Stable'
+        : forecast.deadlineCoverage.label;
+      const benefit = forecast.payoffTradeoff?.benefit
+        ?? (forecast.queuedAction ? `${forecast.queuedAction}: ${forecast.currentRisk} → ${forecast.projectedRisk}.` : 'Action immédiate: bénéfice limité ou non confirmé.');
+      const delayRisk = forecast.deadlineCoverage.residualRisk
+        ?? (residualCascade ? `${residualCascade.type}: ${residualCascade.scope}` : 'Peut attendre sans gros coût visible.');
+
+      return {
+        provinceId: province.provinceId,
+        provinceLabel: province.label,
+        deadline,
+        deadlineState: forecast.deadlineCoverage.state,
+        riskLevel,
+        delayRisk,
+        benefit,
+        canWait,
+        cueLabel: primaryCue?.label ?? 'Fenêtre climat',
+        rank: 0,
+      };
+    })
+    .sort((left, right) => getClimateInterventionWindowRank(left) - getClimateInterventionWindowRank(right)
+      || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 3)
+    .map((entry, index) => ({ ...entry, rank: index + 1 }));
+
+  const urgentCount = windows.filter((window) => !window.canWait && window.deadlineState !== 'covered').length;
+
+  return {
+    state: urgentCount > 0 ? 'urgent' : windows.some((window) => !window.canWait) ? 'watch' : 'calm',
+    urgentCount,
+    windows,
+    summary: windows.length > 1
+      ? `${windows.length} fenêtres climat comparées; ${urgentCount} urgence${urgentCount > 1 ? 's' : ''} à traiter maintenant.`
+      : windows.length === 1
+        ? 'Une seule région climat concernée: comparaison réduite à la fenêtre locale.'
+        : 'Aucune fenêtre d’intervention climat prioritaire à comparer.',
+  };
+}
+
+function renderMapClimateInterventionWindows(view) {
+  if (view.windows.length === 0) {
+    return `
+      <section class="map-climate-windows map-climate-windows--calm" aria-label="Comparaison des fenêtres d’intervention climatique">
+        <strong>Fenêtres climat</strong>
+        <p>${view.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="map-climate-windows map-climate-windows--${view.state}" aria-label="Comparaison des fenêtres d’intervention climatique">
+      <div class="map-climate-windows__header">
+        <strong>Fenêtres d’intervention climat</strong>
+        <span>${view.urgentCount} maintenant · ${view.windows.length - view.urgentCount} peut attendre</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-climate-windows__list">
+        ${view.windows.map((window) => `
+          <li class="map-climate-windows__item map-climate-windows__item--${window.deadlineState} ${window.canWait ? 'map-climate-windows__item--wait' : ''}">
+            <b>${window.rank}. ${window.provinceLabel}</b>
+            <span>${window.deadline} · risque ${window.riskLevel}</span>
+            <small><b>Si retard</b> · ${window.delayRisk}</small>
+            <small><b>Bénéfice immédiat</b> · ${window.benefit}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderMapClimatePreparednessSummary(summary) {
   if (summary.warnings.length === 0) {
     return `
@@ -6465,6 +6553,7 @@ function render() {
     consequenceChips: selectedCultureContext.consequenceChips,
   });
   const climatePreparednessSummary = buildMapClimatePreparednessSummary(shell, focusContext, intrigueView);
+  const climateInterventionWindows = buildMapClimateInterventionWindows(shell);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -6486,6 +6575,7 @@ function render() {
           ${renderConflictReadinessWarnings(shell, intrigueView)}
           ${renderFrontPriorityRanking(shell, intrigueView)}
           ${renderMapClimatePreparednessSummary(climatePreparednessSummary)}
+          ${renderMapClimateInterventionWindows(climateInterventionWindows)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -193,6 +193,62 @@ button { font: inherit; }
   font-size: 12px;
 }
 
+.map-climate-windows {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+  max-width: 72ch;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.42), rgba(8, 47, 73, 0.38));
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.map-climate-windows--urgent { border-color: rgba(248, 113, 113, 0.34); }
+.map-climate-windows--watch { border-color: rgba(251, 191, 36, 0.3); }
+.map-climate-windows--calm { border-color: rgba(74, 222, 128, 0.22); }
+.map-climate-windows__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-climate-windows__header span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.map-climate-windows p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 13px;
+}
+.map-climate-windows__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+.map-climate-windows__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.3);
+  border-left: 3px solid rgba(125, 211, 252, 0.54);
+}
+.map-climate-windows__item--missed { border-left-color: rgba(248, 113, 113, 0.82); }
+.map-climate-windows__item--just-in-time { border-left-color: rgba(251, 191, 36, 0.78); }
+.map-climate-windows__item--covered { border-left-color: rgba(74, 222, 128, 0.72); }
+.map-climate-windows__item--wait { opacity: 0.82; }
+.map-climate-windows__item span,
+.map-climate-windows__item small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.map-climate-windows__item b { color: #f8fafc; }
+.map-climate-windows__item small b { color: #fef3c7; }
+
 .economy-turn-pulse {
   margin-top: 12px;
   display: inline-flex;


### PR DESCRIPTION
Epsilon:

## Summary
- Adds a map-level comparison of 2-3 climate intervention windows across provinces.
- Shows deadline, delay risk, and immediate benefit for each ranked region, while distinguishing urgent windows from actions that can wait.
- Reuses existing climate forecast, deadline coverage, and cascade data, with a graceful single-region fallback.

## Testing
- npm test -- test/ui/climate/webClimateInterventionWindows.test.js test/ui/climate/webClimateRiskReductionForecast.test.js
- node --check web/app.js
- npm test

Fixes loo469/historia#587