### PR TITLE
Alpha: add front overlay overflow summaries

### DIFF
--- a/test/ui/war/webProvinceWarOverlayOverflowSummary.test.js
+++ b/test/ui/war/webProvinceWarOverlayOverflowSummary.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('province cards summarize hidden dense war/front overlays', () => {
+  assert.match(webAppSource, /function buildProvinceWarOverlayOverflowSummary/);
+  assert.match(webAppSource, /function renderProvinceWarOverlayOverflowSummary/);
+  assert.match(webAppSource, /warOverlays\.slice\(displayLimit\)/);
+  assert.match(webAppSource, /frontCount/);
+  assert.match(webAppSource, /supplyCount/);
+  assert.match(webAppSource, /front\$\{frontCount > 1 \? 's' : ''\}/);
+  assert.match(webAppSource, /alerte\$\{supplyCount > 1 \? 's' : ''\} ravitaillement/);
+  assert.match(webAppSource, /signaux? militaire/);
+  assert.match(webAppSource, /province-node__war-overflow/);
+  assert.match(webAppSource, /renderProvinceWarOverlayOverflowSummary\(warOverlayOverflow\)/);
+  assert.match(stylesSource, /\.province-node__war-overflow/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1238,6 +1238,53 @@ function renderFocusedLogisticsOutcomeGroup(province) {
 }
 
 
+function buildProvinceWarOverlayOverflowSummary(province, overlays = {}, displayLimit = 2) {
+  const warOverlays = [
+    province.contested ? { kind: 'front', label: 'Front actif' } : null,
+    overlays.readinessTone ? { kind: 'front', label: 'Alerte préparation' } : null,
+    overlays.militaryOutcomeMarker ? { kind: 'front', label: overlays.militaryOutcomeMarker.label } : null,
+    overlays.logisticsOutcomeMarker ? { kind: 'supply', label: overlays.logisticsOutcomeMarker.label } : null,
+    ['collapsed', 'disrupted', 'strained'].includes(province.supplyLevel) ? { kind: 'supply', label: `Ravitaillement ${province.supplyTone}` } : null,
+  ].filter(Boolean);
+  const hidden = warOverlays.slice(displayLimit);
+
+  if (hidden.length === 0) {
+    return null;
+  }
+
+  const frontCount = hidden.filter((entry) => entry.kind === 'front').length;
+  const supplyCount = hidden.filter((entry) => entry.kind === 'supply').length;
+  const parts = [
+    frontCount > 0 ? `${frontCount} front${frontCount > 1 ? 's' : ''}` : null,
+    supplyCount > 0 ? `${supplyCount} alerte${supplyCount > 1 ? 's' : ''} ravitaillement` : null,
+  ].filter(Boolean);
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return {
+    hiddenCount: hidden.length,
+    frontCount,
+    supplyCount,
+    label: parts.join(' / '),
+    detail: `${hidden.length} signal${hidden.length > 1 ? 'aux' : ''} militaire${hidden.length > 1 ? 's' : ''} masqué${hidden.length > 1 ? 's' : ''} par la carte compacte.`,
+  };
+}
+
+function renderProvinceWarOverlayOverflowSummary(summary) {
+  if (!summary) {
+    return '';
+  }
+
+  return `
+    <span class="province-node__war-overflow" aria-label="Résumé des signaux militaires masqués: ${summary.detail}">
+      <b>${summary.label}</b>
+      <small>${summary.detail}</small>
+    </span>
+  `;
+}
+
 function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null) {
   const layout = province.geometry.layout ?? getProvinceLayout(province.provinceId);
   const badges = province.badges.map((badge) => `<span class="province-badge">${badge}</span>`).join('');
@@ -1251,6 +1298,7 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
   const logisticsOutcomeMarker = getLogisticsOutcomeMarkerForProvince(province.provinceId);
   const climateMarker = postCommitClimateMarkers.find((marker) => marker.provinceId === province.provinceId) ?? null;
   const climateCascadeGroupMarker = selectedClimateCascadeGroup?.markers.find((marker) => marker.provinceId === province.provinceId) ?? null;
+  const warOverlayOverflow = buildProvinceWarOverlayOverflowSummary(province, { readinessTone, militaryOutcomeMarker, logisticsOutcomeMarker });
   const isReadinessHighlight = Boolean(readinessTone);
   const isMilitaryOutcomeHighlight = Boolean(militaryOutcomeMarker);
   const isLogisticsOutcomeHighlight = Boolean(logisticsOutcomeMarker);
@@ -1310,6 +1358,7 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
       ${climateMarker ? `<span class="province-node__climate-marker"><b>${climateMarker.label}</b>${climateMarker.summary}<small>${climateMarker.detail}</small></span>` : ''}
       <span class="province-node__badges">${badges}</span>
       ${renderPostCommitMilitaryOutcomeMarker(militaryOutcomeMarker)}
+      ${renderProvinceWarOverlayOverflowSummary(warOverlayOverflow)}
       ${isNeighbor ? '<span class="province-node__link">Voisine directe</span>' : ''}
     </button>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -2457,6 +2457,28 @@ button { font: inherit; }
 .province-node__military-outcome--worsened { border-color: rgba(251, 113, 133, 0.5); color: #fecdd3; }
 .province-node__military-outcome--blocked { border-color: rgba(148, 163, 184, 0.44); color: #e2e8f0; }
 .province-node__military-outcome--risk { border-color: rgba(251, 191, 36, 0.48); color: #fde68a; }
+.province-node__war-overflow {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  gap: 2px;
+  max-width: 100%;
+  padding: 5px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(251, 191, 36, 0.34);
+  color: #fde68a;
+  font-size: 10px;
+  line-height: 1.2;
+}
+.province-node__war-overflow b {
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.province-node__war-overflow small {
+  color: var(--muted);
+  font-size: 9px;
+}
 .province-node.is-neighbor {
   z-index: 5;
   filter: saturate(1.06);


### PR DESCRIPTION
Alpha: Implements #673.

Summary:
- Adds a compact province-card overflow summary for dense war/front overlays hidden by the compact card limit.
- Summarizes hidden military signals as front counts and supply-alert counts instead of leaving dense war provinces as generic hidden content.
- Leaves existing filter behavior and selected-province details untouched; non-war overlays are not changed.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webProvinceWarOverlayOverflowSummary.test.js test/ui/war/webPinnedCriticalMilitaryMarkers.test.js
- npm test (479 tests)
- git diff --check

Zeta: PR prête pour revue. Merci de valider avant tout merge.
