### PR TITLE
Beta: sequence logistics interventions

### DIFF
--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -10,12 +10,19 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /buildProvinceLogisticsBottleneckWarnings/);
   assert.match(webAppSource, /buildProvinceLogisticsBottleneckPriorities/);
   assert.match(webAppSource, /buildProvinceLogisticsInterventionTradeoff/);
+  assert.match(webAppSource, /buildProvinceLogisticsInterventionSequence/);
   assert.match(webAppSource, /province-logistics-bottleneck-warning/);
   assert.match(webAppSource, /province-logistics-bottleneck-priorities/);
   assert.match(webAppSource, /Priorités aval/);
   assert.match(webAppSource, /Raison du classement/);
   assert.match(webAppSource, /Action probable/);
   assert.match(webAppSource, /Compromis d’intervention logistique/);
+  assert.match(webAppSource, /Séquence recommandée d’interventions logistiques/);
+  assert.match(webAppSource, /Séquence recommandée/);
+  assert.match(webAppSource, /alternative équivalente/);
+  assert.match(webAppSource, /ordre dépendant du choix militaire/);
+  assert.match(webAppSource, /ordre dépendant du choix culturel\/production/);
+  assert.match(webAppSource, /interventionSequence/);
   assert.match(webAppSource, /Améliore/);
   assert.match(webAppSource, /Retarde/);
   assert.match(webAppSource, /Risque/);
@@ -118,6 +125,7 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-bottleneck-warning--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck-priorities/);
   assert.match(stylesSource, /province-logistics-bottleneck-tradeoff/);
+  assert.match(stylesSource, /province-logistics-intervention-sequence/);
   assert.match(stylesSource, /province-logistics-bottleneck-priority--high/);
   assert.match(stylesSource, /province-logistics-bottleneck-priority--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck--low/);

--- a/web/app.js
+++ b/web/app.js
@@ -1928,6 +1928,48 @@ function buildProvinceLogisticsBottleneckPriorities(comparisons) {
     .slice(0, 3);
 }
 
+function buildProvinceLogisticsInterventionSequence(priorities) {
+  if (priorities.length === 0) {
+    return null;
+  }
+
+  const steps = priorities.slice(0, 3).map((entry, index, ordered) => {
+    const previous = ordered[index - 1] ?? null;
+    const next = ordered[index + 1] ?? null;
+    const equivalentWithPrevious = previous ? Math.abs(entry.priorityScore - previous.priorityScore) <= 10 : false;
+    const equivalentWithNext = next ? Math.abs(next.priorityScore - entry.priorityScore) <= 10 : false;
+    const dependency = entry.recoveryAction.includes('Escorter')
+      ? 'ordre dépendant du choix militaire'
+      : entry.reinforcement.includes('ressource')
+        ? 'ordre dépendant du choix culturel/production'
+        : null;
+    const reason = equivalentWithPrevious || equivalentWithNext
+      ? 'alternative équivalente: arbitrer selon disponibilité locale'
+      : entry.tone === 'high'
+        ? 'urgence et impact aval prioritaire'
+        : entry.interventionTradeoff.risk.includes('critique')
+          ? 'évite bascule en goulot critique'
+          : 'coût d’opportunité contenu après les urgences';
+
+    return {
+      routeId: entry.routeId,
+      routeName: entry.routeName,
+      order: index + 1,
+      reason,
+      dependency,
+      label: `${index + 1}. ${entry.routeName}`,
+    };
+  });
+
+  return {
+    steps,
+    path: steps.map((step) => step.order).join(' → '),
+    routes: steps.map((step) => step.routeName).join(' → '),
+    hasAlternative: steps.some((step) => step.reason.includes('alternative équivalente')),
+    dependency: steps.find((step) => step.dependency)?.dependency ?? null,
+  };
+}
+
 function buildProvinceLogisticsBottleneckWarnings(province, economyView, comparisons = null) {
   if (!province || !economyView) {
     return [];
@@ -1963,6 +2005,7 @@ function renderProvinceLogisticsBottleneckComparison(province, economyView) {
   const comparisons = buildProvinceLogisticsBottleneckComparison(province, economyView);
   const warnings = buildProvinceLogisticsBottleneckWarnings(province, economyView, comparisons);
   const priorities = buildProvinceLogisticsBottleneckPriorities(comparisons);
+  const interventionSequence = buildProvinceLogisticsInterventionSequence(priorities);
 
   if (comparisons.length < 2 && warnings.length === 0 && priorities.length === 0) {
     return '';
@@ -1987,6 +2030,20 @@ function renderProvinceLogisticsBottleneckComparison(province, economyView) {
             <b>Priorités aval</b>
             <span>${priorities.length} goulot${priorities.length > 1 ? 's' : ''} classé${priorities.length > 1 ? 's' : ''}</span>
           </div>
+          ${interventionSequence ? `
+            <div class="province-logistics-intervention-sequence" aria-label="Séquence recommandée d’interventions logistiques">
+              <b>Séquence recommandée</b>
+              <strong>${interventionSequence.path}</strong>
+              <span>${interventionSequence.routes}</span>
+              ${interventionSequence.hasAlternative ? '<small>Alternative équivalente détectée: l’ordre peut être inversé selon disponibilité locale.</small>' : ''}
+              ${interventionSequence.dependency ? `<small>${interventionSequence.dependency}: vérifier avant d'engager.</small>` : ''}
+              <ol>
+                ${interventionSequence.steps.map((step) => `
+                  <li><b>${step.label}</b><span>${step.reason}${step.dependency ? ` · ${step.dependency}` : ''}</span></li>
+                `).join('')}
+              </ol>
+            </div>
+          ` : ''}
           <ol>
             ${priorities.map((entry, index) => `
               <li class="province-logistics-bottleneck-priority province-logistics-bottleneck-priority--${entry.tone}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -9160,3 +9160,45 @@ button { font: inherit; }
   background: rgba(20, 83, 45, 0.24);
   border: 1px solid rgba(74, 222, 128, 0.24);
 }
+.province-logistics-intervention-sequence {
+  display: grid;
+  gap: 5px;
+  padding: 9px;
+  border-radius: 13px;
+  background: linear-gradient(135deg, rgba(14, 116, 144, 0.2), rgba(2, 6, 23, 0.42));
+  border: 1px solid rgba(56, 189, 248, 0.22);
+}
+.province-logistics-intervention-sequence > b {
+  color: #bae6fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-logistics-intervention-sequence > strong {
+  color: #f8fafc;
+  font-size: 17px;
+  letter-spacing: 0.12em;
+}
+.province-logistics-intervention-sequence > span,
+.province-logistics-intervention-sequence small {
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.3;
+}
+.province-logistics-intervention-sequence ol {
+  display: grid;
+  gap: 4px;
+  margin: 2px 0 0;
+  padding-left: 0;
+  list-style: none;
+}
+.province-logistics-intervention-sequence li {
+  display: grid;
+  grid-template-columns: minmax(90px, auto) 1fr;
+  gap: 6px;
+  padding: 5px;
+  border-radius: 9px;
+  background: rgba(15, 23, 42, 0.46);
+}
+.province-logistics-intervention-sequence li b { color: #e0f2fe; font-size: 11px; }
+.province-logistics-intervention-sequence li span { color: #dbeafe; font-size: 11px; line-height: 1.25; }


### PR DESCRIPTION
Beta: Implements #700.

## Summary
- Adds a compact “Séquence recommandée” block above logistics bottleneck priority details.
- Orders the top 2–3 interventions from existing priority scores, urgency, downstream impact, and trade-off/risk context.
- Flags equivalent alternatives and military/culture-production dependent ordering without replacing current priority details, route lists, or rollups.

## Validation
- npm test (489 OK)
- targeted economy UI tests (7 OK)
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check
