### PR TITLE
Alpha: highlight front decision dependencies

### DIFF
--- a/test/ui/war/webCriticalFrontDecisionComparison.test.js
+++ b/test/ui/war/webCriticalFrontDecisionComparison.test.js
@@ -17,12 +17,26 @@ test('critical front decision comparison reuses map priority and action data', (
   assert.match(webAppSource, /ignoredRisk/);
 });
 
+test('critical front decision comparison highlights immediate military and non-military dependencies', () => {
+  assert.match(webAppSource, /function buildFrontDecisionDependencies/);
+  assert.match(webAppSource, /kind: 'military'/);
+  assert.match(webAppSource, /Soutenir \$\{neighborFront\.label\}/);
+  assert.match(webAppSource, /Neutraliser marqueur adverse/);
+  assert.match(webAppSource, /kind: 'logistics'/);
+  assert.match(webAppSource, /Sécuriser ravitaillement/);
+  assert.match(webAppSource, /kind: 'stability'/);
+  assert.match(webAppSource, /dependencies\.slice\(0, 2\)/);
+});
+
 test('critical front decision comparison renders compact navigation cards without changing filters', () => {
   assert.match(webAppSource, /function renderCriticalFrontDecisionComparison/);
   assert.match(webAppSource, /data-province-id="\$\{decision\.provinceId\}"/);
   assert.match(webAppSource, /data-readiness-focus="\$\{decision\.provinceId\}"/);
   assert.match(webAppSource, /sans perdre les filtres carte/);
   assert.match(webAppSource, /renderCriticalFrontDecisionComparison\(shell, intrigueView\)/);
+  assert.match(webAppSource, /critical-front-decision__dependencies/);
   assert.match(stylesSource, /\.critical-front-decision-comparison/);
   assert.match(stylesSource, /\.critical-front-decision--danger/);
+  assert.match(stylesSource, /\.critical-front-decision__dependency--military/);
+  assert.match(stylesSource, /\.critical-front-decision__dependency--logistics/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -5618,6 +5618,57 @@ function buildRecommendedMilitaryActionPreview(shell, intrigueView = null) {
     sideEffect,
   };
 }
+function buildFrontDecisionDependencies(province, shell, projection, actionQueue, risks) {
+  if (!province || !projection) {
+    return [];
+  }
+
+  const dependencies = [];
+  const hasDriver = (label) => projection.drivers.some((driver) => driver.label === label);
+  const neighborFront = shell.provinces.find((candidate) => province.neighborIds.includes(candidate.provinceId) && (candidate.contested || candidate.occupied));
+  const blockedAction = actionQueue.find((entry) => entry.status === 'blocked');
+  const riskyAction = actionQueue.find((entry) => entry.status === 'risky');
+  const stabilityValue = projection.lines.find((line) => line.label === 'Stabilité attendue')?.value ?? projection.title;
+
+  if (hasDriver('Front voisin') && neighborFront) {
+    dependencies.push({
+      kind: 'military',
+      label: `Soutenir ${neighborFront.label}`,
+      reason: 'Front voisin conditionne la pression locale.',
+    });
+  } else if (hasDriver('Pression')) {
+    dependencies.push({
+      kind: 'military',
+      label: 'Neutraliser marqueur adverse',
+      reason: risks[0]?.summary ?? 'Pression ennemie visible avant engagement.',
+    });
+  }
+
+  if (blockedAction) {
+    dependencies.push({
+      kind: 'logistics',
+      label: 'Débloquer contrainte logistique',
+      reason: `${blockedAction.label} reste bloquée avant succès probable.`,
+    });
+  } else if (hasDriver('Fatigue / supply') || ['collapsed', 'disrupted', 'strained'].includes(province.supplyLevel)) {
+    dependencies.push({
+      kind: 'logistics',
+      label: `Sécuriser ravitaillement ${province.supplyTone}`,
+      reason: 'La contrainte supply conditionne le coût réel de l’action.',
+    });
+  }
+
+  if (dependencies.length < 2 && (projection.tone !== 'ready' || riskyAction)) {
+    dependencies.push({
+      kind: 'stability',
+      label: 'Confirmer stabilité projetée',
+      reason: `${stabilityValue}; ${riskyAction ? `${riskyAction.label} reste risquée.` : 'suivi nécessaire avant commit.'}`,
+    });
+  }
+
+  return dependencies.slice(0, 2);
+}
+
 function buildCriticalFrontDecisionComparison(shell, intrigueView = null) {
   const priorities = buildFrontPriorityRanking(shell, intrigueView)
     .filter((priority) => priority.tone !== 'ready')
@@ -5672,6 +5723,7 @@ function buildCriticalFrontDecisionComparison(shell, intrigueView = null) {
         : riskyCount > 0
           ? `${riskyCount} option${riskyCount > 1 ? 's' : ''} risquée${riskyCount > 1 ? 's' : ''}; garder une réserve.`
           : ignoredRisk;
+    const dependencies = buildFrontDecisionDependencies(province, shell, projection, actionQueue, risks);
 
     return {
       rank: index + 1,
@@ -5684,6 +5736,7 @@ function buildCriticalFrontDecisionComparison(shell, intrigueView = null) {
       actionCode: recommendedAction?.actionCode ?? priority.actionCode,
       costRisk,
       ignoredRisk,
+      dependencies,
       comparison: index === 0
         ? 'Choix recommandé en premier: menace cumulée maximale.'
         : `Comparer après ${priorities[index - 1].provinceLabel}: menace ${priority.score} vs ${priorities[index - 1].score}.`,
@@ -5735,6 +5788,14 @@ function renderCriticalFrontDecisionComparison(shell, intrigueView = null) {
               <div><dt>Action</dt><dd>${decision.recommendedAction}</dd></div>
               <div><dt>Coût / risque</dt><dd>${decision.costRisk}</dd></div>
             </dl>
+            ${decision.dependencies.length > 0 ? `
+              <div class="critical-front-decision__dependencies" aria-label="Dépendances avant engagement">
+                <span>Dépendances</span>
+                ${decision.dependencies.map((dependency) => `
+                  <em class="critical-front-decision__dependency critical-front-decision__dependency--${dependency.kind}"><b>${dependency.label}</b>${dependency.reason}</em>
+                `).join('')}
+              </div>
+            ` : ''}
             <small>${decision.ignoredRisk} ${decision.comparison}</small>
           </button>
         `).join('')}

--- a/web/styles.css
+++ b/web/styles.css
@@ -660,6 +660,37 @@ button { font: inherit; }
   font-size: 11px;
   line-height: 1.3;
 }
+
+.critical-front-decision__dependencies {
+  display: grid;
+  gap: 4px;
+  padding-top: 2px;
+}
+.critical-front-decision__dependencies span {
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.critical-front-decision__dependency {
+  display: grid;
+  gap: 1px;
+  padding: 5px 6px;
+  border-radius: 9px;
+  background: rgba(15, 23, 42, 0.66);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: var(--muted);
+  font-size: 10px;
+  font-style: normal;
+  line-height: 1.25;
+}
+.critical-front-decision__dependency b {
+  color: #f8fafc;
+  font-size: 11px;
+}
+.critical-front-decision__dependency--military { border-color: rgba(248, 113, 113, 0.34); }
+.critical-front-decision__dependency--logistics { border-color: rgba(56, 189, 248, 0.3); }
+.critical-front-decision__dependency--stability { border-color: rgba(251, 191, 36, 0.3); }
 .critical-front-decision small {
   color: var(--muted);
   font-size: 11px;


### PR DESCRIPTION
Alpha: Implements #693.

Summary:
- Adds immediate dependencies to the critical-front decision comparison panel before commit.
- Reuses existing priority, projection, action queue, risk, neighbor, and supply data; no new source of truth.
- Shows up to two compact dependencies per decision: military support/neutralization plus logistics or stability constraints, while preserving existing map filters and quick navigation.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webCriticalFrontDecisionComparison.test.js
- npm test (489 tests)
- git diff --check

Zeta: PR prête pour revue. Merci de valider avant tout merge.
