### PR TITLE
Delta: queue safe intrigue responses from map

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -145,3 +145,22 @@ test('queued intrigue preview shows exposure deltas before confirmation', () => 
   assert.match(stylesSource, /province-intrigue-queue-change-preview__scenario--retrait/);
   assert.match(stylesSource, /province-intrigue-queue-change-preview__scenario--remplacement/);
 });
+
+test('map panel can queue safe intrigue responses with guarded states', () => {
+  assert.match(webAppSource, /function buildMapIntrigueSafeQueueAction/);
+  assert.match(webAppSource, /Queue carte réponse intrigue sûre/);
+  assert.match(webAppSource, /data-action="queue-safe-intrigue-response"/);
+  assert.match(webAppSource, /déjà en file/);
+  assert.match(webAppSource, /trop risqué/);
+  assert.match(webAppSource, /aucune réponse disponible/);
+  assert.match(webAppSource, /fallback proposé/);
+  assert.match(webAppSource, /Exposition/);
+  assert.match(webAppSource, /Risque résiduel/);
+  assert.match(webAppSource, /Sources majeures/);
+  assert.match(webAppSource, /Ignorer maintenant laisse la pression visible s’accumuler au prochain tour/);
+  assert.match(webAppSource, /La réponse recommandée est remplacée par un fallback sûr déjà connu/);
+  assert.match(webAppSource, /Queue directe depuis le panneau carte, sans navigation lourde/);
+  assert.match(stylesSource, /province-intrigue-map-queue-action/);
+  assert.match(stylesSource, /province-intrigue-map-queue-action--disabled/);
+  assert.match(stylesSource, /province-intrigue-map-queue-action__cta:disabled/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3015,10 +3015,60 @@ function buildIntrigueQueueChangePreview(projection, cumulativeRisk) {
   };
 }
 
+function buildMapIntrigueSafeQueueAction(province, projection, cumulativeRisk, queueChangePreview) {
+  const alreadyQueued = !projection.empty;
+  const tooRisky = projection.tone === 'danger' && projection.fallback.empty;
+  const fallbackReady = !projection.fallback.empty && ['danger', 'warning', 'masked'].includes(projection.tone);
+  const unavailable = projection.empty && projection.fallback.empty;
+  const status = alreadyQueued
+    ? 'déjà en file'
+    : tooRisky
+      ? 'trop risqué'
+      : unavailable
+        ? 'aucune réponse disponible'
+        : fallbackReady
+          ? 'fallback proposé'
+          : 'prêt';
+  const actionLabel = fallbackReady
+    ? projection.fallback.action
+    : unavailable
+      ? 'Aucune réponse disponible'
+      : projection.label.replace(/^Réponse en file · /, '') || 'Réponse intrigue recommandée';
+  const disabled = alreadyQueued || tooRisky || unavailable;
+  const residualRisk = queueChangePreview.scenarios.find((scenario) => scenario.code === 'remplacement')?.after
+    ?? Number.parseInt(cumulativeRisk.totalLabel, 10)
+    ?? 0;
+  const majorSources = projection.sources.slice(0, 2).map((source) => source.label).join(' · ') || 'Sources masquées';
+
+  return {
+    status,
+    actionLabel,
+    disabled,
+    residualRisk,
+    majorSources,
+    beforeLabel: projection.beforeLabel,
+    afterLabel: projection.afterLabel,
+    ignoredConsequence: cumulativeRisk.level === 'critique' || cumulativeRisk.level === 'élevé'
+      ? 'Ignorer maintenant laisse la pression visible s’accumuler au prochain tour.'
+      : 'Ignorer conserve le signal sous observation, mais le brouillard peut réduire la confiance.',
+    ctaLabel: disabled ? 'Action non queueable' : `Queue carte: ${actionLabel}`,
+    detail: fallbackReady
+      ? 'La réponse recommandée est remplacée par un fallback sûr déjà connu.'
+      : alreadyQueued
+        ? 'Une réponse intrigue est déjà en file pour cette province.'
+        : tooRisky
+          ? 'Risque trop élevé sans fallback sûr; attendre un signal confirmé.'
+          : unavailable
+            ? 'Aucune réponse exploitable depuis la carte sans lever le brouillard.'
+            : 'Queue directe depuis le panneau carte, sans navigation lourde.',
+  };
+}
+
 function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView) {
   const projection = buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView);
   const cumulativeRisk = buildCumulativeQueuedIntrigueExposureRisk(province, projection, intrigueView);
   const queueChangePreview = buildIntrigueQueueChangePreview(projection, cumulativeRisk);
+  const mapQueueAction = buildMapIntrigueSafeQueueAction(province, projection, cumulativeRisk, queueChangePreview);
 
   return `
     <section class="province-intrigue-detection-projection province-intrigue-detection-projection--${projection.tone}" aria-label="Projection du risque de détection intrigue">
@@ -3080,6 +3130,20 @@ function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intr
         </div>
         <small>Alternative sûre: ${queueChangePreview.safeAlternative}.</small>
         <small>${queueChangePreview.fogLimit}</small>
+      </div>
+      <div class="province-intrigue-map-queue-action province-intrigue-map-queue-action--${mapQueueAction.disabled ? 'disabled' : 'ready'}" aria-label="Queue carte réponse intrigue sûre">
+        <div class="province-intrigue-map-queue-action__header">
+          <span>${mapQueueAction.status}</span>
+          <strong>${mapQueueAction.actionLabel}</strong>
+        </div>
+        <dl>
+          <div><dt>Exposition</dt><dd>${mapQueueAction.beforeLabel} → ${mapQueueAction.afterLabel}</dd></div>
+          <div><dt>Risque résiduel</dt><dd>${mapQueueAction.residualRisk}</dd></div>
+          <div><dt>Sources majeures</dt><dd>${mapQueueAction.majorSources}</dd></div>
+        </dl>
+        <p>${mapQueueAction.ignoredConsequence}</p>
+        <button type="button" class="province-intrigue-map-queue-action__cta" data-action="queue-safe-intrigue-response" data-province-id="${province.provinceId}" ${mapQueueAction.disabled ? 'disabled' : ''}>${mapQueueAction.ctaLabel}</button>
+        <small>${mapQueueAction.detail}</small>
       </div>
       <small>${projection.fogLimit}</small>
     </section>

--- a/web/styles.css
+++ b/web/styles.css
@@ -6786,8 +6786,73 @@ button { font: inherit; }
 .province-intrigue-queue-change-preview__scenario small {
   color: var(--muted);
 }
+.province-intrigue-map-queue-action {
+  display: grid;
+  gap: 8px;
+  margin: 8px 0;
+  padding: 10px;
+  border-radius: 13px;
+  background: rgba(15, 23, 42, 0.42);
+  border: 1px solid rgba(34, 197, 94, 0.26);
+}
+.province-intrigue-map-queue-action--disabled {
+  border-color: rgba(148, 163, 184, 0.22);
+  opacity: 0.82;
+}
+.province-intrigue-map-queue-action__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-map-queue-action__header span {
+  color: #86efac;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.province-intrigue-map-queue-action dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+  margin: 0;
+}
+.province-intrigue-map-queue-action dl div {
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.24);
+}
+.province-intrigue-map-queue-action dt {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+.province-intrigue-map-queue-action dd {
+  margin: 0;
+  font-weight: 700;
+}
+.province-intrigue-map-queue-action p,
+.province-intrigue-map-queue-action small {
+  margin: 0;
+  color: var(--muted);
+}
+.province-intrigue-map-queue-action__cta {
+  justify-self: start;
+  padding: 7px 11px;
+  border-radius: 999px;
+  border: 1px solid rgba(34, 197, 94, 0.45);
+  color: #dcfce7;
+  background: rgba(22, 101, 52, 0.34);
+  cursor: pointer;
+}
+.province-intrigue-map-queue-action__cta:disabled {
+  cursor: not-allowed;
+  color: var(--muted);
+  border-color: rgba(148, 163, 184, 0.24);
+  background: rgba(51, 65, 85, 0.28);
+}
 @media (max-width: 760px) {
-  .province-intrigue-queue-change-preview__grid {
+  .province-intrigue-queue-change-preview__grid,
+  .province-intrigue-map-queue-action dl {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
Delta: Implements #606.

Summary:
- adds a fog-safe map-panel CTA for queueing a recommended safe intrigue response or fallback
- keeps exposure before/after, residual risk, major risk sources, and ignored-action consequence visible before confirmation
- covers already queued, too risky, fallback replacement, and no-response states without leaving the map

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Ready for Zeta validation before merge.