### PR TITLE
Gamma: summarize culture queue resolution

### DIFF
--- a/src/ui/culture/buildCultureOpportunityReminders.js
+++ b/src/ui/culture/buildCultureOpportunityReminders.js
@@ -596,6 +596,79 @@ function attachQueueConfirmation(reminders, confirmation) {
   }));
 }
 
+
+function buildCultureResolutionSummary(reminders, actionQueue) {
+  const queuedEntries = actionQueue
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry }) => String(entry.actionCode ?? entry.code ?? '').startsWith('culture:'));
+
+  const queuedActions = queuedEntries.map(({ entry, index }) => {
+    const actionCode = String(entry.actionCode ?? entry.code ?? '');
+    const label = normalizeText(entry.label, entry.title ?? 'Action culturelle');
+    const reminder = reminders.find((candidate) => candidate.queueAction
+      && (candidate.queueAction.code === actionCode || candidate.queueAction.label === label));
+
+    if (!reminder) {
+      return {
+        queueIndex: index,
+        actionCode,
+        label,
+        cultureName: normalizeText(entry.cultureName, 'Culture locale'),
+        provinceId: entry.provinceId ?? null,
+        provinceLabel: normalizeText(entry.provinceLabel, entry.provinceId ?? 'province'),
+        outcome: 'ignoré',
+        tone: 'unmatched',
+        effect: normalizeText(entry.expectedResult, entry.mainRisk ?? 'Effet culturel à confirmer après résolution.'),
+        reason: 'Aucun rappel culturel actif ne correspond encore à cette entrée de file.',
+        summary: `${label}: effet culturel à confirmer.`
+      };
+    }
+
+    const stabilizes = reminder.stabilityPreview?.stabilityDelta ?? '+ stabilité locale';
+    const opportunity = reminder.stabilityPreview?.urgencyDelta ?? reminder.queueAction?.horizon ?? 'fenêtre suivie';
+    const cohesion = reminder.stabilityPreview?.dissentDelta ?? reminder.confidenceCue?.dissent ?? 'dissidence clarifiée';
+
+    return {
+      queueIndex: index,
+      actionCode: reminder.queueAction.code,
+      label: reminder.queueAction.label,
+      cultureName: reminder.cultureName,
+      provinceId: reminder.provinceId,
+      provinceLabel: reminder.focusTarget?.label ?? reminder.provinceId,
+      outcome: 'apaisé',
+      tone: reminder.stabilityPreview?.level ?? 'steady',
+      effect: `${stabilizes}; ${opportunity}; ${cohesion}`,
+      reason: reminder.stabilityPreview?.reason ?? reminder.reasonCopy,
+      summary: `${reminder.cultureName}: ${stabilizes}; ${opportunity}.`,
+    };
+  });
+
+  const coveredCodes = new Set(queuedActions.map((action) => action.actionCode));
+  const uncoveredUrgent = reminders
+    .filter((reminder) => reminder.queueAction && !coveredCodes.has(reminder.queueAction.code))
+    .filter((reminder) => reminder.urgency?.level === 'soon' || reminder.inactionCost?.level === 'closing' || reminder.confidenceCue?.level === 'risky')
+    .map((reminder) => ({
+      reminderId: reminder.reminderId,
+      cultureName: reminder.cultureName,
+      provinceId: reminder.provinceId,
+      label: reminder.queueAction.label,
+      tone: reminder.inactionCost?.level === 'closing' ? 'aggravated' : 'ignored',
+      expectedImpact: reminder.inactionCost?.summary ?? reminder.stabilityPreview?.reason ?? reminder.reasonCopy,
+      summary: `${reminder.cultureName}: ${reminder.inactionCost?.summary ?? 'recommandation urgente non couverte.'}`,
+    }));
+
+  const apaisées = queuedActions.filter((action) => action.outcome === 'apaisé').length;
+  const aggravées = uncoveredUrgent.filter((entry) => entry.tone === 'aggravated').length;
+  const ignorées = uncoveredUrgent.length - aggravées;
+
+  return {
+    state: queuedActions.length > 0 ? 'queued' : uncoveredUrgent.length > 0 ? 'uncovered' : 'clear',
+    queuedActions,
+    uncoveredUrgent,
+    summary: `${apaisées} tension${apaisées > 1 ? 's' : ''} apaisée${apaisées > 1 ? 's' : ''}, ${ignorées} ignorée${ignorées > 1 ? 's' : ''}, ${aggravées} aggravée${aggravées > 1 ? 's' : ''} après résolution.`,
+  };
+}
+
 function dedupeAndSort(reminders) {
   const remindersByKey = new Map();
 
@@ -646,6 +719,7 @@ export function buildCultureOpportunityReminders({
   const remindersWithQueueActions = attachQueueActions(remindersWithStabilityPreviews);
   const queuedCultureAction = findQueuedCultureConfirmation(remindersWithQueueActions, actionQueue);
   const remindersWithQueueConfirmation = attachQueueConfirmation(remindersWithQueueActions, queuedCultureAction);
+  const resolutionSummary = buildCultureResolutionSummary(remindersWithQueueActions, actionQueue);
 
   return {
     state: 'active',
@@ -654,5 +728,6 @@ export function buildCultureOpportunityReminders({
     reminders: remindersWithQueueConfirmation,
     priorityConflicts,
     queuedCultureAction,
+    resolutionSummary,
   };
 }

--- a/test/ui/culture/buildCultureOpportunityReminders.test.js
+++ b/test/ui/culture/buildCultureOpportunityReminders.test.js
@@ -177,6 +177,11 @@ test('buildCultureOpportunityReminders confirms queued culture actions and expos
   assert.equal(report.queuedCultureAction.undoAction.label, 'Retirer de la file');
   assert.equal(report.reminders[0].queueConfirmation.actionCode, 'culture:follow-event:river-gate');
   assert.equal(report.reminders[0].queueConfirmation.summary, 'Suivre l’événement est en file: + stabilité locale; urgence baisse si action validée; dissidence faible. Ouverture des archives risque de sortir de la timeline locale sans action (ce tour).');
+  assert.equal(report.resolutionSummary.state, 'queued');
+  assert.equal(report.resolutionSummary.summary, '1 tension apaisée, 0 ignorée, 0 aggravée après résolution.');
+  assert.deepEqual(report.resolutionSummary.queuedActions.map((action) => [action.cultureName, action.label, action.outcome, action.effect]), [
+    ['Compact d’Aurora', 'Suivre l’événement', 'apaisé', '+ stabilité locale; urgence baisse si action validée; dissidence faible'],
+  ]);
 });
 
 test('buildCultureOpportunityReminders returns a compact quiet summary without hints', () => {

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -35,6 +35,9 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /cultureQueueAction/);
   assert.match(webAppSource, /cultureUndoAction/);
   assert.match(webAppSource, /Action culturelle en file/);
+  assert.match(webAppSource, /culture-opportunity-resolution/);
+  assert.match(webAppSource, /Résumé de résolution culturelle/);
+  assert.match(webAppSource, /Urgences non couvertes/);
   assert.match(webAppSource, /Mettre en file/);
   assert.match(webAppSource, /Aucune action culturelle pertinente/);
   assert.match(webAppSource, /Pas de perte culturelle claire/);
@@ -53,6 +56,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-opportunity-reminder__stability-preview--steady/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-action/);
   assert.match(stylesSource, /\.culture-opportunity-queued-action/);
+  assert.match(stylesSource, /\.culture-opportunity-resolution/);
+  assert.match(stylesSource, /\.culture-opportunity-resolution__uncovered/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-confirmation/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-empty/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--positive/);

--- a/web/app.js
+++ b/web/app.js
@@ -955,6 +955,33 @@ function renderCultureOpportunityReminders(report) {
           </button>
         </div>
       ` : ''}
+      ${report.resolutionSummary ? `
+        <div class="culture-opportunity-resolution culture-opportunity-resolution--${report.resolutionSummary.state}" aria-label="Résumé de résolution culturelle">
+          <div class="culture-opportunity-resolution__header">
+            <span>Après validation</span>
+            <strong>${report.resolutionSummary.summary}</strong>
+          </div>
+          ${(report.resolutionSummary.queuedActions ?? []).length > 0 ? `
+            <ul>
+              ${report.resolutionSummary.queuedActions.map((action) => `
+                <li class="culture-opportunity-resolution__item culture-opportunity-resolution__item--${action.tone}">
+                  <b>${action.cultureName}</b>
+                  <span>${action.label} · ${action.outcome}</span>
+                  <small>${action.effect} · ${action.reason}</small>
+                </li>
+              `).join('')}
+            </ul>
+          ` : ''}
+          ${(report.resolutionSummary.uncoveredUrgent ?? []).length > 0 ? `
+            <div class="culture-opportunity-resolution__uncovered" aria-label="Recommandations culturelles urgentes non couvertes">
+              <b>Urgences non couvertes</b>
+              ${(report.resolutionSummary.uncoveredUrgent ?? []).map((entry) => `
+                <small>${entry.cultureName}: ${entry.expectedImpact}</small>
+              `).join('')}
+            </div>
+          ` : ''}
+        </div>
+      ` : ''}
       ${(report.priorityConflicts ?? []).length > 0 ? `
         <div class="culture-opportunity-priority-conflicts" aria-label="Conflits de priorité culturelle">
           ${(report.priorityConflicts ?? []).map((conflict) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -3052,6 +3052,47 @@ button { font: inherit; }
 .culture-opportunity-queued-action strong { color: #f0fdf4; font-size: 12px; }
 .culture-opportunity-queued-action small { color: #dcfce7; font-size: 11px; line-height: 1.3; }
 .culture-opportunity-queued-action button { width: fit-content; }
+.culture-opportunity-resolution {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 8px;
+  padding: 8px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.culture-opportunity-resolution__header span {
+  display: block;
+  color: #bae6fd;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.culture-opportunity-resolution__header strong { color: #f8fafc; font-size: 12px; }
+.culture-opportunity-resolution ul { display: grid; gap: 5px; margin: 0; padding: 0; list-style: none; }
+.culture-opportunity-resolution__item {
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.culture-opportunity-resolution__item b { color: #e0f2fe; font-size: 12px; }
+.culture-opportunity-resolution__item span,
+.culture-opportunity-resolution__item small { color: #cbd5e1; font-size: 11px; line-height: 1.3; }
+.culture-opportunity-resolution__item--urgent { border-color: rgba(248, 113, 113, 0.28); }
+.culture-opportunity-resolution__item--steady { border-color: rgba(74, 222, 128, 0.22); }
+.culture-opportunity-resolution__uncovered {
+  display: grid;
+  gap: 3px;
+  padding-top: 4px;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+.culture-opportunity-resolution__uncovered b { color: #fde68a; font-size: 11px; }
+.culture-opportunity-resolution__uncovered small { color: #fef3c7; font-size: 11px; line-height: 1.3; }
+.culture-opportunity-resolution--uncovered { border-color: rgba(251, 191, 36, 0.28); }
 .culture-opportunity-priority-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Gamma: Implements #625.

Summary:
- adds a compact culture resolution summary for queued map actions
- groups pending culture actions by culture/province and shows expected cohesion/stability/opportunity changes
- flags urgent culture recommendations left uncovered after the queued actions
- preserves existing queue, confirm, and undo behavior

Validation:
- npm test
- npm test -- test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js
- node --check web/app.js
- node --check src/ui/culture/buildCultureOpportunityReminders.js
- git diff --check

Zeta: PR prête pour validation avant merge.