### PR TITLE
Epsilon: summarize cumulative climate impact

### DIFF
--- a/test/ui/climate/webCumulativeClimateImpactSummary.test.js
+++ b/test/ui/climate/webCumulativeClimateImpactSummary.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('map summarizes cumulative queued climate impact before turn commit', () => {
+  assert.match(webAppSource, /function buildCumulativeClimateImpactSummary/);
+  assert.match(webAppSource, /function renderCumulativeClimateImpactSummary/);
+  assert.match(webAppSource, /Impact climat cumulé avant validation/);
+  assert.match(webAppSource, /Impact climatique cumulé avant résolution du tour/);
+  assert.match(webAppSource, /intervention.*climat en attente/);
+  assert.match(webAppSource, /délai.*sauvé/);
+  assert.match(webAppSource, /encore critique/);
+  assert.match(webAppSource, /redondance/);
+  assert.match(webAppSource, /Après résolution/);
+  assert.match(webAppSource, /risque \$\{entry\.riskReduction\}/);
+  assert.match(webAppSource, /Délai/);
+  assert.match(webAppSource, /Tradeoff/);
+  assert.match(webAppSource, /une autre intervention cible déjà cette province/);
+  assert.match(webAppSource, /buildCumulativeClimateImpactSummary\(shell, state\.queuedClimateInterventions\)/);
+  assert.match(webAppSource, /renderCumulativeClimateImpactSummary\(cumulativeClimateImpact\)/);
+
+  assert.match(stylesSource, /\.map-climate-cumulative/);
+  assert.match(stylesSource, /\.map-climate-cumulative--warning/);
+  assert.match(stylesSource, /\.map-climate-cumulative__item--missed/);
+  assert.match(stylesSource, /\.map-climate-cumulative__item--redundant/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2535,6 +2535,81 @@ function buildMapClimateInterventionWindows(shell) {
   };
 }
 
+function buildCumulativeClimateImpactSummary(shell, queuedClimateInterventions = []) {
+  const duplicateCounts = queuedClimateInterventions.reduce((counts, entry) => {
+    counts.set(entry.provinceId, (counts.get(entry.provinceId) ?? 0) + 1);
+    return counts;
+  }, new Map());
+  const interventions = queuedClimateInterventions.map((entry, index) => {
+    const province = shell.provinces.find((candidate) => candidate.provinceId === entry.provinceId) ?? null;
+    const forecast = province ? buildProvinceClimateRiskReductionForecast(province, shell) : null;
+    const deadlineState = entry.missedDeadline ? 'missed' : forecast?.deadlineCoverage.state ?? 'covered';
+    const redundant = (duplicateCounts.get(entry.provinceId) ?? 0) > 1;
+    const tooLate = Boolean(entry.missedDeadline) || deadlineState === 'missed';
+
+    return {
+      ...entry,
+      rank: index + 1,
+      provinceLabel: entry.provinceLabel ?? province?.label ?? entry.provinceId,
+      deadlineWindow: entry.deadlineWindow ?? forecast?.criticalDeadline ?? 'deadline inconnue',
+      riskReduction: entry.riskReduction ?? (forecast ? `${forecast.currentRisk} → ${forecast.projectedRisk}` : 'réduction à confirmer'),
+      tradeoff: entry.tradeoff ?? forecast?.payoffTradeoff?.tradeoff ?? 'tradeoff à confirmer',
+      mitigationDirection: entry.expectedResult ?? (forecast?.queuedAction ? `${forecast.queuedAction}: ${forecast.summary}` : 'mitigation à confirmer'),
+      deadlineStatus: tooLate ? 'trop tardive' : deadlineState === 'just-in-time' ? 'sauvée de justesse' : 'sauvée par le plan',
+      deadlineState: tooLate ? 'missed' : deadlineState,
+      redundant,
+      tooLate,
+    };
+  });
+  const savedCount = interventions.filter((entry) => !entry.tooLate).length;
+  const missedCount = interventions.filter((entry) => entry.tooLate).length;
+  const redundantCount = interventions.filter((entry) => entry.redundant).length;
+
+  return {
+    state: interventions.length === 0 ? 'empty' : missedCount > 0 || redundantCount > 0 ? 'warning' : 'ready',
+    interventions,
+    savedCount,
+    missedCount,
+    redundantCount,
+    summary: interventions.length === 0
+      ? 'Aucune intervention climat confirmée: l’impact cumulé sera calculé dès qu’une action est mise en file.'
+      : `${interventions.length} intervention${interventions.length > 1 ? 's' : ''} climat en attente: ${savedCount} délai${savedCount > 1 ? 's' : ''} sauvé${savedCount > 1 ? 's' : ''}, ${missedCount} encore critique${missedCount > 1 ? 's' : ''}, ${redundantCount} redondance${redundantCount > 1 ? 's' : ''}.`,
+  };
+}
+
+function renderCumulativeClimateImpactSummary(view) {
+  if (view.interventions.length === 0) {
+    return `
+      <section class="map-climate-cumulative map-climate-cumulative--empty" aria-label="Impact climatique cumulé avant résolution du tour">
+        <strong>Impact climat cumulé</strong>
+        <p>${view.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="map-climate-cumulative map-climate-cumulative--${view.state}" aria-label="Impact climatique cumulé avant résolution du tour">
+      <div class="map-climate-cumulative__header">
+        <strong>Impact climat cumulé avant validation</strong>
+        <span>${view.savedCount} sauvé${view.savedCount > 1 ? 's' : ''} · ${view.missedCount} critique${view.missedCount > 1 ? 's' : ''} · ${view.redundantCount} redondant${view.redundantCount > 1 ? 's' : ''}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-climate-cumulative__list">
+        ${view.interventions.map((entry) => `
+          <li class="map-climate-cumulative__item map-climate-cumulative__item--${entry.deadlineState} ${entry.redundant ? 'map-climate-cumulative__item--redundant' : ''}">
+            <b>${entry.rank}. ${entry.provinceLabel}</b>
+            <span>${entry.label} · ${entry.deadlineStatus}</span>
+            <small><b>Après résolution</b> · risque ${entry.riskReduction}</small>
+            <small><b>Délai</b> · ${entry.deadlineWindow}</small>
+            <small><b>Tradeoff</b> · ${entry.tradeoff}</small>
+            ${entry.redundant ? '<small><b>Redondance</b> · une autre intervention cible déjà cette province.</small>' : ''}
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderMapClimateInterventionWindows(view) {
   if (view.windows.length === 0) {
     return `
@@ -7500,6 +7575,7 @@ function render() {
   });
   const climatePreparednessSummary = buildMapClimatePreparednessSummary(shell, focusContext, intrigueView);
   const climateInterventionWindows = buildMapClimateInterventionWindows(shell);
+  const cumulativeClimateImpact = buildCumulativeClimateImpactSummary(shell, state.queuedClimateInterventions);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -7524,6 +7600,7 @@ function render() {
           ${renderQueuedMilitaryResolutionSummary(shell, intrigueView)}
           ${renderMapClimatePreparednessSummary(climatePreparednessSummary)}
           ${renderMapClimateInterventionWindows(climateInterventionWindows)}
+          ${renderCumulativeClimateImpactSummary(cumulativeClimateImpact)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -249,6 +249,61 @@ button { font: inherit; }
 .map-climate-windows__item b { color: #f8fafc; }
 .map-climate-windows__item small b { color: #fef3c7; }
 
+.map-climate-cumulative {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+  max-width: 72ch;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(20, 83, 45, 0.28), rgba(15, 23, 42, 0.54));
+  border: 1px solid rgba(74, 222, 128, 0.2);
+}
+.map-climate-cumulative--warning { border-color: rgba(251, 191, 36, 0.34); }
+.map-climate-cumulative--empty { border-color: rgba(148, 163, 184, 0.16); }
+.map-climate-cumulative__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-climate-cumulative__header span,
+.map-climate-cumulative p {
+  color: #d1fae5;
+  font-size: 13px;
+  margin: 0;
+}
+.map-climate-cumulative__header span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.map-climate-cumulative__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+.map-climate-cumulative__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px 9px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.3);
+  border-left: 3px solid rgba(74, 222, 128, 0.72);
+}
+.map-climate-cumulative__item--missed { border-left-color: rgba(248, 113, 113, 0.82); }
+.map-climate-cumulative__item--just-in-time { border-left-color: rgba(251, 191, 36, 0.78); }
+.map-climate-cumulative__item--redundant { box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.18); }
+.map-climate-cumulative__item span,
+.map-climate-cumulative__item small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.map-climate-cumulative__item b { color: #f8fafc; }
+.map-climate-cumulative__item small b { color: #fef3c7; }
+
 .economy-turn-pulse {
   margin-top: 12px;
   display: inline-flex;


### PR DESCRIPTION
Epsilon: Implements #627.

Summary:
- Adds a web map cumulative climate impact summary before turn commit.
- Summarizes queued/confirmed climate interventions by province with estimated post-resolution risk reduction, deadline status, and tradeoff.
- Flags still-critical/tardy and redundant queued climate interventions while preserving queue/confirm/undo behavior.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webCumulativeClimateImpactSummary.test.js test/ui/climate/webClimateInterventionConfirmUndo.test.js test/ui/climate/webClimateInterventionQueueAction.test.js
- npm test