### PR TITLE
Beta: surface route bottleneck warnings

### DIFF
--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -7,6 +7,12 @@ const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta
 
 test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /function renderProvinceLogisticsChoicePreview/);
+  assert.match(webAppSource, /buildProvinceLogisticsBottleneckWarnings/);
+  assert.match(webAppSource, /province-logistics-bottleneck-warning/);
+  assert.match(webAppSource, /Alerte goulot logistique/);
+  assert.match(webAppSource, /Route logistique sous tension/);
+  assert.match(webAppSource, /stock en tension haute/);
+  assert.match(webAppSource, /sous tension autour de la province/);
   assert.match(webAppSource, /province-logistics-cause-summary/);
   assert.match(webAppSource, /Cause locale/);
   assert.match(webAppSource, /option\.causeLabel/);
@@ -94,6 +100,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-recovery--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck--high/);
   assert.match(stylesSource, /province-logistics-bottleneck--medium/);
+  assert.match(stylesSource, /province-logistics-bottleneck-warning--high/);
+  assert.match(stylesSource, /province-logistics-bottleneck-warning--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck--low/);
   assert.match(stylesSource, /province-logistics-timeline-summary--queued/);
   assert.match(stylesSource, /province-logistics-downstream-summary--aggravée/);

--- a/web/app.js
+++ b/web/app.js
@@ -1816,10 +1816,42 @@ function buildProvinceLogisticsBottleneckComparison(province, economyView) {
     .slice(0, 3);
 }
 
+function buildProvinceLogisticsBottleneckWarnings(province, economyView, comparisons = null) {
+  if (!province || !economyView) {
+    return [];
+  }
+
+  const entries = comparisons ?? buildProvinceLogisticsBottleneckComparison(province, economyView);
+  const provinceCities = economyView.overlay.cities.filter((city) => city.regionId === province.provinceId);
+  const tensionByCityId = Object.fromEntries(economyView.comparison.rows.map((row) => [row.cityId, row]));
+  const localShortageCity = provinceCities.find((city) => tensionByCityId[city.cityId]?.tensionLevel === 'high')
+    ?? provinceCities.slice().sort((left, right) => left.resources.totalStock - right.resources.totalStock)[0]
+    ?? null;
+  const strainedRoutes = entries.filter((entry) => entry.tone === 'high' || entry.tone === 'medium');
+
+  if (strainedRoutes.length === 0) {
+    return [];
+  }
+
+  const priorityRoute = strainedRoutes[0];
+  const shortageContext = localShortageCity
+    ? `${localShortageCity.cityName}: ${tensionByCityId[localShortageCity.cityId]?.tensionLevel === 'high' ? 'stock en tension haute' : `${localShortageCity.resources.totalStock} unités disponibles`}`
+    : 'stock local à vérifier';
+  const relatedRoutes = strainedRoutes.slice(0, 2).map((entry) => entry.routeName).join(' + ');
+
+  return [{
+    tone: priorityRoute.tone,
+    label: priorityRoute.tone === 'high' ? 'Alerte goulot logistique' : 'Route logistique sous tension',
+    text: `${shortageContext}; ${relatedRoutes} explique le marqueur par ${priorityRoute.consequence.toLowerCase()}.`,
+    routeCount: strainedRoutes.length,
+  }];
+}
+
 function renderProvinceLogisticsBottleneckComparison(province, economyView) {
   const comparisons = buildProvinceLogisticsBottleneckComparison(province, economyView);
+  const warnings = buildProvinceLogisticsBottleneckWarnings(province, economyView, comparisons);
 
-  if (comparisons.length < 2) {
+  if (comparisons.length < 2 && warnings.length === 0) {
     return '';
   }
 
@@ -1827,8 +1859,15 @@ function renderProvinceLogisticsBottleneckComparison(province, economyView) {
     <section class="province-logistics-comparison" aria-label="Comparatif des goulets logistiques">
       <div class="province-logistics-comparison__header">
         <strong>Goulets logistiques comparés</strong>
-        <span>${comparisons.length} routes liées</span>
+        <span>${comparisons.length} route${comparisons.length > 1 ? 's' : ''} liée${comparisons.length > 1 ? 's' : ''}</span>
       </div>
+      ${warnings.map((warning) => `
+        <div class="province-logistics-bottleneck-warning province-logistics-bottleneck-warning--${warning.tone}" role="note">
+          <b>${warning.label}</b>
+          <span>${warning.text}</span>
+          <small>${warning.routeCount} route${warning.routeCount > 1 ? 's' : ''} sous tension autour de la province.</small>
+        </div>
+      `).join('')}
       ${comparisons.map((entry, index) => `
         <article class="province-logistics-route province-logistics-route--${entry.tone} ${index === 0 ? 'is-priority' : ''}">
           <div class="province-logistics-route__rank">${index === 0 ? 'Priorité' : `#${index + 1}`}</div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -8608,3 +8608,30 @@ button { font: inherit; }
 .culture-tension-marker-card--trend-falling p mark { background: rgba(74, 222, 128, 0.14); color: #bbf7d0; }
 .culture-tension-marker-card--trend-stable p mark { background: rgba(251, 191, 36, 0.14); color: #fde68a; }
 .culture-tension-marker-card--trend-unknown p mark { background: rgba(148, 163, 184, 0.14); color: #cbd5e1; }
+.province-logistics-bottleneck-warning {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+.province-logistics-bottleneck-warning b {
+  color: #e0f2fe;
+}
+.province-logistics-bottleneck-warning span {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.province-logistics-bottleneck-warning small {
+  color: var(--muted);
+}
+.province-logistics-bottleneck-warning--high {
+  border-color: rgba(251, 113, 133, 0.5);
+  background: linear-gradient(135deg, rgba(127, 29, 29, 0.28), rgba(15, 23, 42, 0.62));
+}
+.province-logistics-bottleneck-warning--medium {
+  border-color: rgba(245, 158, 11, 0.42);
+  background: linear-gradient(135deg, rgba(120, 53, 15, 0.24), rgba(15, 23, 42, 0.58));
+}


### PR DESCRIPTION
Beta: Implements #674.

## Summary
- Adds a compact bottleneck warning before the selected-province logistics route comparison when connected routes are strained.
- Derives warning context from existing route stress, city tension, and local stock data; healthy routes remain quiet.
- Keeps the existing route comparison/details list and filter-related logistics UI intact.

## Validation
- npm test (478 OK)
- targeted economy UI tests (7 OK)
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check
