### PR TITLE
Alpha: pin critical military markers

### DIFF
--- a/test/ui/war/webPinnedCriticalMilitaryMarkers.test.js
+++ b/test/ui/war/webPinnedCriticalMilitaryMarkers.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('critical military follow-up markers stay pinned through filters', () => {
+  assert.match(webAppSource, /function isCriticalMilitaryOutcomeMarker/);
+  assert.match(webAppSource, /function getMilitaryOutcomePinReason/);
+  assert.match(webAppSource, /worsened', 'blocked', 'risk/);
+  assert.match(webAppSource, /state\.militaryOutcomeMarkerFilters\[marker\.tone\] !== false \|\| isCriticalMilitaryOutcomeMarker\(marker\)/);
+  assert.match(webAppSource, /pinnedCount/);
+  assert.match(webAppSource, /pinnedReasons/);
+  assert.match(webAppSource, /pinSummary/);
+  assert.match(webAppSource, /épinglé: front aggravé/);
+  assert.match(webAppSource, /épinglé: action bloquée/);
+  assert.match(webAppSource, /épinglé: risque de suivi critique/);
+  assert.match(webAppSource, /marker\.pinReason/);
+  assert.match(webAppSource, /épinglé\$\{summary\.pinnedCount > 1 \? 's' : ''\}/);
+  assert.match(stylesSource, /\.military-front-marker-summary__item em/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -678,8 +678,24 @@ const militaryOutcomeMarkerCategories = [
   { tone: 'risk', label: 'Risque de suivi', shortLabel: 'Risque' },
 ];
 
+function isCriticalMilitaryOutcomeMarker(marker) {
+  return Boolean(marker && ['worsened', 'blocked', 'risk'].includes(marker.tone));
+}
+
+function getMilitaryOutcomePinReason(marker) {
+  if (!isCriticalMilitaryOutcomeMarker(marker)) {
+    return null;
+  }
+
+  return {
+    worsened: 'épinglé: front aggravé à traiter avant densité/filtre',
+    blocked: 'épinglé: action bloquée à débloquer avant nouvel ordre',
+    risk: 'épinglé: risque de suivi critique à surveiller',
+  }[marker.tone] ?? 'épinglé: suivi militaire prioritaire';
+}
+
 function isMilitaryOutcomeMarkerVisible(marker) {
-  return Boolean(marker && state.militaryOutcomeMarkerFilters[marker.tone] !== false);
+  return Boolean(marker && (state.militaryOutcomeMarkerFilters[marker.tone] !== false || isCriticalMilitaryOutcomeMarker(marker)));
 }
 
 function getMilitaryOutcomeMarkerForProvince(provinceId) {
@@ -701,7 +717,8 @@ function buildMilitaryOutcomeMarkerFilterState(markers = state.lastMilitaryOutco
       ...category,
       count,
       enabled,
-      hiddenCount: enabled ? 0 : count,
+      hiddenCount: enabled ? 0 : markers.filter((marker) => marker.tone === category.tone && !isCriticalMilitaryOutcomeMarker(marker)).length,
+      pinnedCount: markers.filter((marker) => marker.tone === category.tone && isCriticalMilitaryOutcomeMarker(marker)).length,
     };
   });
 }
@@ -740,12 +757,19 @@ function buildMilitaryFrontMarkerSummaries(markers = state.lastMilitaryOutcomeMa
       dominantTone: marker.tone,
       dominantLabel: marker.label,
       urgentAction: getMilitaryOutcomeUrgentAction(marker.tone),
+      pinnedCount: 0,
+      pinnedReasons: [],
     };
     const visible = isMilitaryOutcomeMarkerVisible(marker);
+    const pinReason = getMilitaryOutcomePinReason(marker);
 
     existing.markers.push(marker);
     existing.visibleCount += visible ? 1 : 0;
     existing.hiddenCount += visible ? 0 : 1;
+    existing.pinnedCount += pinReason ? 1 : 0;
+    if (pinReason && !existing.pinnedReasons.includes(pinReason)) {
+      existing.pinnedReasons.push(pinReason);
+    }
 
     if ((militaryOutcomeSeverityRank[marker.tone] ?? 0) > (militaryOutcomeSeverityRank[existing.dominantTone] ?? 0)) {
       existing.dominantTone = marker.tone;
@@ -761,6 +785,7 @@ function buildMilitaryFrontMarkerSummaries(markers = state.lastMilitaryOutcomeMa
       ...group,
       totalCount: group.markers.length,
       status: group.visibleCount > 0 ? 'visible' : 'hidden',
+      pinSummary: group.pinnedReasons[0] ?? 'aucun épinglage critique',
     }))
     .sort((left, right) => {
       const severityDelta = (militaryOutcomeSeverityRank[right.dominantTone] ?? 0) - (militaryOutcomeSeverityRank[left.dominantTone] ?? 0);
@@ -794,9 +819,10 @@ function renderMilitaryFrontMarkerSummaries(markers = state.lastMilitaryOutcomeM
           <article class="military-front-marker-summary__item military-front-marker-summary__item--${summary.dominantTone} military-front-marker-summary__item--${summary.status}">
             <div>
               <strong>${summary.frontLabel}</strong>
-              <small>${summary.visibleCount} visible${summary.visibleCount > 1 ? 's' : ''} · ${summary.hiddenCount} masqué${summary.hiddenCount > 1 ? 's' : ''}</small>
+              <small>${summary.visibleCount} visible${summary.visibleCount > 1 ? 's' : ''} · ${summary.hiddenCount} masqué${summary.hiddenCount > 1 ? 's' : ''} · ${summary.pinnedCount} épinglé${summary.pinnedCount > 1 ? 's' : ''}</small>
             </div>
             <p><b>${summary.dominantLabel}</b> · ${summary.urgentAction}</p>
+            ${summary.pinnedCount > 0 ? `<em>${summary.pinSummary}</em>` : ''}
           </article>
         `).join('')}
       </div>
@@ -816,7 +842,7 @@ function renderMilitaryOutcomeMarkerFilters(markers = state.lastMilitaryOutcomeM
           <span>Marqueurs militaires</span>
           <strong>${total} post-commit</strong>
         </div>
-        <small>${hiddenTotal} masqué${hiddenTotal > 1 ? 's' : ''}</small>
+        <small>${hiddenTotal} masqué${hiddenTotal > 1 ? 's' : ''} · ${filters.reduce((sum, filter) => sum + filter.pinnedCount, 0)} épinglé${filters.reduce((sum, filter) => sum + filter.pinnedCount, 0) > 1 ? 's' : ''}</small>
       </div>
       <div class="military-outcome-filter__buttons">
         ${filters.map((filter) => `
@@ -874,6 +900,8 @@ function buildPostCommitMilitaryOutcomeMarker(province, shell, intrigueView = nu
     summaryItem,
     changed: `${labels[tone]} après résolution: ${action?.expectedResult ?? projection.summary}`,
     why: `Référence rapport militaire: ${summaryItem}. ${why}`,
+    pinReason: getMilitaryOutcomePinReason({ tone }),
+    pinned: isCriticalMilitaryOutcomeMarker({ tone }),
     turn: state.turn + 1,
   };
 }
@@ -907,7 +935,7 @@ function renderSelectedProvinceMilitaryOutcomeMarker(province) {
       </div>
       <p>${marker.changed}</p>
       <small>${marker.why}</small>
-      ${isMilitaryOutcomeMarkerVisible(marker) ? '' : '<em>Marqueur masqué par le filtre de légende.</em>'}
+      ${marker.pinReason ? `<em>${marker.pinReason}</em>` : isMilitaryOutcomeMarkerVisible(marker) ? '' : '<em>Marqueur masqué par le filtre de légende.</em>'}
     </section>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -1214,6 +1214,7 @@ button { font: inherit; }
 }
 .military-front-marker-summary__item strong { color: #f8fafc; }
 .military-front-marker-summary__item small { color: var(--muted); font-size: 10px; }
+.military-front-marker-summary__item em { color: #fde68a; font-size: 10px; font-style: normal; }
 .military-front-marker-summary__item--hidden { opacity: 0.66; }
 .military-front-marker-summary__item--stabilized { border-color: rgba(74, 222, 128, 0.32); }
 .military-front-marker-summary__item--worsened { border-color: rgba(251, 113, 133, 0.4); }


### PR DESCRIPTION
Alpha: Implements #663.

Summary:
- Pins critical military follow-up markers (worsened fronts, blocked actions, follow-up risks) so they remain visible even when their category filter is off.
- Adds pin counts and reasons to the military front summaries and filter rollup.
- Keeps stabilized/non-critical markers controlled by existing filters and preserves empty/non-critical behavior.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webPinnedCriticalMilitaryMarkers.test.js test/ui/war/webMilitaryFrontMarkerSummaries.test.js test/ui/war/webMilitaryOutcomeMarkerFilters.test.js
- npm test (476 tests)

Zeta: PR prête pour revue. Merci de valider avant tout merge.
