### PR TITLE
Alpha: confirm undo map military queue

### DIFF
--- a/test/ui/war/webQueuedMilitaryActionConfirmation.test.js
+++ b/test/ui/war/webQueuedMilitaryActionConfirmation.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('selected province confirms and can undo a queued military map action', () => {
+  assert.match(webAppSource, /function buildQueuedMilitaryMapActionConfirmation/);
+  assert.match(webAppSource, /function renderQueuedMilitaryMapActionConfirmation/);
+  assert.match(webAppSource, /Action carte en file/);
+  assert.match(webAppSource, /Confirmation de l’action militaire ajoutée depuis la carte/);
+  assert.match(webAppSource, /Cible \/ front/);
+  assert.match(webAppSource, /Effet prévu/);
+  assert.match(webAppSource, /Retirer de la file/);
+  assert.match(webAppSource, /data-undo-recommended-action="true"/);
+  assert.match(webAppSource, /state\.acceptedRecommendedMilitaryAction = null/);
+  assert.match(webAppSource, /retiré de la file militaire avant résolution/);
+  assert.match(webAppSource, /renderQueuedMilitaryMapActionConfirmation\(province, shell, intrigueView\)/);
+  assert.match(webAppSource, /provinceId: province\.provinceId/);
+  assert.match(stylesSource, /\.queued-map-action-confirmation/);
+  assert.match(stylesSource, /queued-map-action-confirmation--blocked/);
+  assert.match(stylesSource, /queued-map-action-confirmation--risky/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3994,6 +3994,7 @@ function buildRecommendedMilitaryActionPreview(shell, intrigueView = null) {
   return {
     empty: !recommendedAction,
     tone: criticalCount > 0 ? 'danger' : watchCount > 0 ? 'warning' : 'ready',
+    provinceId: province.provinceId,
     provinceLabel: province.label,
     actionCode: recommendedAction?.actionCode ?? 'WAR-HOLD',
     actionLabel: recommendedAction?.label ?? 'Aucune action militaire recommandée',
@@ -4040,6 +4041,68 @@ function renderRecommendedMilitaryActionPreview(shell, intrigueView = null) {
         <button type="button" data-queue-recommended-action="true" data-province-id="${preview.provinceId ?? ''}" data-action-code="${preview.actionCode}" ${preview.queueState.disabled ? 'disabled' : ''}>${preview.queueState.buttonLabel}</button>
       </div>
       <small class="recommended-action-preview__side-effect">${preview.sideEffect}</small>
+    </section>
+  `;
+}
+
+
+
+function buildQueuedMilitaryMapActionConfirmation(province, shell, intrigueView = null) {
+  const queuedAction = state.acceptedRecommendedMilitaryAction;
+
+  if (!queuedAction || queuedAction.provinceId !== province.provinceId) {
+    return null;
+  }
+
+  const focusContext = {
+    focusedProvinceId: province.provinceId,
+    focusedProvince: province,
+    neighborIds: new Set(province.neighborIds),
+  };
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const action = actionQueue.find((entry) => entry.actionCode === queuedAction.actionCode) ?? actionQueue[0] ?? null;
+  const projection = buildProjectedFrontStability(province, shell, actionQueue);
+  const stability = projection.lines.find((line) => line.label === 'Stabilité attendue')?.value ?? projection.title;
+  const target = province.contested ? `Front contesté ${province.label}` : `Province ${province.label}`;
+
+  return {
+    actionCode: queuedAction.actionCode,
+    actionLabel: action?.label ?? queuedAction.actionCode,
+    target,
+    status: action?.status ?? 'ready',
+    mainEffect: action?.expectedResult ?? `Stabilité prévue: ${stability}.`,
+    risk: action?.mainRisk ?? 'risque contenu avant résolution',
+    queuedTurn: queuedAction.turn,
+    stability,
+  };
+}
+
+function renderQueuedMilitaryMapActionConfirmation(province, shell, intrigueView = null) {
+  const confirmation = buildQueuedMilitaryMapActionConfirmation(province, shell, intrigueView);
+
+  if (!confirmation) {
+    return '';
+  }
+
+  return `
+    <section class="queued-map-action-confirmation queued-map-action-confirmation--${confirmation.status}" aria-label="Confirmation de l’action militaire ajoutée depuis la carte">
+      <div class="queued-map-action-confirmation__header">
+        <div>
+          <span>Action carte en file</span>
+          <strong>${confirmation.actionLabel}</strong>
+        </div>
+        <code>${confirmation.actionCode}</code>
+      </div>
+      <dl>
+        <div><dt>Cible / front</dt><dd>${confirmation.target}</dd></div>
+        <div><dt>Effet prévu</dt><dd>${confirmation.mainEffect}</dd></div>
+        <div><dt>Stabilité</dt><dd>${confirmation.stability}</dd></div>
+        <div><dt>Risque principal</dt><dd>${confirmation.risk}</dd></div>
+      </dl>
+      <div class="queued-map-action-confirmation__footer">
+        <small>Ajoutée au tour ${confirmation.queuedTurn}, modifiable avant résolution.</small>
+        <button type="button" data-undo-recommended-action="true" data-province-id="${province.provinceId}">Retirer de la file</button>
+      </div>
     </section>
   `;
 }
@@ -4403,6 +4466,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceConflictNextAction(province, shell, focusContext, intrigueView)}
+      ${renderQueuedMilitaryMapActionConfirmation(province, shell, intrigueView)}
       ${renderMilitaryResponseOptions(province, shell, focusContext, intrigueView)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView)}
@@ -6879,6 +6943,7 @@ function advanceTurn() {
   ];
 
   state.lastTurnSummary = summaries[(state.turn - 2) % summaries.length];
+  state.acceptedRecommendedMilitaryAction = null;
 }
 
 function renderMobileToolbar() {
@@ -7298,6 +7363,23 @@ function render() {
 
       const viewport = document.querySelector('.map-viewport');
       centerMapOnProvince(provinceId, viewport);
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-undo-recommended-action]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const provinceId = element.dataset.provinceId;
+      const queuedAction = state.acceptedRecommendedMilitaryAction;
+
+      if (!queuedAction || queuedAction.provinceId !== provinceId) {
+        return;
+      }
+
+      state.acceptedRecommendedMilitaryAction = null;
+      state.selectedProvinceId = provinceId;
+      state.focusedProvinceId = provinceId;
+      state.lastTurnSummary = `${queuedAction.actionCode} retiré de la file militaire avant résolution.`;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -507,6 +507,63 @@ button { font: inherit; }
 .recommended-action-preview--ready { border-color: rgba(74, 222, 128, 0.28); }
 .recommended-action-preview--warning { border-color: rgba(251, 191, 36, 0.34); }
 .recommended-action-preview--danger { border-color: rgba(251, 113, 133, 0.4); }
+.queued-map-action-confirmation {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.74), rgba(22, 163, 74, 0.12));
+  border: 1px solid rgba(74, 222, 128, 0.28);
+}
+.queued-map-action-confirmation__header,
+.queued-map-action-confirmation__footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.queued-map-action-confirmation__header span,
+.queued-map-action-confirmation__header code,
+.queued-map-action-confirmation__footer small {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.queued-map-action-confirmation__header strong {
+  display: block;
+  margin-top: 3px;
+  color: #dcfce7;
+}
+.queued-map-action-confirmation dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+.queued-map-action-confirmation dt {
+  color: var(--muted);
+  font-size: 11px;
+}
+.queued-map-action-confirmation dd {
+  margin: 2px 0 0;
+  color: #f8fafc;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.queued-map-action-confirmation button {
+  flex: 0 0 auto;
+  padding: 8px 10px;
+  border: 1px solid rgba(251, 113, 133, 0.42);
+  border-radius: 999px;
+  background: rgba(127, 29, 29, 0.34);
+  color: #fecdd3;
+  font-weight: 700;
+  cursor: pointer;
+}
+.queued-map-action-confirmation--blocked { border-color: rgba(251, 113, 133, 0.38); }
+.queued-map-action-confirmation--risky { border-color: rgba(251, 191, 36, 0.34); }
 .economy-readiness-warnings {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Alpha: Implements #613.

Summary:
- Adds a selected-province confirmation card after a recommended military map action is queued.
- Shows queued action, target/front, predicted effect, projected stability, and main risk.
- Adds an undo affordance before turn resolution and clears the local queued action on turn advance.

Tests:
- npm test

Zeta: PR prête pour revue. Merci de valider avant tout merge.
