### PR TITLE
Delta: compare intrigue response timing

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -276,3 +276,19 @@ test('selected province intrigue details show ordered fog-safe timeline hints', 
   assert.match(stylesSource, /province-intrigue-timeline-hints/);
   assert.match(stylesSource, /province-intrigue-timeline-hint--danger/);
 });
+
+test('safe intrigue responses compare exposure timing without breaking fog', () => {
+  assert.match(webAppSource, /function buildSafeIntrigueResponseTimingOptions/);
+  assert.match(webAppSource, /function renderSafeIntrigueResponseTimingComparison/);
+  assert.match(webAppSource, /Comparaison fog-safe des réponses intrigue sous timing d’exposition/);
+  assert.match(webAppSource, /exposition réduite/);
+  assert.match(webAppSource, /brouillard conservé/);
+  assert.match(webAppSource, /aggravation possible immédiate/);
+  assert.match(webAppSource, /risque secondaire élevé: chaleur visible à compenser/);
+  assert.match(webAppSource, /sûr maintenant, risqué si le joueur attend/);
+  assert.match(webAppSource, /Comparaison prudente: seules les tendances visibles sont comparées; cellule, cible, relais et état caché restent masqués/);
+  assert.match(webAppSource, /renderSafeIntrigueResponseTimingComparison\(province, intrigueView\)/);
+  assert.match(stylesSource, /province-intrigue-response-timing/);
+  assert.match(stylesSource, /province-intrigue-response-option--mitigated/);
+  assert.match(stylesSource, /province-intrigue-response-option--danger/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -4009,6 +4009,105 @@ function renderProvinceIntrigueExposureTimelineHints(province, intrigueView) {
   `;
 }
 
+function buildSafeIntrigueResponseTimingOptions(province, intrigueView) {
+  const drillDown = findProvinceIntrigueDrillDown(province, intrigueView);
+  const entry = (intrigueView?.map?.entries ?? []).find((candidate) => candidate.locationId === province?.provinceId) ?? null;
+  const responses = drillDown?.quickResponses ?? [];
+
+  if (!drillDown || responses.length === 0) {
+    return [];
+  }
+
+  const baseExposure = drillDown.riskBand === 'high' || drillDown.criticality === 'critical'
+    ? 3
+    : drillDown.riskBand === 'medium'
+      ? 2
+      : 1;
+
+  return responses.map((response) => {
+    const lowersExposure = ['contenir', 'surveiller'].includes(response.code) && response.escalationProbability !== 'élevée';
+    const fogState = !entry?.showSecondaryDetails
+      ? 'brouillard conservé'
+      : (entry.metrics?.exposedCellCount ?? 0) > 0
+        ? 'signal confirmé visible'
+        : 'signal partiel visible';
+    const delayTurns = response.cooldownTurns > 0
+      ? response.cooldownTurns
+      : lowersExposure
+        ? 2
+        : response.escalationProbability === 'élevée'
+          ? 0
+          : 1;
+    const secondaryRisk = response.escalationProbability === 'élevée' || response.heatGenerated >= 10
+      ? 'risque secondaire élevé: chaleur visible à compenser'
+      : response.heatGenerated >= 5
+        ? 'risque secondaire modéré: surveiller la chaleur'
+        : 'risque secondaire faible: garder la couverture discrète';
+    const waitingRisk = delayTurns <= 0 || (!lowersExposure && baseExposure >= 2)
+      ? 'sûr maintenant, risqué si le joueur attend'
+      : delayTurns === 1
+        ? 'fenêtre courte: revalider au prochain tour'
+        : 'marge de délai confortable sous signaux visibles';
+    const tone = waitingRisk.includes('risqué') || response.escalationProbability === 'élevée'
+      ? 'danger'
+      : lowersExposure
+        ? 'mitigated'
+        : 'watch';
+    const score = (lowersExposure ? 40 : 0) + delayTurns * 10 - (response.heatGenerated ?? 0) - (response.escalationProbability === 'élevée' ? 20 : 0);
+
+    return {
+      code: response.code,
+      label: response.label,
+      tone,
+      score,
+      exposureChange: lowersExposure ? 'exposition réduite' : response.code === 'exposer' ? 'exposition assumée' : 'exposition surveillée',
+      fogState,
+      delayLabel: delayTurns <= 0 ? 'aggravation possible immédiate' : `${delayTurns} tour${delayTurns > 1 ? 's' : ''} avant aggravation probable`,
+      secondaryRisk,
+      waitingRisk,
+      summary: response.aftermathSummary ?? response.summary,
+    };
+  })
+    .sort((left, right) => right.score - left.score || left.label.localeCompare(right.label))
+    .slice(0, 4);
+}
+
+function renderSafeIntrigueResponseTimingComparison(province, intrigueView) {
+  const options = buildSafeIntrigueResponseTimingOptions(province, intrigueView);
+
+  if (options.length === 0) {
+    return '';
+  }
+
+  return `
+    <section class="province-intrigue-response-timing" aria-label="Comparaison fog-safe des réponses intrigue sous timing d’exposition">
+      <div class="province-intrigue-response-timing__header">
+        <strong>Réponses intrigue sûres</strong>
+        <span>exposition · délai · risque secondaire</span>
+      </div>
+      <div class="province-intrigue-response-timing__grid">
+        ${options.map((option) => `
+          <article class="province-intrigue-response-option province-intrigue-response-option--${option.tone}">
+            <div>
+              <b>${option.label}</b>
+              <code>${option.code}</code>
+            </div>
+            <dl>
+              <div><dt>Exposition</dt><dd>${option.exposureChange}</dd></div>
+              <div><dt>Incertitude</dt><dd>${option.fogState}</dd></div>
+              <div><dt>Délai</dt><dd>${option.delayLabel}</dd></div>
+              <div><dt>Risque</dt><dd>${option.secondaryRisk}</dd></div>
+            </dl>
+            <p>${option.waitingRisk}</p>
+            <small>${option.summary}</small>
+          </article>
+        `).join('')}
+      </div>
+      <small>Comparaison prudente: seules les tendances visibles sont comparées; cellule, cible, relais et état caché restent masqués.</small>
+    </section>
+  `;
+}
+
 function buildProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView) {
   const drillDown = findProvinceIntrigueDrillDown(province, intrigueView);
   const selectedResponse = drillDown?.quickResponses?.find((response) => response.code === drillDown.recommendedResponseCode)
@@ -6185,6 +6284,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       </div>
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
       ${renderProvinceIntrigueExposureTimelineHints(province, intrigueView)}
+      ${renderSafeIntrigueResponseTimingComparison(province, intrigueView)}
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceConflictNextAction(province, shell, focusContext, intrigueView)}
       ${renderQueuedMilitaryMapActionConfirmation(province, shell, intrigueView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -7794,6 +7794,59 @@ button { font: inherit; }
   display: block;
   margin-top: 4px;
 }
+.province-intrigue-response-timing {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.province-intrigue-response-timing__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-response-timing__header span,
+.province-intrigue-response-timing > small,
+.province-intrigue-response-option small {
+  color: var(--muted);
+}
+.province-intrigue-response-timing__grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+}
+.province-intrigue-response-option {
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.3);
+  border-left: 3px solid rgba(148, 163, 184, 0.5);
+}
+.province-intrigue-response-option--mitigated { border-left-color: rgba(34, 197, 94, 0.78); }
+.province-intrigue-response-option--watch { border-left-color: rgba(56, 189, 248, 0.7); }
+.province-intrigue-response-option--danger { border-left-color: rgba(248, 113, 113, 0.8); }
+.province-intrigue-response-option > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.province-intrigue-response-option dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  margin: 8px 0;
+}
+.province-intrigue-response-option dt {
+  color: var(--muted);
+}
+.province-intrigue-response-option dd {
+  margin: 2px 0 0;
+}
+.province-intrigue-response-option p {
+  margin: 6px 0;
+  color: #e0f2fe;
+}
 
 
 


### PR DESCRIPTION
Delta: Implements #686.\n\nSummary:\n- adds a fog-safe comparison panel for safe intrigue responses under exposure timing\n- shows exposure direction, uncertainty/fog state, delay before worsening, and secondary risk for each visible response\n- highlights options that are safe now but become risky if the player waits without revealing hidden cells, targets, relays, or concealed states\n\nValidation:\n- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js\n- node --check web/app.js\n- git diff --check\n- npm test