### PR TITLE
Delta: add intrigue marker freshness cues

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -243,3 +243,19 @@ test('intrigue exposure rollups separate confirmed suspected and unknown certain
   assert.match(webAppSource, /aria-label="Niveau de certitude fog-safe des marqueurs intrigue"/);
   assert.match(stylesSource, /intrigue-exposure-certainty-rollup/);
 });
+
+test('intrigue exposure markers show fog-safe freshness cues', () => {
+  assert.match(webAppSource, /freshnessCounts/);
+  assert.match(webAppSource, /freshnessCopy/);
+  assert.match(webAppSource, /recent: markers\.filter\(\(marker\) => marker\.freshness === 'recent'\)/);
+  assert.match(webAppSource, /stale: markers\.filter\(\(marker\) => marker\.freshness === 'stale'\)/);
+  assert.match(webAppSource, /uncertain: markers\.filter\(\(marker\) => marker\.freshness === 'uncertain'\)/);
+  assert.match(webAppSource, /info récente/);
+  assert.match(webAppSource, /info ancienne/);
+  assert.match(webAppSource, /fraîcheur incertaine/);
+  assert.match(webAppSource, /soupçon ancien à revérifier avant intervention lourde/);
+  assert.match(webAppSource, /fraîcheur déduite seulement des signaux visibles/);
+  assert.match(webAppSource, /Récent = signal visible actif; ancien = soupçon à revérifier; incertain = zone inconnue sans détail caché/);
+  assert.match(webAppSource, /aria-label="Fraîcheur fog-safe des marqueurs intrigue"/);
+  assert.match(stylesSource, /intrigue-exposure-freshness-rollup/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -5618,6 +5618,12 @@ function buildIntrigueExposureMarkerRollup(markers) {
     suspected: `${certaintyGroups.suspected.length} soupçon${certaintyGroups.suspected.length > 1 ? 's' : ''}: tendance lisible, mais source ou relais encore partiellement masqué.`,
     unknown: `${certaintyGroups.unknown.length} zone${certaintyGroups.unknown.length > 1 ? 's' : ''} inconnue${certaintyGroups.unknown.length > 1 ? 's' : ''}: ne pas assimiler à un faible risque confirmé.`,
   };
+  const freshnessCounts = {
+    recent: markers.filter((marker) => marker.freshness === 'recent').length,
+    stale: markers.filter((marker) => marker.freshness === 'stale').length,
+    uncertain: markers.filter((marker) => marker.freshness === 'uncertain').length,
+  };
+  const freshnessCopy = `${freshnessCounts.recent} récent${freshnessCounts.recent > 1 ? 's' : ''} · ${freshnessCounts.stale} ancien${freshnessCounts.stale > 1 ? 's' : ''} · ${freshnessCounts.uncertain} incertain${freshnessCounts.uncertain > 1 ? 's' : ''}; fraîcheur déduite seulement des signaux visibles.`;
 
   return {
     counts,
@@ -5626,6 +5632,8 @@ function buildIntrigueExposureMarkerRollup(markers) {
     totalCount: markers.length,
     certaintyGroups,
     certaintyCopy,
+    freshnessCounts,
+    freshnessCopy,
     summary: activeFilters.length > 0
       ? `${filteredMarkers.length}/${markers.length} marqueur${markers.length > 1 ? 's' : ''} intrigue visible${filteredMarkers.length > 1 ? 's' : ''} après filtre fog-safe.`
       : `${markers.length} marqueur${markers.length > 1 ? 's' : ''} intrigue post-commit visible${markers.length > 1 ? 's' : ''}; aucun filtre d’issue actif.`,
@@ -5689,6 +5697,21 @@ function buildPostCommitIntrigueExposureMarkers(intrigueView = null, options = {
         : certainty === 'suspected'
           ? 'certitude partielle: tendance visible, identité et relais non confirmés'
           : 'certitude inconnue: zone fog-limitée séparée des faibles risques confirmés';
+      const freshness = certainty === 'unknown'
+        ? 'uncertain'
+        : entry.sabotageRiskLevel === 'high' || entry.metrics.exposedCellCount > 0 || response.heatGenerated >= 10
+          ? 'recent'
+          : 'stale';
+      const freshnessLabels = {
+        recent: 'info récente',
+        stale: 'info ancienne',
+        uncertain: 'fraîcheur incertaine',
+      };
+      const freshnessExplanation = freshness === 'recent'
+        ? 'signal récent confirmé par une chaleur ou exposition visible'
+        : freshness === 'stale'
+          ? 'soupçon ancien à revérifier avant intervention lourde'
+          : 'fraîcheur incertaine sous brouillard; vérifier la province sans inférer de cible';
 
       return {
         locationId: entry.locationId,
@@ -5704,9 +5727,12 @@ function buildPostCommitIntrigueExposureMarkers(intrigueView = null, options = {
         certainty,
         certaintyLabel: certaintyLabels[certainty],
         certaintyExplanation,
+        freshness,
+        freshnessLabel: freshnessLabels[freshness],
+        freshnessExplanation,
         residualRisk,
-        copy: `${directionLabels[direction]} après résolution · ${certaintyLabels[certainty]} · ${residualRisk}. Voir synthèse finale exposition intrigue.`,
-        ariaLabel: `${directionLabels[direction]} en ${entry.locationName}: certitude ${certaintyLabels[certainty]}; ${residualRisk}; détails fog-safe liés à la synthèse finale`,
+        copy: `${directionLabels[direction]} après résolution · ${certaintyLabels[certainty]} · ${freshnessLabels[freshness]} · ${residualRisk}. Voir synthèse finale exposition intrigue.`,
+        ariaLabel: `${directionLabels[direction]} en ${entry.locationName}: certitude ${certaintyLabels[certainty]}; ${freshnessLabels[freshness]}; ${freshnessExplanation}; détails fog-safe liés à la synthèse finale`,
       };
     })
     .filter(Boolean)
@@ -5747,6 +5773,11 @@ function renderIntrigueExposureMarkerRollup(rollup) {
         <span><b>Soupçons</b>${rollup.certaintyCopy.suspected}</span>
         <span><b>Inconnues</b>${rollup.certaintyCopy.unknown}</span>
       </div>
+      <div class="intrigue-exposure-freshness-rollup" aria-label="Fraîcheur fog-safe des marqueurs intrigue">
+        <b>Fraîcheur</b>
+        <span>${rollup.freshnessCopy}</span>
+        <small>Récent = signal visible actif; ancien = soupçon à revérifier; incertain = zone inconnue sans détail caché.</small>
+      </div>
       <small>${rollup.hiddenCopy}</small>
       <small>Certitude fog-safe: les zones inconnues restent séparées des faibles risques confirmés et ne nomment jamais cellule, cible ou relais.</small>
     </section>
@@ -5766,7 +5797,7 @@ function renderPostCommitIntrigueExposureMarkers(markers) {
           <circle class="intrigue-post-commit-marker__backplate" cx="${marker.center.x}%" cy="${marker.center.y}%" r="3.3"></circle>
           <text class="intrigue-post-commit-marker__glyph" x="${marker.center.x}%" y="${marker.center.y + 1.15}%" text-anchor="middle">${marker.glyph}</text>
           <text class="intrigue-post-commit-marker__label" x="${marker.center.x + 4.1}%" y="${marker.center.y - 1.15}%" text-anchor="start">${marker.label}</text>
-          <text class="intrigue-post-commit-marker__copy" x="${marker.center.x + 4.1}%" y="${marker.center.y + 2.25}%" text-anchor="start">${marker.certaintyLabel} · ${marker.direction === 'hidden' ? 'fog conservé' : 'voir synthèse finale'}</text>
+          <text class="intrigue-post-commit-marker__copy" x="${marker.center.x + 4.1}%" y="${marker.center.y + 2.25}%" text-anchor="start">${marker.freshnessLabel} · ${marker.certaintyLabel} · ${marker.direction === 'hidden' ? 'fog conservé' : 'voir synthèse finale'}</text>
         </g>
       `).join('')}
     </g>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2226,6 +2226,20 @@ button { font: inherit; }
 .intrigue-exposure-certainty-rollup b {
   color: #f8fafc;
 }
+.intrigue-exposure-freshness-rollup {
+  display: grid;
+  gap: 4px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(14, 165, 233, 0.12);
+  border: 1px solid rgba(125, 211, 252, 0.28);
+}
+.intrigue-exposure-freshness-rollup b {
+  color: #e0f2fe;
+}
+.intrigue-exposure-freshness-rollup span {
+  color: #f8fafc;
+}
 .overlay-anchor-shell--top { left: 18%; top: 3%; width: 64%; height: 9%; }
 .overlay-anchor-shell--left { left: 3%; top: 18%; width: 12%; height: 58%; }
 .overlay-anchor-shell--right { right: 3%; top: 18%; width: 12%; height: 58%; }


### PR DESCRIPTION
Delta: Implements #666.\n\nSummary:\n- adds fog-safe freshness labels for recent, stale, and uncertain intrigue exposure markers\n- separates freshness counts in the rollup so old suspicions and unknown zones are not treated as confirmed fresh signals\n- keeps marker/rollup copy conservative without naming hidden cells, targets, relays, or concealed states\n\nValidation:\n- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js\n- node --check web/app.js\n- git diff --check HEAD~1..HEAD\n- npm test