### PR TITLE
Gamma: queue culture intervention priorities

### DIFF
--- a/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
+++ b/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
@@ -127,6 +127,91 @@ function dedupeItems(items) {
   return [...byKey.values()];
 }
 
+function buildInterventionAction(item) {
+  if (item.group === 'urgent') {
+    return item.kind === 'event'
+      ? 'Suivre le repère maintenant'
+      : 'Stabiliser la découverte';
+  }
+
+  if (item.group === 'active') {
+    return item.kind === 'discovery'
+      ? 'Planifier l’exploitation'
+      : 'Garder dans la file culturelle';
+  }
+
+  return 'Surveiller en arrière-plan';
+}
+
+function buildInterventionRisk(item) {
+  if (item.group === 'urgent') {
+    return item.cause === 'Tension locale'
+      ? 'La tension locale peut masquer la découverte au prochain arbitrage.'
+      : 'Le signal prioritaire risque de glisser derrière les urgences province.';
+  }
+
+  if (item.group === 'active') {
+    return 'La recherche ou le repère reste lisible, mais perd sa priorité si la file se remplit.';
+  }
+
+  return 'Risque faible: conserver comme contexte tant qu’aucune urgence ne remonte.';
+}
+
+function buildInterventionDependency(item, items) {
+  const relatedProvince = items.find((candidate) => candidate.regionId && candidate.regionId !== item.regionId
+    && (candidate.cultureName === item.cultureName || candidate.label === item.label));
+
+  if (relatedProvince) {
+    return `Dépend aussi de ${relatedProvince.regionId}`;
+  }
+
+  const sameProvinceConflict = items.find((candidate) => candidate.itemId !== item.itemId
+    && candidate.regionId === item.regionId
+    && candidate.group === item.group
+    && candidate.cultureName !== item.cultureName);
+
+  if (sameProvinceConflict) {
+    return `Conflit local avec ${sameProvinceConflict.cultureName}`;
+  }
+
+  return item.group === 'background' ? 'Aucune dépendance prioritaire' : 'Dépendance non bloquante';
+}
+
+function buildInterventionPriority(item, items, index) {
+  const dependency = buildInterventionDependency(item, items);
+  const conflict = dependency.startsWith('Conflit local');
+  const action = buildInterventionAction(item);
+
+  return {
+    priorityId: `culture-intervention:${item.itemId}`,
+    rank: index + 1,
+    urgency: item.group,
+    urgencyLabel: GROUP_DEFINITIONS[item.group]?.label ?? 'Signal',
+    action,
+    effect: `${item.shortLabel}: ${item.cause} rendu actionnable pour ${item.cultureName}.`,
+    waitRisk: buildInterventionRisk(item),
+    dependency,
+    conflict,
+    cultureName: item.cultureName,
+    regionId: item.regionId,
+    sourceLabel: item.shortLabel,
+    summary: `${action} · ${GROUP_DEFINITIONS[item.group]?.label ?? 'Signal'} · ${item.cause}`,
+  };
+}
+
+function buildInterventionConflicts(priorities) {
+  return priorities
+    .flatMap((priority, index) => priorities.slice(index + 1).map((candidate) => [priority, candidate]))
+    .filter(([left, right]) => left.conflict || right.conflict || (left.regionId === right.regionId && left.urgency === right.urgency))
+    .map(([left, right]) => ({
+      conflictId: `${left.priorityId}|${right.priorityId}`,
+      label: left.regionId === right.regionId ? 'Même province' : 'Dépendance croisée',
+      summary: `${left.action} concurrence ${right.action}: choisir d’abord ${left.urgency === 'urgent' ? left.cultureName : right.cultureName}.`,
+      priorityIds: [left.priorityId, right.priorityId],
+    }))
+    .slice(0, 2);
+}
+
 export function buildCultureDiscoveryUrgencyGroups({
   selectedMarker = null,
   selectedCluster = null,
@@ -152,5 +237,26 @@ export function buildCultureDiscoveryUrgencyGroups({
       ? `${items.length} signal${items.length > 1 ? 's' : ''} culturel${items.length > 1 ? 's' : ''} groupé${items.length > 1 ? 's' : ''} par urgence.`
       : 'Aucun signal culturel détaillé à grouper pour cette province.',
     groups,
+  };
+}
+
+
+export function buildCultureInterventionPriorities(groupView = {}) {
+  const items = (groupView.groups ?? [])
+    .flatMap((group) => (group.items ?? []).map((item) => ({ ...item, group: item.group ?? group.key })))
+    .sort((left, right) => right.priority - left.priority || left.label.localeCompare(right.label));
+  const priorities = items
+    .filter((item) => item.group !== 'background' || item.priority >= GROUP_DEFINITIONS.background.rank * 100)
+    .slice(0, 4)
+    .map((item, index) => buildInterventionPriority(item, items, index));
+  const conflicts = buildInterventionConflicts(priorities);
+
+  return {
+    state: priorities.length > 0 ? 'active' : 'quiet',
+    summary: priorities.length > 0
+      ? `${priorities.length} intervention${priorities.length > 1 ? 's' : ''} culturelle${priorities.length > 1 ? 's' : ''} priorisée${priorities.length > 1 ? 's' : ''}.`
+      : 'Aucune intervention culturelle prioritaire à mettre en file.',
+    priorities,
+    conflicts,
   };
 }

--- a/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
+++ b/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCultureDiscoveryUrgencyGroups } from '../../../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
+import { buildCultureDiscoveryUrgencyGroups, buildCultureInterventionPriorities } from '../../../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
 
 test('buildCultureDiscoveryUrgencyGroups orders urgent and active culture signals before background lore', () => {
   const groups = buildCultureDiscoveryUrgencyGroups({
@@ -55,6 +55,14 @@ test('buildCultureDiscoveryUrgencyGroups orders urgent and active culture signal
   assert.match(groups.groups[0].items.map((item) => item.label).join(' | '), /routes-célestes/);
   assert.equal(groups.groups[1].items[0].cause, 'Recherche active');
   assert.equal(groups.groups[2].items[0].label, 'Chant de quai');
+
+  const priorities = buildCultureInterventionPriorities(groups);
+  assert.equal(priorities.state, 'active');
+  assert.equal(priorities.priorities[0].urgency, 'urgent');
+  assert.equal(priorities.priorities[0].action, 'Suivre le repère maintenant');
+  assert.match(priorities.priorities[0].effect, /Ouverture des archives/);
+  assert.match(priorities.priorities[0].waitRisk, /signal prioritaire/);
+  assert.match(priorities.summary, /interventions? culturelle/);
 });
 
 test('buildCultureDiscoveryUrgencyGroups names ambiguous empty states without duplicating marker data', () => {
@@ -96,4 +104,47 @@ test('buildCultureDiscoveryUrgencyGroups names ambiguous empty states without du
   assert.equal(grouped.groups[0].key, 'urgent');
   assert.equal(grouped.groups[0].items.length, 1);
   assert.equal(grouped.groups[0].items[0].cause, 'Tension locale');
+
+  const priorities = buildCultureInterventionPriorities(grouped);
+  assert.equal(priorities.priorities.length, 1);
+  assert.equal(priorities.priorities[0].action, 'Stabiliser la découverte');
+  assert.match(priorities.priorities[0].waitRisk, /tension locale/);
+});
+
+test('buildCultureInterventionPriorities flags local priority conflicts', () => {
+  const priorities = buildCultureInterventionPriorities({
+    groups: [{
+      key: 'urgent',
+      items: [
+        {
+          itemId: 'discovery:river:aurora',
+          kind: 'discovery',
+          group: 'urgent',
+          label: 'routes-célestes',
+          shortLabel: 'routes-célestes',
+          cultureName: 'Compact d’Aurora',
+          regionId: 'river-gate',
+          cause: '1 repère',
+          detail: 'route critique',
+          priority: 330,
+        },
+        {
+          itemId: 'discovery:river:ember',
+          kind: 'discovery',
+          group: 'urgent',
+          label: 'glyphes-de-convoi',
+          shortLabel: 'glyphes-de-convoi',
+          cultureName: 'Ligues des Forges',
+          regionId: 'river-gate',
+          cause: 'Tension locale',
+          detail: 'friction locale',
+          priority: 320,
+        },
+      ],
+    }],
+  });
+
+  assert.equal(priorities.priorities[0].conflict, true);
+  assert.equal(priorities.conflicts[0].label, 'Même province');
+  assert.match(priorities.conflicts[0].summary, /concurrence/);
 });

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -52,8 +52,11 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /buildCultureTensionCause/);
   assert.match(webAppSource, /cultureTensionCausePriority/);
   assert.match(webAppSource, /buildCultureDiscoveryUrgencyGroups/);
+  assert.match(webAppSource, /buildCultureInterventionPriorities/);
   assert.match(webAppSource, /renderCultureDiscoveryUrgencyGroups/);
+  assert.match(webAppSource, /renderCultureInterventionPriorities/);
   assert.match(webAppSource, /Découvertes culturelles groupées par urgence/);
+  assert.match(webAppSource, /File recommandée des interventions culturelles/);
   assert.match(webAppSource, /Urgence/);
   assert.match(webAppSource, /Cause floue/);
   assert.match(webAppSource, /urgence puis tendance/);
@@ -89,6 +92,9 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-discovery-urgency-groups/);
   assert.match(stylesSource, /\.culture-discovery-urgency-group--urgent/);
   assert.match(stylesSource, /\.culture-discovery-urgency-item/);
+  assert.match(stylesSource, /\.culture-intervention-priorities/);
+  assert.match(stylesSource, /\.culture-intervention-priority--urgent/);
+  assert.match(stylesSource, /\.culture-intervention-conflicts/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-rising/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-unknown/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-confirmation/);

--- a/web/app.js
+++ b/web/app.js
@@ -18,7 +18,7 @@ import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js
 import { buildIntrigueTurnReportDeltas } from '../src/ui/intrigue/buildIntrigueTurnReportDeltas.js';
 import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMapRecommendations.js';
 import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTimeline.js';
-import { buildCultureDiscoveryUrgencyGroups } from '../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
+import { buildCultureDiscoveryUrgencyGroups, buildCultureInterventionPriorities } from '../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
 import { buildCultureConsequenceChips } from '../src/ui/culture/buildCultureConsequenceChips.js';
 import { buildCultureTurnReportDeltas } from '../src/ui/culture/buildCultureTurnReportDeltas.js';
 import { buildCultureUnlockHints } from '../src/ui/culture/buildCultureUnlockHints.js';
@@ -7707,6 +7707,39 @@ function renderCultureDiscoveryUrgencyGroups(groupView) {
   `;
 }
 
+function renderCultureInterventionPriorities(priorityView) {
+  if (!priorityView || priorityView.state !== 'active') {
+    return '';
+  }
+
+  return `
+    <article class="culture-intervention-priorities" aria-label="File recommandée des interventions culturelles">
+      <div class="culture-intervention-priorities__header">
+        <span>Interventions à mettre en file</span>
+        <strong>${priorityView.summary}</strong>
+      </div>
+      <ol>
+        ${priorityView.priorities.map((priority) => `
+          <li class="culture-intervention-priority culture-intervention-priority--${priority.urgency} ${priority.conflict ? 'has-conflict' : ''}">
+            <div>
+              <b>${priority.rank}. ${priority.action}</b>
+              <span>${priority.urgencyLabel} · ${priority.sourceLabel}</span>
+            </div>
+            <p>${priority.effect}</p>
+            <small>Risque: ${priority.waitRisk} · Dépendance: ${priority.dependency}</small>
+          </li>
+        `).join('')}
+      </ol>
+      ${priorityView.conflicts.length > 0 ? `
+        <div class="culture-intervention-conflicts">
+          <b>Conflits prioritaires</b>
+          ${priorityView.conflicts.map((conflict) => `<p>${conflict.label}: ${conflict.summary}</p>`).join('')}
+        </div>
+      ` : ''}
+    </article>
+  `;
+}
+
 function renderCultureClusterPinList(cluster) {
   if (!cluster) {
     return '';
@@ -8069,6 +8102,7 @@ function renderCultureSidePanel(cultureView) {
     selectedMarker: focus,
     selectedCluster,
   });
+  const interventionPriorities = buildCultureInterventionPriorities(discoveryUrgencyGroups);
   const recommendationView = buildCultureMapRecommendations({
     selectedRegionId: state.selectedProvinceId,
     selectedMarker: focus,
@@ -8100,6 +8134,7 @@ function renderCultureSidePanel(cultureView) {
       ${renderCultureRecommendationPanel(recommendationView)}
       ${renderCultureLocalTimeline(localTimelineView)}
       ${renderCultureDiscoveryUrgencyGroups(discoveryUrgencyGroups)}
+      ${renderCultureInterventionPriorities(interventionPriorities)}
       ${renderCultureClusterPinList(selectedCluster)}
       ${focus ? `
         <article class="culture-focus-card culture-focus-card--${getCultureTone(focus)}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -9003,3 +9003,63 @@ button { font: inherit; }
 }
 .province-logistics-bottleneck-priority small { color: #93c5fd; font-size: 11px; }
 .province-logistics-bottleneck-priority em { margin-top: 4px; color: #fde68a; font-size: 11px; font-style: normal; }
+
+.culture-intervention-priorities {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.56);
+  border: 1px solid rgba(250, 204, 21, 0.18);
+}
+.culture-intervention-priorities__header {
+  display: grid;
+  gap: 2px;
+}
+.culture-intervention-priorities__header span {
+  color: #fde68a;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-intervention-priorities__header strong { color: #f8fafc; font-size: 12px; line-height: 1.3; }
+.culture-intervention-priorities ol {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.culture-intervention-priority {
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.culture-intervention-priority--urgent { border-color: rgba(248, 113, 113, 0.38); }
+.culture-intervention-priority--active { border-color: rgba(56, 189, 248, 0.3); }
+.culture-intervention-priority--background { border-color: rgba(148, 163, 184, 0.16); }
+.culture-intervention-priority.has-conflict { box-shadow: inset 3px 0 rgba(251, 191, 36, 0.78); }
+.culture-intervention-priority div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.culture-intervention-priority b { color: #f8fafc; font-size: 12px; }
+.culture-intervention-priority span { color: #bae6fd; font-size: 10px; font-weight: 900; text-transform: uppercase; }
+.culture-intervention-priority p { margin: 0; color: #e2e8f0; font-size: 12px; line-height: 1.35; }
+.culture-intervention-priority small { color: #cbd5e1; font-size: 11px; line-height: 1.3; }
+.culture-intervention-conflicts {
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(120, 53, 15, 0.18);
+  border: 1px solid rgba(251, 191, 36, 0.22);
+}
+.culture-intervention-conflicts b { color: #fde68a; font-size: 11px; }
+.culture-intervention-conflicts p { margin: 0; color: #fef3c7; font-size: 11px; line-height: 1.3; }


### PR DESCRIPTION
Gamma: Implements #685.

## Summary
- derive a short cultural intervention queue from existing urgency groups
- show each priority with urgency, expected effect, wait risk, dependency, and conflict state
- surface local priority conflicts in the province culture panel without adding a new source of truth

## Validation
- node --check web/app.js
- node --check src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
- node --check src/ui/culture/buildCultureOpportunityReminders.js
- npm test -- test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js
- git diff --check
- npm test (484 OK)