### PR TITLE
Beta: show logistics priority tradeoffs

### DIFF
--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -9,11 +9,17 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /function renderProvinceLogisticsChoicePreview/);
   assert.match(webAppSource, /buildProvinceLogisticsBottleneckWarnings/);
   assert.match(webAppSource, /buildProvinceLogisticsBottleneckPriorities/);
+  assert.match(webAppSource, /buildProvinceLogisticsInterventionTradeoff/);
   assert.match(webAppSource, /province-logistics-bottleneck-warning/);
   assert.match(webAppSource, /province-logistics-bottleneck-priorities/);
   assert.match(webAppSource, /Priorités aval/);
   assert.match(webAppSource, /Raison du classement/);
   assert.match(webAppSource, /Action probable/);
+  assert.match(webAppSource, /Compromis d’intervention logistique/);
+  assert.match(webAppSource, /Améliore/);
+  assert.match(webAppSource, /Retarde/);
+  assert.match(webAppSource, /Risque/);
+  assert.match(webAppSource, /interventionTradeoff/);
   assert.match(webAppSource, /Renforce un autre goulot/);
   assert.match(webAppSource, /downstreamImpact/);
   assert.match(webAppSource, /recoveryAction/);
@@ -111,6 +117,7 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-bottleneck-warning--high/);
   assert.match(stylesSource, /province-logistics-bottleneck-warning--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck-priorities/);
+  assert.match(stylesSource, /province-logistics-bottleneck-tradeoff/);
   assert.match(stylesSource, /province-logistics-bottleneck-priority--high/);
   assert.match(stylesSource, /province-logistics-bottleneck-priority--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck--low/);

--- a/web/app.js
+++ b/web/app.js
@@ -1880,6 +1880,24 @@ function buildProvinceLogisticsBottleneckComparison(province, economyView) {
     .slice(0, 3);
 }
 
+function buildProvinceLogisticsInterventionTradeoff(entry, sharedCity, sharedResource) {
+  const improves = entry.tone === 'high'
+    ? `améliore ${entry.impactedCity} et réduit le risque aval immédiat`
+    : `améliore la marge de ${entry.impactedCity}`;
+  const delays = sharedResource
+    ? `retarde les routes concurrentes sur ${entry.resourceLabel}`
+    : entry.capacity >= 9
+      ? 'retarde le délestage des flux secondaires'
+      : 'retarde les actions de confort sur routes stables';
+  const risk = sharedCity
+    ? `risque: ignorer ce choix laisse deux goulots bloquer ${entry.impactedCity}`
+    : entry.tone === 'high'
+      ? `risque: choisir une autre route prolonge la pénurie aval de ${entry.impactedCity}`
+      : `risque: une autre ressource d'abord peut transformer ce flux en goulot critique`;
+
+  return { improves, delays, risk, summary: `Améliore: ${improves} · Retarde: ${delays} · ${risk}` };
+}
+
 function buildProvinceLogisticsBottleneckPriorities(comparisons) {
   const strained = comparisons.filter((entry) => entry.tone === 'high' || entry.tone === 'medium');
   const impactedCityCounts = strained.reduce((counts, entry) => counts.set(entry.impactedCity, (counts.get(entry.impactedCity) ?? 0) + 1), new Map());
@@ -1902,6 +1920,7 @@ function buildProvinceLogisticsBottleneckPriorities(comparisons) {
         ...entry,
         reinforcement,
         rankReason,
+        interventionTradeoff: buildProvinceLogisticsInterventionTradeoff(entry, sharedCity, sharedResource),
         priorityScore: entry.score + (sharedCity ? 35 : 0) + (sharedResource ? 18 : 0),
       };
     })
@@ -1977,6 +1996,11 @@ function renderProvinceLogisticsBottleneckComparison(province, economyView) {
                   <small>${entry.impactedCity} · ${entry.resourceLabel} · ${entry.headline}</small>
                   <p>${entry.downstreamImpact}</p>
                   <small>Action probable: ${entry.recoveryAction}</small>
+                  <div class="province-logistics-bottleneck-tradeoff" aria-label="Compromis d’intervention logistique">
+                    <span><b>Améliore</b>${entry.interventionTradeoff.improves}</span>
+                    <span><b>Retarde</b>${entry.interventionTradeoff.delays}</span>
+                    <span><b>Risque</b>${entry.interventionTradeoff.risk}</span>
+                  </div>
                   <small>Raison du classement: ${entry.rankReason}</small>
                   ${entry.reinforcement ? `<em>${entry.reinforcement}</em>` : ''}
                 </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -9084,3 +9084,25 @@ button { font: inherit; }
 }
 .culture-intervention-conflicts b { color: #fde68a; font-size: 11px; }
 .culture-intervention-conflicts p { margin: 0; color: #fef3c7; font-size: 11px; line-height: 1.3; }
+.province-logistics-bottleneck-tradeoff {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
+  margin: 6px 0;
+}
+.province-logistics-bottleneck-tradeoff span {
+  display: grid;
+  gap: 2px;
+  padding: 6px;
+  border-radius: 9px;
+  background: rgba(15, 23, 42, 0.56);
+  color: #dbeafe;
+  font-size: 10px;
+  line-height: 1.25;
+}
+.province-logistics-bottleneck-tradeoff b {
+  color: #bae6fd;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
Beta: Implements #694.

## Summary
- Adds compact “Améliore / Retarde / Risque” trade-off chips to the 2–3 logistics bottleneck priorities.
- Derives trade-offs from existing route severity, impacted city, resource pressure, capacity, and shared bottleneck context.
- Keeps the existing bottleneck priority ranking, route list, and rollup/filter UI intact.

## Validation
- npm test (488 OK)
- targeted economy UI tests (7 OK)
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check
