### PR TITLE
Gamma: group culture discoveries by urgency

### DIFF
--- a/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
+++ b/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
@@ -1,0 +1,156 @@
+const GROUP_DEFINITIONS = Object.freeze({
+  urgent: {
+    label: 'Urgent',
+    summary: 'À traiter avant le lore de fond.',
+    rank: 3,
+  },
+  active: {
+    label: 'Actif',
+    summary: 'Signal en cours ou relié à une recherche.',
+    rank: 2,
+  },
+  background: {
+    label: 'Fond',
+    summary: 'Découverte disponible sans urgence claire.',
+    rank: 1,
+  },
+});
+
+function normalizeText(value, fallback = '') {
+  return String(value ?? fallback).trim();
+}
+
+function buildDiscoveryItems(selectedMarker) {
+  return (selectedMarker?.regionalDiscoveryLinks ?? []).map((link) => {
+    const linkedEventCount = Number(link.eventCount ?? link.eventIds?.length ?? 0);
+    const activeResearchCount = Number(link.activeResearchCount ?? selectedMarker.activeResearchCount ?? 0);
+    const urgentMarker = selectedMarker.markerType === 'fragmented';
+    const group = urgentMarker || (linkedEventCount > 0 && selectedMarker.influenceTier === 'dominant')
+      ? 'urgent'
+      : activeResearchCount > 0 || linkedEventCount > 0
+        ? 'active'
+        : 'background';
+    const cause = urgentMarker
+      ? 'Tension locale'
+      : linkedEventCount > 0
+        ? `${linkedEventCount} repère${linkedEventCount > 1 ? 's' : ''}`
+        : activeResearchCount > 0
+          ? 'Recherche active'
+          : 'Catalogue';
+
+    return {
+      itemId: `discovery:${link.linkId ?? `${link.regionId}:${link.cultureId}:${link.discoveryId}`}`,
+      kind: 'discovery',
+      group,
+      label: normalizeText(link.discoveryId, 'Découverte'),
+      shortLabel: normalizeText(link.discoveryId, 'Découverte'),
+      cultureName: normalizeText(selectedMarker?.cultureName, link.cultureName ?? 'Culture locale'),
+      regionId: normalizeText(link.regionId, selectedMarker?.regionId),
+      cause,
+      detail: normalizeText(link.label, `${link.discoveryId} · ${link.regionId}`),
+      priority: GROUP_DEFINITIONS[group].rank * 100 + linkedEventCount * 10 + activeResearchCount,
+    };
+  });
+}
+
+function buildEventItems(selectedMarker) {
+  return (selectedMarker?.eventPopups ?? []).map((event) => {
+    const importance = Number(event.importance ?? 0);
+    const discoveryCount = Number(event.discoveries?.length ?? 0);
+    const group = importance >= 4
+      ? 'urgent'
+      : importance >= 3 || discoveryCount > 0
+        ? 'active'
+        : 'background';
+    const cause = importance >= 4
+      ? `IMP-${importance}`
+      : discoveryCount > 0
+        ? `${discoveryCount} découverte${discoveryCount > 1 ? 's' : ''}`
+        : 'Historique';
+
+    return {
+      itemId: `event:${event.popupId ?? event.eventId ?? event.title}`,
+      kind: 'event',
+      group,
+      label: normalizeText(event.title, 'Repère historique'),
+      shortLabel: normalizeText(event.title, 'Repère historique'),
+      cultureName: normalizeText(selectedMarker?.cultureName, 'Culture locale'),
+      regionId: normalizeText(selectedMarker?.regionId, ''),
+      cause,
+      detail: normalizeText(event.summary, event.label ?? event.title),
+      priority: GROUP_DEFINITIONS[group].rank * 100 + importance * 10 + discoveryCount,
+    };
+  });
+}
+
+function buildClusterPinItems(selectedCluster, selectedMarker) {
+  return (selectedCluster?.pins ?? []).map((pin) => {
+    const importance = Number(pin.importance ?? 0);
+    const group = pin.kind === 'event' && importance >= 4
+      ? 'urgent'
+      : pin.kind === 'event' || selectedMarker?.activeResearchCount > 0
+        ? 'active'
+        : 'background';
+    const cause = pin.kind === 'event'
+      ? `IMP-${importance || 'n/a'}`
+      : selectedMarker?.activeResearchCount > 0
+        ? 'Recherche active'
+        : 'Cluster';
+
+    return {
+      itemId: `cluster:${pin.pinId}`,
+      kind: pin.kind,
+      group,
+      label: normalizeText(pin.name, pin.type ?? 'Signal culturel'),
+      shortLabel: normalizeText(pin.name, pin.type ?? 'Signal culturel'),
+      cultureName: normalizeText(pin.cultureName, selectedMarker?.cultureName ?? 'Culture locale'),
+      regionId: normalizeText(pin.regionId, selectedMarker?.regionId),
+      cause,
+      detail: `${normalizeText(pin.type, 'Signal')} · ${normalizeText(pin.regionId, selectedMarker?.regionId)}`,
+      priority: GROUP_DEFINITIONS[group].rank * 100 + importance * 10,
+    };
+  });
+}
+
+function dedupeItems(items) {
+  const byKey = new Map();
+
+  for (const item of items) {
+    const key = `${item.kind}:${item.regionId}:${item.cultureName}:${item.label}`;
+    const existing = byKey.get(key);
+
+    if (!existing || item.priority > existing.priority) {
+      byKey.set(key, item);
+    }
+  }
+
+  return [...byKey.values()];
+}
+
+export function buildCultureDiscoveryUrgencyGroups({
+  selectedMarker = null,
+  selectedCluster = null,
+} = {}) {
+  const items = dedupeItems([
+    ...buildEventItems(selectedMarker),
+    ...buildDiscoveryItems(selectedMarker),
+    ...buildClusterPinItems(selectedCluster, selectedMarker),
+  ]).sort((left, right) => right.priority - left.priority || left.label.localeCompare(right.label));
+
+  const groups = Object.entries(GROUP_DEFINITIONS)
+    .map(([key, definition]) => ({
+      key,
+      label: definition.label,
+      summary: definition.summary,
+      items: items.filter((item) => item.group === key).slice(0, key === 'background' ? 3 : 4),
+    }))
+    .filter((group) => group.items.length > 0);
+
+  return {
+    state: groups.length > 0 ? 'active' : 'quiet',
+    summary: groups.length > 0
+      ? `${items.length} signal${items.length > 1 ? 's' : ''} culturel${items.length > 1 ? 's' : ''} groupé${items.length > 1 ? 's' : ''} par urgence.`
+      : 'Aucun signal culturel détaillé à grouper pour cette province.',
+    groups,
+  };
+}

--- a/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
+++ b/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCultureDiscoveryUrgencyGroups } from '../../../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
+
+test('buildCultureDiscoveryUrgencyGroups orders urgent and active culture signals before background lore', () => {
+  const groups = buildCultureDiscoveryUrgencyGroups({
+    selectedMarker: {
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      markerType: 'innovation',
+      influenceTier: 'dominant',
+      activeResearchCount: 1,
+      regionalDiscoveryLinks: [
+        {
+          linkId: 'river:aurora:routes',
+          regionId: 'river-gate',
+          cultureId: 'culture-aurora',
+          discoveryId: 'routes-célestes',
+          eventCount: 1,
+          activeResearchCount: 1,
+          label: 'routes-célestes · river-gate · 1 événement',
+        },
+        {
+          linkId: 'river:aurora:catalogue',
+          regionId: 'river-gate',
+          cultureId: 'culture-aurora',
+          discoveryId: 'catalogues-publics',
+          eventCount: 0,
+          activeResearchCount: 1,
+          label: 'catalogues-publics · river-gate',
+        },
+      ],
+      eventPopups: [
+        {
+          popupId: 'river:aurora:archive',
+          title: 'Ouverture des archives',
+          summary: 'Les maîtres-cartographes publient une route exploitable.',
+          importance: 4,
+          discoveries: ['routes-célestes'],
+        },
+        {
+          popupId: 'river:aurora:chant',
+          title: 'Chant de quai',
+          summary: 'Un chant ancien reste consultable.',
+          importance: 1,
+          discoveries: [],
+        },
+      ],
+    },
+  });
+
+  assert.equal(groups.state, 'active');
+  assert.deepEqual(groups.groups.map((group) => group.key), ['urgent', 'active', 'background']);
+  assert.equal(groups.groups[0].items[0].label, 'Ouverture des archives');
+  assert.match(groups.groups[0].items.map((item) => item.label).join(' | '), /routes-célestes/);
+  assert.equal(groups.groups[1].items[0].cause, 'Recherche active');
+  assert.equal(groups.groups[2].items[0].label, 'Chant de quai');
+});
+
+test('buildCultureDiscoveryUrgencyGroups names ambiguous empty states without duplicating marker data', () => {
+  assert.deepEqual(buildCultureDiscoveryUrgencyGroups(), {
+    state: 'quiet',
+    summary: 'Aucun signal culturel détaillé à grouper pour cette province.',
+    groups: [],
+  });
+
+  const grouped = buildCultureDiscoveryUrgencyGroups({
+    selectedMarker: {
+      regionId: 'red-ridge',
+      cultureName: 'Ligues des Forges',
+      markerType: 'fragmented',
+      influenceTier: 'emerging',
+      activeResearchCount: 0,
+      regionalDiscoveryLinks: [{
+        linkId: 'ridge:forge:alloy',
+        regionId: 'red-ridge',
+        cultureId: 'culture-forge',
+        discoveryId: 'alliages-de-siège',
+        eventCount: 0,
+        activeResearchCount: 0,
+      }],
+      eventPopups: [],
+    },
+    selectedCluster: {
+      pins: [{
+        pinId: 'red-ridge:culture-forge:discovery:alliages-de-siège',
+        kind: 'discovery',
+        name: 'alliages-de-siège',
+        type: 'Découverte',
+        regionId: 'red-ridge',
+        cultureName: 'Ligues des Forges',
+      }],
+    },
+  });
+
+  assert.equal(grouped.groups[0].key, 'urgent');
+  assert.equal(grouped.groups[0].items.length, 1);
+  assert.equal(grouped.groups[0].items[0].cause, 'Tension locale');
+});

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -51,6 +51,9 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /cultureTensionTrendPriority/);
   assert.match(webAppSource, /buildCultureTensionCause/);
   assert.match(webAppSource, /cultureTensionCausePriority/);
+  assert.match(webAppSource, /buildCultureDiscoveryUrgencyGroups/);
+  assert.match(webAppSource, /renderCultureDiscoveryUrgencyGroups/);
+  assert.match(webAppSource, /Découvertes culturelles groupées par urgence/);
   assert.match(webAppSource, /Urgence/);
   assert.match(webAppSource, /Cause floue/);
   assert.match(webAppSource, /urgence puis tendance/);
@@ -83,6 +86,9 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-tension-marker__trend/);
   assert.match(stylesSource, /\.culture-tension-marker__cause/);
   assert.match(stylesSource, /\.culture-tension-marker-card p mark/);
+  assert.match(stylesSource, /\.culture-discovery-urgency-groups/);
+  assert.match(stylesSource, /\.culture-discovery-urgency-group--urgent/);
+  assert.match(stylesSource, /\.culture-discovery-urgency-item/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-rising/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-unknown/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-confirmation/);

--- a/web/app.js
+++ b/web/app.js
@@ -18,6 +18,7 @@ import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js
 import { buildIntrigueTurnReportDeltas } from '../src/ui/intrigue/buildIntrigueTurnReportDeltas.js';
 import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMapRecommendations.js';
 import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTimeline.js';
+import { buildCultureDiscoveryUrgencyGroups } from '../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
 import { buildCultureConsequenceChips } from '../src/ui/culture/buildCultureConsequenceChips.js';
 import { buildCultureTurnReportDeltas } from '../src/ui/culture/buildCultureTurnReportDeltas.js';
 import { buildCultureUnlockHints } from '../src/ui/culture/buildCultureUnlockHints.js';
@@ -7323,6 +7324,38 @@ function renderCultureLocalTimeline(timelineView) {
   `;
 }
 
+function renderCultureDiscoveryUrgencyGroups(groupView) {
+  if (!groupView || groupView.state !== 'active') {
+    return '';
+  }
+
+  return `
+    <article class="culture-discovery-urgency-groups" aria-label="Découvertes culturelles groupées par urgence">
+      <div class="culture-discovery-urgency-groups__header">
+        <span>Signaux culturels</span>
+        <strong>${groupView.summary}</strong>
+      </div>
+      ${groupView.groups.map((group) => `
+        <section class="culture-discovery-urgency-group culture-discovery-urgency-group--${group.key}">
+          <div class="culture-discovery-urgency-group__title">
+            <b>${group.label}</b>
+            <small>${group.summary}</small>
+          </div>
+          <ul>
+            ${group.items.map((item) => `
+              <li class="culture-discovery-urgency-item culture-discovery-urgency-item--${item.kind}">
+                <span>${item.shortLabel}</span>
+                <b>${item.cause}</b>
+                <small>${item.cultureName}${item.regionId ? ` · ${item.regionId}` : ''} · ${item.detail}</small>
+              </li>
+            `).join('')}
+          </ul>
+        </section>
+      `).join('')}
+    </article>
+  `;
+}
+
 function renderCultureClusterPinList(cluster) {
   if (!cluster) {
     return '';
@@ -7681,6 +7714,10 @@ function renderCultureSidePanel(cultureView) {
   const focusSeed = focus ? cultureView.seeds.find((seed) => seed.cultureId === focus.cultureId) : null;
   const selectedCluster = buildCultureClusterSummaries(cultureView.overlay)
     .find((cluster) => cluster.regionIds.includes(state.selectedProvinceId)) ?? null;
+  const discoveryUrgencyGroups = buildCultureDiscoveryUrgencyGroups({
+    selectedMarker: focus,
+    selectedCluster,
+  });
   const recommendationView = buildCultureMapRecommendations({
     selectedRegionId: state.selectedProvinceId,
     selectedMarker: focus,
@@ -7711,6 +7748,7 @@ function renderCultureSidePanel(cultureView) {
       ${renderCultureTensionMarkerPanel(cultureView.selectedTensionMarkers ?? [])}
       ${renderCultureRecommendationPanel(recommendationView)}
       ${renderCultureLocalTimeline(localTimelineView)}
+      ${renderCultureDiscoveryUrgencyGroups(discoveryUrgencyGroups)}
       ${renderCultureClusterPinList(selectedCluster)}
       ${focus ? `
         <article class="culture-focus-card culture-focus-card--${getCultureTone(focus)}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -8704,3 +8704,60 @@ button { font: inherit; }
   border-color: rgba(245, 158, 11, 0.42);
   background: linear-gradient(135deg, rgba(120, 53, 15, 0.24), rgba(15, 23, 42, 0.58));
 }
+.culture-discovery-urgency-groups {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(125, 211, 252, 0.16);
+}
+.culture-discovery-urgency-groups__header {
+  display: grid;
+  gap: 2px;
+}
+.culture-discovery-urgency-groups__header span {
+  color: #bae6fd;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-discovery-urgency-groups__header strong { color: #f8fafc; font-size: 12px; line-height: 1.3; }
+.culture-discovery-urgency-group {
+  display: grid;
+  gap: 6px;
+  padding: 8px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.28);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+.culture-discovery-urgency-group--urgent { border-color: rgba(248, 113, 113, 0.34); }
+.culture-discovery-urgency-group--active { border-color: rgba(56, 189, 248, 0.28); }
+.culture-discovery-urgency-group--background { border-color: rgba(148, 163, 184, 0.14); }
+.culture-discovery-urgency-group__title {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.culture-discovery-urgency-group__title b { color: #f8fafc; font-size: 12px; }
+.culture-discovery-urgency-group__title small { color: #94a3b8; font-size: 10px; text-align: right; }
+.culture-discovery-urgency-group ul {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.culture-discovery-urgency-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2px 7px;
+  padding: 6px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.42);
+}
+.culture-discovery-urgency-item span { color: #e0f2fe; font-size: 12px; font-weight: 800; }
+.culture-discovery-urgency-item b { color: #fde68a; font-size: 10px; text-transform: uppercase; }
+.culture-discovery-urgency-item small { grid-column: 1 / -1; color: #cbd5e1; font-size: 11px; line-height: 1.25; }


### PR DESCRIPTION
Gamma: Implements #675.

## Summary
- add a culture discovery urgency grouping helper that reuses selected marker, research, event, and cluster pin data
- render selected-province culture signals in urgent/active/background buckets before passive lore
- keep existing discovery/event data available while adding compact labels and ordering tests

## Validation
- node --check web/app.js
- node --check src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
- node --check src/ui/culture/buildCultureOpportunityReminders.js
- npm test -- test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js
- git diff --check
- npm test (480 OK)