### PR TITLE
Alpha: filter military outcome markers

### DIFF
--- a/test/ui/war/webMilitaryOutcomeMarkerFilters.test.js
+++ b/test/ui/war/webMilitaryOutcomeMarkerFilters.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('military outcome markers expose legend filters with counts', () => {
+  assert.match(webAppSource, /militaryOutcomeMarkerFilters: \{/);
+  assert.match(webAppSource, /stabilized: true/);
+  assert.match(webAppSource, /worsened: true/);
+  assert.match(webAppSource, /blocked: true/);
+  assert.match(webAppSource, /risk: true/);
+  assert.match(webAppSource, /militaryOutcomeMarkerCategories/);
+  assert.match(webAppSource, /function buildMilitaryOutcomeMarkerFilterState/);
+  assert.match(webAppSource, /function renderMilitaryOutcomeMarkerFilters/);
+  assert.match(webAppSource, /data-military-outcome-filter/);
+  assert.match(webAppSource, /filter\.count/);
+  assert.match(webAppSource, /hiddenCount/);
+  assert.match(webAppSource, /isMilitaryOutcomeMarkerVisible/);
+  assert.match(webAppSource, /getAnyMilitaryOutcomeMarkerForProvince/);
+  assert.match(webAppSource, /Marqueur masqué par le filtre de légende/);
+  assert.match(stylesSource, /\.military-outcome-filter/);
+  assert.match(stylesSource, /\.military-outcome-filter__button--stabilized/);
+  assert.match(stylesSource, /\.military-outcome-filter__button--worsened/);
+  assert.match(stylesSource, /\.military-outcome-filter__button--blocked/);
+  assert.match(stylesSource, /\.military-outcome-filter__button--risk/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -426,6 +426,12 @@ const state = {
   },
   acceptedRecommendedMilitaryAction: null,
   lastMilitaryOutcomeMarkers: [],
+  militaryOutcomeMarkerFilters: {
+    stabilized: true,
+    worsened: true,
+    blocked: true,
+    risk: true,
+  },
 };
 
 function getSelectedMapScenario() {
@@ -657,8 +663,65 @@ function getProvinceShape(provinceId) {
   return getProvinceGeometry(provinceId).shape ?? `polygon(${getProvincePolygon(provinceId).split(' ').map((point) => point.split(',').join('% ')).join('%, ') }%)`;
 }
 
+const militaryOutcomeMarkerCategories = [
+  { tone: 'stabilized', label: 'Front stabilisé', shortLabel: 'Stabilisé' },
+  { tone: 'worsened', label: 'Front aggravé', shortLabel: 'Aggravé' },
+  { tone: 'blocked', label: 'Action bloquée', shortLabel: 'Bloqué' },
+  { tone: 'risk', label: 'Risque de suivi', shortLabel: 'Risque' },
+];
+
+function isMilitaryOutcomeMarkerVisible(marker) {
+  return Boolean(marker && state.militaryOutcomeMarkerFilters[marker.tone] !== false);
+}
+
 function getMilitaryOutcomeMarkerForProvince(provinceId) {
+  const marker = state.lastMilitaryOutcomeMarkers.find((candidate) => candidate.provinceId === provinceId) ?? null;
+
+  return isMilitaryOutcomeMarkerVisible(marker) ? marker : null;
+}
+
+function getAnyMilitaryOutcomeMarkerForProvince(provinceId) {
   return state.lastMilitaryOutcomeMarkers.find((marker) => marker.provinceId === provinceId) ?? null;
+}
+
+function buildMilitaryOutcomeMarkerFilterState(markers = state.lastMilitaryOutcomeMarkers) {
+  return militaryOutcomeMarkerCategories.map((category) => {
+    const count = markers.filter((marker) => marker.tone === category.tone).length;
+    const enabled = state.militaryOutcomeMarkerFilters[category.tone] !== false;
+
+    return {
+      ...category,
+      count,
+      enabled,
+      hiddenCount: enabled ? 0 : count,
+    };
+  });
+}
+
+function renderMilitaryOutcomeMarkerFilters(markers = state.lastMilitaryOutcomeMarkers) {
+  const filters = buildMilitaryOutcomeMarkerFilterState(markers);
+  const total = markers.length;
+  const hiddenTotal = filters.reduce((sum, filter) => sum + filter.hiddenCount, 0);
+
+  return `
+    <section class="military-outcome-filter" aria-label="Filtres des marqueurs d’issue militaire">
+      <div class="military-outcome-filter__header">
+        <div>
+          <span>Marqueurs militaires</span>
+          <strong>${total} post-commit</strong>
+        </div>
+        <small>${hiddenTotal} masqué${hiddenTotal > 1 ? 's' : ''}</small>
+      </div>
+      <div class="military-outcome-filter__buttons">
+        ${filters.map((filter) => `
+          <button type="button" class="military-outcome-filter__button military-outcome-filter__button--${filter.tone} ${filter.enabled ? 'is-active' : 'is-muted'}" data-military-outcome-filter="${filter.tone}" aria-pressed="${filter.enabled}">
+            <span>${filter.shortLabel}</span>
+            <strong>${filter.count}</strong>
+          </button>
+        `).join('')}
+      </div>
+    </section>
+  `;
 }
 
 function buildPostCommitMilitaryOutcomeMarker(province, shell, intrigueView = null) {
@@ -723,7 +786,7 @@ function renderPostCommitMilitaryOutcomeMarker(marker) {
 }
 
 function renderSelectedProvinceMilitaryOutcomeMarker(province) {
-  const marker = getMilitaryOutcomeMarkerForProvince(province.provinceId);
+  const marker = getAnyMilitaryOutcomeMarkerForProvince(province.provinceId);
 
   if (!marker) {
     return '';
@@ -738,6 +801,7 @@ function renderSelectedProvinceMilitaryOutcomeMarker(province) {
       </div>
       <p>${marker.changed}</p>
       <small>${marker.why}</small>
+      ${isMilitaryOutcomeMarkerVisible(marker) ? '' : '<em>Marqueur masqué par le filtre de légende.</em>'}
     </section>
   `;
 }
@@ -8172,6 +8236,7 @@ function render() {
           </div>
           <div class="map-stage" data-map-stage="true" tabindex="0" aria-label="Carte opérationnelle zoomable. Utilisez plus, moins, zéro ou C pour naviguer.">
             ${renderMapControls()}
+            ${renderMilitaryOutcomeMarkerFilters(state.lastMilitaryOutcomeMarkers)}
             <div class="map-viewport" style="transform:${getMapViewportTransform()};">
               ${renderMapLayerStack(shell, economyView, focusContext, cultureView, postCommitClimateMarkers)}
               ${renderIntrigueMapOverlay(intrigueView)}
@@ -8529,6 +8594,14 @@ function render() {
   document.querySelectorAll('[data-mobile-map-toggle]').forEach((element) => {
     element.addEventListener('click', () => {
       state.mobileMapExpanded = !state.mobileMapExpanded;
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-military-outcome-filter]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const tone = element.dataset.militaryOutcomeFilter;
+      state.militaryOutcomeMarkerFilters[tone] = state.militaryOutcomeMarkerFilters[tone] === false;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -1069,6 +1069,69 @@ button { font: inherit; }
   border: 1px solid rgba(148, 163, 184, 0.18);
   backdrop-filter: blur(10px);
 }
+.military-outcome-filter {
+  position: absolute;
+  top: 74px;
+  right: 14px;
+  z-index: 7;
+  display: grid;
+  gap: 7px;
+  width: min(280px, calc(100% - 28px));
+  padding: 9px;
+  border-radius: 16px;
+  background: rgba(8, 15, 28, 0.76);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(10px);
+}
+.military-outcome-filter__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-outcome-filter__header span,
+.military-outcome-filter__header small {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.military-outcome-filter__header strong { color: #e0f2fe; font-size: 12px; }
+.military-outcome-filter__buttons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+.military-outcome-filter__button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  background: rgba(15, 23, 42, 0.72);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 6px 8px;
+  cursor: pointer;
+  font-size: 11px;
+}
+.military-outcome-filter__button strong {
+  display: inline-grid;
+  place-items: center;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.5);
+}
+.military-outcome-filter__button.is-muted {
+  opacity: 0.48;
+  filter: grayscale(0.7);
+}
+.military-outcome-filter__button--stabilized.is-active { border-color: rgba(74, 222, 128, 0.5); color: #bbf7d0; }
+.military-outcome-filter__button--worsened.is-active { border-color: rgba(251, 113, 133, 0.56); color: #fecdd3; }
+.military-outcome-filter__button--blocked.is-active { border-color: rgba(148, 163, 184, 0.48); color: #f8fafc; }
+.military-outcome-filter__button--risk.is-active { border-color: rgba(251, 191, 36, 0.52); color: #fde68a; }
+
 .map-control-button {
   border: 1px solid rgba(148, 163, 184, 0.18);
   background: rgba(15, 23, 42, 0.72);
@@ -3633,7 +3696,8 @@ button { font: inherit; }
 }
 .post-commit-military-outcome span,
 .post-commit-military-outcome code,
-.post-commit-military-outcome small {
+.post-commit-military-outcome small,
+.post-commit-military-outcome em {
   color: var(--muted);
   font-size: 11px;
 }
@@ -3642,6 +3706,7 @@ button { font: inherit; }
   text-transform: uppercase;
 }
 .post-commit-military-outcome strong { color: #f8fafc; }
+.post-commit-military-outcome em { font-style: normal; color: #fde68a; }
 .post-commit-military-outcome p {
   margin: 0;
   color: #dbeafe;
@@ -5968,7 +6033,70 @@ button { font: inherit; }
     justify-content: center;
     border-radius: 18px;
   }
-  .map-control-button {
+  .military-outcome-filter {
+  position: absolute;
+  top: 74px;
+  right: 14px;
+  z-index: 7;
+  display: grid;
+  gap: 7px;
+  width: min(280px, calc(100% - 28px));
+  padding: 9px;
+  border-radius: 16px;
+  background: rgba(8, 15, 28, 0.76);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(10px);
+}
+.military-outcome-filter__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-outcome-filter__header span,
+.military-outcome-filter__header small {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.military-outcome-filter__header strong { color: #e0f2fe; font-size: 12px; }
+.military-outcome-filter__buttons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+.military-outcome-filter__button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  background: rgba(15, 23, 42, 0.72);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 6px 8px;
+  cursor: pointer;
+  font-size: 11px;
+}
+.military-outcome-filter__button strong {
+  display: inline-grid;
+  place-items: center;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.5);
+}
+.military-outcome-filter__button.is-muted {
+  opacity: 0.48;
+  filter: grayscale(0.7);
+}
+.military-outcome-filter__button--stabilized.is-active { border-color: rgba(74, 222, 128, 0.5); color: #bbf7d0; }
+.military-outcome-filter__button--worsened.is-active { border-color: rgba(251, 113, 133, 0.56); color: #fecdd3; }
+.military-outcome-filter__button--blocked.is-active { border-color: rgba(148, 163, 184, 0.48); color: #f8fafc; }
+.military-outcome-filter__button--risk.is-active { border-color: rgba(251, 191, 36, 0.52); color: #fde68a; }
+
+.map-control-button {
     min-width: 44px;
     height: 44px;
   }


### PR DESCRIPTION
Alpha: Implements #643.

Summary:
- Adds a compact military outcome marker legend/filter control on the map.
- Shows counts for stabilized, worsened, blocked, and follow-up risk marker categories.
- Lets players hide/show only the selected marker category while preserving selected-province explanation copy.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webMilitaryOutcomeMarkerFilters.test.js test/ui/war/webPostCommitMilitaryOutcomeMarkers.test.js
- npm test (470 tests)

Zeta: PR prête pour revue. Merci de valider avant tout merge.
