### PR TITLE
Gamma: surface culture queue blockers

### DIFF
--- a/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
+++ b/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
@@ -177,10 +177,67 @@ function buildInterventionDependency(item, items) {
   return item.group === 'background' ? 'Aucune dépendance prioritaire' : 'Dépendance non bloquante';
 }
 
+function buildInterventionBlocker(item, dependency, conflict) {
+  if (conflict) {
+    return {
+      state: 'blocked',
+      label: 'bloqué par',
+      reason: dependency,
+      shortReason: dependency.replace('Conflit local avec ', ''),
+    };
+  }
+
+  if (item.cause === 'Tension locale') {
+    return {
+      state: 'blocked',
+      label: 'bloqué par',
+      reason: 'condition culturelle locale instable',
+      shortReason: 'tension locale',
+    };
+  }
+
+  if (dependency.startsWith('Dépend aussi de ')) {
+    return {
+      state: 'waiting',
+      label: 'bloqué par',
+      reason: dependency,
+      shortReason: dependency.replace('Dépend aussi de ', ''),
+    };
+  }
+
+  return null;
+}
+
+function buildInterventionFollowUp(item, items) {
+  const nextInCulture = items.find((candidate) => candidate.itemId !== item.itemId
+    && candidate.cultureName === item.cultureName
+    && candidate.group !== 'urgent');
+
+  if (nextInCulture) {
+    return {
+      label: 'débloque ensuite',
+      action: nextInCulture.shortLabel,
+      reason: `${nextInCulture.cause} en ${nextInCulture.regionId || item.regionId}`,
+    };
+  }
+
+  if (item.group === 'urgent') {
+    return {
+      label: 'débloque ensuite',
+      action: 'priorités actives',
+      reason: 'une fois le signal urgent stabilisé',
+    };
+  }
+
+  return null;
+}
+
 function buildInterventionPriority(item, items, index) {
   const dependency = buildInterventionDependency(item, items);
   const conflict = dependency.startsWith('Conflit local');
   const action = buildInterventionAction(item);
+  const blocker = buildInterventionBlocker(item, dependency, conflict);
+  const followUp = buildInterventionFollowUp(item, items);
 
   return {
     priorityId: `culture-intervention:${item.itemId}`,
@@ -192,6 +249,8 @@ function buildInterventionPriority(item, items, index) {
     waitRisk: buildInterventionRisk(item),
     dependency,
     conflict,
+    blocker,
+    followUp,
     cultureName: item.cultureName,
     regionId: item.regionId,
     sourceLabel: item.shortLabel,

--- a/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
+++ b/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
@@ -62,6 +62,9 @@ test('buildCultureDiscoveryUrgencyGroups orders urgent and active culture signal
   assert.equal(priorities.priorities[0].action, 'Suivre le repère maintenant');
   assert.match(priorities.priorities[0].effect, /Ouverture des archives/);
   assert.match(priorities.priorities[0].waitRisk, /signal prioritaire/);
+  assert.equal(priorities.priorities[0].blocker, null);
+  assert.equal(priorities.priorities[0].followUp.label, 'débloque ensuite');
+  assert.equal(priorities.priorities[0].followUp.action, 'catalogues-publics');
   assert.match(priorities.summary, /interventions? culturelle/);
 });
 
@@ -109,6 +112,9 @@ test('buildCultureDiscoveryUrgencyGroups names ambiguous empty states without du
   assert.equal(priorities.priorities.length, 1);
   assert.equal(priorities.priorities[0].action, 'Stabiliser la découverte');
   assert.match(priorities.priorities[0].waitRisk, /tension locale/);
+  assert.equal(priorities.priorities[0].blocker.label, 'bloqué par');
+  assert.equal(priorities.priorities[0].blocker.shortReason, 'tension locale');
+  assert.equal(priorities.priorities[0].followUp.label, 'débloque ensuite');
 });
 
 test('buildCultureInterventionPriorities flags local priority conflicts', () => {
@@ -145,6 +151,8 @@ test('buildCultureInterventionPriorities flags local priority conflicts', () => 
   });
 
   assert.equal(priorities.priorities[0].conflict, true);
+  assert.equal(priorities.priorities[0].blocker.label, 'bloqué par');
+  assert.equal(priorities.priorities[0].blocker.shortReason, 'Ligues des Forges');
   assert.equal(priorities.conflicts[0].label, 'Même province');
   assert.match(priorities.conflicts[0].summary, /concurrence/);
 });

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -57,6 +57,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /renderCultureInterventionPriorities/);
   assert.match(webAppSource, /Découvertes culturelles groupées par urgence/);
   assert.match(webAppSource, /File recommandée des interventions culturelles/);
+  assert.match(webAppSource, /culture-intervention-priority__blocker/);
+  assert.match(webAppSource, /culture-intervention-priority__follow-up/);
   assert.match(webAppSource, /Urgence/);
   assert.match(webAppSource, /Cause floue/);
   assert.match(webAppSource, /urgence puis tendance/);
@@ -95,6 +97,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-intervention-priorities/);
   assert.match(stylesSource, /\.culture-intervention-priority--urgent/);
   assert.match(stylesSource, /\.culture-intervention-conflicts/);
+  assert.match(stylesSource, /\.culture-intervention-priority__blocker/);
+  assert.match(stylesSource, /\.culture-intervention-priority__follow-up/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-rising/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-unknown/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-confirmation/);

--- a/web/app.js
+++ b/web/app.js
@@ -7881,6 +7881,8 @@ function renderCultureInterventionPriorities(priorityView) {
             </div>
             <p>${priority.effect}</p>
             <small>Risque: ${priority.waitRisk} · Dépendance: ${priority.dependency}</small>
+            ${priority.blocker ? `<em class="culture-intervention-priority__blocker">${priority.blocker.label} ${priority.blocker.shortReason}</em>` : ''}
+            ${priority.followUp ? `<em class="culture-intervention-priority__follow-up">${priority.followUp.label} ${priority.followUp.action}</em>` : ''}
           </li>
         `).join('')}
       </ol>

--- a/web/styles.css
+++ b/web/styles.css
@@ -9137,3 +9137,26 @@ button { font: inherit; }
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+
+.culture-intervention-priority__blocker,
+.culture-intervention-priority__follow-up {
+  display: inline-flex;
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 900;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.culture-intervention-priority__blocker {
+  color: #fecaca;
+  background: rgba(127, 29, 29, 0.26);
+  border: 1px solid rgba(248, 113, 113, 0.28);
+}
+.culture-intervention-priority__follow-up {
+  color: #bbf7d0;
+  background: rgba(20, 83, 45, 0.24);
+  border: 1px solid rgba(74, 222, 128, 0.24);
+}


### PR DESCRIPTION
Gamma: Implements #695.

## Summary
- add blocker and follow-up unlock metadata to cultural intervention priorities using existing dependency/conflict/cause data
- render compact “bloqué par” and “débloque ensuite” chips in the province culture queue
- cover blocked local tension/conflict priorities and follow-up unlocks in targeted tests

## Validation
- node --check web/app.js
- node --check src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
- node --check src/ui/culture/buildCultureOpportunityReminders.js
- npm test -- test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js
- git diff --check
- npm test (488 OK)