### PR TITLE
Gamma: preview culture blocker gains

### DIFF
--- a/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
+++ b/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
@@ -232,12 +232,59 @@ function buildInterventionFollowUp(item, items) {
   return null;
 }
 
+function buildInterventionResolutionGain(item, blocker, followUp, conflict) {
+  if (blocker) {
+    const gain = conflict
+      ? `tension réduite entre ${item.cultureName} et ${blocker.shortReason}`
+      : item.cause === 'Tension locale'
+        ? 'tension réduite avant le prochain arbitrage'
+        : `coordination clarifiée avec ${blocker.shortReason}`;
+
+    return {
+      label: 'après résolution',
+      gain,
+      next: followUp ? `${followUp.action} devient prioritaire ensuite` : 'file culturelle à nouveau lisible',
+      riskAvoided: item.group === 'urgent'
+        ? 'évite qu’un risque social masque la découverte'
+        : 'évite de bloquer une suite utile',
+    };
+  }
+
+  if (followUp) {
+    return {
+      label: 'après résolution',
+      gain: `action suivante débloquée: ${followUp.action}`,
+      next: followUp.reason,
+      riskAvoided: item.group === 'active'
+        ? 'préserve la synergie locale sans surcharger la file'
+        : 'évite de perdre la fenêtre culturelle utile',
+    };
+  }
+
+  if (item.group === 'urgent') {
+    return {
+      label: 'après résolution',
+      gain: 'risque social évité sur le signal urgent',
+      next: 'priorités locales stabilisées',
+      riskAvoided: 'évite une escalade silencieuse de tension culturelle',
+    };
+  }
+
+  return {
+    label: 'après résolution',
+    gain: 'synergie locale préservée',
+    next: 'contexte gardé pour les prochains arbitrages',
+    riskAvoided: 'limite le bruit dans la file culturelle',
+  };
+}
+
 function buildInterventionPriority(item, items, index) {
   const dependency = buildInterventionDependency(item, items);
   const conflict = dependency.startsWith('Conflit local');
   const action = buildInterventionAction(item);
   const blocker = buildInterventionBlocker(item, dependency, conflict);
   const followUp = buildInterventionFollowUp(item, items);
+  const resolutionGain = buildInterventionResolutionGain(item, blocker, followUp, conflict);
 
   return {
     priorityId: `culture-intervention:${item.itemId}`,
@@ -251,6 +298,7 @@ function buildInterventionPriority(item, items, index) {
     conflict,
     blocker,
     followUp,
+    resolutionGain,
     cultureName: item.cultureName,
     regionId: item.regionId,
     sourceLabel: item.shortLabel,

--- a/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
+++ b/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
@@ -65,6 +65,9 @@ test('buildCultureDiscoveryUrgencyGroups orders urgent and active culture signal
   assert.equal(priorities.priorities[0].blocker, null);
   assert.equal(priorities.priorities[0].followUp.label, 'débloque ensuite');
   assert.equal(priorities.priorities[0].followUp.action, 'catalogues-publics');
+  assert.equal(priorities.priorities[0].resolutionGain.label, 'après résolution');
+  assert.match(priorities.priorities[0].resolutionGain.gain, /action suivante débloquée: catalogues-publics/);
+  assert.match(priorities.priorities[0].resolutionGain.riskAvoided, /fenêtre culturelle utile/);
   assert.match(priorities.summary, /interventions? culturelle/);
 });
 
@@ -115,6 +118,10 @@ test('buildCultureDiscoveryUrgencyGroups names ambiguous empty states without du
   assert.equal(priorities.priorities[0].blocker.label, 'bloqué par');
   assert.equal(priorities.priorities[0].blocker.shortReason, 'tension locale');
   assert.equal(priorities.priorities[0].followUp.label, 'débloque ensuite');
+  assert.equal(priorities.priorities[0].resolutionGain.label, 'après résolution');
+  assert.match(priorities.priorities[0].resolutionGain.gain, /tension réduite/);
+  assert.match(priorities.priorities[0].resolutionGain.next, /priorités actives/);
+  assert.match(priorities.priorities[0].resolutionGain.riskAvoided, /risque social/);
 });
 
 test('buildCultureInterventionPriorities flags local priority conflicts', () => {
@@ -153,6 +160,7 @@ test('buildCultureInterventionPriorities flags local priority conflicts', () => 
   assert.equal(priorities.priorities[0].conflict, true);
   assert.equal(priorities.priorities[0].blocker.label, 'bloqué par');
   assert.equal(priorities.priorities[0].blocker.shortReason, 'Ligues des Forges');
+  assert.match(priorities.priorities[0].resolutionGain.gain, /tension réduite entre Compact d’Aurora et Ligues des Forges/);
   assert.equal(priorities.conflicts[0].label, 'Même province');
   assert.match(priorities.conflicts[0].summary, /concurrence/);
 });

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -59,6 +59,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /File recommandée des interventions culturelles/);
   assert.match(webAppSource, /culture-intervention-priority__blocker/);
   assert.match(webAppSource, /culture-intervention-priority__follow-up/);
+  assert.match(webAppSource, /culture-intervention-priority__resolution-gain/);
+  assert.match(webAppSource, /resolutionGain\.riskAvoided/);
   assert.match(webAppSource, /Urgence/);
   assert.match(webAppSource, /Cause floue/);
   assert.match(webAppSource, /urgence puis tendance/);
@@ -99,6 +101,7 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-intervention-conflicts/);
   assert.match(stylesSource, /\.culture-intervention-priority__blocker/);
   assert.match(stylesSource, /\.culture-intervention-priority__follow-up/);
+  assert.match(stylesSource, /\.culture-intervention-priority__resolution-gain/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-rising/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-unknown/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-confirmation/);

--- a/web/app.js
+++ b/web/app.js
@@ -8036,6 +8036,13 @@ function renderCultureInterventionPriorities(priorityView) {
             <small>Risque: ${priority.waitRisk} · Dépendance: ${priority.dependency}</small>
             ${priority.blocker ? `<em class="culture-intervention-priority__blocker">${priority.blocker.label} ${priority.blocker.shortReason}</em>` : ''}
             ${priority.followUp ? `<em class="culture-intervention-priority__follow-up">${priority.followUp.label} ${priority.followUp.action}</em>` : ''}
+            ${priority.resolutionGain ? `
+              <div class="culture-intervention-priority__resolution-gain">
+                <b>${priority.resolutionGain.label}</b>
+                <span>${priority.resolutionGain.gain}</span>
+                <small>${priority.resolutionGain.next} · ${priority.resolutionGain.riskAvoided}</small>
+              </div>
+            ` : ''}
           </li>
         `).join('')}
       </ol>

--- a/web/styles.css
+++ b/web/styles.css
@@ -9237,3 +9237,29 @@ button { font: inherit; }
 }
 .province-logistics-intervention-sequence li b { color: #e0f2fe; font-size: 11px; }
 .province-logistics-intervention-sequence li span { color: #dbeafe; font-size: 11px; line-height: 1.25; }
+
+
+.culture-intervention-priority__resolution-gain {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 10px;
+  background: rgba(6, 78, 59, 0.22);
+  border: 1px solid rgba(52, 211, 153, 0.2);
+}
+.culture-intervention-priority__resolution-gain b {
+  color: #a7f3d0;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-intervention-priority__resolution-gain span {
+  color: #d1fae5;
+  font-size: 11px;
+  font-weight: 800;
+}
+.culture-intervention-priority__resolution-gain small {
+  color: #bae6fd;
+  font-size: 10px;
+  line-height: 1.3;
+}


### PR DESCRIPTION
Gamma: Implements #701.

## Summary
- add an “après résolution” gain preview to cultural intervention priorities
- derive tension reduction, follow-up unlock, social-risk avoided, and local synergy copy from existing blocker/follow-up/conflict/urgency data
- render the preview compactly in the province culture queue

## Validation
- node --check web/app.js
- node --check src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
- node --check src/ui/culture/buildCultureOpportunityReminders.js
- npm test -- test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js
- git diff --check
- npm test (489 OK)