### PR TITLE
Alpha: mark committed military outcomes

### DIFF
--- a/test/ui/war/webPostCommitMilitaryOutcomeMarkers.test.js
+++ b/test/ui/war/webPostCommitMilitaryOutcomeMarkers.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('committed military map queues leave lightweight outcome markers', () => {
+  assert.match(webAppSource, /lastMilitaryOutcomeMarkers: \[\]/);
+  assert.match(webAppSource, /function buildPostCommitMilitaryOutcomeMarker/);
+  assert.match(webAppSource, /function renderPostCommitMilitaryOutcomeMarker/);
+  assert.match(webAppSource, /function renderSelectedProvinceMilitaryOutcomeMarker/);
+  assert.match(webAppSource, /province-node__military-outcome/);
+  assert.match(webAppSource, /data-military-outcome/);
+  assert.match(webAppSource, /has-military-outcome--\$\{militaryOutcomeMarker\.tone\}/);
+  assert.match(webAppSource, /Issue militaire dernier tour/);
+  assert.match(webAppSource, /Référence rapport militaire/);
+  assert.match(webAppSource, /state\.lastMilitaryOutcomeMarkers = militaryOutcomeMarker \? \[militaryOutcomeMarker\] : \[\]/);
+  assert.match(webAppSource, /state\.acceptedRecommendedMilitaryAction = null/);
+  assert.match(stylesSource, /\.province-surface\.has-military-outcome/);
+  assert.match(stylesSource, /\.province-node__military-outcome--stabilized/);
+  assert.match(stylesSource, /\.province-node__military-outcome--worsened/);
+  assert.match(stylesSource, /\.province-node__military-outcome--blocked/);
+  assert.match(stylesSource, /\.province-node__military-outcome--risk/);
+  assert.match(stylesSource, /\.post-commit-military-outcome/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -423,6 +423,7 @@ const state = {
     sabotage: true,
   },
   acceptedRecommendedMilitaryAction: null,
+  lastMilitaryOutcomeMarkers: [],
 };
 
 function getSelectedMapScenario() {
@@ -654,6 +655,91 @@ function getProvinceShape(provinceId) {
   return getProvinceGeometry(provinceId).shape ?? `polygon(${getProvincePolygon(provinceId).split(' ').map((point) => point.split(',').join('% ')).join('%, ') }%)`;
 }
 
+function getMilitaryOutcomeMarkerForProvince(provinceId) {
+  return state.lastMilitaryOutcomeMarkers.find((marker) => marker.provinceId === provinceId) ?? null;
+}
+
+function buildPostCommitMilitaryOutcomeMarker(province, shell, intrigueView = null) {
+  const queuedAction = state.acceptedRecommendedMilitaryAction;
+
+  if (!queuedAction || !province || queuedAction.provinceId !== province.provinceId) {
+    return null;
+  }
+
+  const focusContext = {
+    focusedProvinceId: province.provinceId,
+    focusedProvince: province,
+    neighborIds: new Set(province.neighborIds),
+  };
+  const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+  const action = actionQueue.find((entry) => entry.actionCode === queuedAction.actionCode) ?? actionQueue[0] ?? null;
+  const outcome = buildConflictOutcomePreview(province, shell);
+  const projection = buildProjectedFrontStability(province, shell, actionQueue);
+  const risks = buildCriticalFrontRiskWarnings(province, projection);
+  const tone = action?.status === 'blocked'
+    ? 'blocked'
+    : outcome.tone === 'success'
+      ? 'stabilized'
+      : outcome.tone === 'danger'
+        ? 'worsened'
+        : risks.length > 0 || action?.status === 'risky'
+          ? 'risk'
+          : 'stabilized';
+  const labels = {
+    stabilized: 'Front stabilisé',
+    worsened: 'Front aggravé',
+    blocked: 'Action bloquée',
+    risk: 'Risque de suivi',
+  };
+  const summaryItem = `${action?.label ?? queuedAction.actionCode}: ${outcome.title.toLowerCase()}`;
+  const why = risks[0]?.detail ?? action?.mainRisk ?? projection.summary;
+
+  return {
+    provinceId: province.provinceId,
+    provinceLabel: province.label,
+    actionCode: queuedAction.actionCode,
+    tone,
+    label: labels[tone],
+    summaryItem,
+    changed: `${labels[tone]} après résolution: ${action?.expectedResult ?? projection.summary}`,
+    why: `Référence rapport militaire: ${summaryItem}. ${why}`,
+    turn: state.turn + 1,
+  };
+}
+
+function renderPostCommitMilitaryOutcomeMarker(marker) {
+  if (!marker) {
+    return '';
+  }
+
+  return `
+    <span class="province-node__military-outcome province-node__military-outcome--${marker.tone}" aria-label="Issue militaire dernier tour: ${marker.label}">
+      <b>${marker.label}</b>
+      <small>${marker.actionCode}</small>
+    </span>
+  `;
+}
+
+function renderSelectedProvinceMilitaryOutcomeMarker(province) {
+  const marker = getMilitaryOutcomeMarkerForProvince(province.provinceId);
+
+  if (!marker) {
+    return '';
+  }
+
+  return `
+    <section class="post-commit-military-outcome post-commit-military-outcome--${marker.tone}" aria-label="Marqueur d’issue militaire post-commit">
+      <div>
+        <span>Issue militaire dernier tour</span>
+        <strong>${marker.label}</strong>
+        <code>${marker.actionCode}</code>
+      </div>
+      <p>${marker.changed}</p>
+      <small>${marker.why}</small>
+    </section>
+  `;
+}
+
 function renderProvinceSurface(shell, focusContext) {
   return `
     <svg class="province-surface-layer" viewBox="0 0 100 100" aria-label="Surface continue des provinces">
@@ -663,10 +749,12 @@ function renderProvinceSurface(shell, focusContext) {
         const isFocused = province.selectionState.focused;
         const isHovered = province.selectionState.hovered;
         const readinessTone = state.readinessFocusProvinceId === province.provinceId ? state.readinessFocusTone : null;
+        const militaryOutcomeMarker = getMilitaryOutcomeMarkerForProvince(province.provinceId);
         const isReadinessHighlight = Boolean(readinessTone);
-        const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && !isReadinessHighlight && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince || state.readinessFocusProvinceId);
+        const isMilitaryOutcomeHighlight = Boolean(militaryOutcomeMarker);
+        const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && !isReadinessHighlight && !isMilitaryOutcomeHighlight && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince || state.readinessFocusProvinceId);
         return `
-          <g class="province-surface ${isSelected ? 'is-selected' : ''} ${isFocused ? 'is-focused' : ''} ${isHovered ? 'is-hovered' : ''} ${isNeighbor ? 'is-neighbor' : ''} ${isReadinessHighlight ? 'is-readiness-highlight' : ''} ${readinessTone ? `is-readiness-${readinessTone}` : ''} ${isMuted ? 'is-muted' : ''} ${province.contested ? 'is-contested' : ''} ${province.occupied ? 'is-occupied' : ''}" style="--province-fill:${province.style.fill};--province-border:${province.style.border};">
+          <g class="province-surface ${isSelected ? 'is-selected' : ''} ${isFocused ? 'is-focused' : ''} ${isHovered ? 'is-hovered' : ''} ${isNeighbor ? 'is-neighbor' : ''} ${isReadinessHighlight ? 'is-readiness-highlight' : ''} ${isMilitaryOutcomeHighlight ? 'has-military-outcome' : ''} ${militaryOutcomeMarker ? `has-military-outcome--${militaryOutcomeMarker.tone}` : ''} ${readinessTone ? `is-readiness-${readinessTone}` : ''} ${isMuted ? 'is-muted' : ''} ${province.contested ? 'is-contested' : ''} ${province.occupied ? 'is-occupied' : ''}" style="--province-fill:${province.style.fill};--province-border:${province.style.border};">
             <polygon class="province-surface__glow" points="${province.geometry.polygon ?? getProvincePolygon(province.provinceId)}"></polygon>
             <polygon class="province-surface__core" points="${province.geometry.polygon ?? getProvincePolygon(province.provinceId)}"></polygon>
             <polygon class="province-surface__hairline" points="${province.geometry.polygon ?? getProvincePolygon(province.provinceId)}"></polygon>
@@ -686,12 +774,14 @@ function renderProvinceCard(province, focusContext) {
   const isHovered = province.selectionState.hovered;
   const readinessTone = state.readinessFocusProvinceId === province.provinceId ? state.readinessFocusTone : null;
   const economyBlocker = state.economyReadinessFocus?.provinceId === province.provinceId ? state.economyReadinessFocus : null;
+  const militaryOutcomeMarker = getMilitaryOutcomeMarkerForProvince(province.provinceId);
   const isReadinessHighlight = Boolean(readinessTone);
-  const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && !isReadinessHighlight && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince || state.readinessFocusProvinceId);
+  const isMilitaryOutcomeHighlight = Boolean(militaryOutcomeMarker);
+  const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && !isReadinessHighlight && !isMilitaryOutcomeHighlight && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince || state.readinessFocusProvinceId);
   const tacticalState = province.contested ? 'front contesté' : province.occupied ? 'occupation' : 'contrôle stable';
   const readinessLabel = readinessTone === 'danger' ? 'menace immédiate' : readinessTone === 'warning' ? 'préparation insuffisante' : readinessTone === 'ready' ? 'opportunité tactique' : null;
   const economyBlockerLabel = economyBlocker ? `${economyBlocker.blocker}: ${economyBlocker.summary}` : null;
-  const selectionSignal = economyBlocker ? 'BLOCAGE' : isReadinessHighlight ? 'ALERTE' : isSelected ? 'ACTIF' : isHovered ? 'SURVOL' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
+  const selectionSignal = economyBlocker ? 'BLOCAGE' : isMilitaryOutcomeHighlight ? 'RÉSOLU' : isReadinessHighlight ? 'ALERTE' : isSelected ? 'ACTIF' : isHovered ? 'SURVOL' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
   const classes = [
     'province-node',
     isSelected ? 'is-selected' : '',
@@ -701,6 +791,8 @@ function renderProvinceCard(province, focusContext) {
     isReadinessHighlight ? 'is-readiness-highlight' : '',
     economyBlocker ? 'has-economy-blocker' : '',
     economyBlocker ? `has-economy-blocker--${economyBlocker.tone}` : '',
+    isMilitaryOutcomeHighlight ? 'has-military-outcome' : '',
+    militaryOutcomeMarker ? `has-military-outcome--${militaryOutcomeMarker.tone}` : '',
     readinessTone ? `is-readiness-${readinessTone}` : '',
     isMuted ? 'is-muted' : '',
     province.contested ? 'is-contested' : '',
@@ -715,7 +807,8 @@ function renderProvinceCard(province, focusContext) {
       data-tactical-state="${readinessLabel ?? tacticalState}"
       data-readiness-highlight="${readinessTone ?? ''}"
       data-economy-blocker="${economyBlockerLabel ?? ''}"
-      title="${economyBlocker ? `${economyBlocker.summary} — ${economyBlocker.effect}` : province.label}"
+      data-military-outcome="${militaryOutcomeMarker?.label ?? ''}"
+      title="${economyBlocker ? `${economyBlocker.summary} — ${economyBlocker.effect}` : militaryOutcomeMarker ? `${militaryOutcomeMarker.label} — ${militaryOutcomeMarker.changed}` : province.label}"
       style="left:${layout.x}%;top:${layout.y}%;width:${layout.w}%;height:${layout.h}%;--province-fill:${province.style.fill};--province-border:${province.style.border};--province-shape:${getProvinceShape(province.provinceId)};"
       aria-pressed="${province.selectionState.selected}"
       aria-label="${province.label}, ${economyBlocker ? `blocage économie/logistique: ${economyBlocker.summary}, ${economyBlocker.effect}` : readinessLabel ? `cible préparation conflit: ${readinessLabel}` : tacticalState}, approvisionnement ${province.supplyTone}, loyauté ${province.loyalty}"
@@ -727,6 +820,7 @@ function renderProvinceCard(province, focusContext) {
       <span class="province-node__meta">${province.supplyTone} · loyauté ${province.loyalty}</span>
       ${economyBlocker ? `<span class="province-node__economy-blocker"><b>${economyBlocker.blocker}</b>${economyBlocker.summary}<small>${economyBlocker.effect}</small></span>` : ''}
       <span class="province-node__badges">${badges}</span>
+      ${renderPostCommitMilitaryOutcomeMarker(militaryOutcomeMarker)}
       ${isNeighbor ? '<span class="province-node__link">Voisine directe</span>' : ''}
     </button>
   `;
@@ -4943,6 +5037,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderMilitaryResponseOptions(province, shell, focusContext, intrigueView)}
       ${renderSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)}
       ${renderMilitaryPlanImpactSummary(province, shell, focusContext, intrigueView)}
+      ${renderSelectedProvinceMilitaryOutcomeMarker(province)}
       ${renderProjectedFrontStability(province, shell, focusContext, intrigueView)}
       ${renderCriticalFrontRiskWarnings(province, shell, focusContext, intrigueView)}
       ${renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView)}
@@ -7405,6 +7500,15 @@ function renderMapArchitecturePanel() {
 }
 
 function advanceTurn() {
+  const shell = getShell();
+  const militaryOutcomeMarker = state.acceptedRecommendedMilitaryAction
+    ? buildPostCommitMilitaryOutcomeMarker(
+      shell.provinces.find((province) => province.provinceId === state.acceptedRecommendedMilitaryAction.provinceId),
+      shell,
+      getIntrigueViewModel(),
+    )
+    : null;
+
   state.turn += 1;
   state.seasonIndex = (state.seasonIndex + 1) % seasonLabels.length;
 
@@ -7417,6 +7521,7 @@ function advanceTurn() {
 
   state.queuedCultureActions = [];
   state.lastTurnSummary = summaries[(state.turn - 2) % summaries.length];
+  state.lastMilitaryOutcomeMarkers = militaryOutcomeMarker ? [militaryOutcomeMarker] : [];
   state.acceptedRecommendedMilitaryAction = null;
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -1328,6 +1328,20 @@ button { font: inherit; }
 .province-surface.is-readiness-warning .province-surface__glow { stroke: rgba(251, 191, 36, 0.9); }
 .province-surface.is-readiness-ready .province-surface__core,
 .province-surface.is-readiness-ready .province-surface__glow { stroke: rgba(74, 222, 128, 0.84); }
+
+.province-surface.has-military-outcome .province-surface__core,
+.province-surface.has-military-outcome .province-surface__glow {
+  stroke-width: 0.58;
+  filter: drop-shadow(0 0 10px rgba(125, 211, 252, 0.32));
+}
+.province-surface.has-military-outcome--stabilized .province-surface__core,
+.province-surface.has-military-outcome--stabilized .province-surface__glow { stroke: rgba(74, 222, 128, 0.92); }
+.province-surface.has-military-outcome--worsened .province-surface__core,
+.province-surface.has-military-outcome--worsened .province-surface__glow { stroke: rgba(251, 113, 133, 0.96); }
+.province-surface.has-military-outcome--blocked .province-surface__core,
+.province-surface.has-military-outcome--blocked .province-surface__glow { stroke: rgba(148, 163, 184, 0.88); stroke-dasharray: 1.6 1.2; }
+.province-surface.has-military-outcome--risk .province-surface__core,
+.province-surface.has-military-outcome--risk .province-surface__glow { stroke: rgba(251, 191, 36, 0.95); }
 .map-label-layer {
   position: absolute;
   inset: 0;
@@ -2069,6 +2083,41 @@ button { font: inherit; }
 .province-node.is-readiness-danger::after { border-color: rgba(251, 113, 133, 0.52); color: #fecdd3; }
 .province-node.is-readiness-warning::after { border-color: rgba(251, 191, 36, 0.52); color: #fde68a; }
 .province-node.is-readiness-ready::after { border-color: rgba(74, 222, 128, 0.48); color: #bbf7d0; }
+
+.province-node.has-military-outcome {
+  box-shadow: 0 0 0 1px rgba(125, 211, 252, 0.24), 0 16px 34px rgba(2, 6, 23, 0.32);
+}
+.province-node.has-military-outcome::before { border-color: rgba(125, 211, 252, 0.62); }
+.province-node.has-military-outcome--stabilized::before { border-color: rgba(74, 222, 128, 0.78); }
+.province-node.has-military-outcome--worsened::before { border-color: rgba(251, 113, 133, 0.84); }
+.province-node.has-military-outcome--blocked::before { border-color: rgba(148, 163, 184, 0.72); }
+.province-node.has-military-outcome--risk::before { border-color: rgba(251, 191, 36, 0.8); }
+.province-node__military-outcome {
+  position: relative;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  width: max-content;
+  max-width: 100%;
+  padding: 4px 7px;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.68);
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  color: #e0f2fe;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.province-node__military-outcome small {
+  color: var(--muted);
+  font-size: 9px;
+}
+.province-node__military-outcome--stabilized { border-color: rgba(74, 222, 128, 0.44); color: #bbf7d0; }
+.province-node__military-outcome--worsened { border-color: rgba(251, 113, 133, 0.5); color: #fecdd3; }
+.province-node__military-outcome--blocked { border-color: rgba(148, 163, 184, 0.44); color: #e2e8f0; }
+.province-node__military-outcome--risk { border-color: rgba(251, 191, 36, 0.48); color: #fde68a; }
 .province-node.is-neighbor {
   z-index: 5;
   filter: saturate(1.06);
@@ -3492,6 +3541,43 @@ button { font: inherit; }
 .resolved-conflict-delta--warning { border-color: rgba(251, 191, 36, 0.32); }
 .resolved-conflict-delta--danger { border-color: rgba(251, 113, 133, 0.38); }
 .resolved-conflict-delta--neutral { border-color: rgba(148, 163, 184, 0.18); }
+
+.post-commit-military-outcome {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(125, 211, 252, 0.22);
+}
+.post-commit-military-outcome div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.post-commit-military-outcome span,
+.post-commit-military-outcome code,
+.post-commit-military-outcome small {
+  color: var(--muted);
+  font-size: 11px;
+}
+.post-commit-military-outcome span {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.post-commit-military-outcome strong { color: #f8fafc; }
+.post-commit-military-outcome p {
+  margin: 0;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.post-commit-military-outcome--stabilized { border-color: rgba(74, 222, 128, 0.34); }
+.post-commit-military-outcome--worsened { border-color: rgba(251, 113, 133, 0.4); }
+.post-commit-military-outcome--blocked { border-color: rgba(148, 163, 184, 0.32); }
+.post-commit-military-outcome--risk { border-color: rgba(251, 191, 36, 0.38); }
 .resolved-conflict-deltas.is-empty { border-style: dashed; }
 .context-summary {
   margin-top: 14px;


### PR DESCRIPTION
Alpha: Implements #633.

Summary:
- Adds post-commit military outcome markers for provinces touched by a committed map military queue.
- Marks outcomes as stabilized, worsened, blocked, or follow-up risk on the map surface and province node.
- Adds selected-province copy that points back to the relevant military resolution summary item while preserving queue/confirm/undo behavior.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webPostCommitMilitaryOutcomeMarkers.test.js test/ui/war/webQueuedMilitaryResolutionSummary.test.js test/ui/war/webQueueRecommendedMilitaryAction.test.js
- npm test (467 tests)

Zeta: PR prête pour revue. Merci de valider avant tout merge.
