### PR TITLE
Epsilon: highlight climate cascade groups

### DIFF
--- a/test/ui/climate/webClimateCascadeGroupHighlights.test.js
+++ b/test/ui/climate/webClimateCascadeGroupHighlights.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('aggregated climate markers expose selected cascade groups while urgent markers stay pinned', () => {
+  assert.match(webAppSource, /function getClimateMarkerCascadeKey/);
+  assert.match(webAppSource, /function buildSelectedClimateCascadeGroup/);
+  assert.match(webAppSource, /getClimateMarkerCascadeKey\(marker\) === key/);
+  assert.match(webAppSource, /Groupe cascade/);
+  assert.match(webAppSource, /selectedCascadeGroup/);
+  assert.match(webAppSource, /renderSelectedClimateCascadeGroup/);
+  assert.match(webAppSource, /Le groupe met en évidence les provinces du risque principal/);
+  assert.match(webAppSource, /has-climate-cascade-group/);
+  assert.match(webAppSource, /is-climate-cascade-group-primary/);
+  assert.match(webAppSource, /renderMapLayerStack\(shell, economyView, focusContext, cultureView, climateMarkerDensity\.visibleMarkers, climateMarkerDensity\.selectedCascadeGroup\)/);
+  assert.match(webAppSource, /marker\.status === 'cascade-active' \|\| marker\.status === 'hazard-unresolved'/);
+
+  assert.match(stylesSource, /\.map-climate-cascade-group/);
+  assert.match(stylesSource, /\.province-node\.has-climate-cascade-group::after/);
+  assert.match(stylesSource, /\.province-node\.is-climate-cascade-group-primary::after/);
+});

--- a/test/ui/climate/webClimateMarkerDensityControls.test.js
+++ b/test/ui/climate/webClimateMarkerDensityControls.test.js
@@ -16,7 +16,7 @@ test('climate post-commit markers have density controls that preserve urgent thr
   assert.match(webAppSource, /Priorité conservée aux cascades et aléas non résolus/);
   assert.match(webAppSource, /climateMarkerDensity = buildClimateMarkerDensityControl\(postCommitClimateMarkers, \{/);
   assert.match(webAppSource, /renderClimateMarkerDensityRollup\(climateMarkerDensity\)/);
-  assert.match(webAppSource, /renderMapLayerStack\(shell, economyView, focusContext, cultureView, climateMarkerDensity\.visibleMarkers\)/);
+  assert.match(webAppSource, /renderMapLayerStack\(shell, economyView, focusContext, cultureView, climateMarkerDensity\.visibleMarkers, climateMarkerDensity\.selectedCascadeGroup\)/);
 
   assert.match(stylesSource, /\.map-climate-density/);
   assert.match(stylesSource, /\.map-climate-density--grouped/);

--- a/test/ui/climate/webPostCommitClimateImpactMarkers.test.js
+++ b/test/ui/climate/webPostCommitClimateImpactMarkers.test.js
@@ -14,11 +14,11 @@ test('map exposes compact post-commit climate impact markers and detail copy', (
   assert.match(webAppSource, /cascade-active/);
   assert.match(webAppSource, /Lié au résumé climat cumulé/);
   assert.match(webAppSource, /Aucune intervention climat confirmée ne couvre encore cet aléa/);
-  assert.match(webAppSource, /slice\(0, 4\)/);
+  assert.match(webAppSource, /buildClimateMarkerDensityControl/);
   assert.match(webAppSource, /has-climate-post-commit/);
   assert.match(webAppSource, /province-node__climate-marker/);
   assert.match(webAppSource, /marqueur climat post-résolution/);
-  assert.match(webAppSource, /renderProvinceCard\(province, focusContext, postCommitClimateMarkers\)/);
+  assert.match(webAppSource, /renderProvinceCard\(province, focusContext, postCommitClimateMarkers, selectedClimateCascadeGroup\)/);
   assert.match(webAppSource, /renderPostCommitClimateMarkerDetail\(province, buildPostCommitClimateImpactMarkers/);
 
   assert.match(stylesSource, /\.province-node\.has-climate-post-commit/);

--- a/web/app.js
+++ b/web/app.js
@@ -1238,7 +1238,7 @@ function renderFocusedLogisticsOutcomeGroup(province) {
 }
 
 
-function renderProvinceCard(province, focusContext, postCommitClimateMarkers = []) {
+function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null) {
   const layout = province.geometry.layout ?? getProvinceLayout(province.provinceId);
   const badges = province.badges.map((badge) => `<span class="province-badge">${badge}</span>`).join('');
   const isNeighbor = focusContext.neighborIds.has(province.provinceId);
@@ -1250,15 +1250,17 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
   const militaryOutcomeMarker = getMilitaryOutcomeMarkerForProvince(province.provinceId);
   const logisticsOutcomeMarker = getLogisticsOutcomeMarkerForProvince(province.provinceId);
   const climateMarker = postCommitClimateMarkers.find((marker) => marker.provinceId === province.provinceId) ?? null;
+  const climateCascadeGroupMarker = selectedClimateCascadeGroup?.markers.find((marker) => marker.provinceId === province.provinceId) ?? null;
   const isReadinessHighlight = Boolean(readinessTone);
   const isMilitaryOutcomeHighlight = Boolean(militaryOutcomeMarker);
   const isLogisticsOutcomeHighlight = Boolean(logisticsOutcomeMarker);
   const isClimateOutcomeHighlight = Boolean(climateMarker);
-  const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && !isReadinessHighlight && !isMilitaryOutcomeHighlight && !isLogisticsOutcomeHighlight && !isClimateOutcomeHighlight && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince || state.readinessFocusProvinceId);
+  const isClimateCascadeGroupHighlight = Boolean(climateCascadeGroupMarker);
+  const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && !isReadinessHighlight && !isMilitaryOutcomeHighlight && !isLogisticsOutcomeHighlight && !isClimateOutcomeHighlight && !isClimateCascadeGroupHighlight && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince || state.readinessFocusProvinceId);
   const tacticalState = province.contested ? 'front contesté' : province.occupied ? 'occupation' : 'contrôle stable';
   const readinessLabel = readinessTone === 'danger' ? 'menace immédiate' : readinessTone === 'warning' ? 'préparation insuffisante' : readinessTone === 'ready' ? 'opportunité tactique' : null;
   const economyBlockerLabel = economyBlocker ? `${economyBlocker.blocker}: ${economyBlocker.summary}` : null;
-  const selectionSignal = climateMarker ? 'CLIMAT' : economyBlocker ? 'BLOCAGE' : isMilitaryOutcomeHighlight ? 'RÉSOLU' : isReadinessHighlight ? 'ALERTE' : isSelected ? 'ACTIF' : isHovered ? 'SURVOL' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
+  const selectionSignal = climateMarker ? 'CLIMAT' : climateCascadeGroupMarker ? 'GROUPE' : economyBlocker ? 'BLOCAGE' : isMilitaryOutcomeHighlight ? 'RÉSOLU' : isReadinessHighlight ? 'ALERTE' : isSelected ? 'ACTIF' : isHovered ? 'SURVOL' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
   const classes = [
     'province-node',
     isSelected ? 'is-selected' : '',
@@ -1274,6 +1276,8 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
     logisticsOutcomeMarker ? `has-logistics-outcome--${logisticsOutcomeMarker.tone}` : '',
     climateMarker ? 'has-climate-post-commit' : '',
     climateMarker ? `has-climate-post-commit--${climateMarker.status}` : '',
+    climateCascadeGroupMarker ? 'has-climate-cascade-group' : '',
+    climateCascadeGroupMarker?.provinceId === selectedClimateCascadeGroup?.primaryProvinceId ? 'is-climate-cascade-group-primary' : '',
     readinessTone ? `is-readiness-${readinessTone}` : '',
     isMuted ? 'is-muted' : '',
     province.contested ? 'is-contested' : '',
@@ -1290,8 +1294,8 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
       data-economy-blocker="${economyBlockerLabel ?? ''}"
       data-military-outcome="${militaryOutcomeMarker?.label ?? ''}"
       data-logistics-outcome="${logisticsOutcomeMarker?.label ?? ''}"
-      data-climate-outcome="${climateMarker?.label ?? ''}"
-      title="${climateMarker ? `${climateMarker.label} — ${climateMarker.summary}` : logisticsOutcomeMarker ? `${logisticsOutcomeMarker.label}: ${logisticsOutcomeMarker.detail}` : economyBlocker ? `${economyBlocker.summary} — ${economyBlocker.effect}` : militaryOutcomeMarker ? `${militaryOutcomeMarker.label} — ${militaryOutcomeMarker.changed}` : province.label}"
+      data-climate-outcome="${climateMarker?.label ?? climateCascadeGroupMarker?.label ?? ''}"
+      title="${climateMarker ? `${climateMarker.label} — ${climateMarker.summary}` : climateCascadeGroupMarker ? `${selectedClimateCascadeGroup.label}: ${climateCascadeGroupMarker.summary}` : logisticsOutcomeMarker ? `${logisticsOutcomeMarker.label}: ${logisticsOutcomeMarker.detail}` : economyBlocker ? `${economyBlocker.summary} — ${economyBlocker.effect}` : militaryOutcomeMarker ? `${militaryOutcomeMarker.label} — ${militaryOutcomeMarker.changed}` : province.label}"
       style="left:${layout.x}%;top:${layout.y}%;width:${layout.w}%;height:${layout.h}%;--province-fill:${province.style.fill};--province-border:${province.style.border};--province-shape:${getProvinceShape(province.provinceId)};"
       aria-pressed="${province.selectionState.selected}"
       aria-label="${province.label}, ${climateMarker ? `marqueur climat post-résolution: ${climateMarker.label}, ${climateMarker.summary}` : logisticsOutcomeMarker ? `résultat logistique post-commit: ${logisticsOutcomeMarker.label}, ${logisticsOutcomeMarker.detail}` : economyBlocker ? `blocage économie/logistique: ${economyBlocker.summary}, ${economyBlocker.effect}` : militaryOutcomeMarker ? `issue militaire post-commit: ${militaryOutcomeMarker.label}, ${militaryOutcomeMarker.changed}` : readinessLabel ? `cible préparation conflit: ${readinessLabel}` : tacticalState}, approvisionnement ${province.supplyTone}, loyauté ${province.loyalty}"
@@ -3285,6 +3289,38 @@ function getClimateMarkerDensityThreshold({ zoom = 1, viewportWidth = 1024, mobi
   return Math.max(3, Math.min(8, 4 + zoomAllowance - viewportPenalty - collapsedPenalty));
 }
 
+function getClimateMarkerCascadeKey(marker) {
+  if (!marker) {
+    return null;
+  }
+
+  const cascadeType = marker.summary?.split(':')[0]?.trim() || marker.label;
+  return `${marker.status}:${cascadeType}`;
+}
+
+function buildSelectedClimateCascadeGroup(markers, selectedProvinceId = null) {
+  const selectedMarker = markers.find((marker) => marker.provinceId === selectedProvinceId) ?? null;
+
+  if (!selectedMarker) {
+    return null;
+  }
+
+  const key = getClimateMarkerCascadeKey(selectedMarker);
+  const groupMarkers = markers
+    .filter((marker) => getClimateMarkerCascadeKey(marker) === key)
+    .sort((left, right) => left.priority - right.priority || left.provinceLabel.localeCompare(right.provinceLabel));
+  const urgentCount = groupMarkers.filter((marker) => marker.status === 'cascade-active' || marker.status === 'hazard-unresolved').length;
+
+  return {
+    key,
+    label: selectedMarker.status === 'cascade-active' ? `Groupe cascade ${selectedMarker.summary.split(':')[0]}` : `Groupe climat ${selectedMarker.label}`,
+    primaryProvinceId: selectedMarker.provinceId,
+    markers: groupMarkers,
+    urgentCount,
+    summary: `${groupMarkers.length} province${groupMarkers.length > 1 ? 's' : ''} liée${groupMarkers.length > 1 ? 's' : ''} au risque principal ${selectedMarker.summary}. ${urgentCount} urgence${urgentCount > 1 ? 's' : ''} reste${urgentCount > 1 ? 'nt' : ''} épinglée${urgentCount > 1 ? 's' : ''}.`,
+  };
+}
+
 function buildClimateMarkerDensityControl(markers, options = {}) {
   const maxVisible = getClimateMarkerDensityThreshold(options);
   const selectedProvinceId = options.selectedProvinceId ?? null;
@@ -3310,6 +3346,8 @@ function buildClimateMarkerDensityControl(markers, options = {}) {
   }, {});
   const thresholdReason = `Seuil ${maxVisible} marqueurs (zoom ${Math.round((options.zoom ?? 1) * 100)}%, viewport ${options.viewportWidth ?? 1024}px${options.mobileMapExpanded === false ? ', carte mobile réduite' : ''}).`;
 
+  const selectedCascadeGroup = buildSelectedClimateCascadeGroup(markers, selectedProvinceId);
+
   return {
     state: groupedMarkers.length > 0 ? 'grouped' : markers.length > maxVisible ? 'dense' : 'clear',
     maxVisible,
@@ -3321,6 +3359,7 @@ function buildClimateMarkerDensityControl(markers, options = {}) {
     groupedCount: groupedMarkers.length,
     groupedByStatus,
     thresholdReason,
+    selectedCascadeGroup,
     summary: groupedMarkers.length > 0
       ? `${visibleMarkers.length} marqueur${visibleMarkers.length > 1 ? 's' : ''} climat affiché${visibleMarkers.length > 1 ? 's' : ''}; ${groupedMarkers.length} réduit${groupedMarkers.length > 1 ? 's' : ''}/retardé${groupedMarkers.length > 1 ? 's' : ''} regroupé${groupedMarkers.length > 1 ? 's' : ''} selon le zoom/viewport. ${urgentMarkers.length} urgence${urgentMarkers.length > 1 ? 's' : ''} cascade/aléa reste${urgentMarkers.length > 1 ? 'nt' : ''} visible${urgentMarkers.length > 1 ? 's' : ''}${selectedMarker ? '; la province sélectionnée reste accessible' : ''}.`
       : markers.length > 0
@@ -3347,6 +3386,23 @@ function renderClimateMarkerDensityRollup(control) {
       <p>${control.summary}</p>
       <small>${control.thresholdReason}</small>
       ${groupedStatuses ? `<small>Regroupés: ${groupedStatuses}. Priorité conservée aux cascades et aléas non résolus${control.selectedPinned ? '; détail de province sélectionnée préservé' : ''}.</small>` : '<small>Cascades et aléas non résolus restent prioritaires sur la carte.</small>'}
+    </section>
+  `;
+}
+
+function renderSelectedClimateCascadeGroup(group) {
+  if (!group || group.markers.length <= 1) {
+    return '';
+  }
+
+  return `
+    <section class="map-climate-cascade-group" aria-label="Groupe de cascade climat sélectionné">
+      <div>
+        <strong>${group.label}</strong>
+        <span>${group.markers.length} provinces liées · ${group.urgentCount} urgentes</span>
+      </div>
+      <p>${group.summary}</p>
+      <small>Le groupe met en évidence les provinces du risque principal pendant que les autres marqueurs restent calmes.</small>
     </section>
   `;
 }
@@ -8521,7 +8577,7 @@ function renderTacticalCoordinateGrid() {
   `;
 }
 
-function getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = []) {
+function getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null) {
   return [
     { key: 'backdrop', className: 'map-layer map-layer--backdrop', content: `<div class="map-backdrop"></div>${renderTacticalCoordinateGrid()}` },
     { key: 'terrain', className: 'map-layer map-layer--terrain', content: renderTerrainDecor() },
@@ -8531,12 +8587,12 @@ function getMapRenderLayers(shell, economyView, focusContext, cultureView, postC
     { key: 'anchors', className: 'map-layer map-layer--anchors', content: renderMapAnchorShells() },
     { key: 'economy', className: 'map-layer map-layer--economy', content: `${renderEconomyMapOverlay(economyView)}${renderCultureMapOverlay(cultureView)}` },
     { key: 'hud', className: 'map-layer map-layer--hud', content: `${renderCityQuickPanel(economyView)}<div class="focus-hint">${focusContext.selectedProvince ? `Sélection active, ${focusContext.selectedProvince.label}` : 'Survolez une province pour déplacer le focus'}</div>` },
-    { key: 'interactions', className: 'map-layer map-layer--interactions', content: `${shell.provinces.map((province) => renderProvinceCard(province, focusContext, postCommitClimateMarkers)).join('')}${renderProvincePopup(shell)}` },
+    { key: 'interactions', className: 'map-layer map-layer--interactions', content: `${shell.provinces.map((province) => renderProvinceCard(province, focusContext, postCommitClimateMarkers, selectedClimateCascadeGroup)).join('')}${renderProvincePopup(shell)}` },
   ];
 }
 
-function renderMapLayerStack(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = []) {
-  return getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers)
+function renderMapLayerStack(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null) {
+  return getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers, selectedClimateCascadeGroup)
     .map((layer) => `<div class="${layer.className}" data-map-layer="${layer.key}">${layer.content}</div>`)
     .join('');
 }
@@ -8819,6 +8875,7 @@ function render() {
           ${renderMapClimateInterventionWindows(climateInterventionWindows)}
           ${renderCumulativeClimateImpactSummary(cumulativeClimateImpact)}
           ${renderClimateMarkerDensityRollup(climateMarkerDensity)}
+          ${renderSelectedClimateCascadeGroup(climateMarkerDensity.selectedCascadeGroup)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">
@@ -8852,7 +8909,7 @@ function render() {
             ${renderMilitaryOutcomeMarkerFilters(state.lastMilitaryOutcomeMarkers)}
             ${renderMilitaryFrontMarkerSummaries(state.lastMilitaryOutcomeMarkers)}
             <div class="map-viewport" style="transform:${getMapViewportTransform()};">
-              ${renderMapLayerStack(shell, economyView, focusContext, cultureView, climateMarkerDensity.visibleMarkers)}
+              ${renderMapLayerStack(shell, economyView, focusContext, cultureView, climateMarkerDensity.visibleMarkers, climateMarkerDensity.selectedCascadeGroup)}
               ${renderIntrigueMapOverlay(intrigueView)}
             </div>
             ${renderBottomTray(economyView, intrigueView, cultureView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -334,6 +334,32 @@ button { font: inherit; }
 .map-climate-density p { color: #dbeafe; }
 .map-climate-density small { color: #bae6fd; }
 
+.map-climate-cascade-group {
+  display: grid;
+  gap: 7px;
+  margin-top: 8px;
+  max-width: 72ch;
+  padding: 10px 12px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(127, 29, 29, 0.34), rgba(67, 56, 202, 0.18));
+  border: 1px solid rgba(248, 113, 113, 0.28);
+}
+.map-climate-cascade-group div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-climate-cascade-group p,
+.map-climate-cascade-group span,
+.map-climate-cascade-group small {
+  color: #fecaca;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-climate-cascade-group small { color: #fde68a; }
+
 .economy-turn-pulse {
   margin-top: 12px;
   display: inline-flex;
@@ -851,6 +877,14 @@ button { font: inherit; }
 .province-node.has-climate-post-commit--cascade-active::before { border-color: rgba(248, 113, 113, 0.82); }
 .province-node.has-climate-post-commit--hazard-delayed::before { border-color: rgba(251, 191, 36, 0.8); }
 .province-node.has-climate-post-commit--risk-reduced::before { border-color: rgba(74, 222, 128, 0.82); }
+.province-node.has-climate-cascade-group::after {
+  border-color: rgba(251, 146, 60, 0.6);
+  box-shadow: 0 0 16px rgba(251, 146, 60, 0.2);
+}
+.province-node.is-climate-cascade-group-primary::after {
+  border-color: rgba(248, 113, 113, 0.88);
+  box-shadow: 0 0 22px rgba(248, 113, 113, 0.32);
+}
 .province-node__climate-marker {
   position: relative;
   z-index: 1;


### PR DESCRIPTION
Epsilon: Implements #667.

Summary:
- Adds selected climate cascade grouping for aggregated climate markers, keyed by risk/status so related provinces can be highlighted together.
- Preserves cascade/unresolved hazard pinning while adding calmer group highlighting for selected aggregated risks.
- Adds a compact selected cascade group rollup explaining linked provinces and urgent pinned markers.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webClimateCascadeGroupHighlights.test.js test/ui/climate/webAdaptiveClimateMarkerDensityThresholds.test.js test/ui/climate/webClimateMarkerDensityControls.test.js test/ui/climate/webPostCommitClimateImpactMarkers.test.js
- npm test