### PR TITLE
Gamma: confirm queued culture map actions

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -548,6 +548,54 @@ function attachQueueActions(reminders) {
   }));
 }
 
+
+function findQueuedCultureConfirmation(reminders, actionQueue) {
+  const queuedEntries = actionQueue
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry }) => String(entry.actionCode ?? entry.code ?? '').startsWith('culture:')
+      || String(entry.label ?? '').match(/culture|Suivre l’événement|Accélérer la recherche|Protéger le site|Surveiller la fenêtre/i));
+
+  for (const { entry, index } of queuedEntries.reverse()) {
+    const actionCode = String(entry.actionCode ?? entry.code ?? '');
+    const label = normalizeText(entry.label, entry.title ?? 'Action culturelle');
+    const reminder = reminders.find((candidate) => candidate.queueAction
+      && (candidate.queueAction.code === actionCode || candidate.queueAction.label === label));
+
+    if (reminder) {
+      return {
+        queueIndex: index,
+        actionCode: reminder.queueAction.code,
+        label: reminder.queueAction.label,
+        provinceId: reminder.provinceId,
+        cultureName: reminder.cultureName,
+        effect: reminder.queueAction.effect,
+        reason: reminder.stabilityPreview?.reason ?? reminder.reasonCopy,
+        opportunityCost: reminder.queueAction.opportunityCost,
+        horizon: reminder.queueAction.horizon,
+        undoAction: {
+          code: `undo:${reminder.queueAction.code}`,
+          label: 'Retirer de la file',
+          summary: `Retirer ${reminder.queueAction.label} avant résolution du tour.`,
+        },
+        summary: `${reminder.queueAction.label} est en file: ${reminder.queueAction.effect}`,
+      };
+    }
+  }
+
+  return null;
+}
+
+function attachQueueConfirmation(reminders, confirmation) {
+  if (!confirmation) {
+    return reminders;
+  }
+
+  return reminders.map((reminder) => ({
+    ...reminder,
+    queueConfirmation: reminder.queueAction?.code === confirmation.actionCode ? confirmation : null,
+  }));
+}
+
 function dedupeAndSort(reminders) {
   const remindersByKey = new Map();
 
@@ -596,12 +644,15 @@ export function buildCultureOpportunityReminders({
   const priorityConflicts = buildPriorityConflicts(reminders);
   const remindersWithStabilityPreviews = attachStabilityPreviews(reminders, priorityConflicts);
   const remindersWithQueueActions = attachQueueActions(remindersWithStabilityPreviews);
+  const queuedCultureAction = findQueuedCultureConfirmation(remindersWithQueueActions, actionQueue);
+  const remindersWithQueueConfirmation = attachQueueConfirmation(remindersWithQueueActions, queuedCultureAction);
 
   return {
     state: 'active',
     provinceLabel,
     summary: `${provinceLabel}: ${probableCount} opportunité${probableCount > 1 ? 's' : ''} probable${probableCount > 1 ? 's' : ''}, ${missingCount} condition${missingCount > 1 ? 's' : ''} à surveiller.`,
-    reminders: remindersWithQueueActions,
+    reminders: remindersWithQueueConfirmation,
     priorityConflicts,
+    queuedCultureAction,
   };
 }

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -143,6 +143,42 @@ test('buildCultureOpportunityReminders prioritizes actionable culture end-turn r
   });
 });
 
+test('buildCultureOpportunityReminders confirms queued culture actions and exposes undo', () => {
+  const report = buildCultureOpportunityReminders({
+    province: { provinceId: 'river-gate', label: 'Porte du Fleuve' },
+    actionQueue: [
+      { actionCode: 'culture:follow-event:river-gate', label: 'Suivre l’événement' },
+    ],
+    unlockHintsByAction: [
+      {
+        action: { label: 'Suivre l’événement' },
+        hints: [
+          {
+            status: 'probable',
+            tone: 'event',
+            label: 'Événement cluster',
+            regionId: 'river-gate',
+            cultureName: 'Compact d’Aurora',
+            focusTarget: {
+              type: 'cluster',
+              id: 'river-gate:culture-cluster',
+              regionId: 'river-gate',
+              label: 'Ouverture des archives',
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(report.queuedCultureAction.label, 'Suivre l’événement');
+  assert.equal(report.queuedCultureAction.reason, 'Ouverture des archives risque de sortir de la timeline locale sans action (ce tour).');
+  assert.equal(report.queuedCultureAction.undoAction.code, 'undo:culture:follow-event:river-gate');
+  assert.equal(report.queuedCultureAction.undoAction.label, 'Retirer de la file');
+  assert.equal(report.reminders[0].queueConfirmation.actionCode, 'culture:follow-event:river-gate');
+  assert.equal(report.reminders[0].queueConfirmation.summary, 'Suivre l’événement est en file: + stabilité locale; urgence baisse si action validée; dissidence faible. Ouverture des archives risque de sortir de la timeline locale sans action (ce tour).');
+});
+
 test('buildCultureOpportunityReminders returns a compact quiet summary without hints', () => {
   assert.deepEqual(buildCultureOpportunityReminders({
     province: { provinceId: 'quiet-field', label: 'Champ Calme' },

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -28,6 +28,13 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /Aperçu de stabilité culturelle/);
   assert.match(webAppSource, /culture-opportunity-reminder__queue-action/);
   assert.match(webAppSource, /data-culture-queue-action/);
+  assert.match(webAppSource, /culture-opportunity-queued-action/);
+  assert.match(webAppSource, /culture-opportunity-reminder__queue-confirmation/);
+  assert.match(webAppSource, /data-culture-undo-action/);
+  assert.match(webAppSource, /queuedCultureActions/);
+  assert.match(webAppSource, /cultureQueueAction/);
+  assert.match(webAppSource, /cultureUndoAction/);
+  assert.match(webAppSource, /Action culturelle en file/);
   assert.match(webAppSource, /Mettre en file/);
   assert.match(webAppSource, /Aucune action culturelle pertinente/);
   assert.match(webAppSource, /Pas de perte culturelle claire/);
@@ -45,6 +52,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-opportunity-reminder__stability-preview--urgent/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__stability-preview--steady/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-action/);
+  assert.match(stylesSource, /\.culture-opportunity-queued-action/);
+  assert.match(stylesSource, /\.culture-opportunity-reminder__queue-confirmation/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-empty/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--positive/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--uncertain/);

--- a/web/app.js
+++ b/web/app.js
@@ -401,6 +401,7 @@ const state = {
   hoveredRouteId: null,
   selectedRouteId: null,
   queuedLogisticsActions: [],
+  queuedCultureActions: [],
   comparedCityIds: ['river-gate-city', 'crown-port'],
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
   mobilePanelSection: 'details',
@@ -943,6 +944,17 @@ function renderCultureOpportunityReminders(report) {
         <small>${report.reminders.length} signal${report.reminders.length > 1 ? 's' : ''}</small>
       </div>
       <p>${report.summary}</p>
+      ${report.queuedCultureAction ? `
+        <div class="culture-opportunity-queued-action" aria-label="Action culturelle en file">
+          <span>Action culturelle en file</span>
+          <strong>${report.queuedCultureAction.label}</strong>
+          <small>${report.queuedCultureAction.effect}</small>
+          <small>Pourquoi: ${report.queuedCultureAction.reason}</small>
+          <button type="button" data-culture-undo-action="${report.queuedCultureAction.undoAction.code}" data-culture-undo-index="${report.queuedCultureAction.queueIndex}" aria-label="${report.queuedCultureAction.undoAction.summary}">
+            ${report.queuedCultureAction.undoAction.label}
+          </button>
+        </div>
+      ` : ''}
       ${(report.priorityConflicts ?? []).length > 0 ? `
         <div class="culture-opportunity-priority-conflicts" aria-label="Conflits de priorité culturelle">
           ${(report.priorityConflicts ?? []).map((conflict) => `
@@ -987,12 +999,22 @@ function renderCultureOpportunityReminders(report) {
                   </ul>
                 ` : '<small>Aucun effet de propagation culturel en file.</small>'}
               </div>
+              ${reminder.queueConfirmation ? `
+                <div class="culture-opportunity-reminder__queue-confirmation" aria-label="Confirmation d’action culturelle en file">
+                  <b>En file</b>
+                  <small>${reminder.queueConfirmation.effect}</small>
+                  <small>Raison: ${reminder.queueConfirmation.reason}</small>
+                  <button type="button" data-culture-undo-action="${reminder.queueConfirmation.undoAction.code}" data-culture-undo-index="${reminder.queueConfirmation.queueIndex}" aria-label="${reminder.queueConfirmation.undoAction.summary}">
+                    ${reminder.queueConfirmation.undoAction.label}
+                  </button>
+                </div>
+              ` : ''}
               ${reminder.queueAction ? `
                 <div class="culture-opportunity-reminder__queue-action" aria-label="Action culturelle à mettre en file">
                   <b>${reminder.queueAction.label}</b>
                   <small>${reminder.queueAction.effect} · ${reminder.queueAction.confidence} (${reminder.queueAction.dissent}) · Horizon ${reminder.queueAction.horizon}</small>
                   <small>Coût d’opportunité: ${reminder.queueAction.opportunityCost}</small>
-                  <button type="button" data-culture-queue-action="${reminder.queueAction.code}" data-culture-queue-region="${reminder.provinceId}" data-culture-queue-summary="${reminder.queueAction.summary}" aria-label="Mettre en file ${reminder.queueAction.label}: ${reminder.queueAction.summary}">
+                  <button type="button" data-culture-queue-action="${reminder.queueAction.code}" data-culture-queue-region="${reminder.provinceId}" data-culture-queue-label="${reminder.queueAction.label}" data-culture-queue-summary="${reminder.queueAction.summary}" aria-label="Mettre en file ${reminder.queueAction.label}: ${reminder.queueAction.summary}">
                     Mettre en file
                   </button>
                 </div>
@@ -2677,6 +2699,9 @@ function buildSelectedProvinceActionQueue(province, shell, focusContext, intrigu
   const queuedClimateActions = state.queuedClimateInterventions
     .filter((entry) => entry.provinceId === province.provinceId)
     .map((entry) => ({ ...entry }));
+  const queuedCultureActions = state.queuedCultureActions
+    .filter((entry) => entry.provinceId === province.provinceId)
+    .map((entry) => ({ ...entry }));
 
   return recommendations
     .map((recommendation, index) => ({
@@ -2693,7 +2718,7 @@ function buildSelectedProvinceActionQueue(province, shell, focusContext, intrigu
       status: statusByTone[recommendation.tone] ?? 'ready',
       tone: recommendation.tone,
     }))
-    .concat(queuedClimateActions)
+    .concat(queuedClimateActions, queuedCultureActions)
     .sort((left, right) => left.priority - right.priority || left.actionCode.localeCompare(right.actionCode));
 }
 
@@ -6878,6 +6903,7 @@ function advanceTurn() {
     'Le froid coupe certains flux, les provinces exposées repassent en posture défensive.',
   ];
 
+  state.queuedCultureActions = [];
   state.lastTurnSummary = summaries[(state.turn - 2) % summaries.length];
 }
 
@@ -7349,6 +7375,49 @@ function render() {
       state.focusedProvinceId = provinceId;
       state.activeOverlaySlot = 'climate-overlay';
       state.lastTurnSummary = `Intervention climat planifiée: ${actionCode} sur ${province.label}. Vérifiez deadline, tradeoff et risque résiduel avant validation du tour.`;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-culture-queue-action]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const provinceId = element.dataset.cultureQueueRegion;
+      const actionCode = element.dataset.cultureQueueAction;
+      const shell = getShell();
+      const province = shell.provinces.find((candidate) => candidate.provinceId === provinceId);
+      if (!province || !actionCode || state.queuedCultureActions.some((entry) => entry.actionCode === actionCode)) {
+        return;
+      }
+
+      state.queuedCultureActions = state.queuedCultureActions.concat({
+        actionCode,
+        label: element.dataset.cultureQueueLabel ?? 'Action culturelle',
+        provinceId,
+        priority: 2,
+        orderCost: '1 ordre culturel',
+        mainRisk: element.dataset.cultureQueueSummary ?? 'Effet culturel à confirmer.',
+        expectedResult: element.dataset.cultureQueueSummary ?? 'Stabilité culturelle préparée avant résolution.',
+        status: 'ready',
+        tone: 'ready',
+      });
+      state.selectedProvinceId = provinceId;
+      state.focusedProvinceId = provinceId;
+      state.activeOverlaySlot = 'culture-overlay';
+      state.mobilePanelSection = 'details';
+      state.lastTurnSummary = `Action culturelle planifiée: ${element.dataset.cultureQueueLabel ?? actionCode} sur ${province.label}. Vous pouvez la retirer avant validation du tour.`;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-culture-undo-action]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const actionCode = String(element.dataset.cultureUndoAction ?? '').replace(/^undo:/, '');
+      if (!actionCode) {
+        return;
+      }
+
+      state.queuedCultureActions = state.queuedCultureActions.filter((entry) => entry.actionCode !== actionCode);
+      state.lastTurnSummary = 'Action culturelle retirée de la file avant résolution du tour.';
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -2903,6 +2903,25 @@ button { font: inherit; }
   font-size: 13px;
   line-height: 1.45;
 }
+.culture-opportunity-queued-action {
+  display: grid;
+  gap: 5px;
+  margin-bottom: 8px;
+  padding: 8px;
+  border-radius: 14px;
+  background: rgba(22, 163, 74, 0.1);
+  border: 1px solid rgba(74, 222, 128, 0.22);
+}
+.culture-opportunity-queued-action span {
+  color: #bbf7d0;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.culture-opportunity-queued-action strong { color: #f0fdf4; font-size: 12px; }
+.culture-opportunity-queued-action small { color: #dcfce7; font-size: 11px; line-height: 1.3; }
+.culture-opportunity-queued-action button { width: fit-content; }
 .culture-opportunity-priority-conflicts {
   display: grid;
   gap: 6px;
@@ -3085,6 +3104,18 @@ button { font: inherit; }
 .culture-opportunity-reminder__queue-action b { color: #dbeafe; font-size: 12px; }
 .culture-opportunity-reminder__queue-action small { color: #bfdbfe; font-size: 11px; line-height: 1.3; }
 .culture-opportunity-reminder__queue-action button { width: fit-content; margin-top: 2px; }
+.culture-opportunity-reminder__queue-confirmation {
+  display: grid;
+  gap: 4px;
+  margin-top: 7px;
+  padding: 7px;
+  border-radius: 12px;
+  background: rgba(22, 163, 74, 0.1);
+  border: 1px solid rgba(74, 222, 128, 0.22);
+}
+.culture-opportunity-reminder__queue-confirmation b { color: #bbf7d0; font-size: 12px; }
+.culture-opportunity-reminder__queue-confirmation small { color: #dcfce7; font-size: 11px; line-height: 1.3; }
+.culture-opportunity-reminder__queue-confirmation button { width: fit-content; margin-top: 2px; }
 .culture-opportunity-reminder__queue-empty {
   display: block;
   margin-top: 7px;


### PR DESCRIPTION
Gamma: Implements #615.

Summary:
- confirms the most recent queued cultural stability action in province/region detail
- shows expected culture/stability effect, reason, opportunity cost, and horizon
- adds undo/remove controls before turn resolution and clears queued culture actions on turn advance

Validation:
- npm test
- npm test -- test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js
- node --check web/app.js
- node --check src/ui/culture/buildCultureOpportunityReminders.js
- git diff --check

Zeta: PR prête pour validation avant merge.