### PR TITLE
Beta: queue logistics recovery from map

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -488,6 +488,7 @@ function buildRecoveryPriorityActions(routeChoices) {
         route: option.routes[0],
         resource: option.resources[0],
         tone: impactScore >= 40 ? 'high' : impactScore >= 18 ? 'medium' : 'low',
+        cost: option.cost,
         delay: option.delay,
         impact: choice.benefit,
         reason: `${choice.bottleneck.label}; ${choice.downstreamShortages[0]?.detail ?? 'aucune pénurie aval claire'}`,
@@ -552,12 +553,55 @@ function buildSelectedActionImpactPreview(priorityAction, routeChoices) {
   };
 }
 
+
+function buildPrimaryLogisticsQueueAction(priorityAction, selectedActionPreview, queuedLogisticsActions = []) {
+  if (!priorityAction) {
+    return {
+      actionId: null,
+      label: 'Aucune action logistique à engager',
+      status: 'empty',
+      disabled: true,
+      cost: '—',
+      delay: '—',
+      gain: 'Projection insuffisante',
+      downstreamImpact: 'Aucune pénurie aval claire détectée.',
+      queueWarning: 'Sélectionnez une route logistique ou attendez plus de données.',
+    };
+  }
+
+  const sameRoute = queuedLogisticsActions.find((entry) => entry.routeId === priorityAction.routeId) ?? null;
+  const sameAction = queuedLogisticsActions.find((entry) => entry.actionId === priorityAction.actionId || (entry.routeId === priorityAction.routeId && entry.choiceId === priorityAction.choiceId)) ?? null;
+  const status = sameAction ? 'redundant' : sameRoute ? 'conflict' : selectedActionPreview.criticalRemaining ? 'risky' : 'ready';
+  const queueWarning = sameAction
+    ? 'Action déjà en file: confirmer ajouterait un doublon.'
+    : sameRoute
+      ? `Conflit potentiel avec ${sameRoute.label ?? sameRoute.actionId}: même route déjà planifiée.`
+      : status === 'risky'
+        ? 'Action engageable, mais une pénurie critique peut rester après résolution.'
+        : 'Prêt à engager depuis la carte.';
+
+  return {
+    actionId: priorityAction.actionId,
+    routeId: priorityAction.routeId,
+    choiceId: priorityAction.choiceId,
+    label: priorityAction.action,
+    status,
+    disabled: status === 'redundant' || status === 'conflict',
+    cost: priorityAction.cost,
+    delay: priorityAction.delay,
+    gain: priorityAction.impact,
+    downstreamImpact: selectedActionPreview.summary,
+    queueWarning,
+  };
+}
+
 export function buildProvinceLogisticsChoicePreview(province, economyView, options = {}) {
   const normalizedOptions = requireObject(options, 'ProvinceLogisticsChoicePreview options');
   const resourceLabelById = requireObject(normalizedOptions.resourceLabelById ?? {}, 'ProvinceLogisticsChoicePreview resourceLabelById');
+  const queuedLogisticsActions = Array.isArray(normalizedOptions.queuedLogisticsActions) ? normalizedOptions.queuedLogisticsActions : [];
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', selectedActionPreview: buildSelectedActionImpactPreview(null, []), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', selectedActionPreview: buildSelectedActionImpactPreview(null, []), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -593,6 +637,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       priorityActions: [],
       prioritySummary: 'Aucune action logistique prioritaire disponible.',
       selectedActionPreview: buildSelectedActionImpactPreview(null, []),
+      primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions),
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
       options: [],
@@ -604,6 +649,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const priorityActions = buildRecoveryPriorityActions(routeChoices);
   const recommendedPriority = priorityActions[0] ?? null;
   const selectedActionPreview = buildSelectedActionImpactPreview(recommendedPriority, routeChoices);
+  const primaryLogisticsAction = buildPrimaryLogisticsQueueAction(recommendedPriority, selectedActionPreview, queuedLogisticsActions);
 
   return {
     recommendedOptionId: recommended.optionId,
@@ -621,6 +667,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       ? `${recommendedPriority.action} recommandée: ${recommendedPriority.reason} (${recommendedPriority.tradeoff}, ${recommendedPriority.delay}).`
       : 'Aucune action logistique prioritaire disponible.',
     selectedActionPreview,
+    primaryLogisticsAction,
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker
       ? `${recommended.action} recommandé sur ${recommended.routes[0]}: ${recommended.cause} ${recommended.recoveryChoices[0].label} est prioritaire car ${recommended.recoveryChoices[0].benefit}`

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -87,6 +87,11 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.ok(['critical', 'improved', 'limited'].includes(preview.selectedActionPreview.status));
   assert.equal(preview.selectedActionPreview.badges.length, 3);
   assert.match(`${preview.selectedActionPreview.currentState} ${preview.selectedActionPreview.projectedState}`, /Actuel|Projeté/);
+  assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
+  assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
+  assert.match(preview.primaryLogisticsAction.downstreamImpact, /pénurie|route|province|délai/);
+  assert.ok(['ready', 'risky'].includes(preview.primaryLogisticsAction.status));
+  assert.equal(preview.primaryLogisticsAction.disabled, false);
   assert.ok(preview.options[0].recoveryChoices.length >= 2);
   assert.equal(preview.options[0].recoveryChoices[0].recommended, true);
   assert.match(preview.options[0].recoveryChoices[0].benefit, /Outils|River Gate|Ember Line/);
@@ -138,8 +143,26 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.prioritySummary, /Aucune action logistique prioritaire/);
   assert.equal(preview.selectedActionPreview.status, 'empty');
   assert.deepEqual(preview.selectedActionPreview.badges, []);
+  assert.equal(preview.primaryLogisticsAction.status, 'empty');
+  assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);
   assert.match(preview.summary, /Logistique stable/);
+});
+
+test('buildProvinceLogisticsChoicePreview flags redundant queued logistics actions', () => {
+  const baseline = buildProvinceLogisticsChoicePreview(province, buildEconomyView(), {
+    resourceLabelById: { grain: 'Grain', tools: 'Outils' },
+  });
+  const queuedAction = baseline.primaryLogisticsAction;
+
+  const preview = buildProvinceLogisticsChoicePreview(province, buildEconomyView(), {
+    resourceLabelById: { grain: 'Grain', tools: 'Outils' },
+    queuedLogisticsActions: [{ actionId: queuedAction.actionId, routeId: queuedAction.routeId, choiceId: queuedAction.choiceId, label: queuedAction.label }],
+  });
+
+  assert.equal(preview.primaryLogisticsAction.status, 'redundant');
+  assert.equal(preview.primaryLogisticsAction.disabled, true);
+  assert.match(preview.primaryLogisticsAction.queueWarning, /déjà en file|doublon/);
 });
 
 test('buildProvinceLogisticsChoicePreview exposes stable local route causes', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -27,6 +27,12 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Impact si engagé/);
   assert.match(webAppSource, /selectedActionPreview/);
   assert.match(webAppSource, /badge\.value/);
+  assert.match(webAppSource, /province-logistics-queue-action/);
+  assert.match(webAppSource, /Action carte/);
+  assert.match(webAppSource, /Engager récupération/);
+  assert.match(webAppSource, /data-logistics-queue-action/);
+  assert.match(webAppSource, /queuedLogisticsActions/);
+  assert.match(webAppSource, /primaryLogisticsAction/);
   assert.match(webAppSource, /pénurie/);
   assert.match(webAppSource, /Pénuries aval/);
   assert.match(webAppSource, /choice\.downstreamShortages/);
@@ -58,6 +64,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-priority--high/);
   assert.match(stylesSource, /province-logistics-impact-preview--critical/);
   assert.match(stylesSource, /province-logistics-impact-badge--medium/);
+  assert.match(stylesSource, /province-logistics-queue-action--ready/);
+  assert.match(stylesSource, /province-logistics-queue-action--conflict/);
   assert.match(stylesSource, /province-logistics-downstream-summary--résolue/);
   assert.match(stylesSource, /province-logistics-downstream-shortage--high/);
   assert.match(stylesSource, /province-logistics-timeline-summary--empty/);

--- a/web/app.js
+++ b/web/app.js
@@ -400,6 +400,7 @@ const state = {
   selectedCityId: 'river-gate-city',
   hoveredRouteId: null,
   selectedRouteId: null,
+  queuedLogisticsActions: [],
   comparedCityIds: ['river-gate-city', 'crown-port'],
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
   mobilePanelSection: 'details',
@@ -1207,6 +1208,7 @@ function renderProvinceLogisticsBottleneckComparison(province, economyView) {
 function buildProvinceLogisticsChoicePreviewView(province, economyView) {
   return buildProvinceLogisticsChoicePreview(province, economyView, {
     resourceLabelById: Object.fromEntries(Object.entries(resourceHudById).map(([resourceId, hud]) => [resourceId, hud.label])),
+    queuedLogisticsActions: state.queuedLogisticsActions,
   });
 }
 
@@ -1251,6 +1253,20 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
           `).join('')}
         </div>
       ` : ''}
+      <div class="province-logistics-queue-action province-logistics-queue-action--${preview.primaryLogisticsAction.status}" aria-label="Engager une action logistique depuis la carte">
+        <div>
+          <b>Action carte</b>
+          <strong>${preview.primaryLogisticsAction.label}</strong>
+        </div>
+        <p>${preview.primaryLogisticsAction.gain}</p>
+        <dl>
+          <div><dt>Coût</dt><dd>${preview.primaryLogisticsAction.cost}</dd></div>
+          <div><dt>Délai</dt><dd>${preview.primaryLogisticsAction.delay}</dd></div>
+          <div><dt>Impact aval</dt><dd>${preview.primaryLogisticsAction.downstreamImpact}</dd></div>
+        </dl>
+        <small>${preview.primaryLogisticsAction.queueWarning}</small>
+        <button type="button" data-logistics-queue-action="${preview.primaryLogisticsAction.actionId ?? ''}" ${preview.primaryLogisticsAction.disabled ? 'disabled' : ''}>Engager récupération</button>
+      </div>
       <div class="province-logistics-impact-preview province-logistics-impact-preview--${preview.selectedActionPreview.status}" aria-label="Impact projeté avant engagement logistique">
         <div>
           <b>Impact si engagé</b>
@@ -7258,6 +7274,31 @@ function render() {
     element.addEventListener('click', () => {
       const key = element.dataset.economyFilter;
       state.economyFilters[key] = !state.economyFilters[key];
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-logistics-queue-action]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const actionId = element.dataset.logisticsQueueAction;
+      if (!actionId || element.disabled) {
+        return;
+      }
+
+      const shell = getShell();
+      const province = shell.provinces.find((candidate) => candidate.provinceId === state.selectedProvinceId) ?? null;
+      const economyView = getEconomyViewModel();
+      const preview = province ? buildProvinceLogisticsChoicePreviewView(province, economyView) : null;
+      const action = preview?.primaryLogisticsAction;
+      if (!action || action.disabled) {
+        return;
+      }
+
+      state.queuedLogisticsActions = [
+        ...state.queuedLogisticsActions.filter((entry) => entry.actionId !== action.actionId),
+        { actionId: action.actionId, routeId: action.routeId, choiceId: action.choiceId, label: action.label, status: action.status },
+      ];
+      state.mobilePanelSection = 'details';
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -3452,6 +3452,62 @@ button { font: inherit; }
   font-size: 12px;
   line-height: 1.35;
 }
+.province-logistics-queue-action {
+  display: grid;
+  gap: 7px;
+  margin: 8px 0;
+  padding: 9px 10px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(125, 211, 252, 0.22);
+}
+.province-logistics-queue-action--ready { border-color: rgba(74, 222, 128, 0.32); }
+.province-logistics-queue-action--risky { border-color: rgba(245, 158, 11, 0.34); }
+.province-logistics-queue-action--conflict,
+.province-logistics-queue-action--redundant { border-color: rgba(251, 113, 133, 0.36); }
+.province-logistics-queue-action--empty { opacity: 0.78; }
+.province-logistics-queue-action div:first-child {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.province-logistics-queue-action b {
+  color: #bfdbfe;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.province-logistics-queue-action strong { color: #f8fafc; font-size: 12px; }
+.province-logistics-queue-action p,
+.province-logistics-queue-action small,
+.province-logistics-queue-action dd {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-logistics-queue-action p { margin: 0; }
+.province-logistics-queue-action dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  margin: 0;
+}
+.province-logistics-queue-action dt { color: #93c5fd; font-size: 10px; text-transform: uppercase; }
+.province-logistics-queue-action dd { margin: 0; }
+.province-logistics-queue-action button {
+  justify-self: start;
+  border: 1px solid rgba(125, 211, 252, 0.34);
+  background: rgba(14, 165, 233, 0.18);
+  color: #e0f2fe;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+.province-logistics-queue-action button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
 .province-logistics-impact-preview {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Beta: Implements #604.

## Summary
- exposes a primary logistics recovery action from the map with cost, expected gain, downstream impact, and delay before confirmation
- tracks queued logistics actions in the map UI and flags redundant/conflicting choices against the current logistics queue
- keeps empty/insufficient-data states readable and preserves compact mobile-friendly logistics panels

## Tests
- npm test
- npm test -- --test-reporter=spec test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.