### PR TITLE
Delta: add intrigue exposure rollup filters

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -215,3 +215,18 @@ test('post-commit intrigue exposure markers stay fog-safe on the map', () => {
   assert.match(stylesSource, /intrigue-post-commit-marker--increased/);
   assert.match(stylesSource, /intrigue-post-commit-marker--hidden/);
 });
+
+test('intrigue exposure marker rollup filters reveal only safe counts', () => {
+  assert.match(webAppSource, /intrigueExposureOutcomeFilters/);
+  assert.match(webAppSource, /function getActiveIntrigueExposureOutcomeFilters/);
+  assert.match(webAppSource, /function filterPostCommitIntrigueExposureMarkers/);
+  assert.match(webAppSource, /function buildIntrigueExposureMarkerRollup/);
+  assert.match(webAppSource, /function renderIntrigueExposureMarkerRollup/);
+  assert.match(webAppSource, /data-intrigue-exposure-filter="\$\{key\}"/);
+  assert.match(webAppSource, /state\.intrigueExposureOutcomeFilters\[key\] = !state\.intrigueExposureOutcomeFilters\[key\]/);
+  assert.match(webAppSource, /marqueur\$\{markers\.length > 1 \? 's' : ''\} intrigue post-commit visible/);
+  assert.match(webAppSource, /résultat\$\{counts\.hidden > 1 \? 's' : ''\} fog-limité/);
+  assert.match(webAppSource, /Rollup conservateur: les comptes agrègent uniquement les résultats visibles/);
+  assert.match(stylesSource, /intrigue-exposure-marker-rollup/);
+  assert.match(stylesSource, /intrigue-exposure-marker-filter\.is-active/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -424,6 +424,12 @@ const state = {
     alerts: true,
     sabotage: true,
   },
+  intrigueExposureOutcomeFilters: {
+    lowered: false,
+    unchanged: false,
+    increased: false,
+    hidden: false,
+  },
   acceptedRecommendedMilitaryAction: null,
   lastMilitaryOutcomeMarkers: [],
 };
@@ -5172,8 +5178,48 @@ function renderMapIntrigueExposureSummary(summary) {
   `;
 }
 
-function buildPostCommitIntrigueExposureMarkers(intrigueView = null) {
-  return (intrigueView?.map?.entries ?? [])
+function getActiveIntrigueExposureOutcomeFilters() {
+  return Object.entries(state.intrigueExposureOutcomeFilters)
+    .filter(([, active]) => active)
+    .map(([key]) => key);
+}
+
+function filterPostCommitIntrigueExposureMarkers(markers) {
+  const activeFilters = getActiveIntrigueExposureOutcomeFilters();
+
+  if (activeFilters.length === 0) {
+    return markers;
+  }
+
+  return markers.filter((marker) => activeFilters.includes(marker.direction));
+}
+
+function buildIntrigueExposureMarkerRollup(markers) {
+  const filteredMarkers = filterPostCommitIntrigueExposureMarkers(markers);
+  const counts = {
+    lowered: markers.filter((marker) => marker.direction === 'lowered').length,
+    unchanged: markers.filter((marker) => marker.direction === 'unchanged').length,
+    increased: markers.filter((marker) => marker.direction === 'increased').length,
+    hidden: markers.filter((marker) => marker.direction === 'hidden').length,
+  };
+  const activeFilters = getActiveIntrigueExposureOutcomeFilters();
+
+  return {
+    counts,
+    activeFilters,
+    filteredCount: filteredMarkers.length,
+    totalCount: markers.length,
+    summary: activeFilters.length > 0
+      ? `${filteredMarkers.length}/${markers.length} marqueur${markers.length > 1 ? 's' : ''} intrigue visible${filteredMarkers.length > 1 ? 's' : ''} après filtre fog-safe.`
+      : `${markers.length} marqueur${markers.length > 1 ? 's' : ''} intrigue post-commit visible${markers.length > 1 ? 's' : ''}; aucun filtre d’issue actif.`,
+    hiddenCopy: counts.hidden > 0
+      ? `${counts.hidden} résultat${counts.hidden > 1 ? 's' : ''} fog-limité${counts.hidden > 1 ? 's' : ''}: province inspectable, cible/cellule/relais masqués.`
+      : 'Aucun résultat fog-limité visible dans le rollup actuel.',
+  };
+}
+
+function buildPostCommitIntrigueExposureMarkers(intrigueView = null, options = {}) {
+  const markers = (intrigueView?.map?.entries ?? [])
     .map((entry) => {
       const response = entry.drillDown?.quickResponses?.find((candidate) => candidate.code === entry.drillDown.recommendedResponseCode)
         ?? entry.drillDown?.quickResponses?.[0]
@@ -5230,6 +5276,40 @@ function buildPostCommitIntrigueExposureMarkers(intrigueView = null) {
     .filter(Boolean)
     .sort((left, right) => left.locationName.localeCompare(right.locationName))
     .slice(0, 5);
+
+  return options.ignoreFilters ? markers : filterPostCommitIntrigueExposureMarkers(markers);
+}
+
+function renderIntrigueExposureMarkerRollup(rollup) {
+  if (rollup.totalCount === 0) {
+    return '';
+  }
+
+  const labels = {
+    lowered: 'Réduite',
+    unchanged: 'Stable',
+    increased: 'Accrue',
+    hidden: 'Fog-limité',
+  };
+
+  return `
+    <section class="intrigue-exposure-marker-rollup" aria-label="Filtres fog-safe des marqueurs exposition intrigue">
+      <div class="intrigue-exposure-marker-rollup__header">
+        <strong>Marqueurs exposition</strong>
+        <span>${rollup.filteredCount}/${rollup.totalCount} visibles</span>
+      </div>
+      <p>${rollup.summary}</p>
+      <div class="intrigue-exposure-marker-rollup__chips">
+        ${Object.entries(labels).map(([key, label]) => `
+          <button type="button" class="intrigue-exposure-marker-filter ${state.intrigueExposureOutcomeFilters[key] ? 'is-active' : ''}" data-intrigue-exposure-filter="${key}" aria-pressed="${state.intrigueExposureOutcomeFilters[key]}">
+            ${label} <b>${rollup.counts[key]}</b>
+          </button>
+        `).join('')}
+      </div>
+      <small>${rollup.hiddenCopy}</small>
+      <small>Rollup conservateur: les comptes agrègent uniquement les résultats visibles et ne nomment jamais cellule, cible ou relais.</small>
+    </section>
+  `;
 }
 
 function renderPostCommitIntrigueExposureMarkers(markers) {
@@ -7023,6 +7103,9 @@ function renderIntrigueSidePanel(intrigueView) {
     return null;
   }
 
+  const exposureMarkers = buildPostCommitIntrigueExposureMarkers(intrigueView, { ignoreFilters: true });
+  const exposureMarkerRollup = buildIntrigueExposureMarkerRollup(exposureMarkers);
+
   return `
     <section class="panel overlay-panel overlay-panel--intrigue">
       <div class="panel-header">
@@ -7040,6 +7123,7 @@ function renderIntrigueSidePanel(intrigueView) {
         <button type="button" class="intrigue-filter-chip ${intrigueView.filters.alerts ? 'is-active' : ''}" data-intrigue-filter="alerts">Alertes</button>
         <button type="button" class="intrigue-filter-chip ${intrigueView.filters.sabotage ? 'is-active' : ''}" data-intrigue-filter="sabotage">Sabotage</button>
       </section>
+      ${renderIntrigueExposureMarkerRollup(exposureMarkerRollup)}
       <section class="intrigue-alert-panel intrigue-alert-panel--${intrigueView.alertPanel.tone}" aria-label="Lecture du niveau d'alerte">
         <div class="intrigue-alert-panel__header">
           <div>
@@ -8742,6 +8826,14 @@ function render() {
     element.addEventListener('click', () => {
       const key = element.dataset.intrigueFilter;
       state.intrigueFilters[key] = !state.intrigueFilters[key];
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-intrigue-exposure-filter]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const key = element.dataset.intrigueExposureFilter;
+      state.intrigueExposureOutcomeFilters[key] = !state.intrigueExposureOutcomeFilters[key];
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -2010,6 +2010,52 @@ button { font: inherit; }
   stroke-width: 0.72;
   filter: drop-shadow(0 0 10px rgba(216, 180, 254, 0.68));
 }
+.intrigue-exposure-marker-rollup {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(168, 85, 247, 0.22);
+  background: rgba(15, 23, 42, 0.48);
+}
+.intrigue-exposure-marker-rollup__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.intrigue-exposure-marker-rollup__header span,
+.intrigue-exposure-marker-rollup p,
+.intrigue-exposure-marker-rollup small {
+  margin: 0;
+  color: var(--muted);
+}
+.intrigue-exposure-marker-rollup__chips {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+.intrigue-exposure-marker-filter {
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+  align-items: center;
+  padding: 7px 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  color: #e2e8f0;
+  background: rgba(2, 6, 23, 0.24);
+  cursor: pointer;
+}
+.intrigue-exposure-marker-filter.is-active,
+.intrigue-exposure-marker-filter:hover,
+.intrigue-exposure-marker-filter:focus-visible {
+  border-color: rgba(216, 180, 254, 0.64);
+  background: rgba(88, 28, 135, 0.34);
+}
+.intrigue-exposure-marker-filter b {
+  color: #f8fafc;
+}
 .overlay-anchor-shell--top { left: 18%; top: 3%; width: 64%; height: 9%; }
 .overlay-anchor-shell--left { left: 3%; top: 18%; width: 12%; height: 58%; }
 .overlay-anchor-shell--right { right: 3%; top: 18%; width: 12%; height: 58%; }


### PR DESCRIPTION
Delta: Implements #646.\n\nSummary:\n- adds fog-safe filter chips for lowered, stable, increased, and fog-limited intrigue exposure markers\n- adds compact rollup counts that only aggregate visible post-commit marker outcomes\n- keeps hidden/fog-limited wording conservative in the rollup and marker flow\n\nValidation:\n- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js\n- node --check web/app.js\n- git diff --check HEAD~1..HEAD\n- npm test