### PR TITLE
Delta: summarize final intrigue exposure

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -181,3 +181,18 @@ test('queued intrigue map responses show fog-safe confirmation and undo affordan
   assert.match(stylesSource, /province-intrigue-map-confirmation--confirmed/);
   assert.match(stylesSource, /province-intrigue-map-confirmation__undo:disabled/);
 });
+
+test('final intrigue exposure summary is visible before turn commit', () => {
+  assert.match(webAppSource, /function buildFinalIntrigueExposureCommitSummary/);
+  assert.match(webAppSource, /Synthèse finale exposition intrigue avant commit du tour/);
+  assert.match(webAppSource, /Avant commit du tour/);
+  assert.match(webAppSource, /Cellule masquée · \$\{contribution\.provinceLabel\}/);
+  assert.match(webAppSource, /exposition estimée après résolution \$\{cumulativeRisk\.totalLabel\}/);
+  assert.match(webAppSource, /cellule\$\{finalCommitSummary\.riskyCells\.length > 1 \? 's' : ''\} encore trop risquée/);
+  assert.match(webAppSource, /Combinaison gênante: plusieurs réponses visibles peuvent cumuler chaleur et réduire la couverture/);
+  assert.match(webAppSource, /Dernière confirmation conservée; undo encore possible avant commit du tour/);
+  assert.match(webAppSource, /Synthèse finale fog-safe: cellule, cible et relais restent masqués/);
+  assert.match(stylesSource, /province-intrigue-final-commit-summary/);
+  assert.match(stylesSource, /province-intrigue-final-commit-summary--danger/);
+  assert.match(stylesSource, /province-intrigue-final-commit-summary__item--trop-risqué/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3277,12 +3277,47 @@ function buildConfirmedQueuedIntrigueMapResponse(province, projection, mapQueueA
   };
 }
 
+function buildFinalIntrigueExposureCommitSummary(province, projection, cumulativeRisk, confirmation) {
+  const pendingResponses = cumulativeRisk.contributions.map((contribution) => ({
+    context: `Cellule masquée · ${contribution.provinceLabel}`,
+    response: contribution.actionLabel,
+    exposureAfter: Math.min(100, contribution.score),
+    riskState: contribution.score >= 70 ? 'trop risqué' : contribution.score >= 45 ? 'à surveiller' : 'contenu',
+  }));
+  const localDuplicates = pendingResponses.filter((response) => response.context.includes(province.label)).length;
+  const interference = localDuplicates > 1 || cumulativeRisk.level === 'critique' || cumulativeRisk.level === 'élevé'
+    ? 'Combinaison gênante: plusieurs réponses visibles peuvent cumuler chaleur et réduire la couverture.'
+    : 'Aucune combinaison gênante majeure dans les signaux visibles.';
+  const riskyCells = pendingResponses.filter((response) => response.riskState === 'trop risqué');
+
+  return {
+    empty: pendingResponses.length === 0,
+    level: cumulativeRisk.level,
+    tone: cumulativeRisk.tone,
+    exposureAfter: cumulativeRisk.totalLabel,
+    summary: pendingResponses.length === 0
+      ? 'Synthèse finale indisponible: aucune réponse intrigue confirmée avant résolution.'
+      : `${pendingResponses.length} réponse${pendingResponses.length > 1 ? 's' : ''} intrigue en attente; exposition estimée après résolution ${cumulativeRisk.totalLabel}.`,
+    pendingResponses,
+    riskyCells,
+    interference,
+    confirmationHint: confirmation.confirmed
+      ? 'Dernière confirmation conservée; undo encore possible avant commit du tour.'
+      : 'Confirmer une réponse carte pour verrouiller la synthèse finale.',
+    fogLimit: 'Synthèse finale fog-safe: cellule, cible et relais restent masqués; seules province visible et tendance d’exposition sont listées.',
+    residualWarning: projection.tone === 'danger'
+      ? 'Risque résiduel élevé: différer ou remplacer avant résolution.'
+      : 'Risque résiduel lisible; conserver les détails existants pour arbitrage final.',
+  };
+}
+
 function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView) {
   const projection = buildQueuedIntrigueDetectionRiskProjection(province, actionQueue, intrigueView);
   const cumulativeRisk = buildCumulativeQueuedIntrigueExposureRisk(province, projection, intrigueView);
   const queueChangePreview = buildIntrigueQueueChangePreview(projection, cumulativeRisk);
   const mapQueueAction = buildMapIntrigueSafeQueueAction(province, projection, cumulativeRisk, queueChangePreview);
   const confirmation = buildConfirmedQueuedIntrigueMapResponse(province, projection, mapQueueAction);
+  const finalCommitSummary = buildFinalIntrigueExposureCommitSummary(province, projection, cumulativeRisk, confirmation);
 
   return `
     <section class="province-intrigue-detection-projection province-intrigue-detection-projection--${projection.tone}" aria-label="Projection du risque de détection intrigue">
@@ -3372,6 +3407,28 @@ function renderQueuedIntrigueDetectionRiskProjection(province, actionQueue, intr
         </dl>
         <button type="button" class="province-intrigue-map-confirmation__undo" data-action="undo-last-intrigue-response" data-province-id="${province.provinceId}" ${confirmation.confirmed ? '' : 'disabled'}>${confirmation.undoLabel}</button>
         <small>${confirmation.undoDetail}</small>
+      </div>
+      <div class="province-intrigue-final-commit-summary province-intrigue-final-commit-summary--${finalCommitSummary.tone}" aria-label="Synthèse finale exposition intrigue avant commit du tour">
+        <div class="province-intrigue-final-commit-summary__header">
+          <span>Avant commit du tour</span>
+          <strong>${finalCommitSummary.level} · ${finalCommitSummary.exposureAfter}</strong>
+        </div>
+        <p>${finalCommitSummary.summary}</p>
+        ${finalCommitSummary.pendingResponses.length > 0 ? `
+          <ol>
+            ${finalCommitSummary.pendingResponses.map((response) => `
+              <li class="province-intrigue-final-commit-summary__item province-intrigue-final-commit-summary__item--${response.riskState.replaceAll(' ', '-')}">
+                <strong>${response.context}</strong>
+                <span>${response.response} · exposition après ${response.exposureAfter} · ${response.riskState}</span>
+              </li>
+            `).join('')}
+          </ol>
+        ` : ''}
+        <small>${finalCommitSummary.interference}</small>
+        <small>${finalCommitSummary.riskyCells.length > 0 ? `${finalCommitSummary.riskyCells.length} cellule${finalCommitSummary.riskyCells.length > 1 ? 's' : ''} encore trop risquée${finalCommitSummary.riskyCells.length > 1 ? 's' : ''}.` : 'Aucune cellule visible encore trop risquée.'}</small>
+        <small>${finalCommitSummary.residualWarning}</small>
+        <small>${finalCommitSummary.confirmationHint}</small>
+        <small>${finalCommitSummary.fogLimit}</small>
       </div>
       <small>${projection.fogLimit}</small>
     </section>

--- a/web/styles.css
+++ b/web/styles.css
@@ -7237,6 +7237,55 @@ button { font: inherit; }
   border-color: rgba(148, 163, 184, 0.24);
   background: rgba(51, 65, 85, 0.24);
 }
+.province-intrigue-final-commit-summary {
+  display: grid;
+  gap: 8px;
+  margin: 8px 0;
+  padding: 10px;
+  border-radius: 13px;
+  background: rgba(15, 23, 42, 0.38);
+  border: 1px solid rgba(168, 85, 247, 0.26);
+}
+.province-intrigue-final-commit-summary--danger { border-color: rgba(248, 113, 113, 0.42); }
+.province-intrigue-final-commit-summary--warning { border-color: rgba(250, 204, 21, 0.36); }
+.province-intrigue-final-commit-summary--watch { border-color: rgba(96, 165, 250, 0.34); }
+.province-intrigue-final-commit-summary--masked { border-color: rgba(148, 163, 184, 0.22); }
+.province-intrigue-final-commit-summary__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-final-commit-summary__header span {
+  color: #ddd6fe;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.province-intrigue-final-commit-summary p,
+.province-intrigue-final-commit-summary small {
+  margin: 0;
+  color: var(--muted);
+}
+.province-intrigue-final-commit-summary ol {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.province-intrigue-final-commit-summary__item {
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.24);
+  border-left: 3px solid rgba(148, 163, 184, 0.44);
+}
+.province-intrigue-final-commit-summary__item--trop-risqué { border-left-color: rgba(248, 113, 113, 0.78); }
+.province-intrigue-final-commit-summary__item--à-surveiller { border-left-color: rgba(250, 204, 21, 0.72); }
+.province-intrigue-final-commit-summary__item--contenu { border-left-color: rgba(34, 197, 94, 0.68); }
+.province-intrigue-final-commit-summary__item span {
+  display: block;
+  color: var(--muted);
+}
 @media (max-width: 760px) {
   .province-intrigue-queue-change-preview__grid,
   .province-intrigue-map-queue-action dl,


### PR DESCRIPTION
Delta: Implements #626.\n\nSummary:\n- adds a fog-safe final intrigue exposure summary before turn commit\n- lists pending intrigue responses by masked cell/province with estimated exposure after resolution\n- flags risky cells and interfering combinations while preserving queue/confirm/undo details\n\nValidation:\n- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js\n- node --check web/app.js\n- git diff --check\n- npm test