### PR TITLE
Gamma: queue culture stability actions

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -515,6 +515,39 @@ function attachStabilityPreviews(reminders, priorityConflicts) {
   }));
 }
 
+
+function buildQueueAction(reminder) {
+  if (reminder.recommendedAction?.code === 'accept-risk') {
+    return null;
+  }
+
+  const horizon = reminder.recommendedAction?.timing ?? reminder.urgency?.timingLabel ?? reminder.urgency?.window ?? 'à confirmer';
+  const effect = reminder.stabilityPreview?.summary
+    ?? reminder.rippleEffects?.[0]?.summary
+    ?? reminder.recommendedAction?.summary;
+  const opportunityCost = reminder.tradeoff?.risk
+    ?? reminder.inactionCost?.summary
+    ?? 'Peut retarder une autre fenêtre culturelle.';
+
+  return {
+    code: `culture:${reminder.recommendedAction?.code ?? 'watch-window'}:${reminder.provinceId}`,
+    label: reminder.recommendedAction?.label ?? 'Stabiliser la culture',
+    effect,
+    confidence: reminder.confidenceCue?.label ?? 'Confiance mixte',
+    dissent: reminder.confidenceCue?.dissent ?? 'Effet à confirmer',
+    opportunityCost,
+    horizon,
+    summary: `${effect} Horizon ${horizon}; coût: ${opportunityCost}`,
+  };
+}
+
+function attachQueueActions(reminders) {
+  return reminders.map((reminder) => ({
+    ...reminder,
+    queueAction: buildQueueAction(reminder),
+  }));
+}
+
 function dedupeAndSort(reminders) {
   const remindersByKey = new Map();
 
@@ -562,12 +595,13 @@ export function buildCultureOpportunityReminders({
   const missingCount = reminders.filter((reminder) => reminder.status === 'missing').length;
   const priorityConflicts = buildPriorityConflicts(reminders);
   const remindersWithStabilityPreviews = attachStabilityPreviews(reminders, priorityConflicts);
+  const remindersWithQueueActions = attachQueueActions(remindersWithStabilityPreviews);
 
   return {
     state: 'active',
     provinceLabel,
     summary: `${provinceLabel}: ${probableCount} opportunité${probableCount > 1 ? 's' : ''} probable${probableCount > 1 ? 's' : ''}, ${missingCount} condition${missingCount > 1 ? 's' : ''} à surveiller.`,
-    reminders: remindersWithStabilityPreviews,
+    reminders: remindersWithQueueActions,
     priorityConflicts,
   };
 }

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -116,6 +116,13 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
   ]);
   assert.equal(report.reminders[0].stabilityPreview.conflictImpact, 'Même action en file: peut aggraver le conflit détecté.');
   assert.equal(report.reminders[1].stabilityPreview.reason, 'Compact d’Aurora garde la fenêtre culturelle ouverte.');
+  assert.deepEqual(report.reminders.map((reminder) => reminder.queueAction && [reminder.queueAction.code, reminder.queueAction.label, reminder.queueAction.horizon]), [
+    ['culture:follow-event:river-gate', 'Suivre l’événement', 'ce tour'],
+    ['culture:accelerate-research:river-gate', 'Accélérer la recherche', 'maintenant'],
+    null,
+  ]);
+  assert.equal(report.reminders[0].queueAction.opportunityCost, 'Événement ignoré si ce tour passe');
+  assert.match(report.reminders[0].queueAction.summary, /coût: Événement ignoré si ce tour passe/);
   assert.deepEqual(report.reminders[0].urgency, {
     level: 'soon',
     label: 'Expire bientôt',

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -26,6 +26,10 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /culture-opportunity-reminder__stability-preview/);
   assert.match(webAppSource, /reminder\.stabilityPreview/);
   assert.match(webAppSource, /Aperçu de stabilité culturelle/);
+  assert.match(webAppSource, /culture-opportunity-reminder__queue-action/);
+  assert.match(webAppSource, /data-culture-queue-action/);
+  assert.match(webAppSource, /Mettre en file/);
+  assert.match(webAppSource, /Aucune action culturelle pertinente/);
   assert.match(webAppSource, /Pas de perte culturelle claire/);
   assert.match(webAppSource, /Aucun effet de propagation culturel en file/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__reason/);
@@ -40,6 +44,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-opportunity-priority-conflict--shared/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__stability-preview--urgent/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__stability-preview--steady/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__queue-action/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__queue-empty/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--positive/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--uncertain/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--risky/);

--- a/web/app.js
+++ b/web/app.js
@@ -984,6 +984,16 @@ function renderCultureOpportunityReminders(report) {
                   </ul>
                 ` : '<small>Aucun effet de propagation culturel en file.</small>'}
               </div>
+              ${reminder.queueAction ? `
+                <div class="culture-opportunity-reminder__queue-action" aria-label="Action culturelle à mettre en file">
+                  <b>${reminder.queueAction.label}</b>
+                  <small>${reminder.queueAction.effect} · ${reminder.queueAction.confidence} (${reminder.queueAction.dissent}) · Horizon ${reminder.queueAction.horizon}</small>
+                  <small>Coût d’opportunité: ${reminder.queueAction.opportunityCost}</small>
+                  <button type="button" data-culture-queue-action="${reminder.queueAction.code}" data-culture-queue-region="${reminder.provinceId}" data-culture-queue-summary="${reminder.queueAction.summary}" aria-label="Mettre en file ${reminder.queueAction.label}: ${reminder.queueAction.summary}">
+                    Mettre en file
+                  </button>
+                </div>
+              ` : '<small class="culture-opportunity-reminder__queue-empty">Aucune action culturelle pertinente à mettre en file.</small>'}
               <button type="button" data-culture-focus-region="${reminder.focusTarget.regionId}" data-culture-focus-type="${reminder.focusTarget.type}" data-culture-focus-id="${reminder.focusTarget.id}" aria-label="Voir ${reminder.focusCopy}: ${reminder.urgency?.detail ?? reminder.summary}">
                 Voir ${reminder.focusCopy}
               </button>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3035,6 +3035,24 @@ button { font: inherit; }
 .culture-opportunity-reminder__ripple--positive { border-left-color: rgba(74, 222, 128, 0.62); }
 .culture-opportunity-reminder__ripple--uncertain { border-left-color: rgba(56, 189, 248, 0.56); }
 .culture-opportunity-reminder__ripple--risky { border-left-color: rgba(251, 191, 36, 0.62); }
+.culture-opportunity-reminder__queue-action {
+  display: grid;
+  gap: 4px;
+  margin-top: 7px;
+  padding: 7px;
+  border-radius: 12px;
+  background: rgba(14, 165, 233, 0.1);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.culture-opportunity-reminder__queue-action b { color: #dbeafe; font-size: 12px; }
+.culture-opportunity-reminder__queue-action small { color: #bfdbfe; font-size: 11px; line-height: 1.3; }
+.culture-opportunity-reminder__queue-action button { width: fit-content; margin-top: 2px; }
+.culture-opportunity-reminder__queue-empty {
+  display: block;
+  margin-top: 7px;
+  color: var(--muted);
+  font-size: 11px;
+}
 .culture-opportunity-reminder button {
   margin-top: 7px;
   padding: 5px 8px;


### PR DESCRIPTION
Gamma: PR prête pour validation.

Scope #605:
- ajoute une action culturelle jouable depuis chaque recommandation pertinente de la carte;
- expose effet prévu, confiance/dissentiment, coût d’opportunité et horizon avant mise en file;
- garde les conflits/priorités visibles et documente l’état sans action pertinente;
- conserve une copie concise orientée décision.

Tests:
- `npm test`
- `npm test -- test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js`
- `node --check web/app.js`
- `node --check src/ui/culture/buildCultureOpportunityReminders.js`
- `git diff --check`

Zeta, peux-tu valider cette PR avant tout merge ?

Closes #605