### PR TITLE
Alpha: compare critical front decisions

### DIFF
--- a/test/ui/war/webCriticalFrontDecisionComparison.test.js
+++ b/test/ui/war/webCriticalFrontDecisionComparison.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('critical front decision comparison reuses map priority and action data', () => {
+  assert.match(webAppSource, /function buildCriticalFrontDecisionComparison/);
+  assert.match(webAppSource, /buildFrontPriorityRanking\(shell, intrigueView\)/);
+  assert.match(webAppSource, /buildSelectedProvinceActionQueue\(province, shell, focusContext, intrigueView\)/);
+  assert.match(webAppSource, /buildProjectedFrontStability\(province, shell, actionQueue\)/);
+  assert.match(webAppSource, /buildCriticalFrontRiskWarnings\(province, projection\)/);
+  assert.match(webAppSource, /dominantCause/);
+  assert.match(webAppSource, /recommendedAction/);
+  assert.match(webAppSource, /costRisk/);
+  assert.match(webAppSource, /ignoredRisk/);
+});
+
+test('critical front decision comparison renders compact navigation cards without changing filters', () => {
+  assert.match(webAppSource, /function renderCriticalFrontDecisionComparison/);
+  assert.match(webAppSource, /data-province-id="\$\{decision\.provinceId\}"/);
+  assert.match(webAppSource, /data-readiness-focus="\$\{decision\.provinceId\}"/);
+  assert.match(webAppSource, /sans perdre les filtres carte/);
+  assert.match(webAppSource, /renderCriticalFrontDecisionComparison\(shell, intrigueView\)/);
+  assert.match(stylesSource, /\.critical-front-decision-comparison/);
+  assert.match(stylesSource, /\.critical-front-decision--danger/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -5383,6 +5383,132 @@ function buildRecommendedMilitaryActionPreview(shell, intrigueView = null) {
     sideEffect,
   };
 }
+function buildCriticalFrontDecisionComparison(shell, intrigueView = null) {
+  const priorities = buildFrontPriorityRanking(shell, intrigueView)
+    .filter((priority) => priority.tone !== 'ready')
+    .slice(0, 4);
+
+  if (priorities.length === 0) {
+    return {
+      empty: true,
+      title: 'Comparaison décisions fronts',
+      summary: 'Aucun front critique visible à comparer pour ce tour.',
+      decisions: [],
+    };
+  }
+
+  const decisions = priorities.map((priority, index) => {
+    const province = shell.provinces.find((candidate) => candidate.provinceId === priority.provinceId) ?? null;
+    const focusContext = province ? {
+      focusedProvinceId: province.provinceId,
+      focusedProvince: province,
+      neighborIds: new Set(province.neighborIds),
+    } : null;
+    const actionQueue = province && focusContext
+      ? buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView)
+      : [];
+    const projection = province && focusContext
+      ? buildProjectedFrontStability(province, shell, actionQueue)
+      : null;
+    const risks = province && projection
+      ? buildCriticalFrontRiskWarnings(province, projection)
+      : [];
+    const recommendedAction = actionQueue[0] ?? null;
+    const leadRisk = risks[0] ?? { label: priority.leadRisk, driver: 'Projection', tone: priority.tone === 'danger' ? 'critical' : 'watch' };
+    const stabilityValue = projection?.lines.find((line) => line.label === 'Stabilité attendue')?.value ?? 'stabilité non calculée';
+    const blockedCount = actionQueue.filter((entry) => entry.status === 'blocked').length;
+    const riskyCount = actionQueue.filter((entry) => entry.status === 'risky').length;
+    const dominantCause = leadRisk.driver === 'Fatigue / supply'
+      ? `Ravitaillement ${province?.supplyTone ?? 'fragile'}`
+      : leadRisk.driver === 'Front voisin'
+        ? 'Pression front voisin'
+        : leadRisk.driver === 'Pression'
+          ? 'Pression ennemie visible'
+          : leadRisk.label;
+    const ignoredRisk = leadRisk.tone === 'critical' || priority.tone === 'danger'
+      ? `Ignorer: brèche probable (${stabilityValue}).`
+      : leadRisk.tone === 'watch' || priority.tone === 'warning'
+        ? `Ignorer: suivi nécessaire au prochain tour (${stabilityValue}).`
+        : `Ignorer: surveillance suffisante (${stabilityValue}).`;
+    const costRisk = recommendedAction
+      ? `${recommendedAction.orderCost} · ${recommendedAction.mainRisk}`
+      : blockedCount > 0
+        ? `${blockedCount} option${blockedCount > 1 ? 's' : ''} bloquée${blockedCount > 1 ? 's' : ''}; arbitrage manuel requis.`
+        : riskyCount > 0
+          ? `${riskyCount} option${riskyCount > 1 ? 's' : ''} risquée${riskyCount > 1 ? 's' : ''}; garder une réserve.`
+          : ignoredRisk;
+
+    return {
+      rank: index + 1,
+      provinceId: priority.provinceId,
+      provinceLabel: priority.provinceLabel,
+      tone: priority.tone,
+      threatLevel: priority.tone === 'danger' ? 'Critique' : priority.tone === 'warning' ? 'Sous tension' : 'À surveiller',
+      dominantCause,
+      recommendedAction: recommendedAction?.label ?? priority.actionCode,
+      actionCode: recommendedAction?.actionCode ?? priority.actionCode,
+      costRisk,
+      ignoredRisk,
+      comparison: index === 0
+        ? 'Choix recommandé en premier: menace cumulée maximale.'
+        : `Comparer après ${priorities[index - 1].provinceLabel}: menace ${priority.score} vs ${priorities[index - 1].score}.`,
+    };
+  });
+
+  return {
+    empty: false,
+    title: 'Comparaison décisions fronts',
+    summary: `${decisions.length} front${decisions.length > 1 ? 's' : ''} critique${decisions.length > 1 ? 's' : ''} visible${decisions.length > 1 ? 's' : ''}: choisir la prochaine action sans perdre les filtres carte.`,
+    decisions,
+  };
+}
+
+function renderCriticalFrontDecisionComparison(shell, intrigueView = null) {
+  const comparison = buildCriticalFrontDecisionComparison(shell, intrigueView);
+
+  if (comparison.empty) {
+    return `
+      <section class="critical-front-decision-comparison is-empty" aria-label="Comparaison des décisions de fronts critiques">
+        <div class="critical-front-decision-comparison__header">
+          <strong>${comparison.title}</strong>
+          <span>calme</span>
+        </div>
+        <p>${comparison.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="critical-front-decision-comparison" aria-label="Comparaison des décisions de fronts critiques">
+      <div class="critical-front-decision-comparison__header">
+        <div>
+          <strong>${comparison.title}</strong>
+          <p>${comparison.summary}</p>
+        </div>
+        <span>navigation rapide</span>
+      </div>
+      <div class="critical-front-decision-comparison__grid">
+        ${comparison.decisions.map((decision) => `
+          <button class="critical-front-decision critical-front-decision--${decision.tone}" type="button" data-province-id="${decision.provinceId}" data-readiness-focus="${decision.provinceId}" aria-label="Comparer ${decision.provinceLabel}: ${decision.threatLevel}">
+            <div class="critical-front-decision__title">
+              <strong>#${decision.rank} ${decision.provinceLabel}</strong>
+              <code>${decision.actionCode}</code>
+            </div>
+            <dl>
+              <div><dt>Menace</dt><dd>${decision.threatLevel}</dd></div>
+              <div><dt>Cause</dt><dd>${decision.dominantCause}</dd></div>
+              <div><dt>Action</dt><dd>${decision.recommendedAction}</dd></div>
+              <div><dt>Coût / risque</dt><dd>${decision.costRisk}</dd></div>
+            </dl>
+            <small>${decision.ignoredRisk} ${decision.comparison}</small>
+          </button>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
+
 
 function renderRecommendedMilitaryActionPreview(shell, intrigueView = null) {
   const preview = buildRecommendedMilitaryActionPreview(shell, intrigueView);
@@ -9224,6 +9350,7 @@ function render() {
           <p class="turn-summary">${state.lastTurnSummary}</p>
           ${renderConflictReadinessWarnings(shell, intrigueView)}
           ${renderFrontPriorityRanking(shell, intrigueView)}
+          ${renderCriticalFrontDecisionComparison(shell, intrigueView)}
           ${renderRecommendedMilitaryActionPreview(shell, intrigueView)}
           ${renderQueuedMilitaryResolutionSummary(shell, intrigueView)}
           ${renderMapClimatePreparednessSummary(climatePreparednessSummary)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -558,6 +558,94 @@ button { font: inherit; }
 .front-priority--ready { border-color: rgba(74, 222, 128, 0.24); }
 .front-priority--warning { border-color: rgba(251, 191, 36, 0.32); }
 .front-priority--danger { border-color: rgba(251, 113, 133, 0.38); }
+.critical-front-decision-comparison {
+  display: grid;
+  gap: 9px;
+  margin-top: 10px;
+  max-width: 72ch;
+  padding: 11px 12px;
+  border-radius: 15px;
+  background: rgba(15, 23, 42, 0.68);
+  border: 1px solid rgba(251, 191, 36, 0.22);
+}
+.critical-front-decision-comparison__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+.critical-front-decision-comparison__header strong { color: #fde68a; font-size: 13px; }
+.critical-front-decision-comparison__header p {
+  margin: 2px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.critical-front-decision-comparison__header span {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.critical-front-decision-comparison__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 7px;
+}
+.critical-front-decision {
+  display: grid;
+  gap: 7px;
+  padding: 9px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  text-align: left;
+  cursor: pointer;
+}
+.critical-front-decision:hover,
+.critical-front-decision:focus-visible {
+  border-color: rgba(251, 191, 36, 0.52);
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.14);
+  outline: none;
+}
+.critical-front-decision__title {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+.critical-front-decision strong { color: #f8fafc; }
+.critical-front-decision code { color: #fde68a; font-size: 11px; }
+.critical-front-decision dl {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+}
+.critical-front-decision dl div {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 6px;
+}
+.critical-front-decision dt {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.critical-front-decision dd {
+  margin: 0;
+  color: #e5e7eb;
+  font-size: 11px;
+  line-height: 1.3;
+}
+.critical-front-decision small {
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+.critical-front-decision--warning { border-color: rgba(251, 191, 36, 0.34); }
+.critical-front-decision--danger { border-color: rgba(251, 113, 133, 0.42); }
 .recommended-action-preview {
   display: grid;
   gap: 9px;


### PR DESCRIPTION
Alpha: Implements #683.

Summary:
- Adds a compact critical-front decision comparison panel on the map.
- Reuses existing front priority, action queue, projected stability, and critical risk builders.
- Shows each critical province's threat level, dominant cause, recommended next action, cost/risk, ignored-risk impact, and quick navigation without changing current map filters.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webCriticalFrontDecisionComparison.test.js test/ui/war/webProvinceWarOverlayOverflowSummary.test.js test/ui/war/webPinnedCriticalMilitaryMarkers.test.js
- npm test (485 tests)
- git diff --check

Zeta: PR prête pour revue. Merci de valider avant tout merge.
