### PR TITLE
Epsilon: add climate severity legend

### DIFF
--- a/test/ui/climate/webClimateSeverityLegend.test.js
+++ b/test/ui/climate/webClimateSeverityLegend.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('climate overlay exposes compact severity legend for stacked markers', () => {
+  assert.match(webAppSource, /function buildClimateSeverityLegend/);
+  assert.match(webAppSource, /function renderClimateSeverityLegend/);
+  assert.match(webAppSource, /state\.activeOverlaySlot !== 'climate-overlay' \|\| markers\.length === 0/);
+  assert.match(webAppSource, /Légende climat inactive: overlay climat masqué ou aucun marqueur/);
+  assert.match(webAppSource, /'cascade-active': \{ label: 'Critique'/);
+  assert.match(webAppSource, /'hazard-unresolved': \{ label: 'Élevé'/);
+  assert.match(webAppSource, /'hazard-delayed': \{ label: 'Surveillance'/);
+  assert.match(webAppSource, /'risk-reduced': \{ label: 'Réduit'/);
+  assert.match(webAppSource, /map-climate-severity-legend/);
+  assert.match(webAppSource, /la sévérité explique les piles sans ouvrir chaque province/);
+  assert.match(webAppSource, /climateSeverityLegend = buildClimateSeverityLegend\(postCommitClimateMarkers, climateMarkerDensity\)/);
+  assert.match(webAppSource, /renderClimateSeverityLegend\(climateSeverityLegend\)/);
+
+  assert.match(stylesSource, /\.map-climate-severity-legend/);
+  assert.match(stylesSource, /\.map-climate-severity-legend__item--cascade-active/);
+  assert.match(stylesSource, /\.map-climate-severity-legend__item--hazard-unresolved/);
+  assert.match(stylesSource, /\.map-climate-severity-legend__item--hazard-delayed/);
+  assert.match(stylesSource, /\.map-climate-severity-legend__item--risk-reduced/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3478,6 +3478,64 @@ function renderClimateMarkerDensityRollup(control) {
   `;
 }
 
+function buildClimateSeverityLegend(markers = [], densityControl = null) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || markers.length === 0) {
+    return { active: false, entries: [], summary: 'Légende climat inactive: overlay climat masqué ou aucun marqueur.' };
+  }
+
+  const severityLabels = {
+    'cascade-active': { label: 'Critique', cue: 'Cascade active épinglée', detail: 'Risque régional principal toujours visible.' },
+    'hazard-unresolved': { label: 'Élevé', cue: 'Aléa non résolu', detail: 'Danger restant sans intervention confirmée.' },
+    'hazard-delayed': { label: 'Surveillance', cue: 'Aléa retardé', detail: 'Impact ralenti mais à relire après commit.' },
+    'risk-reduced': { label: 'Réduit', cue: 'Risque réduit', detail: 'Mitigation confirmée dans le résumé cumulé.' },
+  };
+  const entries = Object.entries(severityLabels)
+    .map(([status, copy]) => ({
+      status,
+      count: markers.filter((marker) => marker.status === status).length,
+      ...copy,
+    }))
+    .filter((entry) => entry.count > 0);
+  const groupedCount = densityControl?.groupedCount ?? 0;
+  const cascadeGroupCount = densityControl?.selectedCascadeGroup?.markers.length ?? 0;
+
+  return {
+    active: true,
+    entries,
+    groupedCount,
+    cascadeGroupCount,
+    summary: groupedCount > 0
+      ? `${groupedCount} marqueur${groupedCount > 1 ? 's' : ''} agrégé${groupedCount > 1 ? 's' : ''}; la sévérité explique les piles sans ouvrir chaque province.`
+      : 'Sévérité climat lisible directement sur les marqueurs visibles.',
+  };
+}
+
+function renderClimateSeverityLegend(legend) {
+  if (!legend.active || legend.entries.length === 0) {
+    return '';
+  }
+
+  return `
+    <section class="map-climate-severity-legend" aria-label="Légende de sévérité des marqueurs climat empilés">
+      <div>
+        <strong>Sévérité climat</strong>
+        <span>${legend.entries.length} niveau${legend.entries.length > 1 ? 'x' : ''} · ${legend.groupedCount} agrégé${legend.groupedCount > 1 ? 's' : ''}</span>
+      </div>
+      <p>${legend.summary}</p>
+      <ul>
+        ${legend.entries.map((entry) => `
+          <li class="map-climate-severity-legend__item map-climate-severity-legend__item--${entry.status}">
+            <b>${entry.label}</b>
+            <span>${entry.cue} · ${entry.count}</span>
+            <small>${entry.detail}</small>
+          </li>
+        `).join('')}
+      </ul>
+      ${legend.cascadeGroupCount > 1 ? `<small>Groupe sélectionné: ${legend.cascadeGroupCount} provinces liées au risque principal.</small>` : '<small>Les cascades et aléas non résolus restent épinglés en priorité.</small>'}
+    </section>
+  `;
+}
+
 function renderSelectedClimateCascadeGroup(group) {
   if (!group || group.markers.length <= 1) {
     return '';
@@ -9107,6 +9165,7 @@ function render() {
     mobileMapExpanded: state.mobileMapExpanded,
     selectedProvinceId: state.selectedProvinceId,
   });
+  const climateSeverityLegend = buildClimateSeverityLegend(postCommitClimateMarkers, climateMarkerDensity);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -9162,6 +9221,7 @@ function render() {
             </div>
             <div class="overlay-tabs">${renderOverlaySlots(shell)}</div>
           </div>
+          ${renderClimateSeverityLegend(climateSeverityLegend)}
           <div class="map-stage" data-map-stage="true" tabindex="0" aria-label="Carte opérationnelle zoomable. Utilisez plus, moins, zéro ou C pour naviguer.">
             ${renderMapControls()}
             ${renderMilitaryOutcomeMarkerFilters(state.lastMilitaryOutcomeMarkers)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -360,6 +360,47 @@ button { font: inherit; }
 }
 .map-climate-cascade-group small { color: #fde68a; }
 
+.map-climate-severity-legend {
+  display: grid;
+  gap: 7px;
+  margin: 0 0 10px;
+  padding: 9px 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.54);
+  border: 1px solid rgba(125, 211, 252, 0.2);
+}
+.map-climate-severity-legend div,
+.map-climate-severity-legend ul {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+.map-climate-severity-legend div { justify-content: space-between; }
+.map-climate-severity-legend p,
+.map-climate-severity-legend span,
+.map-climate-severity-legend small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-climate-severity-legend__item {
+  display: grid;
+  gap: 2px;
+  min-width: 132px;
+  padding: 6px 8px;
+  border-radius: 11px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  list-style: none;
+}
+.map-climate-severity-legend__item--cascade-active { border-color: rgba(248, 113, 113, 0.54); }
+.map-climate-severity-legend__item--hazard-unresolved { border-color: rgba(251, 191, 36, 0.5); }
+.map-climate-severity-legend__item--hazard-delayed { border-color: rgba(56, 189, 248, 0.48); }
+.map-climate-severity-legend__item--risk-reduced { border-color: rgba(74, 222, 128, 0.48); }
+
 .economy-turn-pulse {
   margin-top: 12px;
   display: inline-flex;


### PR DESCRIPTION
Epsilon: Implements #677.

Summary:
- Adds a compact climate severity legend when the climate overlay is active and post-commit climate markers exist.
- Derives legend entries from existing marker statuses: cascade-active, hazard-unresolved, hazard-delayed, and risk-reduced.
- Explains stacked/grouped climate severity without opening every province, while staying hidden when the climate overlay is inactive or no climate markers exist.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webClimateSeverityLegend.test.js test/ui/climate/webClimateCascadeGroupHighlights.test.js test/ui/climate/webAdaptiveClimateMarkerDensityThresholds.test.js
- npm test