### PR TITLE
Gamma: preview culture stability changes

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -463,6 +463,58 @@ function buildPriorityConflicts(reminders) {
     .slice(0, 2);
 }
 
+
+function buildStabilityPreview(reminder, priorityConflicts = []) {
+  const knownRipple = reminder.rippleEffects?.find((effect) => effect.tone === 'positive' || effect.tone === 'risky' || effect.tone === 'uncertain');
+  const relatedConflict = priorityConflicts.find((conflict) => conflict.primaryReminderId === reminder.reminderId
+    || conflict.secondaryReminderId === reminder.reminderId);
+
+  if (!knownRipple && reminder.inactionCost?.level === 'low' && !relatedConflict) {
+    return null;
+  }
+
+  const stabilityDelta = reminder.inactionCost?.level === 'closing' || reminder.urgency?.level === 'soon'
+    ? '+ stabilité locale'
+    : knownRipple?.tone === 'risky'
+      ? 'stabilité fragile'
+      : knownRipple?.tone === 'positive'
+        ? '+ cohésion culturelle'
+        : 'effet limité';
+  const urgencyDelta = reminder.inactionCost?.level === 'closing'
+    ? 'urgence baisse si action validée'
+    : reminder.urgency?.level === 'soon'
+      ? 'fenêtre sécurisée'
+      : 'urgence stable';
+  const dissentDelta = reminder.confidenceCue?.level === 'risky'
+    ? 'dissidence à surveiller'
+    : reminder.confidenceCue?.level === 'mixed'
+      ? 'dissidence clarifiée'
+      : 'dissidence faible';
+  const conflictImpact = relatedConflict
+    ? `${relatedConflict.label}: peut aggraver ${relatedConflict.secondaryReminderId === reminder.reminderId ? 'la priorité adverse' : 'le conflit détecté'}.`
+    : 'Aucun conflit culturel aggravé détecté.';
+  const reason = reminder.inactionCost?.level !== 'low'
+    ? reminder.inactionCost.summary
+    : (knownRipple?.summary ?? reminder.reasonCopy);
+
+  return {
+    level: relatedConflict?.level ?? (knownRipple?.tone === 'risky' ? 'watch' : 'steady'),
+    stabilityDelta,
+    urgencyDelta,
+    dissentDelta,
+    conflictImpact,
+    reason,
+    summary: `${stabilityDelta}; ${urgencyDelta}; ${dissentDelta}. ${reason}`,
+  };
+}
+
+function attachStabilityPreviews(reminders, priorityConflicts) {
+  return reminders.map((reminder) => ({
+    ...reminder,
+    stabilityPreview: buildStabilityPreview(reminder, priorityConflicts),
+  }));
+}
+
 function dedupeAndSort(reminders) {
   const remindersByKey = new Map();
 
@@ -509,12 +561,13 @@ export function buildCultureOpportunityReminders({
   const probableCount = reminders.filter((reminder) => reminder.status === 'probable').length;
   const missingCount = reminders.filter((reminder) => reminder.status === 'missing').length;
   const priorityConflicts = buildPriorityConflicts(reminders);
+  const remindersWithStabilityPreviews = attachStabilityPreviews(reminders, priorityConflicts);
 
   return {
     state: 'active',
     provinceLabel,
     summary: `${provinceLabel}: ${probableCount} opportunité${probableCount > 1 ? 's' : ''} probable${probableCount > 1 ? 's' : ''}, ${missingCount} condition${missingCount > 1 ? 's' : ''} à surveiller.`,
-    reminders,
+    reminders: remindersWithStabilityPreviews,
     priorityConflicts,
   };
 }

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -109,6 +109,13 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
     ['urgent', 'Même action en file', 'Agir maintenant', ['Compact d’Aurora', 'Compact d’Aurora']],
   ]);
   assert.equal(report.priorityConflicts[0].summary, 'Agir maintenant: prioriser Compact d’Aurora avant Compact d’Aurora. Ouverture des archives risque de sortir de la timeline locale sans action (ce tour).');
+  assert.deepEqual(report.reminders.map((reminder) => reminder.stabilityPreview && [reminder.stabilityPreview.level, reminder.stabilityPreview.stabilityDelta, reminder.stabilityPreview.urgencyDelta]), [
+    ['urgent', '+ stabilité locale', 'urgence baisse si action validée'],
+    ['urgent', 'effet limité', 'urgence stable'],
+    null,
+  ]);
+  assert.equal(report.reminders[0].stabilityPreview.conflictImpact, 'Même action en file: peut aggraver le conflit détecté.');
+  assert.equal(report.reminders[1].stabilityPreview.reason, 'Compact d’Aurora garde la fenêtre culturelle ouverte.');
   assert.deepEqual(report.reminders[0].urgency, {
     level: 'soon',
     label: 'Expire bientôt',

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -23,6 +23,9 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /culture-opportunity-priority-conflicts/);
   assert.match(webAppSource, /report\.priorityConflicts/);
   assert.match(webAppSource, /Conflits de priorité culturelle/);
+  assert.match(webAppSource, /culture-opportunity-reminder__stability-preview/);
+  assert.match(webAppSource, /reminder\.stabilityPreview/);
+  assert.match(webAppSource, /Aperçu de stabilité culturelle/);
   assert.match(webAppSource, /Pas de perte culturelle claire/);
   assert.match(webAppSource, /Aucun effet de propagation culturel en file/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__reason/);
@@ -35,6 +38,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-opportunity-reminder__inaction--low/);
   assert.match(stylesSource, /\.culture-opportunity-priority-conflict--urgent/);
   assert.match(stylesSource, /\.culture-opportunity-priority-conflict--shared/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__stability-preview--urgent/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__stability-preview--steady/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--positive/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--uncertain/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--risky/);

--- a/web/app.js
+++ b/web/app.js
@@ -964,6 +964,13 @@ function renderCultureOpportunityReminders(report) {
               <p class="culture-opportunity-reminder__tradeoff"><b>Compromis</b> · ${reminder.tradeoff?.summary ?? reminder.tradeoffCopy ?? 'Bénéfice culturel contre risque narratif.'}</p>
               <p class="culture-opportunity-reminder__confidence culture-opportunity-reminder__confidence--${reminder.confidenceCue?.level ?? 'mixed'}"><b>${reminder.confidenceCue?.label ?? 'Confiance mixte'}</b> · ${reminder.confidenceCue?.summary ?? reminder.confidenceCopy ?? 'Effet culturel à confirmer.'}</p>
               <p class="culture-opportunity-reminder__inaction culture-opportunity-reminder__inaction--${reminder.inactionCost?.level ?? 'low'}"><b>Inaction</b> · ${reminder.inactionCost?.summary ?? reminder.inactionCopy ?? 'Pas de perte culturelle claire si la recommandation attend.'}</p>
+              ${reminder.stabilityPreview ? `
+                <div class="culture-opportunity-reminder__stability-preview culture-opportunity-reminder__stability-preview--${reminder.stabilityPreview.level}" aria-label="Aperçu de stabilité culturelle">
+                  <b>Aperçu stabilité</b>
+                  <span>${reminder.stabilityPreview.stabilityDelta} · ${reminder.stabilityPreview.urgencyDelta} · ${reminder.stabilityPreview.dissentDelta}</span>
+                  <small>${reminder.stabilityPreview.conflictImpact}</small>
+                </div>
+              ` : ''}
               <div class="culture-opportunity-reminder__ripples" aria-label="Effets de propagation culturelle">
                 <b>Propagation</b>
                 ${(reminder.rippleEffects ?? []).length > 0 ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -2988,6 +2988,22 @@ button { font: inherit; }
 .culture-opportunity-reminder__inaction--risky,
 .culture-opportunity-reminder__inaction--blocked { border-color: rgba(251, 191, 36, 0.34); background: rgba(120, 53, 15, 0.12); color: #fde68a !important; }
 .culture-opportunity-reminder__inaction--low { border-color: rgba(148, 163, 184, 0.14); opacity: 0.82; }
+.culture-opportunity-reminder__stability-preview {
+  display: grid;
+  gap: 3px;
+  margin-top: 6px;
+  padding: 7px;
+  border-radius: 12px;
+  background: rgba(22, 78, 99, 0.12);
+  border: 1px solid rgba(103, 232, 249, 0.16);
+}
+.culture-opportunity-reminder__stability-preview b { color: #cffafe; font-size: 11px; }
+.culture-opportunity-reminder__stability-preview span { color: #ecfeff; font-size: 11px; text-transform: none; letter-spacing: 0; margin: 0; }
+.culture-opportunity-reminder__stability-preview small { color: #bae6fd; font-size: 11px; line-height: 1.3; }
+.culture-opportunity-reminder__stability-preview--urgent { border-color: rgba(248, 113, 113, 0.34); background: rgba(127, 29, 29, 0.12); }
+.culture-opportunity-reminder__stability-preview--shared { border-color: rgba(251, 191, 36, 0.32); background: rgba(120, 53, 15, 0.1); }
+.culture-opportunity-reminder__stability-preview--watch { border-color: rgba(56, 189, 248, 0.28); }
+.culture-opportunity-reminder__stability-preview--steady { border-color: rgba(74, 222, 128, 0.24); background: rgba(22, 163, 74, 0.08); }
 .culture-opportunity-reminder__ripples {
   display: grid;
   gap: 5px;


### PR DESCRIPTION
Gamma: PR prête pour validation.

Scope #595:
- ajoute un aperçu court des changements culturels attendus pour chaque recommandation sélectionnable;
- expose stabilité/cohésion, urgence et dissidence projetées à partir des ripples, coûts d’inaction et conflits déjà calculés;
- indique quand la recommandation peut aggraver un conflit de priorité existant;
- reste discret quand l’effet projeté est négligeable ou insuffisamment connu.

Tests:
- `npm test`
- `npm test -- test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js`
- `node --check web/app.js`
- `node --check src/ui/culture/buildCultureOpportunityReminders.js`
- `git diff --check`

Zeta, peux-tu valider cette PR avant tout merge ?

Closes #595