### PR TITLE
Epsilon: queue climate interventions from map

### DIFF
--- a/test/ui/climate/webClimateInterventionQueueAction.test.js
+++ b/test/ui/climate/webClimateInterventionQueueAction.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected province climate forecast can queue the recommended intervention from the map', () => {
+  assert.match(webAppSource, /queuedClimateInterventions: \[\]/);
+  assert.match(webAppSource, /function buildClimateInterventionQueueEntry/);
+  assert.match(webAppSource, /function buildClimateInterventionQueuePlan/);
+  assert.match(webAppSource, /function renderClimateInterventionQueueAction/);
+  assert.match(webAppSource, /Planification de l’intervention climat recommandée/);
+  assert.match(webAppSource, /data-queue-climate-intervention/);
+  assert.match(webAppSource, /Planifier intervention climat/);
+  assert.match(webAppSource, /Déjà en file/);
+  assert.match(webAppSource, /Aucune action climat/);
+  assert.match(webAppSource, /Chevauchement: une intervention climat ou mitigation proche est déjà en file/);
+  assert.match(webAppSource, /Deadline manquée:/);
+  assert.match(webAppSource, /Fenêtre/);
+  assert.match(webAppSource, /Réduction/);
+  assert.match(webAppSource, /Tradeoff/);
+  assert.match(webAppSource, /Intervention climat planifiée:/);
+  assert.match(webAppSource, /state\.queuedClimateInterventions = state\.queuedClimateInterventions\.concat/);
+  assert.match(webAppSource, /category: 'climate'/);
+  assert.match(webAppSource, /renderClimateInterventionQueueAction\(province, forecast, actionQueue, queuedClimateInterventions\)/);
+
+  assert.match(stylesSource, /\.province-climate-risk-forecast__queue/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__queue--blocked/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__queue button:disabled/);
+});

--- a/test/ui/climate/webClimateRiskReductionForecast.test.js
+++ b/test/ui/climate/webClimateRiskReductionForecast.test.js
@@ -35,7 +35,7 @@ test('selected province panel forecasts climate risk reduction after queued miti
   assert.match(webAppSource, /remainingCascades/);
   assert.match(webAppSource, /Aucune mitigation climat décisive en file/);
   assert.match(webAppSource, /surveillance résiduelle/);
-  assert.match(webAppSource, /renderProvinceClimateRiskReductionForecast\(province, shell\)/);
+  assert.match(webAppSource, /renderProvinceClimateRiskReductionForecast\(province, shell, actionQueue/);
 
   assert.match(stylesSource, /\.province-climate-risk-forecast/);
   assert.match(stylesSource, /\.province-climate-risk-forecast--empty/);

--- a/web/app.js
+++ b/web/app.js
@@ -410,6 +410,7 @@ const state = {
   mapPanY: 0,
   lastTurnSummary: 'Le théâtre reste sous tension, sans bascule majeure.',
   selectedIntrigueOperationId: 'op-river-ashes',
+  queuedClimateInterventions: [],
   economyFilters: {
     criticalRoutes: false,
     resourceMarkers: true,
@@ -1842,7 +1843,70 @@ function buildProvinceClimateRiskReductionForecast(province, shell, report = bui
   };
 }
 
-function renderProvinceClimateRiskReductionForecast(province, shell) {
+function buildClimateInterventionQueueEntry(province, plan) {
+  return {
+    actionCode: plan.actionCode,
+    label: plan.actionLabel,
+    priority: 2,
+    orderCost: '1 ordre climat',
+    mainRisk: plan.tradeoff,
+    expectedResult: `Réduction climat ${plan.riskReduction}; fenêtre ${plan.window}.`,
+    status: plan.missedDeadline ? 'risky' : 'ready',
+    tone: plan.missedDeadline ? 'warning' : 'ready',
+    provinceId: province.provinceId,
+    category: 'climate',
+  };
+}
+
+function buildClimateInterventionQueuePlan(province, forecast, actionQueue = [], queuedClimateInterventions = []) {
+  const alreadyQueued = actionQueue.some((entry) => /climat|climate|mitigation|réserves|reparation|réparation/i.test(`${entry.actionCode} ${entry.label} ${entry.expectedResult}`))
+    || queuedClimateInterventions.some((entry) => entry.provinceId === province.provinceId || entry.actionCode === `CLIMATE-${province.provinceId.toUpperCase()}`);
+  const overlap = alreadyQueued
+    ? 'Chevauchement: une intervention climat ou mitigation proche est déjà en file.'
+    : forecast.queuedAction
+      ? 'Aucun chevauchement détecté avec la file actuelle.'
+      : 'Aucune intervention climat planifiable pour cette sélection.';
+  const disabled = !forecast.queuedAction || alreadyQueued;
+  const missedDeadline = forecast.deadlineCoverage.state === 'missed'
+    ? `Deadline manquée: ${forecast.deadlineCoverage.label}. ${forecast.deadlineCoverage.residualRisk ?? 'Risque résiduel à surveiller.'}`
+    : null;
+
+  return {
+    disabled,
+    alreadyQueued,
+    actionCode: `CLIMATE-${province.provinceId.toUpperCase()}`,
+    actionLabel: forecast.queuedAction ?? 'Aucune intervention recommandée',
+    window: forecast.criticalDeadline,
+    riskReduction: `${forecast.currentRisk} → ${forecast.projectedRisk}`,
+    tradeoff: forecast.payoffTradeoff?.tradeoff ?? 'Tradeoff non confirmé par les données disponibles.',
+    overlap,
+    missedDeadline,
+    cta: disabled ? (alreadyQueued ? 'Déjà en file' : 'Aucune action climat') : 'Planifier intervention climat',
+  };
+}
+
+function renderClimateInterventionQueueAction(province, forecast, actionQueue = [], queuedClimateInterventions = []) {
+  const plan = buildClimateInterventionQueuePlan(province, forecast, actionQueue, queuedClimateInterventions);
+
+  return `
+    <div class="province-climate-risk-forecast__queue province-climate-risk-forecast__queue--${plan.disabled ? 'blocked' : 'ready'}" aria-label="Planification de l’intervention climat recommandée">
+      <div>
+        <strong>${plan.actionLabel}</strong>
+        <code>${plan.actionCode}</code>
+      </div>
+      <dl>
+        <div><dt>Fenêtre</dt><dd>${plan.window}</dd></div>
+        <div><dt>Réduction</dt><dd>${plan.riskReduction}</dd></div>
+        <div><dt>Tradeoff</dt><dd>${plan.tradeoff}</dd></div>
+      </dl>
+      ${plan.missedDeadline ? `<small><b>${plan.missedDeadline}</b></small>` : ''}
+      <small>${plan.overlap}</small>
+      <button type="button" data-queue-climate-intervention="true" data-province-id="${province.provinceId}" data-climate-action-code="${plan.actionCode}" ${plan.disabled ? 'disabled' : ''}>${plan.cta}</button>
+    </div>
+  `;
+}
+
+function renderProvinceClimateRiskReductionForecast(province, shell, actionQueue = [], queuedClimateInterventions = []) {
   const forecast = buildProvinceClimateRiskReductionForecast(province, shell);
 
   return `
@@ -1864,6 +1928,7 @@ function renderProvinceClimateRiskReductionForecast(province, shell) {
         </div>
       ` : ''}
       ${renderSelectedClimateInterventionRiskPreview(forecast.selectedInterventionPreview)}
+      ${renderClimateInterventionQueueAction(province, forecast, actionQueue, queuedClimateInterventions)}
       <div class="province-climate-risk-forecast__deadline province-climate-risk-forecast__deadline--${forecast.deadlineCoverage.state}">
         <span><b>Deadline</b> · ${forecast.deadlineCoverage.label}</span>
         <small>${forecast.deadlineCoverage.detail}</small>
@@ -2609,6 +2674,9 @@ function buildSelectedProvinceActionQueue(province, shell, focusContext, intrigu
   const priorityByTone = { danger: 1, warning: 2, ready: 3, info: 4, neutral: 5 };
   const statusByTone = { danger: 'blocked', warning: 'risky', ready: 'ready', info: 'ready', neutral: 'ready' };
   const outcomeRisk = outcome.tone === 'danger' ? 'risque élevé' : outcome.tone === 'warning' ? 'issue disputée' : 'risque maîtrisé';
+  const queuedClimateActions = state.queuedClimateInterventions
+    .filter((entry) => entry.provinceId === province.provinceId)
+    .map((entry) => ({ ...entry }));
 
   return recommendations
     .map((recommendation, index) => ({
@@ -2625,6 +2693,7 @@ function buildSelectedProvinceActionQueue(province, shell, focusContext, intrigu
       status: statusByTone[recommendation.tone] ?? 'ready',
       tone: recommendation.tone,
     }))
+    .concat(queuedClimateActions)
     .sort((left, right) => left.priority - right.priority || left.actionCode.localeCompare(right.actionCode));
 }
 
@@ -4345,7 +4414,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderIntrigueTurnReportDeltas(province, intrigueView)}
       ${renderProvinceClimateCountdownCues(province)}
       ${renderProvinceClimateMitigationPriorities(province)}
-      ${renderProvinceClimateRiskReductionForecast(province, shell)}
+      ${renderProvinceClimateRiskReductionForecast(province, shell, buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView), state.queuedClimateInterventions)}
       ${renderProvinceClimateCascadePreview(province, shell)}
       ${renderProvinceClimateTurnReport(province)}
       <div class="context-summary">
@@ -7255,6 +7324,31 @@ function render() {
       state.readinessFocusProvinceId = provinceId;
       state.readinessFocusTone = 'ready';
       state.lastTurnSummary = `${actionCode} ajouté à la file militaire depuis la carte pour ${province.label}.`;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-queue-climate-intervention]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const provinceId = element.dataset.provinceId;
+      const actionCode = element.dataset.climateActionCode;
+      const shell = getShell();
+      const province = shell.provinces.find((candidate) => candidate.provinceId === provinceId);
+      if (!province || state.queuedClimateInterventions.some((entry) => entry.actionCode === actionCode || entry.provinceId === provinceId)) {
+        return;
+      }
+      const focusContext = { focusedProvinceId: provinceId, focusedProvince: province, neighborIds: new Set(province.neighborIds) };
+      const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, buildIntrigueView(shell));
+      const forecast = buildProvinceClimateRiskReductionForecast(province, shell);
+      const plan = buildClimateInterventionQueuePlan(province, forecast, actionQueue, state.queuedClimateInterventions);
+      if (plan.disabled) {
+        return;
+      }
+      state.queuedClimateInterventions = state.queuedClimateInterventions.concat(buildClimateInterventionQueueEntry(province, plan));
+      state.selectedProvinceId = provinceId;
+      state.focusedProvinceId = provinceId;
+      state.activeOverlaySlot = 'climate-overlay';
+      state.lastTurnSummary = `Intervention climat planifiée: ${actionCode} sur ${province.label}. Vérifiez deadline, tradeoff et risque résiduel avant validation du tour.`;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -4009,6 +4009,58 @@ button { font: inherit; }
 .province-climate-risk-forecast__selected b {
   color: #fef3c7;
 }
+.province-climate-risk-forecast__queue {
+  display: grid;
+  gap: 6px;
+  padding: 9px 10px;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(74, 222, 128, 0.22);
+}
+.province-climate-risk-forecast__queue--blocked { border-color: rgba(248, 113, 113, 0.26); }
+.province-climate-risk-forecast__queue div:first-child {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-climate-risk-forecast__queue dl {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+}
+.province-climate-risk-forecast__queue dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.province-climate-risk-forecast__queue dt,
+.province-climate-risk-forecast__queue small {
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-climate-risk-forecast__queue dd {
+  margin: 0;
+  color: #ecfeff;
+  font-size: 12px;
+  text-align: right;
+}
+.province-climate-risk-forecast__queue button {
+  justify-self: start;
+  border: 1px solid rgba(74, 222, 128, 0.32);
+  background: rgba(22, 101, 52, 0.32);
+  color: #dcfce7;
+  border-radius: 999px;
+  padding: 5px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+}
+.province-climate-risk-forecast__queue button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
 .province-climate-risk-forecast__deadline {
   display: grid;
   gap: 3px;


### PR DESCRIPTION
Epsilon: Implements #607.

Summary:
- Adds a selected-province climate queue CTA for the recommended intervention.
- Shows intervention window, projected risk reduction, main tradeoff, missed-deadline context, and overlap/already-queued states.
- Queues the selected climate intervention into the map action queue and disables duplicate climate planning for the province.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webClimateInterventionQueueAction.test.js test/ui/climate/webSelectedClimateInterventionPreview.test.js test/ui/climate/webClimateRiskReductionForecast.test.js
- npm test