### PR TITLE
Beta: prioritize logistics bottlenecks

### DIFF
--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -8,7 +8,15 @@ const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta
 test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /function renderProvinceLogisticsChoicePreview/);
   assert.match(webAppSource, /buildProvinceLogisticsBottleneckWarnings/);
+  assert.match(webAppSource, /buildProvinceLogisticsBottleneckPriorities/);
   assert.match(webAppSource, /province-logistics-bottleneck-warning/);
+  assert.match(webAppSource, /province-logistics-bottleneck-priorities/);
+  assert.match(webAppSource, /Priorités aval/);
+  assert.match(webAppSource, /Raison du classement/);
+  assert.match(webAppSource, /Action probable/);
+  assert.match(webAppSource, /Renforce un autre goulot/);
+  assert.match(webAppSource, /downstreamImpact/);
+  assert.match(webAppSource, /recoveryAction/);
   assert.match(webAppSource, /Alerte goulot logistique/);
   assert.match(webAppSource, /Route logistique sous tension/);
   assert.match(webAppSource, /stock en tension haute/);
@@ -102,6 +110,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-bottleneck--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck-warning--high/);
   assert.match(stylesSource, /province-logistics-bottleneck-warning--medium/);
+  assert.match(stylesSource, /province-logistics-bottleneck-priorities/);
+  assert.match(stylesSource, /province-logistics-bottleneck-priority--high/);
+  assert.match(stylesSource, /province-logistics-bottleneck-priority--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck--low/);
   assert.match(stylesSource, /province-logistics-timeline-summary--queued/);
   assert.match(stylesSource, /province-logistics-downstream-summary--aggravée/);

--- a/web/app.js
+++ b/web/app.js
@@ -1859,10 +1859,53 @@ function buildProvinceLogisticsBottleneckComparison(province, economyView) {
         impactedCity: cityNameById[localCityId] ?? cityNameById[otherCityId] ?? route.destinationCityId,
         consequence: stress.summary,
         leverage,
+        downstreamImpact: stress.tone === 'high'
+          ? `${cityNameById[otherCityId] ?? route.destinationCityId}: pénurie aval probable si le flux reste bloqué.`
+          : stress.tone === 'medium'
+            ? `${cityNameById[otherCityId] ?? route.destinationCityId}: marge réduite, impact aval à contenir.`
+            : `${cityNameById[otherCityId] ?? route.destinationCityId}: impact aval limité pour l'instant.`,
+        recoveryAction: !route.active
+          ? 'Réouvrir ou détourner la route'
+          : localTension === 'high'
+            ? 'Prioriser convoi et stock local'
+            : route.riskLevel >= 70
+              ? 'Escorter le flux critique'
+              : route.totalCapacity >= 9
+                ? 'Délester vers une route parallèle'
+                : 'Surveiller avant engagement',
         score: (toneRank[stress.tone] ?? 0) * 100 + route.riskLevel + route.totalCapacity,
       };
     })
     .sort((left, right) => right.score - left.score || left.routeName.localeCompare(right.routeName))
+    .slice(0, 3);
+}
+
+function buildProvinceLogisticsBottleneckPriorities(comparisons) {
+  const strained = comparisons.filter((entry) => entry.tone === 'high' || entry.tone === 'medium');
+  const impactedCityCounts = strained.reduce((counts, entry) => counts.set(entry.impactedCity, (counts.get(entry.impactedCity) ?? 0) + 1), new Map());
+  const resourceCounts = strained.reduce((counts, entry) => counts.set(entry.resourceLabel, (counts.get(entry.resourceLabel) ?? 0) + 1), new Map());
+
+  return strained
+    .map((entry) => {
+      const sharedCity = (impactedCityCounts.get(entry.impactedCity) ?? 0) > 1;
+      const sharedResource = (resourceCounts.get(entry.resourceLabel) ?? 0) > 1;
+      const reinforcement = sharedCity
+        ? `Renforce un autre goulot sur ${entry.impactedCity}`
+        : sharedResource
+          ? `Concurrence la même ressource (${entry.resourceLabel})`
+          : 'Goulot isolé, priorité par sévérité et risque.';
+      const rankReason = entry.tone === 'high'
+        ? `Sévérité haute + ${entry.consequence.toLowerCase()}`
+        : `Impact moyen mais ${reinforcement.toLowerCase()}`;
+
+      return {
+        ...entry,
+        reinforcement,
+        rankReason,
+        priorityScore: entry.score + (sharedCity ? 35 : 0) + (sharedResource ? 18 : 0),
+      };
+    })
+    .sort((left, right) => right.priorityScore - left.priorityScore || left.routeName.localeCompare(right.routeName))
     .slice(0, 3);
 }
 
@@ -1900,8 +1943,9 @@ function buildProvinceLogisticsBottleneckWarnings(province, economyView, compari
 function renderProvinceLogisticsBottleneckComparison(province, economyView) {
   const comparisons = buildProvinceLogisticsBottleneckComparison(province, economyView);
   const warnings = buildProvinceLogisticsBottleneckWarnings(province, economyView, comparisons);
+  const priorities = buildProvinceLogisticsBottleneckPriorities(comparisons);
 
-  if (comparisons.length < 2 && warnings.length === 0) {
+  if (comparisons.length < 2 && warnings.length === 0 && priorities.length === 0) {
     return '';
   }
 
@@ -1918,6 +1962,29 @@ function renderProvinceLogisticsBottleneckComparison(province, economyView) {
           <small>${warning.routeCount} route${warning.routeCount > 1 ? 's' : ''} sous tension autour de la province.</small>
         </div>
       `).join('')}
+      ${priorities.length > 0 ? `
+        <div class="province-logistics-bottleneck-priorities" aria-label="Priorités aval des goulets logistiques">
+          <div class="province-logistics-bottleneck-priorities__header">
+            <b>Priorités aval</b>
+            <span>${priorities.length} goulot${priorities.length > 1 ? 's' : ''} classé${priorities.length > 1 ? 's' : ''}</span>
+          </div>
+          <ol>
+            ${priorities.map((entry, index) => `
+              <li class="province-logistics-bottleneck-priority province-logistics-bottleneck-priority--${entry.tone}">
+                <span class="province-logistics-bottleneck-priority__rank">#${index + 1}</span>
+                <div>
+                  <strong>${entry.routeName}</strong>
+                  <small>${entry.impactedCity} · ${entry.resourceLabel} · ${entry.headline}</small>
+                  <p>${entry.downstreamImpact}</p>
+                  <small>Action probable: ${entry.recoveryAction}</small>
+                  <small>Raison du classement: ${entry.rankReason}</small>
+                  ${entry.reinforcement ? `<em>${entry.reinforcement}</em>` : ''}
+                </div>
+              </li>
+            `).join('')}
+          </ol>
+        </div>
+      ` : ''}
       ${comparisons.map((entry, index) => `
         <article class="province-logistics-route province-logistics-route--${entry.tone} ${index === 0 ? 'is-priority' : ''}">
           <div class="province-logistics-route__rank">${index === 0 ? 'Priorité' : `#${index + 1}`}</div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -8802,3 +8802,63 @@ button { font: inherit; }
 .culture-discovery-urgency-item span { color: #e0f2fe; font-size: 12px; font-weight: 800; }
 .culture-discovery-urgency-item b { color: #fde68a; font-size: 10px; text-transform: uppercase; }
 .culture-discovery-urgency-item small { grid-column: 1 / -1; color: #cbd5e1; font-size: 11px; line-height: 1.25; }
+.province-logistics-bottleneck-priorities {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(8, 15, 28, 0.54);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.province-logistics-bottleneck-priorities__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.province-logistics-bottleneck-priorities__header span {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-logistics-bottleneck-priorities ol {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+.province-logistics-bottleneck-priority {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.province-logistics-bottleneck-priority--high { border-color: rgba(251, 113, 133, 0.48); }
+.province-logistics-bottleneck-priority--medium { border-color: rgba(245, 158, 11, 0.42); }
+.province-logistics-bottleneck-priority__rank {
+  display: inline-grid;
+  place-items: center;
+  min-width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  color: #e0f2fe;
+  background: rgba(14, 116, 144, 0.28);
+  font-weight: 800;
+  font-size: 11px;
+}
+.province-logistics-bottleneck-priority strong,
+.province-logistics-bottleneck-priority small,
+.province-logistics-bottleneck-priority em { display: block; }
+.province-logistics-bottleneck-priority p {
+  margin: 4px 0;
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.province-logistics-bottleneck-priority small { color: #93c5fd; font-size: 11px; }
+.province-logistics-bottleneck-priority em { margin-top: 4px; color: #fde68a; font-size: 11px; font-style: normal; }


### PR DESCRIPTION
Beta: Implements #684.

## Summary
- Adds a compact “Priorités aval” comparison inside the selected-province logistics bottleneck section.
- Ranks strained route bottlenecks by downstream impact, route/city/resource severity, and reinforcing bottlenecks on the same city/resource.
- Shows likely recovery action and explicit ranking rationale without replacing the existing route list or outcome filters/rollups.

## Validation
- npm test (483 OK)
- targeted economy UI tests (7 OK)
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check
