### PR TITLE
Beta: group logistics outcome markers

### DIFF
--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -37,13 +37,19 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /buildLogisticsTurnCommitSummary/);
   assert.match(webAppSource, /renderLogisticsTurnCommitSummary/);
   assert.match(webAppSource, /buildLogisticsOutcomeMarkers/);
+  assert.match(webAppSource, /sortLogisticsOutcomeDetails/);
+  assert.match(webAppSource, /getLogisticsOutcomeSeverityRank/);
   assert.match(webAppSource, /renderProvinceLogisticsOutcomeMarker/);
   assert.match(webAppSource, /renderLogisticsOutcomeRouteBadge/);
+  assert.match(webAppSource, /renderFocusedLogisticsOutcomeGroup/);
   assert.match(webAppSource, /logisticsOutcomeMarkers/);
   assert.match(webAppSource, /data-logistics-outcome-marker/);
   assert.match(webAppSource, /Pénurie résolue/);
   assert.match(webAppSource, /Nouveau goulot/);
   assert.match(webAppSource, /Synthèse pénuries restantes/);
+  assert.match(webAppSource, /Résultat logistique groupé/);
+  assert.match(webAppSource, /trié.*par gravité/);
+  assert.match(webAppSource, /logistics-outcome-group:/);
   assert.match(webAppSource, /File logistique/);
   assert.match(webAppSource, /Avant validation du tour/);
   assert.match(webAppSource, /unresolvedShortages/);
@@ -93,6 +99,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-node__logistics-outcome--resolved/);
   assert.match(stylesSource, /province-node__logistics-outcome--new-bottleneck/);
   assert.match(stylesSource, /economy-logistics-outcome--unresolved/);
+  assert.match(stylesSource, /province-logistics-outcome-group--unresolved/);
+  assert.match(stylesSource, /province-logistics-outcome-group__item--new-bottleneck/);
   assert.match(stylesSource, /province-logistics-downstream-summary--résolue/);
   assert.match(stylesSource, /province-logistics-downstream-shortage--high/);
   assert.match(stylesSource, /province-logistics-timeline-summary--empty/);

--- a/web/app.js
+++ b/web/app.js
@@ -792,12 +792,25 @@ function getLogisticsOutcomeCode(status) {
   }[status] ?? '?';
 }
 
+function getLogisticsOutcomeSeverityRank(status) {
+  return {
+    unresolved: 4,
+    'new-bottleneck': 3,
+    reduced: 2,
+    resolved: 1,
+  }[status] ?? 0;
+}
+
+function sortLogisticsOutcomeDetails(details) {
+  return details.slice().sort((left, right) => getLogisticsOutcomeSeverityRank(right.status) - getLogisticsOutcomeSeverityRank(left.status) || left.routeLabel.localeCompare(right.routeLabel) || left.actionLabel.localeCompare(right.actionLabel));
+}
+
 function buildLogisticsOutcomeMarkers(shell, economyView, queuedLogisticsActions = state.queuedLogisticsActions) {
   if (!queuedLogisticsActions.length) {
     return [];
   }
 
-  return queuedLogisticsActions.map((entry) => {
+  const singleMarkers = queuedLogisticsActions.map((entry) => {
     const province = shell.provinces.find((candidate) => candidate.provinceId === entry.provinceId) ?? shell.provinces.find((candidate) => {
       const cityIds = new Set(economyView.overlay.cities.filter((city) => city.regionId === candidate.provinceId).map((city) => city.cityId));
       const route = economyView.overlay.routes.find((candidateRoute) => candidateRoute.routeId === entry.routeId);
@@ -817,6 +830,7 @@ function buildLogisticsOutcomeMarkers(shell, economyView, queuedLogisticsActions
             ? 'new-bottleneck'
             : 'unresolved';
     const label = getLogisticsOutcomeLabel(status);
+    const routeLabel = option?.routes[0] ?? entry.target ?? entry.routeId;
     const detail = shortage
       ? `${shortage.city} / ${shortage.route}: ${shortage.detail}`
       : entry.downstreamEffect ?? 'Effet aval estimé depuis la file logistique.';
@@ -828,11 +842,38 @@ function buildLogisticsOutcomeMarkers(shell, economyView, queuedLogisticsActions
       code: getLogisticsOutcomeCode(status),
       label,
       detail,
+      details: [{ status, tone: getLogisticsOutcomeTone(status), code: getLogisticsOutcomeCode(status), label, detail, routeLabel, actionLabel: entry.label }],
       provinceId: province?.provinceId ?? entry.provinceId,
       provinceLabel: province?.label ?? entry.provinceId,
       routeId: entry.routeId,
-      routeLabel: option?.routes[0] ?? entry.target ?? entry.routeId,
+      routeLabel,
       actionLabel: entry.label,
+      summaryLink: 'Synthèse pénuries restantes',
+    };
+  });
+
+  const groupedByCluster = new Map();
+  for (const marker of singleMarkers) {
+    const clusterKey = `${marker.routeId ?? 'route-inconnue'}:${marker.provinceId ?? 'province-inconnue'}`;
+    const existing = groupedByCluster.get(clusterKey) ?? { ...marker, markerId: `logistics-outcome-group:${clusterKey}`, details: [], actionLabel: '' };
+    existing.details.push(...marker.details);
+    existing.actionLabel = [...new Set([...existing.actionLabel.split(', ').filter(Boolean), marker.actionLabel])].join(', ');
+    groupedByCluster.set(clusterKey, existing);
+  }
+
+  return Array.from(groupedByCluster.values()).map((group) => {
+    const details = sortLogisticsOutcomeDetails(group.details);
+    const top = details[0];
+    const grouped = details.length > 1;
+    return {
+      ...group,
+      status: top.status,
+      tone: top.tone,
+      code: grouped ? `${top.code}+${details.length}` : top.code,
+      label: grouped ? `${top.label} · ${details.length} effets` : top.label,
+      detail: top.detail,
+      details,
+      grouped,
       summaryLink: 'Synthèse pénuries restantes',
     };
   });
@@ -867,6 +908,36 @@ function renderLogisticsOutcomeRouteBadge(marker, visual) {
     </g>
   `;
 }
+
+function renderFocusedLogisticsOutcomeGroup(province) {
+  const marker = getLogisticsOutcomeMarkerForProvince(province.provinceId);
+
+  if (!marker) {
+    return '';
+  }
+
+  const details = sortLogisticsOutcomeDetails(marker.details ?? [{ ...marker, routeLabel: marker.routeLabel, actionLabel: marker.actionLabel }]);
+
+  return `
+    <section class="province-logistics-outcome-group province-logistics-outcome-group--${marker.tone}" aria-label="Détails groupés des marqueurs logistiques post-commit">
+      <div class="province-logistics-outcome-group__header">
+        <span>Résultat logistique groupé</span>
+        <strong>${marker.label}</strong>
+        <small>${marker.routeLabel} · ${details.length} détail${details.length > 1 ? 's' : ''} trié${details.length > 1 ? 's' : ''} par gravité</small>
+      </div>
+      <ol>
+        ${details.map((detail) => `
+          <li class="province-logistics-outcome-group__item province-logistics-outcome-group__item--${detail.tone}">
+            <strong>${detail.label}</strong>
+            <span>${detail.routeLabel}: ${detail.detail}</span>
+            <small>${detail.actionLabel}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 
 function renderProvinceCard(province, focusContext, postCommitClimateMarkers = []) {
   const layout = province.geometry.layout ?? getProvinceLayout(province.provinceId);
@@ -5333,6 +5404,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderProvinceEconomyConsequences(province, economyView)}
       ${renderProvinceEconomyTurnReport(province, economyView)}
       ${renderProvinceLogisticsBottleneckComparison(province, economyView)}
+      ${renderFocusedLogisticsOutcomeGroup(province)}
       ${renderProvinceLogisticsChoicePreview(province, economyView)}
     </section>
   `;
@@ -8261,7 +8333,7 @@ function render() {
       state.hoveredRouteId = marker.routeId;
       state.activeOverlaySlot = 'economy-overlay';
       state.mobilePanelSection = 'details';
-      state.lastTurnSummary = `${marker.label}: ${marker.detail} (${marker.summaryLink}).`;
+      state.lastTurnSummary = `${marker.label}: ${(marker.details ?? [marker]).map((detail) => detail.detail).join(' | ')} (${marker.summaryLink}).`;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -7942,3 +7942,51 @@ button { font: inherit; }
 .culture-tension-marker-card--opportunity { border-color: rgba(74, 222, 128, 0.24); }
 .culture-tension-marker-card--unresolved { border-color: rgba(251, 191, 36, 0.28); }
 .culture-tension-marker-card--escalated { border-color: rgba(248, 113, 113, 0.3); }
+.province-logistics-outcome-group {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.56);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+.province-logistics-outcome-group--unresolved { border-color: rgba(245, 158, 11, 0.48); }
+.province-logistics-outcome-group--new-bottleneck { border-color: rgba(251, 113, 133, 0.52); }
+.province-logistics-outcome-group--reduced { border-color: rgba(56, 189, 248, 0.46); }
+.province-logistics-outcome-group--resolved { border-color: rgba(74, 222, 128, 0.48); }
+.province-logistics-outcome-group__header {
+  display: grid;
+  gap: 3px;
+}
+.province-logistics-outcome-group__header span {
+  color: #bfdbfe;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.province-logistics-outcome-group__header strong { color: #f8fafc; }
+.province-logistics-outcome-group__header small { color: #cbd5e1; }
+.province-logistics-outcome-group ol {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.province-logistics-outcome-group__item {
+  padding: 7px 8px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-logistics-outcome-group__item strong,
+.province-logistics-outcome-group__item span,
+.province-logistics-outcome-group__item small { display: block; }
+.province-logistics-outcome-group__item strong { color: #f8fafc; font-size: 12px; }
+.province-logistics-outcome-group__item span { color: #dbeafe; font-size: 12px; line-height: 1.35; }
+.province-logistics-outcome-group__item small { color: #93c5fd; font-size: 11px; }
+.province-logistics-outcome-group__item--unresolved { border-color: rgba(245, 158, 11, 0.42); }
+.province-logistics-outcome-group__item--new-bottleneck { border-color: rgba(251, 113, 133, 0.48); }
+.province-logistics-outcome-group__item--reduced { border-color: rgba(56, 189, 248, 0.42); }
+.province-logistics-outcome-group__item--resolved { border-color: rgba(74, 222, 128, 0.42); }


### PR DESCRIPTION
Beta: Implements #644.

## Summary
- Groups post-commit logistics markers by route/province cluster instead of duplicating nearby markers.
- Sorts grouped details by severity: unresolved shortage, new bottleneck, reduced shortage, resolved shortage.
- Keeps a concise top-line map label and renders the full grouped detail list in the focused province panel.
- Marker clicks preserve the route/province focus and link back to the unresolved-shortage context.

## Validation
- npm test (469 OK)
- targeted economy UI tests (7 OK)
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check
