### PR TITLE
Gamma: filter culture tension markers

### DIFF
--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -42,6 +42,10 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /buildPostCommitCultureTensionMarkers/);
   assert.match(webAppSource, /culture-tension-marker/);
   assert.match(webAppSource, /Tensions culturelles après résolution/);
+  assert.match(webAppSource, /cultureTensionFilters/);
+  assert.match(webAppSource, /data-culture-tension-filter/);
+  assert.match(webAppSource, /data-culture-tension-jump/);
+  assert.match(webAppSource, /Accès rapide aux tensions culturelles prioritaires/);
   assert.match(webAppSource, /Mettre en file/);
   assert.match(webAppSource, /Aucune action culturelle pertinente/);
   assert.match(webAppSource, /Pas de perte culturelle claire/);
@@ -64,6 +68,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-opportunity-resolution__uncovered/);
   assert.match(stylesSource, /\.culture-tension-marker/);
   assert.match(stylesSource, /\.culture-tension-marker-card--escalated/);
+  assert.match(stylesSource, /\.culture-tension-filters/);
+  assert.match(stylesSource, /\.culture-tension-quick-jump/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-confirmation/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-empty/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__ripple--positive/);

--- a/web/app.js
+++ b/web/app.js
@@ -404,6 +404,7 @@ const state = {
   logisticsOutcomeMarkers: [],
   queuedCultureActions: [],
   cultureTensionMarkers: [],
+  cultureTensionFilters: { eased: true, unresolved: true, escalated: true, opportunity: true },
   comparedCityIds: ['river-gate-city', 'crown-port'],
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
   mobilePanelSection: 'details',
@@ -6300,6 +6301,8 @@ function getCultureViewModel() {
   const selectedRegionId = state.selectedProvinceId;
   const selectedMarkers = overlay.filter((entry) => entry.regionId === selectedRegionId);
   const selectedMarker = selectedMarkers[0] ?? overlay[0] ?? null;
+  const tensionFilters = state.cultureTensionFilters ?? {};
+  const filteredTensionMarkers = state.cultureTensionMarkers.filter((marker) => tensionFilters[marker.state] !== false);
 
   return {
     overlay,
@@ -6308,8 +6311,10 @@ function getCultureViewModel() {
     selectedRegionId,
     selectedMarkers,
     selectedMarker,
-    tensionMarkers: state.cultureTensionMarkers,
-    selectedTensionMarkers: state.cultureTensionMarkers.filter((marker) => marker.provinceId === selectedRegionId),
+    tensionMarkers: filteredTensionMarkers,
+    tensionFilters,
+    allTensionMarkers: state.cultureTensionMarkers,
+    selectedTensionMarkers: filteredTensionMarkers.filter((marker) => marker.provinceId === selectedRegionId),
     metrics: {
       markerCount: overlay.length,
       cultureCount: seeds.length,
@@ -6727,6 +6732,69 @@ function buildPostCommitCultureTensionMarkers(shell) {
   }).slice(0, 8);
 }
 
+
+const CULTURE_TENSION_FILTER_LABELS = {
+  eased: 'Apaisées',
+  unresolved: 'Non couvertes',
+  escalated: 'Aggravées',
+  opportunity: 'Opportunités',
+};
+
+function cultureTensionPriority(marker) {
+  return { escalated: 4, unresolved: 3, opportunity: 2, eased: 1 }[marker.state] ?? 0;
+}
+
+function renderCultureTensionFilters(cultureView) {
+  const markers = cultureView.allTensionMarkers ?? [];
+
+  if (!markers.length) {
+    return '';
+  }
+
+  return `
+    <div class="culture-tension-filters" aria-label="Filtres des marqueurs culturels post-commit">
+      ${Object.entries(CULTURE_TENSION_FILTER_LABELS).map(([stateKey, label]) => {
+        const active = cultureView.tensionFilters?.[stateKey] !== false;
+        const count = markers.filter((marker) => marker.state === stateKey).length;
+        return `
+          <button type="button" class="culture-tension-filter ${active ? 'is-active' : ''}" data-culture-tension-filter="${stateKey}" aria-pressed="${active}" aria-label="Filtrer les marqueurs culturels ${label}: ${count}">
+            <span>${label}</span><b>${count}</b>
+          </button>
+        `;
+      }).join('')}
+    </div>
+  `;
+}
+
+function renderCultureTensionQuickJump(markers) {
+  const entries = [...markers]
+    .sort((left, right) => cultureTensionPriority(right) - cultureTensionPriority(left) || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 4);
+
+  if (!entries.length) {
+    return '';
+  }
+
+  return `
+    <div class="culture-tension-quick-jump" aria-label="Accès rapide aux tensions culturelles prioritaires">
+      <div class="culture-tension-quick-jump__header">
+        <span>À vérifier</span>
+        <strong>${entries.length} repère${entries.length > 1 ? 's' : ''}</strong>
+      </div>
+      ${entries.map((marker) => {
+        const visual = getCultureTensionMarkerVisual(marker);
+        return `
+          <button type="button" class="culture-tension-jump culture-tension-jump--${marker.state}" data-culture-tension-jump="${marker.provinceId}" aria-label="Aller à ${marker.provinceLabel}: ${marker.label}">
+            <b>${visual.icon}</b>
+            <span>${marker.provinceLabel}</span>
+            <small>${marker.label} · ${marker.cultureName}</small>
+          </button>
+        `;
+      }).join('')}
+    </div>
+  `;
+}
+
 function renderCultureTensionMarker(marker, active) {
   const center = getProvinceCenter(marker.provinceId);
 
@@ -6867,6 +6935,8 @@ function renderCultureSidePanel(cultureView) {
         <div class="overlay-anchor"><span>Repères</span><strong>${cultureView.metrics.eventCount}</strong></div>
       </div>
       ${renderCultureLegendKey(cultureView)}
+      ${renderCultureTensionFilters(cultureView)}
+      ${renderCultureTensionQuickJump(cultureView.tensionMarkers ?? [])}
       ${renderCultureTensionMarkerPanel(cultureView.selectedTensionMarkers ?? [])}
       ${renderCultureRecommendationPanel(recommendationView)}
       ${renderCultureLocalTimeline(localTimelineView)}
@@ -8765,6 +8835,40 @@ function render() {
 
     stage.addEventListener('mouseleave', stopDragging);
     stage.addEventListener('mouseup', stopDragging);
+  });
+
+
+  document.querySelectorAll('[data-culture-tension-filter]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const key = element.dataset.cultureTensionFilter;
+      if (!key) {
+        return;
+      }
+
+      state.cultureTensionFilters[key] = state.cultureTensionFilters[key] === false;
+      state.activeOverlaySlot = 'culture-overlay';
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-culture-tension-jump]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const provinceId = element.dataset.cultureTensionJump;
+      const shell = getShell();
+      const province = shell.provinces.find((candidate) => candidate.provinceId === provinceId);
+
+      if (!province) {
+        return;
+      }
+
+      state.selectedProvinceId = provinceId;
+      state.focusedProvinceId = provinceId;
+      state.activeOverlaySlot = 'culture-overlay';
+      state.mobilePanelSection = 'overlay';
+      const viewport = document.querySelector('.map-viewport');
+      centerMapOnProvince(provinceId, viewport);
+      render();
+    });
   });
 
   document.querySelectorAll('[data-culture-focus-region]').forEach((element) => {

--- a/web/styles.css
+++ b/web/styles.css
@@ -8118,3 +8118,82 @@ button { font: inherit; }
 .province-logistics-outcome-group__item--new-bottleneck { border-color: rgba(251, 113, 133, 0.48); }
 .province-logistics-outcome-group__item--reduced { border-color: rgba(56, 189, 248, 0.42); }
 .province-logistics-outcome-group__item--resolved { border-color: rgba(74, 222, 128, 0.42); }
+
+.culture-tension-filters {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+.culture-tension-filter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.46);
+  color: #cbd5e1;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 800;
+}
+.culture-tension-filter b {
+  display: inline-grid;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.12);
+  color: #f8fafc;
+}
+.culture-tension-filter.is-active {
+  border-color: rgba(125, 211, 252, 0.42);
+  background: rgba(14, 165, 233, 0.12);
+  color: #e0f2fe;
+}
+.culture-tension-filter:not(.is-active) { opacity: 0.58; }
+.culture-tension-quick-jump {
+  display: grid;
+  gap: 6px;
+  padding: 9px;
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.culture-tension-quick-jump__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.culture-tension-quick-jump__header span {
+  color: #fde68a;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.culture-tension-quick-jump__header strong { color: #f8fafc; font-size: 12px; }
+.culture-tension-jump {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1px 7px;
+  align-items: center;
+  padding: 7px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.48);
+  color: #f8fafc;
+  cursor: pointer;
+  text-align: left;
+}
+.culture-tension-jump b { grid-row: span 2; font-size: 13px; }
+.culture-tension-jump span { font-size: 12px; font-weight: 800; }
+.culture-tension-jump small { color: #cbd5e1; font-size: 11px; line-height: 1.25; }
+.culture-tension-jump--eased,
+.culture-tension-jump--opportunity { border-color: rgba(74, 222, 128, 0.22); }
+.culture-tension-jump--unresolved { border-color: rgba(251, 191, 36, 0.28); }
+.culture-tension-jump--escalated { border-color: rgba(248, 113, 113, 0.3); }
+.culture-tension-jump:hover,
+.culture-tension-filter:hover { border-color: rgba(125, 211, 252, 0.5); }


### PR DESCRIPTION
Gamma: Implements #645.

Summary:
- adds outcome filters for post-commit culture tension markers (eased, unresolved, escalated, opportunity)
- adds a compact priority quick-jump list for culture markers that need attention
- quick-jump focuses the selected province on the culture overlay
- preserves existing culture marker details and post-commit marker behavior

Validation:
- npm test
- npm test -- test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js
- node --check web/app.js
- node --check src/ui/culture/buildCultureOpportunityReminders.js
- git diff --check

Zeta: PR prête pour validation avant merge.