### PR TITLE
Delta: separate intrigue rollup certainty

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -226,7 +226,20 @@ test('intrigue exposure marker rollup filters reveal only safe counts', () => {
   assert.match(webAppSource, /state\.intrigueExposureOutcomeFilters\[key\] = !state\.intrigueExposureOutcomeFilters\[key\]/);
   assert.match(webAppSource, /marqueur\$\{markers\.length > 1 \? 's' : ''\} intrigue post-commit visible/);
   assert.match(webAppSource, /résultat\$\{counts\.hidden > 1 \? 's' : ''\} fog-limité/);
-  assert.match(webAppSource, /Rollup conservateur: les comptes agrègent uniquement les résultats visibles/);
+  assert.match(webAppSource, /Certitude fog-safe: les zones inconnues restent séparées des faibles risques confirmés/);
   assert.match(stylesSource, /intrigue-exposure-marker-rollup/);
   assert.match(stylesSource, /intrigue-exposure-marker-filter\.is-active/);
+});
+
+test('intrigue exposure rollups separate confirmed suspected and unknown certainty', () => {
+  assert.match(webAppSource, /certaintyGroups/);
+  assert.match(webAppSource, /confirmed: markers\.filter\(\(marker\) => marker\.certainty === 'confirmed'\)/);
+  assert.match(webAppSource, /suspected: markers\.filter\(\(marker\) => marker\.certainty === 'suspected'\)/);
+  assert.match(webAppSource, /unknown: markers\.filter\(\(marker\) => marker\.certainty === 'unknown'\)/);
+  assert.match(webAppSource, /certitude partielle: tendance visible, identité et relais non confirmés/);
+  assert.match(webAppSource, /certitude inconnue: zone fog-limitée séparée des faibles risques confirmés/);
+  assert.match(webAppSource, /ne pas assimiler à un faible risque confirmé/);
+  assert.match(webAppSource, /Certitude fog-safe: les zones inconnues restent séparées des faibles risques confirmés/);
+  assert.match(webAppSource, /aria-label="Niveau de certitude fog-safe des marqueurs intrigue"/);
+  assert.match(stylesSource, /intrigue-exposure-certainty-rollup/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -5387,12 +5387,24 @@ function buildIntrigueExposureMarkerRollup(markers) {
     hidden: markers.filter((marker) => marker.direction === 'hidden').length,
   };
   const activeFilters = getActiveIntrigueExposureOutcomeFilters();
+  const certaintyGroups = {
+    confirmed: markers.filter((marker) => marker.certainty === 'confirmed'),
+    suspected: markers.filter((marker) => marker.certainty === 'suspected'),
+    unknown: markers.filter((marker) => marker.certainty === 'unknown'),
+  };
+  const certaintyCopy = {
+    confirmed: `${certaintyGroups.confirmed.length} confirmé${certaintyGroups.confirmed.length > 1 ? 's' : ''}: résultat appuyé par un signal visible consolidé.`,
+    suspected: `${certaintyGroups.suspected.length} soupçon${certaintyGroups.suspected.length > 1 ? 's' : ''}: tendance lisible, mais source ou relais encore partiellement masqué.`,
+    unknown: `${certaintyGroups.unknown.length} zone${certaintyGroups.unknown.length > 1 ? 's' : ''} inconnue${certaintyGroups.unknown.length > 1 ? 's' : ''}: ne pas assimiler à un faible risque confirmé.`,
+  };
 
   return {
     counts,
     activeFilters,
     filteredCount: filteredMarkers.length,
     totalCount: markers.length,
+    certaintyGroups,
+    certaintyCopy,
     summary: activeFilters.length > 0
       ? `${filteredMarkers.length}/${markers.length} marqueur${markers.length > 1 ? 's' : ''} intrigue visible${filteredMarkers.length > 1 ? 's' : ''} après filtre fog-safe.`
       : `${markers.length} marqueur${markers.length > 1 ? 's' : ''} intrigue post-commit visible${markers.length > 1 ? 's' : ''}; aucun filtre d’issue actif.`,
@@ -5441,6 +5453,22 @@ function buildPostCommitIntrigueExposureMarkers(intrigueView = null, options = {
             ? 'risque résiduel stable; la synthèse finale conserve le détail visible'
             : 'résultat masqué par le brouillard; seule la province reste inspectable';
 
+      const certainty = direction === 'hidden'
+        ? 'unknown'
+        : entry.metrics.exposedCellCount > 0 || entry.showSecondaryDetails
+          ? 'confirmed'
+          : 'suspected';
+      const certaintyLabels = {
+        confirmed: 'confirmé',
+        suspected: 'soupçon',
+        unknown: 'inconnu',
+      };
+      const certaintyExplanation = certainty === 'confirmed'
+        ? 'certitude confirmée par les marqueurs visibles; pas de détail secret ajouté'
+        : certainty === 'suspected'
+          ? 'certitude partielle: tendance visible, identité et relais non confirmés'
+          : 'certitude inconnue: zone fog-limitée séparée des faibles risques confirmés';
+
       return {
         locationId: entry.locationId,
         locationName: entry.locationName,
@@ -5452,9 +5480,12 @@ function buildPostCommitIntrigueExposureMarkers(intrigueView = null, options = {
         label: directionLabels[direction],
         glyph: glyphs[direction],
         responseLabel: response.label,
+        certainty,
+        certaintyLabel: certaintyLabels[certainty],
+        certaintyExplanation,
         residualRisk,
-        copy: `${directionLabels[direction]} après résolution · ${residualRisk}. Voir synthèse finale exposition intrigue.`,
-        ariaLabel: `${directionLabels[direction]} en ${entry.locationName}: ${residualRisk}; détails fog-safe liés à la synthèse finale`,
+        copy: `${directionLabels[direction]} après résolution · ${certaintyLabels[certainty]} · ${residualRisk}. Voir synthèse finale exposition intrigue.`,
+        ariaLabel: `${directionLabels[direction]} en ${entry.locationName}: certitude ${certaintyLabels[certainty]}; ${residualRisk}; détails fog-safe liés à la synthèse finale`,
       };
     })
     .filter(Boolean)
@@ -5490,8 +5521,13 @@ function renderIntrigueExposureMarkerRollup(rollup) {
           </button>
         `).join('')}
       </div>
+      <div class="intrigue-exposure-certainty-rollup" aria-label="Niveau de certitude fog-safe des marqueurs intrigue">
+        <span><b>Confirmés</b>${rollup.certaintyCopy.confirmed}</span>
+        <span><b>Soupçons</b>${rollup.certaintyCopy.suspected}</span>
+        <span><b>Inconnues</b>${rollup.certaintyCopy.unknown}</span>
+      </div>
       <small>${rollup.hiddenCopy}</small>
-      <small>Rollup conservateur: les comptes agrègent uniquement les résultats visibles et ne nomment jamais cellule, cible ou relais.</small>
+      <small>Certitude fog-safe: les zones inconnues restent séparées des faibles risques confirmés et ne nomment jamais cellule, cible ou relais.</small>
     </section>
   `;
 }
@@ -5509,7 +5545,7 @@ function renderPostCommitIntrigueExposureMarkers(markers) {
           <circle class="intrigue-post-commit-marker__backplate" cx="${marker.center.x}%" cy="${marker.center.y}%" r="3.3"></circle>
           <text class="intrigue-post-commit-marker__glyph" x="${marker.center.x}%" y="${marker.center.y + 1.15}%" text-anchor="middle">${marker.glyph}</text>
           <text class="intrigue-post-commit-marker__label" x="${marker.center.x + 4.1}%" y="${marker.center.y - 1.15}%" text-anchor="start">${marker.label}</text>
-          <text class="intrigue-post-commit-marker__copy" x="${marker.center.x + 4.1}%" y="${marker.center.y + 2.25}%" text-anchor="start">${marker.responseLabel} · ${marker.direction === 'hidden' ? 'fog conservé' : 'voir synthèse finale'}</text>
+          <text class="intrigue-post-commit-marker__copy" x="${marker.center.x + 4.1}%" y="${marker.center.y + 2.25}%" text-anchor="start">${marker.certaintyLabel} · ${marker.direction === 'hidden' ? 'fog conservé' : 'voir synthèse finale'}</text>
         </g>
       `).join('')}
     </g>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2148,6 +2148,25 @@ button { font: inherit; }
 .intrigue-exposure-marker-filter b {
   color: #f8fafc;
 }
+.intrigue-exposure-certainty-rollup {
+  display: grid;
+  gap: 6px;
+}
+.intrigue-exposure-certainty-rollup span {
+  display: grid;
+  gap: 2px;
+  padding: 7px 9px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.26);
+  border-left: 3px solid rgba(148, 163, 184, 0.42);
+  color: var(--muted);
+}
+.intrigue-exposure-certainty-rollup span:nth-child(1) { border-left-color: rgba(34, 197, 94, 0.68); }
+.intrigue-exposure-certainty-rollup span:nth-child(2) { border-left-color: rgba(250, 204, 21, 0.72); }
+.intrigue-exposure-certainty-rollup span:nth-child(3) { border-left-color: rgba(148, 163, 184, 0.7); }
+.intrigue-exposure-certainty-rollup b {
+  color: #f8fafc;
+}
 .overlay-anchor-shell--top { left: 18%; top: 3%; width: 64%; height: 9%; }
 .overlay-anchor-shell--left { left: 3%; top: 18%; width: 12%; height: 58%; }
 .overlay-anchor-shell--right { right: 3%; top: 18%; width: 12%; height: 58%; }


### PR DESCRIPTION
Delta: Implements #656.\n\nSummary:\n- separates intrigue exposure rollup certainty into confirmed, suspected, and unknown groups\n- keeps unknown/fog-limited zones distinct from confirmed low-risk outcomes\n- adds concise fog-safe certainty copy and marker certainty labels without naming hidden cells, targets, or relays\n\nValidation:\n- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js\n- node --check web/app.js\n- git diff --check\n- npm test