### PR TITLE
Delta: preview intrigue queue exposure changes

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -129,3 +129,19 @@ test('queued intrigue actions show cumulative exposure risk and mitigations', ()
   assert.match(stylesSource, /province-intrigue-cumulative-risk--danger/);
   assert.match(stylesSource, /province-intrigue-cumulative-risk--warning/);
 });
+
+test('queued intrigue preview shows exposure deltas before confirmation', () => {
+  assert.match(webAppSource, /function buildIntrigueQueueChangePreview/);
+  assert.match(webAppSource, /Aperçu avant confirmation des changements intrigue/);
+  assert.match(webAppSource, /Avant confirmation/);
+  assert.match(webAppSource, /Ajouter/);
+  assert.match(webAppSource, /Retirer/);
+  assert.match(webAppSource, /Remplacer/);
+  assert.match(webAppSource, /Alternative sûre: \$\{queueChangePreview\.safeAlternative\}/);
+  assert.match(webAppSource, /Prévisualisation fog-safe: seuls delta, province visible et type de réponse sont exposés/);
+  assert.match(webAppSource, /Remplacer par \$\{fallbackAction\} conserve un repli prudent sans révéler cellule ou cible/);
+  assert.match(stylesSource, /province-intrigue-queue-change-preview/);
+  assert.match(stylesSource, /province-intrigue-queue-change-preview__scenario--ajout/);
+  assert.match(stylesSource, /province-intrigue-queue-change-preview__scenario--retrait/);
+  assert.match(stylesSource, /province-intrigue-queue-change-preview__scenario--remplacement/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2954,9 +2954,64 @@ function buildCumulativeQueuedIntrigueExposureRisk(province, projection, intrigu
   };
 }
 
+function buildIntrigueQueueChangePreview(projection, cumulativeRisk) {
+  const lead = cumulativeRisk.contributions[0] ?? null;
+  const fallbackAction = projection.fallback?.empty ? lead?.fallback ?? 'différer' : projection.fallback.action.toLowerCase();
+  const currentScore = Number.parseInt(cumulativeRisk.totalLabel, 10) || 0;
+  const candidateScore = lead?.score ?? 0;
+  const addScore = Math.min(100, currentScore + Math.max(4, Math.round(candidateScore / 4)));
+  const removeScore = Math.max(0, currentScore - Math.max(6, Math.round(candidateScore / 3)));
+  const replaceScore = Math.max(0, currentScore - Math.max(4, Math.round(candidateScore / 4)));
+  const deltaLabel = (nextScore) => {
+    const delta = nextScore - currentScore;
+
+    return delta > 0 ? `+${delta}` : `${delta}`;
+  };
+  const strongestMover = lead
+    ? `${lead.provinceLabel}: ${lead.actionLabel}`
+    : 'Aucune action candidate visible';
+
+  return {
+    strongestMover,
+    safeAlternative: fallbackAction,
+    fogLimit: 'Prévisualisation fog-safe: seuls delta, province visible et type de réponse sont exposés.',
+    scenarios: [
+      {
+        code: 'ajout',
+        label: 'Ajouter',
+        before: currentScore,
+        after: addScore,
+        delta: deltaLabel(addScore),
+        detail: lead
+          ? `Ajout pressenti autour de ${lead.provinceLabel}; garder la source exacte masquée.`
+          : 'Aucun ajout risqué lisible dans la file actuelle.',
+      },
+      {
+        code: 'retrait',
+        label: 'Retirer',
+        before: currentScore,
+        after: removeScore,
+        delta: deltaLabel(removeScore),
+        detail: lead
+          ? `Retirer ${lead.actionLabel} réduit surtout la pression visible sur ${lead.provinceLabel}.`
+          : 'Retrait sans effet estimable tant que la file reste vide.',
+      },
+      {
+        code: 'remplacement',
+        label: 'Remplacer',
+        before: currentScore,
+        after: replaceScore,
+        delta: deltaLabel(replaceScore),
+        detail: `Remplacer par ${fallbackAction} conserve un repli prudent sans révéler cellule ou cible.`,
+      },
+    ],
+  };
+}
+
 function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView) {
   const projection = buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView);
   const cumulativeRisk = buildCumulativeQueuedIntrigueExposureRisk(province, projection, intrigueView);
+  const queueChangePreview = buildIntrigueQueueChangePreview(projection, cumulativeRisk);
 
   return `
     <section class="province-intrigue-detection-projection province-intrigue-detection-projection--${projection.tone}" aria-label="Projection du risque de détection intrigue">
@@ -3001,6 +3056,23 @@ function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intr
         ` : ''}
         <small>${cumulativeRisk.mitigation}</small>
         <small>${cumulativeRisk.fogLimit}</small>
+      </div>
+      <div class="province-intrigue-queue-change-preview" aria-label="Aperçu avant confirmation des changements intrigue">
+        <div class="province-intrigue-queue-change-preview__header">
+          <span>Avant confirmation</span>
+          <strong>${queueChangePreview.strongestMover}</strong>
+        </div>
+        <div class="province-intrigue-queue-change-preview__grid">
+          ${queueChangePreview.scenarios.map((scenario) => `
+            <article class="province-intrigue-queue-change-preview__scenario province-intrigue-queue-change-preview__scenario--${scenario.code}">
+              <strong>${scenario.label}</strong>
+              <span>${scenario.before} → ${scenario.after} (${scenario.delta})</span>
+              <small>${scenario.detail}</small>
+            </article>
+          `).join('')}
+        </div>
+        <small>Alternative sûre: ${queueChangePreview.safeAlternative}.</small>
+        <small>${queueChangePreview.fogLimit}</small>
       </div>
       <small>${projection.fogLimit}</small>
     </section>

--- a/web/styles.css
+++ b/web/styles.css
@@ -6726,6 +6726,55 @@ button { font: inherit; }
   display: block;
   color: var(--muted);
 }
+.province-intrigue-queue-change-preview {
+  display: grid;
+  gap: 8px;
+  margin: 8px 0;
+  padding: 10px;
+  border-radius: 13px;
+  background: rgba(30, 41, 59, 0.32);
+  border: 1px solid rgba(129, 140, 248, 0.24);
+}
+.province-intrigue-queue-change-preview__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-queue-change-preview__header span {
+  color: #c4b5fd;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.province-intrigue-queue-change-preview__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+.province-intrigue-queue-change-preview__scenario {
+  padding: 8px;
+  border-radius: 11px;
+  background: rgba(2, 6, 23, 0.26);
+  border-top: 3px solid rgba(148, 163, 184, 0.42);
+}
+.province-intrigue-queue-change-preview__scenario--ajout { border-top-color: rgba(248, 113, 113, 0.72); }
+.province-intrigue-queue-change-preview__scenario--retrait { border-top-color: rgba(34, 197, 94, 0.68); }
+.province-intrigue-queue-change-preview__scenario--remplacement { border-top-color: rgba(96, 165, 250, 0.68); }
+.province-intrigue-queue-change-preview__scenario strong,
+.province-intrigue-queue-change-preview__scenario span,
+.province-intrigue-queue-change-preview__scenario small {
+  display: block;
+}
+.province-intrigue-queue-change-preview small,
+.province-intrigue-queue-change-preview__scenario small {
+  color: var(--muted);
+}
+@media (max-width: 760px) {
+  .province-intrigue-queue-change-preview__grid {
+    grid-template-columns: 1fr;
+  }
+}
 
 .province-intrigue-risk-warnings {
   margin-top: 12px;


### PR DESCRIPTION
Delta: Implements #596.

Summary:
- adds a fog-safe pre-confirmation preview for queued intrigue exposure changes
- shows add/remove/replace before→after deltas and the strongest visible mover
- surfaces an existing safe fallback alternative while preserving cumulative risk/details

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Ready for Zeta validation before merge.