### PR TITLE
Beta: confirm and undo logistics queue actions

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -591,6 +591,9 @@ function buildPrimaryLogisticsQueueAction(priorityAction, selectedActionPreview,
     delay: priorityAction.delay,
     gain: priorityAction.impact,
     downstreamImpact: selectedActionPreview.summary,
+    target: priorityAction.route,
+    bottleneckRelieved: priorityAction.reason.split(';')[0] ?? 'goulot logistique',
+    downstreamEffect: selectedActionPreview.projectedState,
     queueWarning,
   };
 }

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -90,6 +90,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
   assert.match(preview.primaryLogisticsAction.downstreamImpact, /pénurie|route|province|délai/);
+  assert.match(preview.primaryLogisticsAction.bottleneckRelieved, /capacité|stock|route|goulot|dégâts/);
+  assert.match(preview.primaryLogisticsAction.downstreamEffect, /Projeté/);
   assert.ok(['ready', 'risky'].includes(preview.primaryLogisticsAction.status));
   assert.equal(preview.primaryLogisticsAction.disabled, false);
   assert.ok(preview.options[0].recoveryChoices.length >= 2);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -33,6 +33,12 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /data-logistics-queue-action/);
   assert.match(webAppSource, /queuedLogisticsActions/);
   assert.match(webAppSource, /primaryLogisticsAction/);
+  assert.match(webAppSource, /renderQueuedLogisticsMapSummary/);
+  assert.match(webAppSource, /File logistique/);
+  assert.match(webAppSource, /data-logistics-undo-last/);
+  assert.match(webAppSource, /Annuler dernière action/);
+  assert.match(webAppSource, /bottleneckRelieved/);
+  assert.match(webAppSource, /downstreamEffect/);
   assert.match(webAppSource, /pénurie/);
   assert.match(webAppSource, /Pénuries aval/);
   assert.match(webAppSource, /choice\.downstreamShortages/);
@@ -66,6 +72,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-impact-badge--medium/);
   assert.match(stylesSource, /province-logistics-queue-action--ready/);
   assert.match(stylesSource, /province-logistics-queue-action--conflict/);
+  assert.match(stylesSource, /province-logistics-queued-summary/);
+  assert.match(stylesSource, /province-logistics-queued-summary--empty/);
   assert.match(stylesSource, /province-logistics-downstream-summary--résolue/);
   assert.match(stylesSource, /province-logistics-downstream-shortage--high/);
   assert.match(stylesSource, /province-logistics-timeline-summary--empty/);

--- a/web/app.js
+++ b/web/app.js
@@ -1224,6 +1224,40 @@ function buildProvinceLogisticsChoicePreviewView(province, economyView) {
   });
 }
 
+
+function renderQueuedLogisticsMapSummary(preview) {
+  const queuedEntries = state.queuedLogisticsActions.filter((entry) => entry.routeId === preview.primaryLogisticsAction.routeId || entry.provinceId === state.selectedProvinceId);
+  const lastEntry = state.queuedLogisticsActions[state.queuedLogisticsActions.length - 1] ?? null;
+
+  if (queuedEntries.length === 0 && !lastEntry) {
+    return `
+      <div class="province-logistics-queued-summary province-logistics-queued-summary--empty" aria-label="File logistique carte">
+        <b>File logistique</b>
+        <span>Aucune récupération logistique engagée depuis la carte.</span>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="province-logistics-queued-summary" aria-label="File logistique carte">
+      <div>
+        <b>File logistique</b>
+        <span>${queuedEntries.length || state.queuedLogisticsActions.length} action${(queuedEntries.length || state.queuedLogisticsActions.length) > 1 ? 's' : ''} à auditer avant résolution</span>
+      </div>
+      <ul>
+        ${(queuedEntries.length > 0 ? queuedEntries : state.queuedLogisticsActions.slice(-1)).map((entry) => `
+          <li>
+            <strong>${entry.label}</strong>
+            <span>Cible: ${entry.target ?? entry.routeId} · Goulot: ${entry.bottleneckRelieved ?? 'à confirmer'}</span>
+            <small>${entry.downstreamEffect ?? 'Impact aval à confirmer avant résolution.'}</small>
+          </li>
+        `).join('')}
+      </ul>
+      ${lastEntry ? `<button type="button" data-logistics-undo-last="${lastEntry.actionId}" aria-label="Retirer la dernière action logistique ${lastEntry.label}">Annuler dernière action</button>` : ''}
+    </div>
+  `;
+}
+
 function renderProvinceLogisticsChoicePreview(province, economyView) {
   const preview = buildProvinceLogisticsChoicePreviewView(province, economyView);
 
@@ -1279,6 +1313,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
         <small>${preview.primaryLogisticsAction.queueWarning}</small>
         <button type="button" data-logistics-queue-action="${preview.primaryLogisticsAction.actionId ?? ''}" ${preview.primaryLogisticsAction.disabled ? 'disabled' : ''}>Engager récupération</button>
       </div>
+      ${renderQueuedLogisticsMapSummary(preview)}
       <div class="province-logistics-impact-preview province-logistics-impact-preview--${preview.selectedActionPreview.status}" aria-label="Impact projeté avant engagement logistique">
         <div>
           <b>Impact si engagé</b>
@@ -7551,8 +7586,36 @@ function render() {
 
       state.queuedLogisticsActions = [
         ...state.queuedLogisticsActions.filter((entry) => entry.actionId !== action.actionId),
-        { actionId: action.actionId, routeId: action.routeId, choiceId: action.choiceId, label: action.label, status: action.status },
+        {
+          actionId: action.actionId,
+          provinceId: state.selectedProvinceId,
+          routeId: action.routeId,
+          choiceId: action.choiceId,
+          label: action.label,
+          status: action.status,
+          target: action.target,
+          bottleneckRelieved: action.bottleneckRelieved,
+          downstreamEffect: action.downstreamEffect,
+        },
       ];
+      state.mobilePanelSection = 'details';
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-logistics-undo-last]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const actionId = element.dataset.logisticsUndoLast;
+      if (!actionId) {
+        return;
+      }
+
+      const lastIndex = state.queuedLogisticsActions.map((entry) => entry.actionId).lastIndexOf(actionId);
+      if (lastIndex < 0) {
+        return;
+      }
+
+      state.queuedLogisticsActions = state.queuedLogisticsActions.filter((_, index) => index !== lastIndex);
       state.mobilePanelSection = 'details';
       render();
     });

--- a/web/styles.css
+++ b/web/styles.css
@@ -3564,6 +3564,59 @@ button { font: inherit; }
   opacity: 0.45;
   cursor: not-allowed;
 }
+.province-logistics-queued-summary {
+  display: grid;
+  gap: 7px;
+  margin: 8px 0;
+  padding: 9px 10px;
+  border-radius: 12px;
+  background: rgba(8, 15, 28, 0.5);
+  border: 1px solid rgba(125, 211, 252, 0.22);
+}
+.province-logistics-queued-summary--empty { opacity: 0.78; }
+.province-logistics-queued-summary > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.province-logistics-queued-summary b {
+  color: #bfdbfe;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.province-logistics-queued-summary span,
+.province-logistics-queued-summary small {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-logistics-queued-summary ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.province-logistics-queued-summary li {
+  display: grid;
+  gap: 3px;
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.province-logistics-queued-summary strong { color: #f8fafc; font-size: 12px; }
+.province-logistics-queued-summary button {
+  justify-self: start;
+  border: 1px solid rgba(248, 113, 113, 0.34);
+  background: rgba(127, 29, 29, 0.18);
+  color: #fee2e2;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+}
 .province-logistics-impact-preview {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Beta: Implements #614.

## Summary
- adds a compact map-side logistics queue summary for selected route/province auditing
- stores queued recovery target, relieved bottleneck, and projected downstream effect when engaging from the map
- adds an undo affordance for the last queued logistics recovery action before turn resolution

## Tests
- npm test
- npm test -- --test-reporter=spec test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check

Zeta: ready for validation before merge.