### PR TITLE
Alpha: preview recommended front action

### DIFF
--- a/test/ui/war/webRecommendedMilitaryActionPreview.test.js
+++ b/test/ui/war/webRecommendedMilitaryActionPreview.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('map previews the front state after the recommended military action', () => {
+  assert.match(webAppSource, /function buildRecommendedMilitaryActionPreview/);
+  assert.match(webAppSource, /function renderRecommendedMilitaryActionPreview/);
+  assert.match(webAppSource, /Aperçu action recommandée/);
+  assert.match(webAppSource, /Aperçu après action militaire recommandée/);
+  assert.match(webAppSource, /buildFrontPriorityRanking\(shell, intrigueView\)/);
+  assert.match(webAppSource, /buildProjectedFrontStability\(province, shell, actionQueue\)/);
+  assert.match(webAppSource, /buildCriticalFrontRiskWarnings\(province, projection\)/);
+  assert.match(webAppSource, /Pression/);
+  assert.match(webAppSource, /Stabilité projetée/);
+  assert.match(webAppSource, /Risque critique restant/);
+  assert.match(webAppSource, /calculé: action recommandée \+ projection actuelle/);
+  assert.match(webAppSource, /estimé prudent/);
+  assert.match(webAppSource, /Front voisin soulagé partiellement|province encore bloquée|Urgence qui demeure/);
+  assert.match(webAppSource, /renderRecommendedMilitaryActionPreview\(shell, intrigueView\)/);
+  assert.match(stylesSource, /\.recommended-action-preview/);
+  assert.match(stylesSource, /\.recommended-action-preview__effects/);
+  assert.match(stylesSource, /\.recommended-action-preview--danger/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3548,6 +3548,117 @@ function renderFrontPriorityRanking(shell, intrigueView = null) {
 
 
 
+function buildRecommendedMilitaryActionPreview(shell, intrigueView = null) {
+  const [priority] = buildFrontPriorityRanking(shell, intrigueView);
+
+  if (!priority) {
+    return {
+      empty: true,
+      tone: 'ready',
+      provinceLabel: 'Aucun front prioritaire',
+      actionCode: 'WAR-HOLD',
+      actionLabel: 'Aucune action militaire recommandée',
+      confidence: 'calculé: aucune priorité immédiate détectée',
+      effects: [
+        { label: 'Pression', value: 'aucun changement urgent', source: 'calculé' },
+        { label: 'Stabilité projetée', value: 'position maintenue', source: 'estimé prudent' },
+        { label: 'Risque critique restant', value: 'aucun signal critique prioritaire', source: 'calculé' },
+      ],
+      sideEffect: 'Dégradation propre: garder la file militaire actuelle ou surveiller les fronts voisins.',
+    };
+  }
+
+  const province = shell.provinces.find((candidate) => candidate.provinceId === priority.provinceId) ?? null;
+
+  if (!province) {
+    return {
+      empty: true,
+      tone: 'warning',
+      provinceLabel: priority.provinceLabel,
+      actionCode: priority.actionCode,
+      actionLabel: 'Action introuvable',
+      confidence: 'estimé prudent: province prioritaire non résolue',
+      effects: [
+        { label: 'Pression', value: 'donnée indisponible', source: 'estimé prudent' },
+        { label: 'Stabilité projetée', value: 'donnée indisponible', source: 'estimé prudent' },
+        { label: 'Risque critique restant', value: priority.leadRisk, source: 'calculé' },
+      ],
+      sideEffect: 'Province prioritaire introuvable: ne pas empiler de nouvel ordre sans vérifier la sélection.',
+    };
+  }
+
+  const focusContext = {
+    focusedProvinceId: province.provinceId,
+    focusedProvince: province,
+    neighborIds: new Set(province.neighborIds),
+  };
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const recommendedAction = actionQueue[0] ?? null;
+  const projection = buildProjectedFrontStability(province, shell, actionQueue);
+  const risks = buildCriticalFrontRiskWarnings(province, projection);
+  const criticalCount = risks.filter((risk) => risk.tone === 'critical').length;
+  const watchCount = risks.filter((risk) => risk.tone === 'watch').length;
+  const stabilityValue = projection.lines.find((line) => line.label === 'Stabilité attendue')?.value ?? projection.title;
+  const residualRisk = risks[0]?.label ?? 'Risque acceptable';
+  const pressureValue = projection.drivers.some((driver) => driver.label === 'Pression')
+    ? 'pression traitée mais encore visible'
+    : projection.tone === 'ready'
+      ? 'pression en baisse estimée'
+      : 'pression encore contestée';
+  const sensitiveNeighbor = projection.lines.find((line) => line.label === 'Voisine sensible')?.value ?? 'aucune menace adjacente prioritaire';
+  const sideEffect = recommendedAction?.status === 'blocked'
+    ? `${recommendedAction.label}: province encore bloquée avant résolution.`
+    : risks.some((risk) => risk.driver === 'Front voisin')
+      ? `Front voisin soulagé partiellement: ${sensitiveNeighbor}.`
+      : criticalCount > 0 || watchCount > 0
+        ? 'Urgence qui demeure: prévoir un suivi au prochain tour.'
+        : 'Effet secondaire favorable: l’urgence locale baisse sans surcharge visible.';
+
+  return {
+    empty: !recommendedAction,
+    tone: criticalCount > 0 ? 'danger' : watchCount > 0 ? 'warning' : 'ready',
+    provinceLabel: province.label,
+    actionCode: recommendedAction?.actionCode ?? 'WAR-HOLD',
+    actionLabel: recommendedAction?.label ?? 'Aucune action militaire recommandée',
+    confidence: recommendedAction ? 'calculé: action recommandée + projection actuelle' : 'estimé prudent: aucune action disponible',
+    effects: [
+      { label: 'Pression', value: pressureValue, source: projection.drivers.some((driver) => driver.label === 'Pression') ? 'calculé' : 'estimé prudent' },
+      { label: 'Stabilité projetée', value: stabilityValue, source: 'calculé' },
+      { label: 'Risque critique restant', value: residualRisk, source: criticalCount > 0 || watchCount > 0 ? 'calculé' : 'estimé prudent' },
+    ],
+    sideEffect,
+  };
+}
+
+function renderRecommendedMilitaryActionPreview(shell, intrigueView = null) {
+  const preview = buildRecommendedMilitaryActionPreview(shell, intrigueView);
+
+  return `
+    <section class="recommended-action-preview recommended-action-preview--${preview.tone} ${preview.empty ? 'is-empty' : ''}" aria-label="Aperçu après action militaire recommandée">
+      <div class="recommended-action-preview__header">
+        <div>
+          <span>Aperçu action recommandée</span>
+          <strong>${preview.provinceLabel}</strong>
+        </div>
+        <code>${preview.actionCode}</code>
+      </div>
+      <p><strong>${preview.actionLabel}</strong> · ${preview.confidence}</p>
+      <div class="recommended-action-preview__effects">
+        ${preview.effects.map((effect) => `
+          <article class="recommended-action-preview__effect">
+            <span>${effect.label}</span>
+            <strong>${effect.value}</strong>
+            <small>${effect.source}</small>
+          </article>
+        `).join('')}
+      </div>
+      <small class="recommended-action-preview__side-effect">${preview.sideEffect}</small>
+    </section>
+  `;
+}
+
+
+
 function buildConflictReadinessWarnings(shell, intrigueView = null) {
   return shell.provinces
     .map((province) => {
@@ -6585,6 +6696,7 @@ function render() {
           <p class="turn-summary">${state.lastTurnSummary}</p>
           ${renderConflictReadinessWarnings(shell, intrigueView)}
           ${renderFrontPriorityRanking(shell, intrigueView)}
+          ${renderRecommendedMilitaryActionPreview(shell, intrigueView)}
           ${renderMapClimatePreparednessSummary(climatePreparednessSummary)}
           ${renderMapClimateInterventionWindows(climateInterventionWindows)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -406,6 +406,69 @@ button { font: inherit; }
 .front-priority--ready { border-color: rgba(74, 222, 128, 0.24); }
 .front-priority--warning { border-color: rgba(251, 191, 36, 0.32); }
 .front-priority--danger { border-color: rgba(251, 113, 133, 0.38); }
+.recommended-action-preview {
+  display: grid;
+  gap: 9px;
+  margin-top: 10px;
+  max-width: 62ch;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.64), rgba(14, 116, 144, 0.14));
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.recommended-action-preview__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: flex-start;
+}
+.recommended-action-preview__header span,
+.recommended-action-preview__header code,
+.recommended-action-preview__effect small {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.recommended-action-preview__header strong {
+  display: block;
+  margin-top: 3px;
+  color: #e0f2fe;
+}
+.recommended-action-preview p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.recommended-action-preview__effects {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+.recommended-action-preview__effect {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.recommended-action-preview__effect span {
+  color: var(--muted);
+  font-size: 11px;
+}
+.recommended-action-preview__effect strong {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.recommended-action-preview__side-effect {
+  color: #bae6fd;
+  font-size: 12px;
+}
+.recommended-action-preview--ready { border-color: rgba(74, 222, 128, 0.28); }
+.recommended-action-preview--warning { border-color: rgba(251, 191, 36, 0.34); }
+.recommended-action-preview--danger { border-color: rgba(251, 113, 133, 0.4); }
 .economy-readiness-warnings {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Alpha: Implements #593.

Summary:
- Adds a compact “Aperçu action recommandée” block after the front-priority ranking.
- Previews pressure, projected stability, and remaining critical risk for the top recommended military action.
- Distinguishes calculated signals from prudent estimates, includes a readable side effect, and degrades cleanly when no recommendation is available.

Tests:
- npm test

Zeta: PR prête pour revue. Merci de valider avant tout merge.
