### PR TITLE
Alpha: summarize military marker fronts

### DIFF
--- a/test/ui/war/webMilitaryFrontMarkerSummaries.test.js
+++ b/test/ui/war/webMilitaryFrontMarkerSummaries.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('military marker filters include compact front summaries', () => {
+  assert.match(webAppSource, /militaryOutcomeSeverityRank/);
+  assert.match(webAppSource, /function buildMilitaryFrontMarkerSummaries/);
+  assert.match(webAppSource, /function renderMilitaryFrontMarkerSummaries/);
+  assert.match(webAppSource, /visibleCount/);
+  assert.match(webAppSource, /hiddenCount/);
+  assert.match(webAppSource, /dominantTone/);
+  assert.match(webAppSource, /urgentAction/);
+  assert.match(webAppSource, /Lecture fronts/);
+  assert.match(webAppSource, /Aucun marqueur militaire/);
+  assert.match(webAppSource, /renderMilitaryFrontMarkerSummaries\(state\.lastMilitaryOutcomeMarkers\)/);
+  assert.match(webAppSource, /isMilitaryOutcomeMarkerVisible\(marker\)/);
+  assert.match(stylesSource, /\.military-front-marker-summary/);
+  assert.match(stylesSource, /\.military-front-marker-summary__item--hidden/);
+  assert.match(stylesSource, /\.military-front-marker-summary__item--worsened/);
+  assert.match(stylesSource, /\.military-front-marker-summary__item--blocked/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -705,6 +705,104 @@ function buildMilitaryOutcomeMarkerFilterState(markers = state.lastMilitaryOutco
   });
 }
 
+const militaryOutcomeSeverityRank = {
+  worsened: 4,
+  blocked: 3,
+  risk: 2,
+  stabilized: 1,
+};
+
+function getMilitaryOutcomeUrgentAction(tone) {
+  return {
+    worsened: 'Renforcer ce front en priorité au prochain tour.',
+    blocked: 'Lever le blocage avant de relancer l’ordre.',
+    risk: 'Surveiller le risque restant et préparer un appui ciblé.',
+    stabilized: 'Maintenir la pression sans détourner la réserve.',
+  }[tone] ?? 'Réévaluer le front au prochain tour.';
+}
+
+function buildMilitaryFrontMarkerSummaries(markers = state.lastMilitaryOutcomeMarkers) {
+  if (markers.length === 0) {
+    return [];
+  }
+
+  const groups = new Map();
+
+  for (const marker of markers) {
+    const frontKey = marker.provinceId;
+    const existing = groups.get(frontKey) ?? {
+      frontKey,
+      frontLabel: marker.provinceLabel ?? marker.provinceId,
+      markers: [],
+      visibleCount: 0,
+      hiddenCount: 0,
+      dominantTone: marker.tone,
+      dominantLabel: marker.label,
+      urgentAction: getMilitaryOutcomeUrgentAction(marker.tone),
+    };
+    const visible = isMilitaryOutcomeMarkerVisible(marker);
+
+    existing.markers.push(marker);
+    existing.visibleCount += visible ? 1 : 0;
+    existing.hiddenCount += visible ? 0 : 1;
+
+    if ((militaryOutcomeSeverityRank[marker.tone] ?? 0) > (militaryOutcomeSeverityRank[existing.dominantTone] ?? 0)) {
+      existing.dominantTone = marker.tone;
+      existing.dominantLabel = marker.label;
+      existing.urgentAction = getMilitaryOutcomeUrgentAction(marker.tone);
+    }
+
+    groups.set(frontKey, existing);
+  }
+
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      totalCount: group.markers.length,
+      status: group.visibleCount > 0 ? 'visible' : 'hidden',
+    }))
+    .sort((left, right) => {
+      const severityDelta = (militaryOutcomeSeverityRank[right.dominantTone] ?? 0) - (militaryOutcomeSeverityRank[left.dominantTone] ?? 0);
+      return severityDelta || right.visibleCount - left.visibleCount || left.frontLabel.localeCompare(right.frontLabel);
+    });
+}
+
+function renderMilitaryFrontMarkerSummaries(markers = state.lastMilitaryOutcomeMarkers) {
+  const summaries = buildMilitaryFrontMarkerSummaries(markers);
+
+  if (summaries.length === 0) {
+    return `
+      <section class="military-front-marker-summary is-empty" aria-label="Résumé compact des fronts militaires marqués">
+        <div class="military-front-marker-summary__header">
+          <span>Lecture fronts</span>
+          <strong>Aucun marqueur militaire</strong>
+        </div>
+        <p>Aucune issue militaire post-commit visible ou masquée pour ce tour.</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="military-front-marker-summary" aria-label="Résumé compact des fronts militaires marqués">
+      <div class="military-front-marker-summary__header">
+        <span>Lecture fronts</span>
+        <strong>${summaries.length} zone${summaries.length > 1 ? 's' : ''}</strong>
+      </div>
+      <div class="military-front-marker-summary__list">
+        ${summaries.map((summary) => `
+          <article class="military-front-marker-summary__item military-front-marker-summary__item--${summary.dominantTone} military-front-marker-summary__item--${summary.status}">
+            <div>
+              <strong>${summary.frontLabel}</strong>
+              <small>${summary.visibleCount} visible${summary.visibleCount > 1 ? 's' : ''} · ${summary.hiddenCount} masqué${summary.hiddenCount > 1 ? 's' : ''}</small>
+            </div>
+            <p><b>${summary.dominantLabel}</b> · ${summary.urgentAction}</p>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderMilitaryOutcomeMarkerFilters(markers = state.lastMilitaryOutcomeMarkers) {
   const filters = buildMilitaryOutcomeMarkerFilterState(markers);
   const total = markers.length;
@@ -8513,6 +8611,7 @@ function render() {
           <div class="map-stage" data-map-stage="true" tabindex="0" aria-label="Carte opérationnelle zoomable. Utilisez plus, moins, zéro ou C pour naviguer.">
             ${renderMapControls()}
             ${renderMilitaryOutcomeMarkerFilters(state.lastMilitaryOutcomeMarkers)}
+            ${renderMilitaryFrontMarkerSummaries(state.lastMilitaryOutcomeMarkers)}
             <div class="map-viewport" style="transform:${getMapViewportTransform()};">
               ${renderMapLayerStack(shell, economyView, focusContext, cultureView, climateMarkerDensity.visibleMarkers)}
               ${renderIntrigueMapOverlay(intrigueView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -1161,6 +1161,64 @@ button { font: inherit; }
 .military-outcome-filter__button--blocked.is-active { border-color: rgba(148, 163, 184, 0.48); color: #f8fafc; }
 .military-outcome-filter__button--risk.is-active { border-color: rgba(251, 191, 36, 0.52); color: #fde68a; }
 
+.military-front-marker-summary {
+  position: absolute;
+  top: 212px;
+  right: 14px;
+  z-index: 7;
+  display: grid;
+  gap: 7px;
+  width: min(280px, calc(100% - 28px));
+  max-height: 190px;
+  overflow: auto;
+  padding: 9px;
+  border-radius: 16px;
+  background: rgba(8, 15, 28, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  backdrop-filter: blur(10px);
+}
+.military-front-marker-summary__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-front-marker-summary__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.military-front-marker-summary__header strong { color: #e0f2fe; font-size: 12px; }
+.military-front-marker-summary p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.3;
+}
+.military-front-marker-summary__list { display: grid; gap: 6px; }
+.military-front-marker-summary__item {
+  display: grid;
+  gap: 4px;
+  padding: 7px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.5);
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.military-front-marker-summary__item div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-front-marker-summary__item strong { color: #f8fafc; }
+.military-front-marker-summary__item small { color: var(--muted); font-size: 10px; }
+.military-front-marker-summary__item--hidden { opacity: 0.66; }
+.military-front-marker-summary__item--stabilized { border-color: rgba(74, 222, 128, 0.32); }
+.military-front-marker-summary__item--worsened { border-color: rgba(251, 113, 133, 0.4); }
+.military-front-marker-summary__item--blocked { border-color: rgba(148, 163, 184, 0.34); }
+.military-front-marker-summary__item--risk { border-color: rgba(251, 191, 36, 0.36); }
+
 .map-control-button {
   border: 1px solid rgba(148, 163, 184, 0.18);
   background: rgba(15, 23, 42, 0.72);
@@ -6170,6 +6228,64 @@ button { font: inherit; }
 .military-outcome-filter__button--worsened.is-active { border-color: rgba(251, 113, 133, 0.56); color: #fecdd3; }
 .military-outcome-filter__button--blocked.is-active { border-color: rgba(148, 163, 184, 0.48); color: #f8fafc; }
 .military-outcome-filter__button--risk.is-active { border-color: rgba(251, 191, 36, 0.52); color: #fde68a; }
+
+.military-front-marker-summary {
+  position: absolute;
+  top: 212px;
+  right: 14px;
+  z-index: 7;
+  display: grid;
+  gap: 7px;
+  width: min(280px, calc(100% - 28px));
+  max-height: 190px;
+  overflow: auto;
+  padding: 9px;
+  border-radius: 16px;
+  background: rgba(8, 15, 28, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  backdrop-filter: blur(10px);
+}
+.military-front-marker-summary__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-front-marker-summary__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.military-front-marker-summary__header strong { color: #e0f2fe; font-size: 12px; }
+.military-front-marker-summary p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.3;
+}
+.military-front-marker-summary__list { display: grid; gap: 6px; }
+.military-front-marker-summary__item {
+  display: grid;
+  gap: 4px;
+  padding: 7px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.5);
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.military-front-marker-summary__item div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-front-marker-summary__item strong { color: #f8fafc; }
+.military-front-marker-summary__item small { color: var(--muted); font-size: 10px; }
+.military-front-marker-summary__item--hidden { opacity: 0.66; }
+.military-front-marker-summary__item--stabilized { border-color: rgba(74, 222, 128, 0.32); }
+.military-front-marker-summary__item--worsened { border-color: rgba(251, 113, 133, 0.4); }
+.military-front-marker-summary__item--blocked { border-color: rgba(148, 163, 184, 0.34); }
+.military-front-marker-summary__item--risk { border-color: rgba(251, 191, 36, 0.36); }
 
 .map-control-button {
     min-width: 44px;


### PR DESCRIPTION
Alpha: Implements #653.

Summary:
- Adds compact per-front military marker summaries next to the existing marker filters.
- Shows visible/hidden marker counts, dominant severity, and the most urgent follow-up action per front/zone.
- Keeps the summary based only on existing post-commit marker data, so hidden categories are counted without revealing non-visible details.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webMilitaryFrontMarkerSummaries.test.js test/ui/war/webMilitaryOutcomeMarkerFilters.test.js test/ui/war/webPostCommitMilitaryOutcomeMarkers.test.js
- npm test (473 tests)

Zeta: PR prête pour revue. Merci de valider avant tout merge.
