### PR TITLE
Gamma: add post-commit culture tension markers

### DIFF
--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -38,6 +38,10 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /culture-opportunity-resolution/);
   assert.match(webAppSource, /Résumé de résolution culturelle/);
   assert.match(webAppSource, /Urgences non couvertes/);
+  assert.match(webAppSource, /cultureTensionMarkers/);
+  assert.match(webAppSource, /buildPostCommitCultureTensionMarkers/);
+  assert.match(webAppSource, /culture-tension-marker/);
+  assert.match(webAppSource, /Tensions culturelles après résolution/);
   assert.match(webAppSource, /Mettre en file/);
   assert.match(webAppSource, /Aucune action culturelle pertinente/);
   assert.match(webAppSource, /Pas de perte culturelle claire/);
@@ -58,6 +62,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-opportunity-queued-action/);
   assert.match(stylesSource, /\.culture-opportunity-resolution/);
   assert.match(stylesSource, /\.culture-opportunity-resolution__uncovered/);
+  assert.match(stylesSource, /\.culture-tension-marker/);
+  assert.match(stylesSource, /\.culture-tension-marker-card--escalated/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-confirmation/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-empty/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--positive/);

--- a/web/app.js
+++ b/web/app.js
@@ -403,6 +403,7 @@ const state = {
   queuedLogisticsActions: [],
   logisticsOutcomeMarkers: [],
   queuedCultureActions: [],
+  cultureTensionMarkers: [],
   comparedCityIds: ['river-gate-city', 'crown-port'],
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
   mobilePanelSection: 'details',
@@ -6084,6 +6085,8 @@ function getCultureViewModel() {
     selectedRegionId,
     selectedMarkers,
     selectedMarker,
+    tensionMarkers: state.cultureTensionMarkers,
+    selectedTensionMarkers: state.cultureTensionMarkers.filter((marker) => marker.provinceId === selectedRegionId),
     metrics: {
       markerCount: overlay.length,
       cultureCount: seeds.length,
@@ -6437,6 +6440,116 @@ function renderCultureClusterPinList(cluster) {
   `;
 }
 
+
+function getCultureTensionMarkerVisual(marker) {
+  const visuals = {
+    eased: { code: 'OK', label: 'Tension apaisée', icon: '✓' },
+    unresolved: { code: '!', label: 'Tension non couverte', icon: '!' },
+    escalated: { code: '↑', label: 'Tension aggravée', icon: '▲' },
+    opportunity: { code: '+', label: 'Opportunité ouverte', icon: '+' },
+  };
+
+  return visuals[marker.state] ?? visuals.unresolved;
+}
+
+function buildCulturePostCommitTensionMarkers(province, report) {
+  if (!province || !report?.resolutionSummary) {
+    return [];
+  }
+
+  const queuedMarkers = (report.resolutionSummary.queuedActions ?? []).map((action, index) => {
+    const state = String(action.effect ?? '').toLowerCase().includes('opportun') ? 'opportunity' : 'eased';
+    return {
+      markerId: `culture-tension:${state}:${province.provinceId}:${action.actionCode}:${index}`,
+      provinceId: province.provinceId,
+      provinceLabel: province.label,
+      cultureName: action.cultureName,
+      state,
+      label: state === 'opportunity' ? 'Opportunité ouverte' : 'Tension apaisée',
+      summary: action.summary ?? `${action.cultureName}: ${action.effect}`,
+      detail: `${action.label}: ${action.effect}. ${action.reason}`,
+      source: 'Action culturelle résolue',
+    };
+  });
+
+  const uncoveredMarkers = (report.resolutionSummary.uncoveredUrgent ?? []).map((entry, index) => {
+    const state = entry.tone === 'aggravated' ? 'escalated' : 'unresolved';
+    return {
+      markerId: `culture-tension:${state}:${province.provinceId}:${entry.reminderId}:${index}`,
+      provinceId: province.provinceId,
+      provinceLabel: province.label,
+      cultureName: entry.cultureName,
+      state,
+      label: state === 'escalated' ? 'Tension aggravée' : 'Tension non couverte',
+      summary: entry.summary,
+      detail: entry.expectedImpact,
+      source: 'Recommandation urgente non couverte',
+    };
+  });
+
+  return [...queuedMarkers, ...uncoveredMarkers].slice(0, 4);
+}
+
+function buildPostCommitCultureTensionMarkers(shell) {
+  const provinces = shell.provinces ?? [];
+  const intrigueView = buildIntrigueView(shell);
+
+  return provinces.flatMap((province) => {
+    const focusContext = { focusedProvinceId: province.provinceId, focusedProvince: province, neighborIds: new Set(province.neighborIds) };
+    const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
+    const cultureContext = getSelectedCultureContext(province.provinceId);
+    const unlockHintsByAction = buildCultureUnlockHintsForActions(province, actionQueue, cultureContext);
+    const report = buildCultureOpportunityReminders({ province, actionQueue, unlockHintsByAction });
+    return buildCulturePostCommitTensionMarkers(province, report);
+  }).slice(0, 8);
+}
+
+function renderCultureTensionMarker(marker, active) {
+  const center = getProvinceCenter(marker.provinceId);
+
+  if (!center || !active) {
+    return '';
+  }
+
+  const visual = getCultureTensionMarkerVisual(marker);
+  const selected = marker.provinceId === state.selectedProvinceId;
+  const y = center.y - 9.2;
+
+  return `
+    <g class="culture-tension-marker culture-tension-marker--${marker.state} ${selected ? 'is-selected' : ''}" data-culture-tension-region="${marker.provinceId}">
+      <title>${visual.label} · ${marker.cultureName} · ${marker.detail}</title>
+      <circle class="culture-tension-marker__pulse" cx="${center.x}%" cy="${y}%" r="3.5"></circle>
+      <rect x="${center.x - 3.2}%" y="${y - 2.35}%" width="6.4%" height="4.7%" rx="1.5%"></rect>
+      <text x="${center.x}%" y="${y + 0.62}%" text-anchor="middle">${visual.code}</text>
+    </g>
+  `;
+}
+
+function renderCultureTensionMarkerPanel(markers) {
+  if (!markers.length) {
+    return '';
+  }
+
+  return `
+    <article class="culture-tension-marker-panel" aria-label="Tensions culturelles après résolution">
+      <div class="culture-tension-marker-panel__header">
+        <span>Après commit</span>
+        <strong>${markers.length} tension${markers.length > 1 ? 's' : ''} visible${markers.length > 1 ? 's' : ''}</strong>
+      </div>
+      ${markers.map((marker) => {
+        const visual = getCultureTensionMarkerVisual(marker);
+        return `
+          <section class="culture-tension-marker-card culture-tension-marker-card--${marker.state}">
+            <b>${visual.icon} ${marker.label}</b>
+            <p>${marker.summary}</p>
+            <small>${marker.cultureName} · ${marker.provinceLabel} · ${marker.source} · ${marker.detail}</small>
+          </section>
+        `;
+      }).join('')}
+    </article>
+  `;
+}
+
 function renderCultureMapOverlay(cultureView) {
   const active = state.activeOverlaySlot === 'culture-overlay';
   const markerEntries = active
@@ -6445,6 +6558,7 @@ function renderCultureMapOverlay(cultureView) {
   const clusterSummaries = buildCultureClusterSummaries(markerEntries);
   const clusteredRegionIds = new Set(clusterSummaries.flatMap((cluster) => cluster.regionIds));
   const markerNodes = markerEntries.map((entry) => renderCultureMarker(entry, active, clusteredRegionIds)).join('');
+  const tensionMarkerNodes = (cultureView.tensionMarkers ?? []).map((marker) => renderCultureTensionMarker(marker, active)).join('');
   const clusterNodes = clusterSummaries.map((cluster) => renderCultureClusterSummary(cluster, active)).join('');
 
   const discoveryLinks = active ? cultureView.overlay.flatMap((entry) => {
@@ -6489,6 +6603,7 @@ function renderCultureMapOverlay(cultureView) {
         </filter>
       </defs>
       ${markerNodes}
+      ${tensionMarkerNodes}
       ${clusterNodes}
       ${discoveryLinks}
     </svg>
@@ -6529,6 +6644,7 @@ function renderCultureSidePanel(cultureView) {
         <div class="overlay-anchor"><span>Repères</span><strong>${cultureView.metrics.eventCount}</strong></div>
       </div>
       ${renderCultureLegendKey(cultureView)}
+      ${renderCultureTensionMarkerPanel(cultureView.selectedTensionMarkers ?? [])}
       ${renderCultureRecommendationPanel(recommendationView)}
       ${renderCultureLocalTimeline(localTimelineView)}
       ${renderCultureClusterPinList(selectedCluster)}
@@ -7717,6 +7833,7 @@ function advanceTurn() {
   const economyView = getEconomyViewModel();
   const logisticsOutcomeMarkers = buildLogisticsOutcomeMarkers(shell, economyView);
 
+  state.cultureTensionMarkers = buildPostCommitCultureTensionMarkers(shell);
   state.queuedCultureActions = [];
   state.lastMilitaryOutcomeMarkers = militaryOutcomeMarker ? [militaryOutcomeMarker] : [];
   state.logisticsOutcomeMarkers = logisticsOutcomeMarkers;

--- a/web/styles.css
+++ b/web/styles.css
@@ -7827,3 +7827,48 @@ button { font: inherit; }
 .economy-logistics-outcome--reduced rect { stroke: rgba(56, 189, 248, 0.7); }
 .economy-logistics-outcome--unresolved rect { stroke: rgba(245, 158, 11, 0.72); }
 .economy-logistics-outcome--new-bottleneck rect { stroke: rgba(251, 113, 133, 0.76); }
+.culture-tension-marker { filter: url(#cultureHudGlow); pointer-events: none; }
+.culture-tension-marker__pulse { opacity: 0.22; }
+.culture-tension-marker rect { stroke-width: 0.42; }
+.culture-tension-marker text { fill: #020617; font-size: 2.9px; font-weight: 900; dominant-baseline: middle; }
+.culture-tension-marker--eased rect,
+.culture-tension-marker--opportunity rect { fill: #86efac; stroke: #dcfce7; }
+.culture-tension-marker--eased .culture-tension-marker__pulse,
+.culture-tension-marker--opportunity .culture-tension-marker__pulse { fill: #22c55e; }
+.culture-tension-marker--unresolved rect { fill: #fde68a; stroke: #fef3c7; }
+.culture-tension-marker--unresolved .culture-tension-marker__pulse { fill: #f59e0b; }
+.culture-tension-marker--escalated rect { fill: #fca5a5; stroke: #fee2e2; }
+.culture-tension-marker--escalated .culture-tension-marker__pulse { fill: #ef4444; }
+.culture-tension-marker.is-selected rect { stroke-width: 0.72; }
+.culture-tension-marker-panel {
+  display: grid;
+  gap: 7px;
+  padding: 10px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.culture-tension-marker-panel__header span {
+  display: block;
+  color: #bae6fd;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.culture-tension-marker-panel__header strong { color: #f8fafc; font-size: 13px; }
+.culture-tension-marker-card {
+  display: grid;
+  gap: 3px;
+  padding: 7px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.culture-tension-marker-card b { color: #f8fafc; font-size: 12px; }
+.culture-tension-marker-card p { margin: 0; color: #cbd5e1; font-size: 12px; line-height: 1.35; }
+.culture-tension-marker-card small { color: #94a3b8; font-size: 11px; line-height: 1.35; }
+.culture-tension-marker-card--eased,
+.culture-tension-marker-card--opportunity { border-color: rgba(74, 222, 128, 0.24); }
+.culture-tension-marker-card--unresolved { border-color: rgba(251, 191, 36, 0.28); }
+.culture-tension-marker-card--escalated { border-color: rgba(248, 113, 113, 0.3); }


### PR DESCRIPTION
Gamma: Implements #635.

Summary:
- adds post-commit culture tension markers on the culture map overlay
- distinguishes eased tension, unresolved tension, escalated tension, and opportunity-opened states
- connects selected province marker details back to the culture resolution summary language
- preserves existing culture queue, confirm, undo, and resolution summary behavior

Validation:
- npm test
- npm test -- test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js
- node --check web/app.js
- node --check src/ui/culture/buildCultureOpportunityReminders.js
- git diff --check

Zeta: PR prête pour validation avant merge.