### PR TITLE
Epsilon: control climate marker density

### DIFF
--- a/test/ui/climate/webClimateMarkerDensityControls.test.js
+++ b/test/ui/climate/webClimateMarkerDensityControls.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('climate post-commit markers have density controls that preserve urgent threats', () => {
+  assert.match(webAppSource, /function buildClimateMarkerDensityControl/);
+  assert.match(webAppSource, /function renderClimateMarkerDensityRollup/);
+  assert.match(webAppSource, /maxVisible = 4/);
+  assert.match(webAppSource, /marker\.status === 'cascade-active' \|\| marker\.status === 'hazard-unresolved'/);
+  assert.match(webAppSource, /visibleMarkers = urgentMarkers\.concat/);
+  assert.match(webAppSource, /groupedMarkers/);
+  assert.match(webAppSource, /Densité marqueurs climat/);
+  assert.match(webAppSource, /Priorité conservée aux cascades et aléas non résolus/);
+  assert.match(webAppSource, /climateMarkerDensity = buildClimateMarkerDensityControl\(postCommitClimateMarkers\)/);
+  assert.match(webAppSource, /renderClimateMarkerDensityRollup\(climateMarkerDensity\)/);
+  assert.match(webAppSource, /renderMapLayerStack\(shell, economyView, focusContext, cultureView, climateMarkerDensity\.visibleMarkers\)/);
+
+  assert.match(stylesSource, /\.map-climate-density/);
+  assert.match(stylesSource, /\.map-climate-density--grouped/);
+  assert.match(stylesSource, /\.map-climate-density--dense/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3039,8 +3039,56 @@ function buildPostCommitClimateImpactMarkers(shell, queuedClimateInterventions =
   });
 
   return [...markerByProvince.values()]
-    .sort((left, right) => left.priority - right.priority || left.provinceLabel.localeCompare(right.provinceLabel))
-    .slice(0, 4);
+    .sort((left, right) => left.priority - right.priority || left.provinceLabel.localeCompare(right.provinceLabel));
+}
+
+function buildClimateMarkerDensityControl(markers, maxVisible = 4) {
+  const urgentMarkers = markers.filter((marker) => marker.status === 'cascade-active' || marker.status === 'hazard-unresolved');
+  const lowerPriorityMarkers = markers.filter((marker) => marker.status !== 'cascade-active' && marker.status !== 'hazard-unresolved');
+  const remainingSlots = Math.max(0, maxVisible - urgentMarkers.length);
+  const visibleMarkers = urgentMarkers.concat(lowerPriorityMarkers.slice(0, remainingSlots));
+  const visibleIds = new Set(visibleMarkers.map((marker) => marker.provinceId));
+  const groupedMarkers = markers.filter((marker) => !visibleIds.has(marker.provinceId));
+  const groupedByStatus = groupedMarkers.reduce((counts, marker) => {
+    counts[marker.status] = (counts[marker.status] ?? 0) + 1;
+    return counts;
+  }, {});
+
+  return {
+    state: groupedMarkers.length > 0 ? 'grouped' : markers.length > maxVisible ? 'dense' : 'clear',
+    visibleMarkers,
+    groupedMarkers,
+    urgentCount: urgentMarkers.length,
+    visibleCount: visibleMarkers.length,
+    groupedCount: groupedMarkers.length,
+    groupedByStatus,
+    summary: groupedMarkers.length > 0
+      ? `${visibleMarkers.length} marqueur${visibleMarkers.length > 1 ? 's' : ''} climat affiché${visibleMarkers.length > 1 ? 's' : ''}; ${groupedMarkers.length} réduit${groupedMarkers.length > 1 ? 's' : ''}/retardé${groupedMarkers.length > 1 ? 's' : ''} regroupé${groupedMarkers.length > 1 ? 's' : ''} pour préserver la lisibilité. ${urgentMarkers.length} urgence${urgentMarkers.length > 1 ? 's' : ''} cascade/aléa reste${urgentMarkers.length > 1 ? 'nt' : ''} visible${urgentMarkers.length > 1 ? 's' : ''}.`
+      : markers.length > 0
+        ? `${markers.length} marqueur${markers.length > 1 ? 's' : ''} climat affiché${markers.length > 1 ? 's' : ''}; aucune urgence masquée.`
+        : 'Aucun marqueur climat post-résolution à densifier.',
+  };
+}
+
+function renderClimateMarkerDensityRollup(control) {
+  if (control.visibleCount === 0 && control.groupedCount === 0) {
+    return '';
+  }
+
+  const groupedStatuses = Object.entries(control.groupedByStatus)
+    .map(([status, count]) => `${count} ${status}`)
+    .join(' · ');
+
+  return `
+    <section class="map-climate-density map-climate-density--${control.state}" aria-label="Contrôle de densité des marqueurs climat">
+      <div>
+        <strong>Densité marqueurs climat</strong>
+        <span>${control.visibleCount} visibles · ${control.groupedCount} regroupés</span>
+      </div>
+      <p>${control.summary}</p>
+      ${groupedStatuses ? `<small>Regroupés: ${groupedStatuses}. Priorité conservée aux cascades et aléas non résolus.</small>` : '<small>Cascades et aléas non résolus restent prioritaires sur la carte.</small>'}
+    </section>
+  `;
 }
 
 function renderPostCommitClimateMarkerDetail(province, markers = []) {
@@ -8253,6 +8301,7 @@ function render() {
   const climateInterventionWindows = buildMapClimateInterventionWindows(shell);
   const cumulativeClimateImpact = buildCumulativeClimateImpactSummary(shell, state.queuedClimateInterventions);
   const postCommitClimateMarkers = buildPostCommitClimateImpactMarkers(shell, state.queuedClimateInterventions);
+  const climateMarkerDensity = buildClimateMarkerDensityControl(postCommitClimateMarkers);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -8278,6 +8327,7 @@ function render() {
           ${renderMapClimatePreparednessSummary(climatePreparednessSummary)}
           ${renderMapClimateInterventionWindows(climateInterventionWindows)}
           ${renderCumulativeClimateImpactSummary(cumulativeClimateImpact)}
+          ${renderClimateMarkerDensityRollup(climateMarkerDensity)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">
@@ -8310,7 +8360,7 @@ function render() {
             ${renderMapControls()}
             ${renderMilitaryOutcomeMarkerFilters(state.lastMilitaryOutcomeMarkers)}
             <div class="map-viewport" style="transform:${getMapViewportTransform()};">
-              ${renderMapLayerStack(shell, economyView, focusContext, cultureView, postCommitClimateMarkers)}
+              ${renderMapLayerStack(shell, economyView, focusContext, cultureView, climateMarkerDensity.visibleMarkers)}
               ${renderIntrigueMapOverlay(intrigueView)}
             </div>
             ${renderBottomTray(economyView, intrigueView, cultureView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -304,6 +304,35 @@ button { font: inherit; }
 .map-climate-cumulative__item b { color: #f8fafc; }
 .map-climate-cumulative__item small b { color: #fef3c7; }
 
+.map-climate-density {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  max-width: 72ch;
+  padding: 10px 12px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.54), rgba(8, 47, 73, 0.34));
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.map-climate-density--grouped { border-color: rgba(251, 191, 36, 0.3); }
+.map-climate-density--dense { border-color: rgba(56, 189, 248, 0.28); }
+.map-climate-density div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-climate-density div span,
+.map-climate-density p,
+.map-climate-density small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-climate-density p { color: #dbeafe; }
+.map-climate-density small { color: #bae6fd; }
+
 .economy-turn-pulse {
   margin-top: 12px;
   display: inline-flex;


### PR DESCRIPTION
Epsilon: Implements #647.

Summary:
- Adds density control for post-commit climate markers, keeping cascade and unresolved hazard markers visible first.
- Groups/deemphasizes lower-priority reduced/delayed climate markers when the map gets dense.
- Adds a concise rollup explaining how many markers are visible/grouped and why urgent climate threats remain prioritized.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webClimateMarkerDensityControls.test.js test/ui/climate/webPostCommitClimateImpactMarkers.test.js
- npm test