### PR TITLE
Alpha: summarize queued military resolution

### DIFF
--- a/test/ui/war/webQueuedMilitaryResolutionSummary.test.js
+++ b/test/ui/war/webQueuedMilitaryResolutionSummary.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('map summarizes queued military resolution before turn commit', () => {
+  assert.match(webAppSource, /function buildQueuedMilitaryResolutionSummary/);
+  assert.match(webAppSource, /function renderQueuedMilitaryResolutionSummary/);
+  assert.match(webAppSource, /Résumé de résolution militaire avant validation du tour/);
+  assert.match(webAppSource, /Résolution avant commit/);
+  assert.match(webAppSource, /Stabilité/);
+  assert.match(webAppSource, /Pression ennemie/);
+  assert.match(webAppSource, /Risque restant/);
+  assert.match(webAppSource, /Conflits à vérifier/);
+  assert.match(webAppSource, /Aucun conflit de file détecté/);
+  assert.match(webAppSource, /duplicateCount > 1/);
+  assert.match(webAppSource, /Action bloquée: la province resterait critique après résolution/);
+  assert.match(webAppSource, /renderQueuedMilitaryResolutionSummary\(shell, intrigueView\)/);
+  assert.match(stylesSource, /\.queued-military-resolution/);
+  assert.match(stylesSource, /queued-military-resolution__conflicts\.has-conflicts/);
+  assert.match(stylesSource, /queued-military-resolution--danger/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -4178,6 +4178,131 @@ function renderRecommendedMilitaryActionPreview(shell, intrigueView = null) {
 
 
 
+function buildQueuedMilitaryResolutionSummary(shell, intrigueView = null) {
+  const queuedAction = state.acceptedRecommendedMilitaryAction;
+
+  if (!queuedAction) {
+    return {
+      empty: true,
+      tone: 'ready',
+      title: 'Aucune résolution militaire en attente',
+      summary: 'Aucune action militaire ajoutée depuis la carte: le tour peut être validé sans changement de front immédiat.',
+      items: [],
+      conflicts: [],
+    };
+  }
+
+  const province = shell.provinces.find((candidate) => candidate.provinceId === queuedAction.provinceId) ?? null;
+
+  if (!province) {
+    return {
+      empty: false,
+      tone: 'warning',
+      title: 'Action en file à vérifier',
+      summary: `${queuedAction.actionCode} référence une province introuvable avant résolution.`,
+      items: [{
+        provinceLabel: queuedAction.provinceLabel,
+        actionCode: queuedAction.actionCode,
+        target: 'province indisponible',
+        effect: 'résolution suspendue tant que la cible n’est pas retrouvée',
+        pressure: 'pression inconnue',
+        residualRisk: 'risque à vérifier',
+        status: 'risky',
+      }],
+      conflicts: ['Cible introuvable: vérifier la sélection avant de valider le tour.'],
+    };
+  }
+
+  const focusContext = {
+    focusedProvinceId: province.provinceId,
+    focusedProvince: province,
+    neighborIds: new Set(province.neighborIds),
+  };
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const action = actionQueue.find((entry) => entry.actionCode === queuedAction.actionCode) ?? actionQueue[0] ?? null;
+  const projection = buildProjectedFrontStability(province, shell, actionQueue);
+  const risks = buildCriticalFrontRiskWarnings(province, projection);
+  const stability = projection.lines.find((line) => line.label === 'Stabilité attendue')?.value ?? projection.title;
+  const pressure = projection.drivers.some((driver) => driver.label === 'Pression')
+    ? 'pression ennemie encore visible'
+    : projection.tone === 'ready'
+      ? 'pression en baisse'
+      : 'pression contestée';
+  const residualRisk = risks[0]?.label ?? 'Risque acceptable';
+  const duplicateCount = actionQueue.filter((entry) => entry.actionCode === queuedAction.actionCode).length;
+  const conflicts = [];
+
+  if (duplicateCount > 1) {
+    conflicts.push(`${queuedAction.actionCode} apparaît ${duplicateCount} fois dans la file locale.`);
+  }
+
+  if (action?.status === 'blocked') {
+    conflicts.push('Action bloquée: la province resterait critique après résolution.');
+  }
+
+  if (action?.status === 'risky') {
+    conflicts.push('Action risquée: confirmer l’appui avant commit du tour.');
+  }
+
+  return {
+    empty: false,
+    tone: conflicts.length > 0 ? (action?.status === 'blocked' ? 'danger' : 'warning') : 'ready',
+    title: 'Résolution militaire prête',
+    summary: `${queuedAction.actionCode} sera résolue au prochain commit de tour pour ${province.label}.`,
+    items: [{
+      provinceLabel: province.label,
+      actionCode: queuedAction.actionCode,
+      target: province.contested ? `Front contesté ${province.label}` : `Province ${province.label}`,
+      effect: action?.expectedResult ?? `Stabilité prévue: ${stability}.`,
+      pressure,
+      residualRisk,
+      status: action?.status ?? 'ready',
+      stability,
+    }],
+    conflicts,
+  };
+}
+
+function renderQueuedMilitaryResolutionSummary(shell, intrigueView = null) {
+  const report = buildQueuedMilitaryResolutionSummary(shell, intrigueView);
+
+  return `
+    <section class="queued-military-resolution queued-military-resolution--${report.tone} ${report.empty ? 'is-empty' : ''}" aria-label="Résumé de résolution militaire avant validation du tour">
+      <div class="queued-military-resolution__header">
+        <div>
+          <span>Résolution avant commit</span>
+          <strong>${report.title}</strong>
+        </div>
+        <small>${report.items.length} action${report.items.length > 1 ? 's' : ''}</small>
+      </div>
+      <p>${report.summary}</p>
+      ${report.items.length > 0 ? `
+        <div class="queued-military-resolution__items">
+          ${report.items.map((item) => `
+            <article class="queued-military-resolution__item queued-military-resolution__item--${item.status}">
+              <div>
+                <strong>${item.provinceLabel}</strong>
+                <code>${item.actionCode}</code>
+              </div>
+              <dl>
+                <div><dt>Cible / front</dt><dd>${item.target}</dd></div>
+                <div><dt>Stabilité</dt><dd>${item.stability}</dd></div>
+                <div><dt>Pression ennemie</dt><dd>${item.pressure}</dd></div>
+                <div><dt>Risque restant</dt><dd>${item.residualRisk}</dd></div>
+              </dl>
+              <p>${item.effect}</p>
+            </article>
+          `).join('')}
+        </div>
+      ` : ''}
+      <div class="queued-military-resolution__conflicts ${report.conflicts.length > 0 ? 'has-conflicts' : ''}">
+        <strong>${report.conflicts.length > 0 ? 'Conflits à vérifier' : 'Aucun conflit de file détecté'}</strong>
+        <span>${report.conflicts.length > 0 ? report.conflicts.join(' · ') : 'Pas de doublon militaire carte avant validation du tour.'}</span>
+      </div>
+    </section>
+  `;
+}
+
 function buildQueuedMilitaryMapActionConfirmation(province, shell, intrigueView = null) {
   const queuedAction = state.acceptedRecommendedMilitaryAction;
 
@@ -7281,6 +7406,7 @@ function render() {
           ${renderConflictReadinessWarnings(shell, intrigueView)}
           ${renderFrontPriorityRanking(shell, intrigueView)}
           ${renderRecommendedMilitaryActionPreview(shell, intrigueView)}
+          ${renderQueuedMilitaryResolutionSummary(shell, intrigueView)}
           ${renderMapClimatePreparednessSummary(climatePreparednessSummary)}
           ${renderMapClimateInterventionWindows(climateInterventionWindows)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -564,6 +564,79 @@ button { font: inherit; }
 }
 .queued-map-action-confirmation--blocked { border-color: rgba(251, 113, 133, 0.38); }
 .queued-map-action-confirmation--risky { border-color: rgba(251, 191, 36, 0.34); }
+.queued-military-resolution {
+  display: grid;
+  gap: 9px;
+  margin-top: 10px;
+  max-width: 62ch;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.64);
+  border: 1px solid rgba(74, 222, 128, 0.22);
+}
+.queued-military-resolution__header,
+.queued-military-resolution__item div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.queued-military-resolution__header span,
+.queued-military-resolution__header small,
+.queued-military-resolution__item code {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.queued-military-resolution__header strong,
+.queued-military-resolution__item strong { color: #dcfce7; }
+.queued-military-resolution p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.queued-military-resolution__items { display: grid; gap: 7px; }
+.queued-military-resolution__item {
+  display: grid;
+  gap: 7px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.queued-military-resolution__item dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin: 0;
+}
+.queued-military-resolution__item dt {
+  color: var(--muted);
+  font-size: 11px;
+}
+.queued-military-resolution__item dd {
+  margin: 2px 0 0;
+  color: #f8fafc;
+  font-size: 12px;
+}
+.queued-military-resolution__conflicts {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(74, 222, 128, 0.18);
+}
+.queued-military-resolution__conflicts span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.queued-military-resolution__conflicts.has-conflicts { border-color: rgba(251, 191, 36, 0.36); }
+.queued-military-resolution--warning { border-color: rgba(251, 191, 36, 0.34); }
+.queued-military-resolution--danger,
+.queued-military-resolution__item--blocked { border-color: rgba(251, 113, 133, 0.4); }
 .economy-readiness-warnings {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Alpha: Implements #623.

Summary:
- Adds a compact pre-turn military resolution summary for queued map actions.
- Shows province/front target, expected effect, projected stability, enemy pressure, and residual risk.
- Highlights missing targets, blocked/risky actions, and duplicate queue conflicts while preserving existing queue/confirm/undo behavior.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webQueuedMilitaryResolutionSummary.test.js test/ui/war/webQueuedMilitaryActionConfirmation.test.js test/ui/war/webQueueRecommendedMilitaryAction.test.js
- npm test (464 tests)

Zeta: PR prête pour revue. Merci de valider avant tout merge.
