### PR TITLE
Beta: preview logistics action impact

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -481,6 +481,9 @@ function buildRecoveryPriorityActions(routeChoices) {
 
       return {
         actionId: `${option.routeId}:${choice.choiceId}`,
+        optionId: option.optionId,
+        routeId: option.routeId,
+        choiceId: choice.choiceId,
         action: `${choice.label} · ${option.routes[0]}`,
         route: option.routes[0],
         resource: option.resources[0],
@@ -504,12 +507,57 @@ function buildRecoveryPriorityActions(routeChoices) {
   return candidates;
 }
 
+
+function buildSelectedActionImpactPreview(priorityAction, routeChoices) {
+  if (!priorityAction) {
+    return {
+      status: 'empty',
+      summary: 'Aucune action candidate sélectionnée: impact à confirmer après choix logistique.',
+      currentState: 'Données insuffisantes',
+      projectedState: 'Projection indisponible',
+      badges: [],
+      criticalRemaining: false,
+    };
+  }
+
+  const option = routeChoices.find((candidate) => candidate.routeId === priorityAction.routeId) ?? routeChoices[0] ?? null;
+  const choice = option?.recoveryChoices.find((candidate) => candidate.choiceId === priorityAction.choiceId) ?? option?.recoveryChoices[0] ?? null;
+  const shortages = choice?.downstreamShortages ?? [];
+  const neighborEffects = choice?.neighborEffects ?? [];
+  const criticalBefore = option?.recoveryChoices.flatMap((candidate) => candidate.downstreamShortages).filter((shortage) => shortage.status === 'aggravée').length ?? 0;
+  const criticalAfter = shortages.filter((shortage) => shortage.status === 'aggravée').length;
+  const reducedShortages = Math.max(priorityAction.shortagesAvoided, criticalBefore - criticalAfter, shortages.filter((shortage) => shortage.status === 'résolue').length);
+  const relievedRoutes = new Set([
+    priorityAction.route,
+    ...neighborEffects.filter((effect) => effect.label === 'hub soulagé' || effect.label === 'axe stabilisé' || effect.tone === 'low').map((effect) => effect.route),
+  ]).size;
+  const delay = priorityAction.delay ?? option?.delay ?? '1 tour';
+  const criticalRemaining = criticalAfter > 0 || choice?.bottleneck?.tone === 'high';
+
+  return {
+    status: criticalRemaining ? 'critical' : reducedShortages > 0 || relievedRoutes > 1 ? 'improved' : 'limited',
+    summary: `${priorityAction.action}: ${reducedShortages} pénurie${reducedShortages > 1 ? 's' : ''} aval réduite${reducedShortages > 1 ? 's' : ''}, ${relievedRoutes} route${relievedRoutes > 1 ? 's' : ''}/province${relievedRoutes > 1 ? 's' : ''} soulagée${relievedRoutes > 1 ? 's' : ''}, délai ${delay}.`,
+    currentState: criticalBefore > 0
+      ? `Actuel: ${criticalBefore} pénurie${criticalBefore > 1 ? 's' : ''} critique${criticalBefore > 1 ? 's' : ''} ou déplacée${criticalBefore > 1 ? 's' : ''}.`
+      : `Actuel: ${priorityAction.downstreamStatus} sur ${priorityAction.route}.`,
+    projectedState: criticalRemaining
+      ? `Projeté: pénurie critique encore possible (${choice?.bottleneck?.label ?? 'goulot restant'}).`
+      : `Projeté: ${priorityAction.downstreamStatus} après ${priorityAction.action}.`,
+    badges: [
+      { label: 'Pénuries réduites', value: String(reducedShortages), tone: reducedShortages > 0 ? 'low' : 'medium' },
+      { label: 'Axes soulagés', value: String(relievedRoutes), tone: relievedRoutes > 1 ? 'low' : 'medium' },
+      { label: 'Délai', value: delay, tone: getDelayTurns(delay) > 1 ? 'medium' : 'low' },
+    ],
+    criticalRemaining,
+  };
+}
+
 export function buildProvinceLogisticsChoicePreview(province, economyView, options = {}) {
   const normalizedOptions = requireObject(options, 'ProvinceLogisticsChoicePreview options');
   const resourceLabelById = requireObject(normalizedOptions.resourceLabelById ?? {}, 'ProvinceLogisticsChoicePreview resourceLabelById');
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', selectedActionPreview: buildSelectedActionImpactPreview(null, []), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -544,6 +592,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       downstreamSummary: 'Aucune pénurie aval claire détectée.',
       priorityActions: [],
       prioritySummary: 'Aucune action logistique prioritaire disponible.',
+      selectedActionPreview: buildSelectedActionImpactPreview(null, []),
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
       options: [],
@@ -554,6 +603,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const hasBlocker = routeChoices.some((choice) => choice.tone === 'high' || choice.tone === 'medium');
   const priorityActions = buildRecoveryPriorityActions(routeChoices);
   const recommendedPriority = priorityActions[0] ?? null;
+  const selectedActionPreview = buildSelectedActionImpactPreview(recommendedPriority, routeChoices);
 
   return {
     recommendedOptionId: recommended.optionId,
@@ -570,6 +620,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
     prioritySummary: recommendedPriority
       ? `${recommendedPriority.action} recommandée: ${recommendedPriority.reason} (${recommendedPriority.tradeoff}, ${recommendedPriority.delay}).`
       : 'Aucune action logistique prioritaire disponible.',
+    selectedActionPreview,
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker
       ? `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.cause} ${recommended.recoveryChoices[0].label} est prioritaire car ${recommended.recoveryChoices[0].benefit}`

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -79,9 +79,14 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.ok(['aggravée', 'déplacée', 'résolue', 'inconnue'].includes(preview.downstreamStatus));
   assert.ok(preview.priorityActions.length >= 2);
   assert.equal(preview.priorityActions[0].recommended, true);
+  assert.ok(preview.selectedActionPreview.badges.length <= 3);
   assert.match(preview.prioritySummary, /recommandée/);
   assert.ok(preview.priorityActions.some((action) => /rapide mais limitée|plus lente mais structurante|équilibrée/.test(action.tradeoff)));
   assert.ok(preview.priorityActions.every((action) => action.impact.length > 0 && action.reason.length > 0 && action.delay.length > 0));
+  assert.match(preview.selectedActionPreview.summary, /pénurie|route|province|délai/);
+  assert.ok(['critical', 'improved', 'limited'].includes(preview.selectedActionPreview.status));
+  assert.equal(preview.selectedActionPreview.badges.length, 3);
+  assert.match(`${preview.selectedActionPreview.currentState} ${preview.selectedActionPreview.projectedState}`, /Actuel|Projeté/);
   assert.ok(preview.options[0].recoveryChoices.length >= 2);
   assert.equal(preview.options[0].recoveryChoices[0].recommended, true);
   assert.match(preview.options[0].recoveryChoices[0].benefit, /Outils|River Gate|Ember Line/);
@@ -131,6 +136,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.downstreamSummary, /Aucune pénurie aval/);
   assert.deepEqual(preview.priorityActions, []);
   assert.match(preview.prioritySummary, /Aucune action logistique prioritaire/);
+  assert.equal(preview.selectedActionPreview.status, 'empty');
+  assert.deepEqual(preview.selectedActionPreview.badges, []);
   assert.match(preview.timelineSummary, /timeline vide/);
   assert.match(preview.summary, /Logistique stable/);
 });

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -23,6 +23,10 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Priorité aval/);
   assert.match(webAppSource, /preview\.priorityActions/);
   assert.match(webAppSource, /action\.tradeoff/);
+  assert.match(webAppSource, /province-logistics-impact-preview/);
+  assert.match(webAppSource, /Impact si engagé/);
+  assert.match(webAppSource, /selectedActionPreview/);
+  assert.match(webAppSource, /badge\.value/);
   assert.match(webAppSource, /pénurie/);
   assert.match(webAppSource, /Pénuries aval/);
   assert.match(webAppSource, /choice\.downstreamShortages/);
@@ -52,6 +56,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-priority-summary/);
   assert.match(stylesSource, /province-logistics-priority-list/);
   assert.match(stylesSource, /province-logistics-priority--high/);
+  assert.match(stylesSource, /province-logistics-impact-preview--critical/);
+  assert.match(stylesSource, /province-logistics-impact-badge--medium/);
   assert.match(stylesSource, /province-logistics-downstream-summary--résolue/);
   assert.match(stylesSource, /province-logistics-downstream-shortage--high/);
   assert.match(stylesSource, /province-logistics-timeline-summary--empty/);

--- a/web/app.js
+++ b/web/app.js
@@ -1244,6 +1244,21 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
           `).join('')}
         </div>
       ` : ''}
+      <div class="province-logistics-impact-preview province-logistics-impact-preview--${preview.selectedActionPreview.status}" aria-label="Impact projeté avant engagement logistique">
+        <div>
+          <b>Impact si engagé</b>
+          <span>${preview.selectedActionPreview.summary}</span>
+        </div>
+        <p>${preview.selectedActionPreview.currentState} → ${preview.selectedActionPreview.projectedState}</p>
+        ${preview.selectedActionPreview.badges.length > 0 ? `
+          <ul>
+            ${preview.selectedActionPreview.badges.slice(0, 3).map((badge) => `
+              <li class="province-logistics-impact-badge province-logistics-impact-badge--${badge.tone}"><strong>${badge.value}</strong><span>${badge.label}</span></li>
+            `).join('')}
+          </ul>
+        ` : ''}
+        ${preview.selectedActionPreview.criticalRemaining ? '<small>Pénurie critique encore possible malgré la meilleure action.</small>' : ''}
+      </div>
       ${preview.options.length > 0 ? `
         <div class="province-logistics-choice-list">
           ${preview.options.map((option) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -3373,6 +3373,56 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.province-logistics-impact-preview {
+  display: grid;
+  gap: 6px;
+  margin: 8px 0;
+  padding: 9px 10px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.48);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+.province-logistics-impact-preview--improved { border-color: rgba(74, 222, 128, 0.28); }
+.province-logistics-impact-preview--limited { border-color: rgba(245, 158, 11, 0.28); }
+.province-logistics-impact-preview--critical { border-color: rgba(251, 113, 133, 0.34); }
+.province-logistics-impact-preview div {
+  display: grid;
+  gap: 3px;
+}
+.province-logistics-impact-preview b {
+  color: #bfdbfe;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.province-logistics-impact-preview span,
+.province-logistics-impact-preview p,
+.province-logistics-impact-preview small {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-logistics-impact-preview p { margin: 0; }
+.province-logistics-impact-preview ul {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.province-logistics-impact-badge {
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.province-logistics-impact-badge--low { border-color: rgba(74, 222, 128, 0.24); }
+.province-logistics-impact-badge--medium { border-color: rgba(245, 158, 11, 0.28); }
+.province-logistics-impact-badge strong { color: #f8fafc; font-size: 13px; }
+.province-logistics-impact-badge span { color: #bfdbfe; font-size: 10px; }
 .province-logistics-cause-summary--high { border-color: rgba(251, 113, 133, 0.38); }
 .province-logistics-cause-summary--medium { border-color: rgba(245, 158, 11, 0.34); }
 .province-logistics-cause-summary--stable,


### PR DESCRIPTION
Beta: Implements #594.

## Summary
- derives a selected-action logistics impact preview from the recommended downstream priority action
- compares current vs projected logistics state with three compact badges for reduced shortages, relieved axes, and delay
- flags when a critical downstream shortage can remain while keeping priority recommendation and downstream details visible

## Tests
- npm test
- npm test -- --test-reporter=spec test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.