### PR TITLE
Epsilon: preview selected climate intervention

### DIFF
--- a/test/ui/climate/webSelectedClimateInterventionPreview.test.js
+++ b/test/ui/climate/webSelectedClimateInterventionPreview.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected province climate forecast previews the selected intervention risk reduction', () => {
+  assert.match(webAppSource, /function buildSelectedClimateInterventionRiskPreview/);
+  assert.match(webAppSource, /function renderSelectedClimateInterventionRiskPreview/);
+  assert.match(webAppSource, /Aperçu de réduction du risque pour l’intervention climat sélectionnée/);
+  assert.match(webAppSource, /Intervention sélectionnée/);
+  assert.match(webAppSource, /gain immédiat/);
+  assert.match(webAppSource, /gain différé/);
+  assert.match(webAppSource, /Urgence persistante/);
+  assert.match(webAppSource, /Cascade évitée non disponible/);
+  assert.match(webAppSource, /candidateComparisons/);
+  assert.match(webAppSource, /selectedInterventionPreview/);
+  assert.match(webAppSource, /renderSelectedClimateInterventionRiskPreview\(forecast\.selectedInterventionPreview\)/);
+
+  assert.match(stylesSource, /\.province-climate-risk-forecast__selected/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__selected--reduced/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__selected--urgent/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__selected--unchanged/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1675,6 +1675,75 @@ function buildClimateMitigationDeadlineCoverage(province, queuedMitigation, cues
   };
 }
 
+function buildSelectedClimateInterventionRiskPreview(province, shell, selectedIntervention = null, report = buildProvinceClimateTurnReport(province)) {
+  const priorities = buildProvinceClimateMitigationPriorities(province, report);
+  const intervention = selectedIntervention ?? priorities.find((priority) => priority.outcomeChange) ?? priorities[0] ?? null;
+  const currentRisk = getProvinceClimateRiskLevel(province);
+  const projectedRisk = getProjectedClimateRiskAfterMitigation(currentRisk, Boolean(intervention?.outcomeChange));
+  const cues = buildProvinceClimateCountdownCues(province, report);
+  const cascades = buildProvinceClimateCascadePreview(province, shell, report);
+  const avoidedCascade = intervention?.outcomeChange
+    ? cascades.find((cascade) => cascade.changesThisTurn) ?? cascades[0] ?? null
+    : null;
+  const deadlineCoverage = buildClimateMitigationDeadlineCoverage(province, intervention, cues, cascades);
+  const timing = intervention && getClimateMitigationDeadlineRank(intervention.deadline) <= 0 ? 'gain immédiat' : 'gain différé';
+  const remainsUrgent = deadlineCoverage.state === 'missed' || (deadlineCoverage.state === 'just-in-time' && projectedRisk === 'critical');
+  const candidateComparisons = priorities.slice(0, 2).map((candidate) => ({
+    option: candidate.option,
+    timing: getClimateMitigationDeadlineRank(candidate.deadline) <= 0 ? 'immédiat' : 'différé',
+    projectedRisk: getProjectedClimateRiskAfterMitigation(currentRisk, Boolean(candidate.outcomeChange)),
+    deadline: candidate.deadline,
+  }));
+
+  if (!intervention) {
+    return {
+      state: 'empty',
+      option: 'Aucune intervention sélectionnée',
+      deadline: cues.find((cue) => cue.level !== 'stable')?.countdown ?? 'Aucune deadline fiable',
+      currentRisk,
+      projectedRisk: currentRisk,
+      timing: 'gain non confirmé',
+      avoidedCascade: 'Cascade évitée non disponible',
+      remainsUrgent: false,
+      deadlineCoverage,
+      candidateComparisons,
+    };
+  }
+
+  return {
+    state: remainsUrgent ? 'urgent' : intervention.outcomeChange ? 'reduced' : 'unchanged',
+    option: intervention.option,
+    deadline: intervention.deadline ?? deadlineCoverage.label ?? 'Deadline absente',
+    currentRisk,
+    projectedRisk,
+    timing,
+    avoidedCascade: avoidedCascade
+      ? `${avoidedCascade.type}: ${avoidedCascade.avoidedImpact}`
+      : 'Cascade évitée non disponible',
+    remainsUrgent,
+    deadlineCoverage,
+    candidateComparisons,
+  };
+}
+
+function renderSelectedClimateInterventionRiskPreview(preview) {
+  return `
+    <div class="province-climate-risk-forecast__selected province-climate-risk-forecast__selected--${preview.state}" aria-label="Aperçu de réduction du risque pour l’intervention climat sélectionnée">
+      <div>
+        <strong>Intervention sélectionnée · ${preview.option}</strong>
+        <span>${preview.deadline} · ${preview.timing}</span>
+      </div>
+      <p><b>${preview.currentRisk}</b> → <b>${preview.projectedRisk}</b> · ${preview.avoidedCascade}</p>
+      ${preview.remainsUrgent ? `<small><b>Urgence persistante</b> · ${preview.deadlineCoverage.detail}</small>` : ''}
+      <ul>
+        ${preview.candidateComparisons.map((candidate) => `
+          <li>${candidate.option}: ${candidate.timing}, risque ${candidate.projectedRisk} (${candidate.deadline})</li>
+        `).join('')}
+      </ul>
+    </div>
+  `;
+}
+
 function buildProvinceClimateRiskReductionForecast(province, shell, report = buildProvinceClimateTurnReport(province)) {
   const priorities = buildProvinceClimateMitigationPriorities(province, report);
   const queuedMitigation = priorities.find((priority) => priority.outcomeChange) ?? null;
@@ -1687,6 +1756,7 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
     .filter((cascade) => !queuedMitigation || !cascade.changesThisTurn)
     .slice(0, 2);
   const deadlineCoverage = buildClimateMitigationDeadlineCoverage(province, queuedMitigation, cues, remainingCascades);
+  const selectedInterventionPreview = buildSelectedClimateInterventionRiskPreview(province, shell, queuedMitigation, report);
 
   if (!queuedMitigation) {
     return {
@@ -1697,6 +1767,7 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
       queuedAction: null,
       payoffTradeoff: null,
       deadlineCoverage,
+      selectedInterventionPreview,
       summary: 'Aucune mitigation climat décisive en file: la réduction de risque projetée reste inchangée.',
       remainingCascades,
     };
@@ -1710,6 +1781,7 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
     queuedAction: queuedMitigation.option,
     payoffTradeoff,
     deadlineCoverage,
+    selectedInterventionPreview,
     summary: `${queuedMitigation.option} projette ${currentRisk} → ${projectedRisk} avant ${criticalDeadline}.`,
     remainingCascades: remainingCascades.length > 0 ? remainingCascades : [{
       type: 'surveillance résiduelle',
@@ -1742,6 +1814,7 @@ function renderProvinceClimateRiskReductionForecast(province, shell) {
           <small><b>${forecast.payoffTradeoff.tradeoffType}</b> · ${forecast.payoffTradeoff.tradeoff}</small>
         </div>
       ` : ''}
+      ${renderSelectedClimateInterventionRiskPreview(forecast.selectedInterventionPreview)}
       <div class="province-climate-risk-forecast__deadline province-climate-risk-forecast__deadline--${forecast.deadlineCoverage.state}">
         <span><b>Deadline</b> · ${forecast.deadlineCoverage.label}</span>
         <small>${forecast.deadlineCoverage.detail}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3731,6 +3731,43 @@ button { font: inherit; }
   color: #fde68a;
   line-height: 1.35;
 }
+.province-climate-risk-forecast__selected {
+  display: grid;
+  gap: 5px;
+  padding: 9px 10px;
+  border-radius: 14px;
+  background: rgba(12, 74, 110, 0.26);
+  border: 1px solid rgba(125, 211, 252, 0.2);
+}
+.province-climate-risk-forecast__selected--reduced { border-color: rgba(74, 222, 128, 0.34); }
+.province-climate-risk-forecast__selected--urgent { border-color: rgba(248, 113, 113, 0.38); }
+.province-climate-risk-forecast__selected--unchanged,
+.province-climate-risk-forecast__selected--empty { border-color: rgba(148, 163, 184, 0.22); }
+.province-climate-risk-forecast__selected div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-climate-risk-forecast__selected span,
+.province-climate-risk-forecast__selected small,
+.province-climate-risk-forecast__selected li {
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-climate-risk-forecast__selected p {
+  color: #ecfeff;
+}
+.province-climate-risk-forecast__selected ul {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding-left: 16px;
+}
+.province-climate-risk-forecast__selected b {
+  color: #fef3c7;
+}
 .province-climate-risk-forecast__deadline {
   display: grid;
   gap: 3px;


### PR DESCRIPTION
Epsilon:

## Summary
- Adds a selected-intervention climate preview inside the province risk forecast.
- Shows deadline, current risk, projected risk, avoided cascade, and whether the gain is immediate or delayed.
- Flags persistent urgency and includes the first two candidate interventions for concise comparison, with graceful fallback copy when cascade/deadline data is missing.

## Testing
- npm test -- test/ui/climate/webSelectedClimateInterventionPreview.test.js test/ui/climate/webClimateInterventionWindows.test.js test/ui/climate/webClimateRiskReductionForecast.test.js
- node --check web/app.js
- npm test

Fixes loo469/historia#597