### PR TITLE
Delta: add intrigue timeline hints

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -259,3 +259,20 @@ test('intrigue exposure markers show fog-safe freshness cues', () => {
   assert.match(webAppSource, /aria-label="Fraîcheur fog-safe des marqueurs intrigue"/);
   assert.match(stylesSource, /intrigue-exposure-freshness-rollup/);
 });
+
+test('selected province intrigue details show ordered fog-safe timeline hints', () => {
+  assert.match(webAppSource, /function buildProvinceIntrigueExposureTimelineHints/);
+  assert.match(webAppSource, /function renderProvinceIntrigueExposureTimelineHints/);
+  assert.match(webAppSource, /resolveIntrigueExposureTimelineHint/);
+  assert.match(webAppSource, /right\.priority - left\.priority/);
+  assert.match(webAppSource, /Signal récent/);
+  assert.match(webAppSource, /Soupçon ancien/);
+  assert.match(webAppSource, /Zone non résolue/);
+  assert.match(webAppSource, /Menace visible récente: vérifier ou contenir avant d’empiler un ordre long/);
+  assert.match(webAppSource, /Information ancienne: confirmer la province avant intervention lourde/);
+  assert.match(webAppSource, /Fraîcheur inconnue sous brouillard: inspecter sans inférer cellule, cible ou relais/);
+  assert.match(webAppSource, /Lecture fog-safe: les indices anciens ou inconnus n’ajoutent aucun nom de cellule, cible ou relais caché/);
+  assert.match(webAppSource, /renderProvinceIntrigueExposureTimelineHints\(province, intrigueView\)/);
+  assert.match(stylesSource, /province-intrigue-timeline-hints/);
+  assert.match(stylesSource, /province-intrigue-timeline-hint--danger/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3772,6 +3772,96 @@ function findProvinceIntrigueDrillDown(province, intrigueView) {
     .find((entry) => entry.locationId === provinceId)?.drillDown ?? null;
 }
 
+function resolveIntrigueExposureTimelineHint(entry, province) {
+  const response = entry.drillDown?.quickResponses?.find((candidate) => candidate.code === entry.drillDown.recommendedResponseCode)
+    ?? entry.drillDown?.quickResponses?.[0]
+    ?? null;
+  const fogLimited = !entry.showSecondaryDetails && entry.sabotageRiskLevel !== 'high' && entry.metrics.exposedCellCount === 0;
+  const certainty = fogLimited
+    ? 'unknown'
+    : entry.metrics.exposedCellCount > 0 || entry.showSecondaryDetails
+      ? 'confirmed'
+      : 'suspected';
+  const freshness = certainty === 'unknown'
+    ? 'unresolved'
+    : entry.sabotageRiskLevel === 'high' || entry.metrics.exposedCellCount > 0 || (response?.heatGenerated ?? 0) >= 10
+      ? 'fresh'
+      : 'stale';
+  const priority = (certainty === 'confirmed' ? 100 : certainty === 'suspected' ? 40 : 0)
+    + (freshness === 'fresh' ? 60 : freshness === 'stale' ? 15 : 0)
+    + (entry.sabotageRiskLevel === 'high' ? 30 : entry.sabotageRiskLevel === 'medium' ? 12 : 0);
+  const tone = freshness === 'fresh' && certainty === 'confirmed'
+    ? 'danger'
+    : freshness === 'stale'
+      ? 'watch'
+      : certainty === 'unknown'
+        ? 'masked'
+        : 'warning';
+  const freshnessLabel = freshness === 'fresh'
+    ? 'Signal récent'
+    : freshness === 'stale'
+      ? 'Soupçon ancien'
+      : 'Zone non résolue';
+  const detail = freshness === 'fresh'
+    ? 'Menace visible récente: vérifier ou contenir avant d’empiler un ordre long.'
+    : freshness === 'stale'
+      ? 'Information ancienne: confirmer la province avant intervention lourde.'
+      : 'Fraîcheur inconnue sous brouillard: inspecter sans inférer cellule, cible ou relais.';
+
+  return {
+    locationId: entry.locationId,
+    locationName: entry.locationName,
+    scope: entry.locationId === province.provinceId ? 'province sélectionnée' : 'voisinage surveillé',
+    certainty,
+    freshness,
+    priority,
+    tone,
+    freshnessLabel,
+    certaintyLabel: certainty === 'confirmed' ? 'confirmé' : certainty === 'suspected' ? 'soupçon' : 'inconnu',
+    responseLabel: response?.label ?? 'surveillance prudente',
+    detail,
+  };
+}
+
+function buildProvinceIntrigueExposureTimelineHints(province, intrigueView) {
+  const neighborIds = new Set(province?.neighborIds ?? []);
+
+  return (intrigueView?.map?.entries ?? [])
+    .filter((entry) => entry.locationId === province?.provinceId || neighborIds.has(entry.locationId))
+    .map((entry) => resolveIntrigueExposureTimelineHint(entry, province))
+    .sort((left, right) => right.priority - left.priority || left.locationName.localeCompare(right.locationName))
+    .slice(0, 4);
+}
+
+function renderProvinceIntrigueExposureTimelineHints(province, intrigueView) {
+  const hints = buildProvinceIntrigueExposureTimelineHints(province, intrigueView);
+
+  if (hints.length === 0) {
+    return '';
+  }
+
+  return `
+    <section class="province-intrigue-timeline-hints" aria-label="Timeline fog-safe des expositions intrigue">
+      <div class="province-intrigue-timeline-hints__header">
+        <strong>Timeline intrigue</strong>
+        <span>fraîcheur · certitude · brouillard</span>
+      </div>
+      <ol class="province-intrigue-timeline-hints__list">
+        ${hints.map((hint) => `
+          <li class="province-intrigue-timeline-hint province-intrigue-timeline-hint--${hint.tone}">
+            <div>
+              <b>${hint.freshnessLabel}</b>
+              <span>${hint.locationName} · ${hint.scope}</span>
+            </div>
+            <small>${hint.certaintyLabel} · ${hint.responseLabel} · ${hint.detail}</small>
+          </li>
+        `).join('')}
+      </ol>
+      <small>Lecture fog-safe: les indices anciens ou inconnus n’ajoutent aucun nom de cellule, cible ou relais caché.</small>
+    </section>
+  `;
+}
+
 function buildProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView) {
   const drillDown = findProvinceIntrigueDrillDown(province, intrigueView);
   const selectedResponse = drillDown?.quickResponses?.find((response) => response.code === drillDown.recommendedResponseCode)
@@ -5947,6 +6037,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
         </div>
       </div>
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
+      ${renderProvinceIntrigueExposureTimelineHints(province, intrigueView)}
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceConflictNextAction(province, shell, focusContext, intrigueView)}
       ${renderQueuedMilitaryMapActionConfirmation(province, shell, intrigueView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -7684,6 +7684,53 @@ button { font: inherit; }
   margin-top: 3px;
   color: var(--muted);
 }
+.province-intrigue-timeline-hints {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(103, 232, 249, 0.18);
+}
+.province-intrigue-timeline-hints__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-timeline-hints__header span,
+.province-intrigue-timeline-hints > small {
+  color: var(--muted);
+}
+.province-intrigue-timeline-hints__list {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.province-intrigue-timeline-hint {
+  padding: 9px 10px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.3);
+  border-left: 3px solid rgba(148, 163, 184, 0.46);
+}
+.province-intrigue-timeline-hint--danger { border-left-color: rgba(248, 113, 113, 0.78); }
+.province-intrigue-timeline-hint--warning { border-left-color: rgba(250, 204, 21, 0.72); }
+.province-intrigue-timeline-hint--watch { border-left-color: rgba(56, 189, 248, 0.68); }
+.province-intrigue-timeline-hint--masked { border-left-color: rgba(148, 163, 184, 0.6); }
+.province-intrigue-timeline-hint div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.province-intrigue-timeline-hint span,
+.province-intrigue-timeline-hint small {
+  color: var(--muted);
+}
+.province-intrigue-timeline-hint small {
+  display: block;
+  margin-top: 4px;
+}
 
 
 


### PR DESCRIPTION
Delta: Implements #676.\n\nSummary:\n- adds selected-province intrigue timeline hints for fresh, stale, and unresolved exposure signals\n- sorts fresh confirmed/high-risk signals ahead of stale or uncertain entries\n- keeps all timeline wording fog-safe without naming hidden cells, targets, or relays\n\nValidation:\n- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js\n- node --check web/app.js\n- git diff --check\n- npm test