### PR TITLE
Delta: add post-commit intrigue exposure markers

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -196,3 +196,22 @@ test('final intrigue exposure summary is visible before turn commit', () => {
   assert.match(stylesSource, /province-intrigue-final-commit-summary--danger/);
   assert.match(stylesSource, /province-intrigue-final-commit-summary__item--trop-risqué/);
 });
+
+test('post-commit intrigue exposure markers stay fog-safe on the map', () => {
+  assert.match(webAppSource, /function buildPostCommitIntrigueExposureMarkers/);
+  assert.match(webAppSource, /function renderPostCommitIntrigueExposureMarkers/);
+  assert.match(webAppSource, /Marqueurs intrigue post-commit fog-safe/);
+  assert.match(webAppSource, /Exposition réduite/);
+  assert.match(webAppSource, /Exposition stable/);
+  assert.match(webAppSource, /Exposition accrue/);
+  assert.match(webAppSource, /Résultat fog-limité/);
+  assert.match(webAppSource, /Voir synthèse finale exposition intrigue/);
+  assert.match(webAppSource, /résultat masqué par le brouillard; seule la province reste inspectable/);
+  assert.match(webAppSource, /détails fog-safe liés à la synthèse finale/);
+  assert.match(webAppSource, /renderPostCommitIntrigueExposureMarkers\(postCommitMarkers\)/);
+  assert.match(stylesSource, /intrigue-post-commit-marker/);
+  assert.match(stylesSource, /intrigue-post-commit-marker--lowered/);
+  assert.match(stylesSource, /intrigue-post-commit-marker--unchanged/);
+  assert.match(stylesSource, /intrigue-post-commit-marker--increased/);
+  assert.match(stylesSource, /intrigue-post-commit-marker--hidden/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -4882,6 +4882,86 @@ function renderMapIntrigueExposureSummary(summary) {
   `;
 }
 
+function buildPostCommitIntrigueExposureMarkers(intrigueView = null) {
+  return (intrigueView?.map?.entries ?? [])
+    .map((entry) => {
+      const response = entry.drillDown?.quickResponses?.find((candidate) => candidate.code === entry.drillDown.recommendedResponseCode)
+        ?? entry.drillDown?.quickResponses?.[0]
+        ?? null;
+
+      if (!response) {
+        return null;
+      }
+
+      const fogLimited = !entry.showSecondaryDetails && entry.sabotageRiskLevel !== 'high' && entry.metrics.exposedCellCount === 0;
+      const direction = fogLimited
+        ? 'hidden'
+        : ['contenir', 'exposer'].includes(response.code) && response.escalationProbability !== 'élevée'
+          ? 'lowered'
+          : response.heatGenerated >= 10 || response.escalationProbability === 'élevée'
+            ? 'increased'
+            : 'unchanged';
+      const directionLabels = {
+        lowered: 'Exposition réduite',
+        unchanged: 'Exposition stable',
+        increased: 'Exposition accrue',
+        hidden: 'Résultat fog-limité',
+      };
+      const glyphs = {
+        lowered: '↓',
+        unchanged: '≈',
+        increased: '↑',
+        hidden: '?',
+      };
+      const residualRisk = direction === 'lowered'
+        ? 'risque résiduel contenu; vérifier la synthèse finale avant commit'
+        : direction === 'increased'
+          ? 'risque résiduel élevé; la synthèse finale signale les combinaisons gênantes'
+          : direction === 'unchanged'
+            ? 'risque résiduel stable; la synthèse finale conserve le détail visible'
+            : 'résultat masqué par le brouillard; seule la province reste inspectable';
+
+      return {
+        locationId: entry.locationId,
+        locationName: entry.locationName,
+        center: {
+          x: clampVisualMetric(entry.center.x + 4.4, 5, 95),
+          y: clampVisualMetric(entry.center.y + 5.6, 6, 96),
+        },
+        direction,
+        label: directionLabels[direction],
+        glyph: glyphs[direction],
+        responseLabel: response.label,
+        residualRisk,
+        copy: `${directionLabels[direction]} après résolution · ${residualRisk}. Voir synthèse finale exposition intrigue.`,
+        ariaLabel: `${directionLabels[direction]} en ${entry.locationName}: ${residualRisk}; détails fog-safe liés à la synthèse finale`,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.locationName.localeCompare(right.locationName))
+    .slice(0, 5);
+}
+
+function renderPostCommitIntrigueExposureMarkers(markers) {
+  if (!markers.length) {
+    return '';
+  }
+
+  return `
+    <g class="intrigue-post-commit-marker-layer" aria-label="Marqueurs intrigue post-commit fog-safe">
+      ${markers.map((marker) => `
+        <g class="intrigue-post-commit-marker intrigue-post-commit-marker--${marker.direction}" data-intrigue-location="${marker.locationId}" tabindex="0" aria-label="${marker.ariaLabel}">
+          <title>${marker.copy}</title>
+          <circle class="intrigue-post-commit-marker__backplate" cx="${marker.center.x}%" cy="${marker.center.y}%" r="3.3"></circle>
+          <text class="intrigue-post-commit-marker__glyph" x="${marker.center.x}%" y="${marker.center.y + 1.15}%" text-anchor="middle">${marker.glyph}</text>
+          <text class="intrigue-post-commit-marker__label" x="${marker.center.x + 4.1}%" y="${marker.center.y - 1.15}%" text-anchor="start">${marker.label}</text>
+          <text class="intrigue-post-commit-marker__copy" x="${marker.center.x + 4.1}%" y="${marker.center.y + 2.25}%" text-anchor="start">${marker.responseLabel} · ${marker.direction === 'hidden' ? 'fog conservé' : 'voir synthèse finale'}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const cultureContext = getSelectedCultureContext(province.provinceId);
@@ -6452,10 +6532,12 @@ function renderEconomyMapOverlay(economyView) {
 }
 
 function renderIntrigueMapOverlay(intrigueView) {
+  const postCommitMarkers = buildPostCommitIntrigueExposureMarkers(intrigueView);
+
   if (state.activeOverlaySlot !== 'intrigue-overlay') {
     const criticalSignals = intrigueView.map.entries.filter((entry) => entry.sabotageRiskLevel === 'high' || entry.metrics.exposedCellCount > 0);
 
-    if (criticalSignals.length === 0) {
+    if (criticalSignals.length === 0 && postCommitMarkers.length === 0) {
       return '';
     }
 
@@ -6467,6 +6549,7 @@ function renderIntrigueMapOverlay(intrigueView) {
             <text class="intrigue-critical-signal__code" x="${entry.center.x + 3.8}%" y="${entry.center.y - 2.6}%">${entry.threatGlyph.code}</text>
           </g>
         `).join('')}
+        ${renderPostCommitIntrigueExposureMarkers(postCommitMarkers)}
       </svg>
     `;
   }
@@ -6521,6 +6604,7 @@ function renderIntrigueMapOverlay(intrigueView) {
         ${threatGlyphMarkup}
       </g>
       ${hotspotMarkup}
+      ${renderPostCommitIntrigueExposureMarkers(postCommitMarkers)}
     </svg>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -1922,6 +1922,42 @@ button { font: inherit; }
 .intrigue-hotspot__marker { font-size: 4.2px; fill: #cffafe; }
 .intrigue-hotspot__label { font-size: 3.1px; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
 .intrigue-hotspot__meta { font-size: 2.25px; fill: #bae6fd; opacity: 0.76; }
+.intrigue-post-commit-marker { cursor: help; }
+.intrigue-post-commit-marker__backplate {
+  fill: rgba(15, 23, 42, 0.9);
+  stroke: rgba(226, 232, 240, 0.74);
+  stroke-width: 0.34;
+  filter: drop-shadow(0 0 6px rgba(168, 85, 247, 0.28));
+}
+.intrigue-post-commit-marker--lowered .intrigue-post-commit-marker__backplate { stroke: rgba(34, 197, 94, 0.86); }
+.intrigue-post-commit-marker--unchanged .intrigue-post-commit-marker__backplate { stroke: rgba(96, 165, 250, 0.8); }
+.intrigue-post-commit-marker--increased .intrigue-post-commit-marker__backplate { stroke: rgba(248, 113, 113, 0.92); }
+.intrigue-post-commit-marker--hidden .intrigue-post-commit-marker__backplate { stroke: rgba(148, 163, 184, 0.68); }
+.intrigue-post-commit-marker__glyph {
+  fill: #f8fafc;
+  font-size: 4.4px;
+  font-weight: 900;
+  pointer-events: none;
+}
+.intrigue-post-commit-marker__label {
+  fill: #f8fafc;
+  font-size: 2.55px;
+  font-weight: 800;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.72);
+  stroke-width: 0.5px;
+}
+.intrigue-post-commit-marker__copy {
+  fill: #cbd5e1;
+  font-size: 2.05px;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.72);
+  stroke-width: 0.45px;
+}
+.intrigue-post-commit-marker:focus-visible .intrigue-post-commit-marker__backplate {
+  stroke-width: 0.72;
+  filter: drop-shadow(0 0 10px rgba(216, 180, 254, 0.68));
+}
 .overlay-anchor-shell--top { left: 18%; top: 3%; width: 64%; height: 9%; }
 .overlay-anchor-shell--left { left: 3%; top: 18%; width: 12%; height: 58%; }
 .overlay-anchor-shell--right { right: 3%; top: 18%; width: 12%; height: 58%; }


### PR DESCRIPTION
Delta: Implements #636.\n\nSummary:\n- adds fog-safe post-commit exposure markers to intrigue hotspots on the map\n- distinguishes lowered, stable, increased, and fog-limited exposure outcomes\n- links marker copy back to the final exposure summary while preserving hidden cell/target/relay details\n\nValidation:\n- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js\n- node --check web/app.js\n- git diff --check HEAD~1..HEAD\n- npm test