### PR TITLE
Epsilon: confirm and undo climate interventions

### DIFF
--- a/test/ui/climate/webClimateInterventionConfirmUndo.test.js
+++ b/test/ui/climate/webClimateInterventionConfirmUndo.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('queued climate intervention exposes confirmation context and undo before turn resolution', () => {
+  assert.match(webAppSource, /function renderQueuedClimateInterventionConfirmation/);
+  assert.match(webAppSource, /Confirmation de l’intervention climat en file/);
+  assert.match(webAppSource, /Intervention climat confirmée/);
+  assert.match(webAppSource, /Deadline confirmée/);
+  assert.match(webAppSource, /Impact risque/);
+  assert.match(webAppSource, /Tradeoff confirmé/);
+  assert.match(webAppSource, /Prête avant résolution du tour; vous pouvez encore annuler ce choix/);
+  assert.match(webAppSource, /data-undo-climate-intervention/);
+  assert.match(webAppSource, /Annuler intervention climat/);
+  assert.match(webAppSource, /Intervention climat annulée:/);
+  assert.match(webAppSource, /deadlineWindow: plan\.window/);
+  assert.match(webAppSource, /riskReduction: plan\.riskReduction/);
+  assert.match(webAppSource, /tradeoff: plan\.tradeoff/);
+  assert.match(webAppSource, /missedDeadline: plan\.missedDeadline/);
+  assert.match(webAppSource, /state\.queuedClimateInterventions = state\.queuedClimateInterventions\.filter/);
+  assert.match(webAppSource, /renderQueuedClimateInterventionConfirmation\(province, queuedClimateInterventions\)/);
+
+  assert.match(stylesSource, /\.province-climate-risk-forecast__confirmation/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__confirmation--warning/);
+  assert.match(stylesSource, /\.province-climate-risk-forecast__confirmation button/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1911,7 +1911,12 @@ function buildClimateInterventionQueueEntry(province, plan) {
     status: plan.missedDeadline ? 'risky' : 'ready',
     tone: plan.missedDeadline ? 'warning' : 'ready',
     provinceId: province.provinceId,
+    provinceLabel: province.label,
     category: 'climate',
+    deadlineWindow: plan.window,
+    riskReduction: plan.riskReduction,
+    tradeoff: plan.tradeoff,
+    missedDeadline: plan.missedDeadline,
   };
 }
 
@@ -1940,6 +1945,32 @@ function buildClimateInterventionQueuePlan(province, forecast, actionQueue = [],
     missedDeadline,
     cta: disabled ? (alreadyQueued ? 'Déjà en file' : 'Aucune action climat') : 'Planifier intervention climat',
   };
+}
+
+function renderQueuedClimateInterventionConfirmation(province, queuedClimateInterventions = []) {
+  const queuedIntervention = [...queuedClimateInterventions].reverse()
+    .find((entry) => entry.provinceId === province.provinceId) ?? null;
+
+  if (!queuedIntervention) {
+    return '';
+  }
+
+  return `
+    <div class="province-climate-risk-forecast__confirmation province-climate-risk-forecast__confirmation--${queuedIntervention.tone}" aria-label="Confirmation de l’intervention climat en file">
+      <div>
+        <strong>Intervention climat confirmée</strong>
+        <code>${queuedIntervention.actionCode}</code>
+      </div>
+      <p>${queuedIntervention.label} est en file pour ${queuedIntervention.provinceLabel ?? province.label}.</p>
+      <dl>
+        <div><dt>Deadline confirmée</dt><dd>${queuedIntervention.deadlineWindow}</dd></div>
+        <div><dt>Impact risque</dt><dd>${queuedIntervention.riskReduction}</dd></div>
+        <div><dt>Tradeoff confirmé</dt><dd>${queuedIntervention.tradeoff}</dd></div>
+      </dl>
+      ${queuedIntervention.missedDeadline ? `<small><b>${queuedIntervention.missedDeadline}</b></small>` : '<small>Prête avant résolution du tour; vous pouvez encore annuler ce choix.</small>'}
+      <button type="button" data-undo-climate-intervention="true" data-climate-action-code="${queuedIntervention.actionCode}">Annuler intervention climat</button>
+    </div>
+  `;
 }
 
 function renderClimateInterventionQueueAction(province, forecast, actionQueue = [], queuedClimateInterventions = []) {
@@ -1985,6 +2016,7 @@ function renderProvinceClimateRiskReductionForecast(province, shell, actionQueue
         </div>
       ` : ''}
       ${renderSelectedClimateInterventionRiskPreview(forecast.selectedInterventionPreview)}
+      ${renderQueuedClimateInterventionConfirmation(province, queuedClimateInterventions)}
       ${renderClimateInterventionQueueAction(province, forecast, actionQueue, queuedClimateInterventions)}
       <div class="province-climate-risk-forecast__deadline province-climate-risk-forecast__deadline--${forecast.deadlineCoverage.state}">
         <span><b>Deadline</b> · ${forecast.deadlineCoverage.label}</span>
@@ -7492,6 +7524,23 @@ function render() {
 
       state.queuedCultureActions = state.queuedCultureActions.filter((entry) => entry.actionCode !== actionCode);
       state.lastTurnSummary = 'Action culturelle retirée de la file avant résolution du tour.';
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-undo-climate-intervention]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const actionCode = element.dataset.climateActionCode;
+      const removed = [...state.queuedClimateInterventions].reverse()
+        .find((entry) => !actionCode || entry.actionCode === actionCode) ?? null;
+      if (!removed) {
+        return;
+      }
+      state.queuedClimateInterventions = state.queuedClimateInterventions.filter((entry) => entry !== removed);
+      state.selectedProvinceId = removed.provinceId;
+      state.focusedProvinceId = removed.provinceId;
+      state.activeOverlaySlot = 'climate-overlay';
+      state.lastTurnSummary = `Intervention climat annulée: ${removed.actionCode} sur ${removed.provinceLabel ?? removed.provinceId}.`;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -4093,7 +4093,8 @@ button { font: inherit; }
 .province-climate-risk-forecast__selected b {
   color: #fef3c7;
 }
-.province-climate-risk-forecast__queue {
+.province-climate-risk-forecast__queue,
+.province-climate-risk-forecast__confirmation {
   display: grid;
   gap: 6px;
   padding: 9px 10px;
@@ -4102,35 +4103,49 @@ button { font: inherit; }
   border: 1px solid rgba(74, 222, 128, 0.22);
 }
 .province-climate-risk-forecast__queue--blocked { border-color: rgba(248, 113, 113, 0.26); }
-.province-climate-risk-forecast__queue div:first-child {
+.province-climate-risk-forecast__confirmation {
+  background: rgba(20, 83, 45, 0.24);
+  border-color: rgba(134, 239, 172, 0.34);
+}
+.province-climate-risk-forecast__confirmation--warning { border-color: rgba(251, 191, 36, 0.38); }
+.province-climate-risk-forecast__queue div:first-child,
+.province-climate-risk-forecast__confirmation div:first-child {
   display: flex;
   justify-content: space-between;
   gap: 8px;
   align-items: center;
 }
-.province-climate-risk-forecast__queue dl {
+.province-climate-risk-forecast__queue dl,
+.province-climate-risk-forecast__confirmation dl {
   display: grid;
   gap: 4px;
   margin: 0;
 }
-.province-climate-risk-forecast__queue dl div {
+.province-climate-risk-forecast__queue dl div,
+.province-climate-risk-forecast__confirmation dl div {
   display: flex;
   justify-content: space-between;
   gap: 8px;
 }
 .province-climate-risk-forecast__queue dt,
-.province-climate-risk-forecast__queue small {
+.province-climate-risk-forecast__queue small,
+.province-climate-risk-forecast__confirmation dt,
+.province-climate-risk-forecast__confirmation p,
+.province-climate-risk-forecast__confirmation small {
   color: #cbd5e1;
   font-size: 12px;
   line-height: 1.35;
+  margin: 0;
 }
-.province-climate-risk-forecast__queue dd {
+.province-climate-risk-forecast__queue dd,
+.province-climate-risk-forecast__confirmation dd {
   margin: 0;
   color: #ecfeff;
   font-size: 12px;
   text-align: right;
 }
-.province-climate-risk-forecast__queue button {
+.province-climate-risk-forecast__queue button,
+.province-climate-risk-forecast__confirmation button {
   justify-self: start;
   border: 1px solid rgba(74, 222, 128, 0.32);
   background: rgba(22, 101, 52, 0.32);
@@ -4140,6 +4155,11 @@ button { font: inherit; }
   cursor: pointer;
   font-size: 12px;
   font-weight: 700;
+}
+.province-climate-risk-forecast__confirmation button {
+  border-color: rgba(248, 113, 113, 0.32);
+  background: rgba(127, 29, 29, 0.28);
+  color: #fee2e2;
 }
 .province-climate-risk-forecast__queue button:disabled {
   opacity: 0.55;


### PR DESCRIPTION
Epsilon: Implements #617.

Summary:
- Adds a confirmation panel for queued climate interventions in the selected province details.
- Confirms deadline window, projected risk impact, expected mitigation/tradeoff, and missed-deadline context from the climate preview data.
- Adds an undo affordance for the queued climate intervention before turn resolution and restores the climate overlay context after removal.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webClimateInterventionConfirmUndo.test.js test/ui/climate/webClimateInterventionQueueAction.test.js test/ui/climate/webSelectedClimateInterventionPreview.test.js test/ui/climate/webClimateRiskReductionForecast.test.js
- npm test