### PR TITLE
Beta: summarize unresolved logistics shortages

### DIFF
--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -34,7 +34,12 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /queuedLogisticsActions/);
   assert.match(webAppSource, /primaryLogisticsAction/);
   assert.match(webAppSource, /renderQueuedLogisticsMapSummary/);
+  assert.match(webAppSource, /buildLogisticsTurnCommitSummary/);
+  assert.match(webAppSource, /renderLogisticsTurnCommitSummary/);
   assert.match(webAppSource, /File logistique/);
+  assert.match(webAppSource, /Avant validation du tour/);
+  assert.match(webAppSource, /unresolvedShortages/);
+  assert.match(webAppSource, /redundantActions/);
   assert.match(webAppSource, /data-logistics-undo-last/);
   assert.match(webAppSource, /Annuler dernière action/);
   assert.match(webAppSource, /bottleneckRelieved/);
@@ -74,6 +79,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-queue-action--conflict/);
   assert.match(stylesSource, /province-logistics-queued-summary/);
   assert.match(stylesSource, /province-logistics-queued-summary--empty/);
+  assert.match(stylesSource, /province-logistics-turn-summary--covered/);
+  assert.match(stylesSource, /province-logistics-turn-summary--danger/);
+  assert.match(stylesSource, /province-logistics-turn-summary__shortage--high/);
   assert.match(stylesSource, /province-logistics-downstream-summary--résolue/);
   assert.match(stylesSource, /province-logistics-downstream-shortage--high/);
   assert.match(stylesSource, /province-logistics-timeline-summary--empty/);

--- a/web/app.js
+++ b/web/app.js
@@ -1280,6 +1280,63 @@ function renderQueuedLogisticsMapSummary(preview) {
   `;
 }
 
+
+function buildLogisticsTurnCommitSummary(province, preview) {
+  const queuedEntries = state.queuedLogisticsActions.filter((entry) => entry.provinceId === province.provinceId || preview.options.some((option) => option.routeId === entry.routeId));
+  const queuedRouteIds = new Set(queuedEntries.map((entry) => entry.routeId));
+  const unresolvedShortages = preview.options
+    .filter((option) => !queuedRouteIds.has(option.routeId))
+    .flatMap((option) => option.recoveryChoices[0]?.downstreamShortages.map((shortage) => ({ ...shortage, routeId: option.routeId, route: option.routes[0], city: option.affectedCity })) ?? [])
+    .filter((shortage) => shortage.status !== 'résolue')
+    .slice(0, 3);
+  const seenRoutes = new Set();
+  const redundantActions = queuedEntries.filter((entry) => {
+    const duplicate = seenRoutes.has(entry.routeId) || entry.status === 'redundant' || entry.status === 'conflict';
+    seenRoutes.add(entry.routeId);
+    return duplicate;
+  });
+
+  return {
+    status: unresolvedShortages.some((shortage) => shortage.status === 'aggravée') ? 'danger' : unresolvedShortages.length > 0 ? 'warning' : queuedEntries.length > 0 ? 'covered' : 'empty',
+    queuedEntries,
+    unresolvedShortages,
+    redundantActions,
+    summary: queuedEntries.length === 0
+      ? 'Aucune action logistique en attente: les pénuries restent à auditer avant résolution.'
+      : unresolvedShortages.length > 0
+        ? `${queuedEntries.length} action${queuedEntries.length > 1 ? 's' : ''} couvre${queuedEntries.length > 1 ? 'nt' : ''} la file; ${unresolvedShortages.length} pénurie${unresolvedShortages.length > 1 ? 's' : ''}/goulot${unresolvedShortages.length > 1 ? 's' : ''} reste${unresolvedShortages.length > 1 ? 'nt' : ''} dangereux.`
+        : `${queuedEntries.length} action${queuedEntries.length > 1 ? 's' : ''} logistique${queuedEntries.length > 1 ? 's' : ''} couvre${queuedEntries.length > 1 ? 'nt' : ''} les pénuries aval visibles.`,
+  };
+}
+
+function renderLogisticsTurnCommitSummary(province, preview) {
+  const summary = buildLogisticsTurnCommitSummary(province, preview);
+
+  return `
+    <div class="province-logistics-turn-summary province-logistics-turn-summary--${summary.status}" aria-label="Synthèse logistique avant validation du tour">
+      <div>
+        <b>Avant validation du tour</b>
+        <span>${summary.summary}</span>
+      </div>
+      ${summary.queuedEntries.length > 0 ? `
+        <ul class="province-logistics-turn-summary__queue">
+          ${summary.queuedEntries.map((entry) => `
+            <li><strong>${entry.label}</strong><span>${entry.target ?? entry.routeId} · ${entry.bottleneckRelieved ?? 'goulot à confirmer'} · ${entry.downstreamEffect ?? 'effet aval à confirmer'}</span></li>
+          `).join('')}
+        </ul>
+      ` : ''}
+      ${summary.unresolvedShortages.length > 0 ? `
+        <ul class="province-logistics-turn-summary__unresolved" aria-label="Pénuries ou goulots restant après estimation de la file">
+          ${summary.unresolvedShortages.map((shortage) => `
+            <li class="province-logistics-turn-summary__shortage province-logistics-turn-summary__shortage--${shortage.tone}"><strong>${shortage.status}</strong><span>${shortage.city} / ${shortage.route}: ${shortage.detail}</span></li>
+          `).join('')}
+        </ul>
+      ` : ''}
+      ${summary.redundantActions.length > 0 ? `<small>Actions redondantes ou moins prioritaires: ${summary.redundantActions.map((entry) => entry.label).join(', ')}.</small>` : ''}
+    </div>
+  `;
+}
+
 function renderProvinceLogisticsChoicePreview(province, economyView) {
   const preview = buildProvinceLogisticsChoicePreviewView(province, economyView);
 
@@ -1336,6 +1393,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
         <button type="button" data-logistics-queue-action="${preview.primaryLogisticsAction.actionId ?? ''}" ${preview.primaryLogisticsAction.disabled ? 'disabled' : ''}>Engager récupération</button>
       </div>
       ${renderQueuedLogisticsMapSummary(preview)}
+      ${renderLogisticsTurnCommitSummary(province, preview)}
       <div class="province-logistics-impact-preview province-logistics-impact-preview--${preview.selectedActionPreview.status}" aria-label="Impact projeté avant engagement logistique">
         <div>
           <b>Impact si engagé</b>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3705,6 +3705,54 @@ button { font: inherit; }
   padding: 6px 10px;
   font-size: 12px;
 }
+.province-logistics-turn-summary {
+  display: grid;
+  gap: 7px;
+  margin: 8px 0;
+  padding: 9px 10px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+.province-logistics-turn-summary--covered { border-color: rgba(74, 222, 128, 0.28); }
+.province-logistics-turn-summary--warning { border-color: rgba(245, 158, 11, 0.32); }
+.province-logistics-turn-summary--danger { border-color: rgba(251, 113, 133, 0.36); }
+.province-logistics-turn-summary--empty { opacity: 0.82; }
+.province-logistics-turn-summary > div {
+  display: grid;
+  gap: 3px;
+}
+.province-logistics-turn-summary b {
+  color: #bfdbfe;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.province-logistics-turn-summary span,
+.province-logistics-turn-summary small {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-logistics-turn-summary ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.province-logistics-turn-summary li {
+  display: grid;
+  gap: 3px;
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.32);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-logistics-turn-summary li strong { color: #f8fafc; font-size: 12px; }
+.province-logistics-turn-summary__shortage--high { border-color: rgba(251, 113, 133, 0.34); }
+.province-logistics-turn-summary__shortage--medium { border-color: rgba(245, 158, 11, 0.3); }
+.province-logistics-turn-summary__shortage--low { border-color: rgba(74, 222, 128, 0.22); }
 .province-logistics-impact-preview {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Beta: Implements #624.

## Summary
- Adds a before-turn-commit logistics summary to the province map/economy panel.
- Lists queued logistics actions by target/bottleneck/downstream effect.
- Estimates unresolved downstream shortages/goulets after queued routes and flags redundant or lower-priority queued actions.
- Keeps rendering local to the existing logistics map panel and preserves queue/confirm/undo behavior.

## Validation
- npm test (463 OK)
- targeted economy UI tests (7 OK)
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check
