### PR TITLE
Epsilon: prioritize climate mitigation sequences

### DIFF
--- a/test/ui/climate/webClimateMitigationSequencePriority.test.js
+++ b/test/ui/climate/webClimateMitigationSequencePriority.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('climate severity legend prioritizes mitigation sequences from marker stacks', () => {
+  assert.match(webAppSource, /function getClimateSeverityRank/);
+  assert.match(webAppSource, /function buildClimateMitigationSequenceFromSeverity/);
+  assert.match(webAppSource, /buildProvinceClimateRiskReductionForecast\(province, shell\)/);
+  assert.match(webAppSource, /buildClimateInterventionQueuePlan\(province, forecast\)/);
+  assert.match(webAppSource, /linkedNeighbors = province\.neighborIds/);
+  assert.match(webAppSource, /Soulage aussi/);
+  assert.match(webAppSource, /Réduit la pression du groupe cascade sélectionné/);
+  assert.match(webAppSource, /mitigationSequence/);
+  assert.match(webAppSource, /Séquence de mitigation climat priorisée/);
+  assert.match(webAppSource, /fenêtre \$\{step\.window\}/);
+  assert.match(webAppSource, /buildClimateSeverityLegend\(postCommitClimateMarkers, climateMarkerDensity, shell\)/);
+
+  assert.match(stylesSource, /\.map-climate-severity-legend__sequence/);
+  assert.match(stylesSource, /\.map-climate-severity-legend__sequence-step/);
+  assert.match(stylesSource, /\.map-climate-severity-legend__sequence-step--cascade-active/);
+  assert.match(stylesSource, /\.map-climate-severity-legend__sequence-step--hazard-unresolved/);
+});

--- a/test/ui/climate/webClimateSeverityLegend.test.js
+++ b/test/ui/climate/webClimateSeverityLegend.test.js
@@ -16,7 +16,7 @@ test('climate overlay exposes compact severity legend for stacked markers', () =
   assert.match(webAppSource, /'risk-reduced': \{ label: 'Réduit'/);
   assert.match(webAppSource, /map-climate-severity-legend/);
   assert.match(webAppSource, /la sévérité explique les piles sans ouvrir chaque province/);
-  assert.match(webAppSource, /climateSeverityLegend = buildClimateSeverityLegend\(postCommitClimateMarkers, climateMarkerDensity\)/);
+  assert.match(webAppSource, /climateSeverityLegend = buildClimateSeverityLegend\(postCommitClimateMarkers, climateMarkerDensity, shell\)/);
   assert.match(webAppSource, /renderClimateSeverityLegend\(climateSeverityLegend\)/);
 
   assert.match(stylesSource, /\.map-climate-severity-legend/);

--- a/web/app.js
+++ b/web/app.js
@@ -3546,7 +3546,63 @@ function renderClimateMarkerDensityRollup(control) {
   `;
 }
 
-function buildClimateSeverityLegend(markers = [], densityControl = null) {
+function getClimateSeverityRank(status) {
+  return {
+    'cascade-active': 1,
+    'hazard-unresolved': 2,
+    'hazard-delayed': 3,
+    'risk-reduced': 4,
+  }[status] ?? 5;
+}
+
+function buildClimateMitigationSequenceFromSeverity(markers = [], shell, densityControl = null) {
+  if (!shell || markers.length === 0) {
+    return [];
+  }
+
+  const markerByProvince = new Map(markers.map((marker) => [marker.provinceId, marker]));
+  const selectedGroupIds = new Set((densityControl?.selectedCascadeGroup?.markers ?? []).map((marker) => marker.provinceId));
+
+  return markers
+    .map((marker) => {
+      const province = shell.provinces.find((candidate) => candidate.provinceId === marker.provinceId) ?? null;
+      if (!province) {
+        return null;
+      }
+
+      const forecast = buildProvinceClimateRiskReductionForecast(province, shell);
+      const plan = buildClimateInterventionQueuePlan(province, forecast);
+      const linkedNeighbors = province.neighborIds
+        .map((provinceId) => markerByProvince.get(provinceId))
+        .filter(Boolean)
+        .sort((left, right) => getClimateSeverityRank(left.status) - getClimateSeverityRank(right.status) || left.provinceLabel.localeCompare(right.provinceLabel))
+        .slice(0, 2);
+      const severityRank = getClimateSeverityRank(marker.status);
+
+      return {
+        provinceId: province.provinceId,
+        provinceLabel: province.label,
+        status: marker.status,
+        severityRank,
+        severityLabel: marker.status === 'cascade-active' ? 'Critique' : marker.status === 'hazard-unresolved' ? 'Élevé' : marker.status === 'hazard-delayed' ? 'Surveillance' : 'Réduit',
+        action: plan.actionLabel,
+        window: plan.window,
+        cascade: forecast.selectedInterventionPreview.avoidedCascade,
+        why: marker.summary,
+        neighborRelief: linkedNeighbors.length > 0
+          ? `Soulage aussi ${linkedNeighbors.map((neighbor) => neighbor.provinceLabel).join(', ')}.`
+          : selectedGroupIds.has(marker.provinceId)
+            ? 'Réduit la pression du groupe cascade sélectionné.'
+            : 'Effet surtout local; surveiller les voisins après résolution.',
+        disabled: plan.disabled,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.severityRank - right.severityRank || Number(left.disabled) - Number(right.disabled) || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 4);
+}
+
+function buildClimateSeverityLegend(markers = [], densityControl = null, shell = null) {
   if (state.activeOverlaySlot !== 'climate-overlay' || markers.length === 0) {
     return { active: false, entries: [], summary: 'Légende climat inactive: overlay climat masqué ou aucun marqueur.' };
   }
@@ -3566,12 +3622,14 @@ function buildClimateSeverityLegend(markers = [], densityControl = null) {
     .filter((entry) => entry.count > 0);
   const groupedCount = densityControl?.groupedCount ?? 0;
   const cascadeGroupCount = densityControl?.selectedCascadeGroup?.markers.length ?? 0;
+  const mitigationSequence = buildClimateMitigationSequenceFromSeverity(markers, shell, densityControl);
 
   return {
     active: true,
     entries,
     groupedCount,
     cascadeGroupCount,
+    mitigationSequence,
     summary: groupedCount > 0
       ? `${groupedCount} marqueur${groupedCount > 1 ? 's' : ''} agrégé${groupedCount > 1 ? 's' : ''}; la sévérité explique les piles sans ouvrir chaque province.`
       : 'Sévérité climat lisible directement sur les marqueurs visibles.',
@@ -3600,6 +3658,17 @@ function renderClimateSeverityLegend(legend) {
         `).join('')}
       </ul>
       ${legend.cascadeGroupCount > 1 ? `<small>Groupe sélectionné: ${legend.cascadeGroupCount} provinces liées au risque principal.</small>` : '<small>Les cascades et aléas non résolus restent épinglés en priorité.</small>'}
+      ${legend.mitigationSequence.length > 0 ? `
+        <ol class="map-climate-severity-legend__sequence" aria-label="Séquence de mitigation climat priorisée">
+          ${legend.mitigationSequence.map((step, index) => `
+            <li class="map-climate-severity-legend__sequence-step map-climate-severity-legend__sequence-step--${step.status}">
+              <b>${index + 1}. ${step.provinceLabel} · ${step.severityLabel}</b>
+              <span>${step.action} · fenêtre ${step.window}</span>
+              <small>${step.cascade} · ${step.neighborRelief}</small>
+            </li>
+          `).join('')}
+        </ol>
+      ` : ''}
     </section>
   `;
 }
@@ -9496,7 +9565,7 @@ function render() {
     mobileMapExpanded: state.mobileMapExpanded,
     selectedProvinceId: state.selectedProvinceId,
   });
-  const climateSeverityLegend = buildClimateSeverityLegend(postCommitClimateMarkers, climateMarkerDensity);
+  const climateSeverityLegend = buildClimateSeverityLegend(postCommitClimateMarkers, climateMarkerDensity, shell);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `

--- a/web/styles.css
+++ b/web/styles.css
@@ -400,6 +400,27 @@ button { font: inherit; }
 .map-climate-severity-legend__item--hazard-unresolved { border-color: rgba(251, 191, 36, 0.5); }
 .map-climate-severity-legend__item--hazard-delayed { border-color: rgba(56, 189, 248, 0.48); }
 .map-climate-severity-legend__item--risk-reduced { border-color: rgba(74, 222, 128, 0.48); }
+.map-climate-severity-legend__sequence {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 7px;
+  margin: 2px 0 0;
+  padding: 0;
+}
+.map-climate-severity-legend__sequence-step {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.42);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  list-style-position: inside;
+}
+.map-climate-severity-legend__sequence-step b,
+.map-climate-severity-legend__sequence-step span,
+.map-climate-severity-legend__sequence-step small { font-size: 12px; }
+.map-climate-severity-legend__sequence-step--cascade-active { border-color: rgba(248, 113, 113, 0.46); }
+.map-climate-severity-legend__sequence-step--hazard-unresolved { border-color: rgba(251, 191, 36, 0.42); }
 
 .economy-turn-pulse {
   margin-top: 12px;


### PR DESCRIPTION
Epsilon: Implements #687.

Summary:
- Extends the existing climate severity legend with a prioritized mitigation sequence derived from stacked climate marker statuses.
- Reuses existing climate forecast/queue planning data for severity, action window, avoidable cascade, and recommended intervention.
- Calls out when a mitigation step can relieve neighboring climate pressure or the selected cascade group.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webClimateMitigationSequencePriority.test.js test/ui/climate/webClimateSeverityLegend.test.js test/ui/climate/webClimateCascadeGroupHighlights.test.js
- npm test