### PR TITLE
Delta: confirm and undo intrigue map responses

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -164,3 +164,20 @@ test('map panel can queue safe intrigue responses with guarded states', () => {
   assert.match(stylesSource, /province-intrigue-map-queue-action--disabled/);
   assert.match(stylesSource, /province-intrigue-map-queue-action__cta:disabled/);
 });
+
+test('queued intrigue map responses show fog-safe confirmation and undo affordance', () => {
+  assert.match(webAppSource, /function buildConfirmedQueuedIntrigueMapResponse/);
+  assert.match(webAppSource, /Confirmation fog-safe réponse intrigue queueée/);
+  assert.match(webAppSource, /Réponse queueée/);
+  assert.match(webAppSource, /Aucune réponse queueée/);
+  assert.match(webAppSource, /Contexte visible/);
+  assert.match(webAppSource, /Direction risque/);
+  assert.match(webAppSource, /Incertitude/);
+  assert.match(webAppSource, /data-action="undo-last-intrigue-response"/);
+  assert.match(webAppSource, /Annuler dernière réponse intrigue/);
+  assert.match(webAppSource, /Annulation disponible avant résolution du tour; le brouillard conserve cible, cellule et relais masqués/);
+  assert.match(webAppSource, /Réponse confirmée: \$\{mapQueueAction\.actionLabel\} sur \$\{province\.label\}/);
+  assert.match(stylesSource, /province-intrigue-map-confirmation/);
+  assert.match(stylesSource, /province-intrigue-map-confirmation--confirmed/);
+  assert.match(stylesSource, /province-intrigue-map-confirmation__undo:disabled/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3161,11 +3161,36 @@ function buildMapIntrigueSafeQueueAction(province, projection, cumulativeRisk, q
   };
 }
 
+function buildConfirmedQueuedIntrigueMapResponse(province, projection, mapQueueAction) {
+  const confirmed = !projection.empty;
+  const direction = projection.deltaLabel === 'stable'
+    ? 'risque stable'
+    : projection.deltaLabel.startsWith('+')
+      ? 'risque en hausse'
+      : 'risque réduit';
+
+  return {
+    confirmed,
+    responseType: mapQueueAction.actionLabel,
+    visibleContext: province.label,
+    exposureDirection: direction,
+    uncertainty: projection.confidence,
+    summary: confirmed
+      ? `Réponse confirmée: ${mapQueueAction.actionLabel} sur ${province.label}; ${direction}, avec ${projection.confidence}.`
+      : 'Aucune confirmation active: queuez une réponse sûre depuis la carte pour obtenir un résumé auditable.',
+    undoLabel: confirmed ? 'Annuler dernière réponse intrigue' : 'Aucune réponse à annuler',
+    undoDetail: confirmed
+      ? 'Annulation disponible avant résolution du tour; le brouillard conserve cible, cellule et relais masqués.'
+      : 'L’undo s’active dès qu’une réponse intrigue carte est en file.',
+  };
+}
+
 function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView) {
   const projection = buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView);
   const cumulativeRisk = buildCumulativeQueuedIntrigueExposureRisk(province, projection, intrigueView);
   const queueChangePreview = buildIntrigueQueueChangePreview(projection, cumulativeRisk);
   const mapQueueAction = buildMapIntrigueSafeQueueAction(province, projection, cumulativeRisk, queueChangePreview);
+  const confirmation = buildConfirmedQueuedIntrigueMapResponse(province, projection, mapQueueAction);
 
   return `
     <section class="province-intrigue-detection-projection province-intrigue-detection-projection--${projection.tone}" aria-label="Projection du risque de détection intrigue">
@@ -3241,6 +3266,20 @@ function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intr
         <p>${mapQueueAction.ignoredConsequence}</p>
         <button type="button" class="province-intrigue-map-queue-action__cta" data-action="queue-safe-intrigue-response" data-province-id="${province.provinceId}" ${mapQueueAction.disabled ? 'disabled' : ''}>${mapQueueAction.ctaLabel}</button>
         <small>${mapQueueAction.detail}</small>
+      </div>
+      <div class="province-intrigue-map-confirmation province-intrigue-map-confirmation--${confirmation.confirmed ? 'confirmed' : 'empty'}" aria-label="Confirmation fog-safe réponse intrigue queueée">
+        <div class="province-intrigue-map-confirmation__header">
+          <span>${confirmation.confirmed ? 'Réponse queueée' : 'Aucune réponse queueée'}</span>
+          <strong>${confirmation.responseType}</strong>
+        </div>
+        <p>${confirmation.summary}</p>
+        <dl>
+          <div><dt>Contexte visible</dt><dd>${confirmation.visibleContext}</dd></div>
+          <div><dt>Direction risque</dt><dd>${confirmation.exposureDirection}</dd></div>
+          <div><dt>Incertitude</dt><dd>${confirmation.uncertainty}</dd></div>
+        </dl>
+        <button type="button" class="province-intrigue-map-confirmation__undo" data-action="undo-last-intrigue-response" data-province-id="${province.provinceId}" ${confirmation.confirmed ? '' : 'disabled'}>${confirmation.undoLabel}</button>
+        <small>${confirmation.undoDetail}</small>
       </div>
       <small>${projection.fogLimit}</small>
     </section>

--- a/web/styles.css
+++ b/web/styles.css
@@ -7014,9 +7014,72 @@ button { font: inherit; }
   border-color: rgba(148, 163, 184, 0.24);
   background: rgba(51, 65, 85, 0.28);
 }
+.province-intrigue-map-confirmation {
+  display: grid;
+  gap: 8px;
+  margin: 8px 0;
+  padding: 10px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.28);
+  border: 1px solid rgba(96, 165, 250, 0.26);
+}
+.province-intrigue-map-confirmation--confirmed { border-color: rgba(34, 197, 94, 0.34); }
+.province-intrigue-map-confirmation--empty { border-color: rgba(148, 163, 184, 0.22); }
+.province-intrigue-map-confirmation__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-map-confirmation__header span {
+  color: #bfdbfe;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.province-intrigue-map-confirmation p,
+.province-intrigue-map-confirmation small {
+  margin: 0;
+  color: var(--muted);
+}
+.province-intrigue-map-confirmation dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+  margin: 0;
+}
+.province-intrigue-map-confirmation dl div {
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.34);
+}
+.province-intrigue-map-confirmation dt {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+.province-intrigue-map-confirmation dd {
+  margin: 0;
+  font-weight: 700;
+}
+.province-intrigue-map-confirmation__undo {
+  justify-self: start;
+  padding: 7px 11px;
+  border-radius: 999px;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #fee2e2;
+  background: rgba(127, 29, 29, 0.28);
+  cursor: pointer;
+}
+.province-intrigue-map-confirmation__undo:disabled {
+  cursor: not-allowed;
+  color: var(--muted);
+  border-color: rgba(148, 163, 184, 0.24);
+  background: rgba(51, 65, 85, 0.24);
+}
 @media (max-width: 760px) {
   .province-intrigue-queue-change-preview__grid,
-  .province-intrigue-map-queue-action dl {
+  .province-intrigue-map-queue-action dl,
+  .province-intrigue-map-confirmation dl {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
Delta: Implements #616.

Summary:
- adds a fog-safe confirmation summary for queued intrigue map responses
- shows response type, visible province context, exposure/risk direction, and existing uncertainty wording
- adds an undo affordance for the last queued intrigue response before turn resolution

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Ready for Zeta validation before merge.