### PR TITLE
Alpha: preview front decision ripple effects

### DIFF
--- a/test/ui/war/webCriticalFrontDecisionComparison.test.js
+++ b/test/ui/war/webCriticalFrontDecisionComparison.test.js
@@ -28,6 +28,18 @@ test('critical front decision comparison highlights immediate military and non-m
   assert.match(webAppSource, /dependencies\.slice\(0, 2\)/);
 });
 
+test('critical front decision comparison previews military and transversal ripple effects before queueing', () => {
+  assert.match(webAppSource, /function buildFrontDecisionRippleEffects/);
+  assert.match(webAppSource, /kind: 'military'/);
+  assert.match(webAppSource, /Front stabilisé|Front encore fragile/);
+  assert.match(webAppSource, /Province alliée impactée/);
+  assert.match(webAppSource, /kind: 'logistics'/);
+  assert.match(webAppSource, /Tension logistique/);
+  assert.match(webAppSource, /kind: 'culture'/);
+  assert.match(webAppSource, /Tension locale/);
+  assert.match(webAppSource, /effects[\s\S]*\.slice\(0, 3\)/);
+});
+
 test('critical front decision comparison renders compact navigation cards without changing filters', () => {
   assert.match(webAppSource, /function renderCriticalFrontDecisionComparison/);
   assert.match(webAppSource, /data-province-id="\$\{decision\.provinceId\}"/);
@@ -35,8 +47,10 @@ test('critical front decision comparison renders compact navigation cards withou
   assert.match(webAppSource, /sans perdre les filtres carte/);
   assert.match(webAppSource, /renderCriticalFrontDecisionComparison\(shell, intrigueView\)/);
   assert.match(webAppSource, /critical-front-decision__dependencies/);
+  assert.match(webAppSource, /critical-front-decision__ripples/);
   assert.match(stylesSource, /\.critical-front-decision-comparison/);
   assert.match(stylesSource, /\.critical-front-decision--danger/);
   assert.match(stylesSource, /\.critical-front-decision__dependency--military/);
   assert.match(stylesSource, /\.critical-front-decision__dependency--logistics/);
+  assert.match(stylesSource, /\.critical-front-decision__ripple--critical/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -5693,6 +5693,66 @@ function buildFrontDecisionDependencies(province, shell, projection, actionQueue
   return dependencies.slice(0, 2);
 }
 
+function buildFrontDecisionRippleEffects(province, projection, recommendedAction, dependencies, risks) {
+  if (!province || !projection) {
+    return [];
+  }
+
+  const effects = [];
+  const stabilityValue = projection.lines.find((line) => line.label === 'Stabilité attendue')?.value ?? projection.title;
+  const leadRisk = risks[0] ?? { label: 'Risque acceptable', tone: 'covered' };
+  const militaryDependency = dependencies.find((dependency) => dependency.kind === 'military');
+  const logisticsDependency = dependencies.find((dependency) => dependency.kind === 'logistics');
+
+  effects.push({
+    kind: 'military',
+    impact: projection.tone === 'ready' ? 'positive' : projection.tone === 'danger' ? 'critical' : 'warning',
+    label: projection.tone === 'ready' ? 'Front stabilisé' : 'Front encore fragile',
+    detail: recommendedAction ? `${recommendedAction.actionCode}: ${stabilityValue}` : stabilityValue,
+    rank: projection.tone === 'danger' ? 1 : projection.tone === 'warning' ? 2 : 4,
+  });
+
+  if (militaryDependency) {
+    effects.push({
+      kind: 'ally',
+      impact: 'warning',
+      label: 'Province alliée impactée',
+      detail: militaryDependency.reason,
+      rank: 2,
+    });
+  }
+
+  if (logisticsDependency) {
+    effects.push({
+      kind: 'logistics',
+      impact: 'warning',
+      label: 'Tension logistique',
+      detail: logisticsDependency.reason,
+      rank: 3,
+    });
+  } else if ((province.loyalty ?? 100) < 50) {
+    effects.push({
+      kind: 'culture',
+      impact: 'warning',
+      label: 'Tension locale',
+      detail: `Loyauté ${province.loyalty}: l’engagement peut raviver une fracture culturelle visible.`,
+      rank: 3,
+    });
+  }
+
+  effects.push({
+    kind: 'delay',
+    impact: leadRisk.tone === 'critical' ? 'critical' : 'warning',
+    label: 'Si retardée',
+    detail: leadRisk.summary ?? leadRisk.label,
+    rank: leadRisk.tone === 'critical' ? 1 : 5,
+  });
+
+  return effects
+    .sort((left, right) => left.rank - right.rank || left.label.localeCompare(right.label))
+    .slice(0, 3);
+}
+
 function buildCriticalFrontDecisionComparison(shell, intrigueView = null) {
   const priorities = buildFrontPriorityRanking(shell, intrigueView)
     .filter((priority) => priority.tone !== 'ready')
@@ -5748,6 +5808,7 @@ function buildCriticalFrontDecisionComparison(shell, intrigueView = null) {
           ? `${riskyCount} option${riskyCount > 1 ? 's' : ''} risquée${riskyCount > 1 ? 's' : ''}; garder une réserve.`
           : ignoredRisk;
     const dependencies = buildFrontDecisionDependencies(province, shell, projection, actionQueue, risks);
+    const rippleEffects = buildFrontDecisionRippleEffects(province, projection, recommendedAction, dependencies, risks);
 
     return {
       rank: index + 1,
@@ -5761,6 +5822,7 @@ function buildCriticalFrontDecisionComparison(shell, intrigueView = null) {
       costRisk,
       ignoredRisk,
       dependencies,
+      rippleEffects,
       comparison: index === 0
         ? 'Choix recommandé en premier: menace cumulée maximale.'
         : `Comparer après ${priorities[index - 1].provinceLabel}: menace ${priority.score} vs ${priorities[index - 1].score}.`,
@@ -5817,6 +5879,14 @@ function renderCriticalFrontDecisionComparison(shell, intrigueView = null) {
                 <span>Dépendances</span>
                 ${decision.dependencies.map((dependency) => `
                   <em class="critical-front-decision__dependency critical-front-decision__dependency--${dependency.kind}"><b>${dependency.label}</b>${dependency.reason}</em>
+                `).join('')}
+              </div>
+            ` : ''}
+            ${decision.rippleEffects.length > 0 ? `
+              <div class="critical-front-decision__ripples" aria-label="Effets domino avant ajout à la file">
+                <span>Effets domino</span>
+                ${decision.rippleEffects.map((effect) => `
+                  <em class="critical-front-decision__ripple critical-front-decision__ripple--${effect.kind} critical-front-decision__ripple--${effect.impact}"><b>${effect.label}</b>${effect.detail}</em>
                 `).join('')}
               </div>
             ` : ''}

--- a/web/styles.css
+++ b/web/styles.css
@@ -691,8 +691,38 @@ button { font: inherit; }
 .critical-front-decision__dependency--military { border-color: rgba(248, 113, 113, 0.34); }
 .critical-front-decision__dependency--logistics { border-color: rgba(56, 189, 248, 0.3); }
 .critical-front-decision__dependency--stability { border-color: rgba(251, 191, 36, 0.3); }
-.critical-front-decision small {
+
+.critical-front-decision__ripples {
+  display: grid;
+  gap: 4px;
+  padding-top: 2px;
+}
+.critical-front-decision__ripples span {
   color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.critical-front-decision__ripple {
+  display: grid;
+  gap: 1px;
+  padding: 5px 6px;
+  border-radius: 9px;
+  background: rgba(2, 6, 23, 0.52);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: var(--muted);
+  font-size: 10px;
+  font-style: normal;
+  line-height: 1.25;
+}
+.critical-front-decision__ripple b {
+  color: #f8fafc;
+  font-size: 11px;
+}
+.critical-front-decision__ripple--positive { border-color: rgba(74, 222, 128, 0.32); }
+.critical-front-decision__ripple--warning { border-color: rgba(251, 191, 36, 0.32); }
+.critical-front-decision__ripple--critical { border-color: rgba(251, 113, 133, 0.4); }
+.critical-front-decision small {  color: var(--muted);
   font-size: 11px;
   line-height: 1.35;
 }


### PR DESCRIPTION
Alpha: Implements #699.

Summary:
- Adds compact ripple-effect previews to the critical-front decision comparison cards before queueing.
- Reuses already computed decision, dependency, projection, action, risk, supply, and loyalty data; no parallel simulation.
- Shows up to three sorted consequences per decision: military front outcome, allied/front dependency impact, logistics or local/cultural tension, and delay risk.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webCriticalFrontDecisionComparison.test.js
- npm test (490 tests)
- git diff --check

Zeta: PR prête pour revue. Merci de valider avant tout merge.
