### PR TITLE
Epsilon: show climate mitigation benefits

### DIFF
--- a/test/ui/climate/webClimateMitigationCrossDomainBenefits.test.js
+++ b/test/ui/climate/webClimateMitigationCrossDomainBenefits.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('climate mitigation sequence shows cross-domain benefits when confirmed and stays quiet otherwise', () => {
+  assert.match(webAppSource, /function buildClimateMitigationSecondaryBenefits/);
+  assert.match(webAppSource, /Route logistique préservée/);
+  assert.match(webAppSource, /Front stabilisé/);
+  assert.match(webAppSource, /Tension culturelle évitée/);
+  assert.match(webAppSource, /Cascade voisine réduite/);
+  assert.match(webAppSource, /return benefits\.slice\(0, 2\)/);
+  assert.match(webAppSource, /secondaryBenefits = buildClimateMitigationSecondaryBenefits\(province, forecast, linkedNeighbors, selectedGroupIds\)/);
+  assert.match(webAppSource, /step\.secondaryBenefits\.length > 0 \? step\.secondaryBenefits\.join\(' · '\) : 'Aucun bénéfice secondaire confirmé\.'/);
+  assert.match(webAppSource, /Aucun bénéfice secondaire confirmé/);
+
+  assert.match(stylesSource, /\.map-climate-severity-legend__sequence-step em/);
+  assert.match(stylesSource, /font-style: normal/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3579,6 +3579,29 @@ function getClimateSeverityRank(status) {
   }[status] ?? 5;
 }
 
+function buildClimateMitigationSecondaryBenefits(province, forecast, linkedNeighbors = [], selectedGroupIds = new Set()) {
+  const benefits = [];
+  const cascadeText = `${forecast.selectedInterventionPreview.avoidedCascade} ${forecast.remainingCascades.map((cascade) => `${cascade.type} ${cascade.scope}`).join(' ')}`;
+
+  if (/route|logistique|frontali/i.test(cascadeText)) {
+    benefits.push('Route logistique préservée: la cascade route/connexion perd de la pression.');
+  }
+
+  if (province.contested || province.occupied) {
+    benefits.push('Front stabilisé: la mitigation réduit une pression météo sur une zone militaire fragile.');
+  }
+
+  if (province.loyalty < 55 || /famine|migration/i.test(cascadeText)) {
+    benefits.push('Tension culturelle évitée: moins de stress population/ressources après mitigation.');
+  }
+
+  if (linkedNeighbors.length > 0 || selectedGroupIds.has(province.provinceId)) {
+    benefits.push(`Cascade voisine réduite: ${linkedNeighbors.length > 0 ? linkedNeighbors.map((neighbor) => neighbor.provinceLabel).join(', ') : 'groupe sélectionné'} profite de la même priorité.`);
+  }
+
+  return benefits.slice(0, 2);
+}
+
 function buildClimateMitigationSequenceFromSeverity(markers = [], shell, densityControl = null) {
   if (!shell || markers.length === 0) {
     return [];
@@ -3602,6 +3625,7 @@ function buildClimateMitigationSequenceFromSeverity(markers = [], shell, density
         .sort((left, right) => getClimateSeverityRank(left.status) - getClimateSeverityRank(right.status) || left.provinceLabel.localeCompare(right.provinceLabel))
         .slice(0, 2);
       const severityRank = getClimateSeverityRank(marker.status);
+      const secondaryBenefits = buildClimateMitigationSecondaryBenefits(province, forecast, linkedNeighbors, selectedGroupIds);
 
       return {
         provinceId: province.provinceId,
@@ -3618,6 +3642,7 @@ function buildClimateMitigationSequenceFromSeverity(markers = [], shell, density
           : selectedGroupIds.has(marker.provinceId)
             ? 'Réduit la pression du groupe cascade sélectionné.'
             : 'Effet surtout local; surveiller les voisins après résolution.',
+        secondaryBenefits,
         disabled: plan.disabled,
       };
     })
@@ -3689,6 +3714,7 @@ function renderClimateSeverityLegend(legend) {
               <b>${index + 1}. ${step.provinceLabel} · ${step.severityLabel}</b>
               <span>${step.action} · fenêtre ${step.window}</span>
               <small>${step.cascade} · ${step.neighborRelief}</small>
+              <em>${step.secondaryBenefits.length > 0 ? step.secondaryBenefits.join(' · ') : 'Aucun bénéfice secondaire confirmé.'}</em>
             </li>
           `).join('')}
         </ol>

--- a/web/styles.css
+++ b/web/styles.css
@@ -418,7 +418,12 @@ button { font: inherit; }
 }
 .map-climate-severity-legend__sequence-step b,
 .map-climate-severity-legend__sequence-step span,
-.map-climate-severity-legend__sequence-step small { font-size: 12px; }
+.map-climate-severity-legend__sequence-step small,
+.map-climate-severity-legend__sequence-step em { font-size: 12px; }
+.map-climate-severity-legend__sequence-step em {
+  color: #bfdbfe;
+  font-style: normal;
+}
 .map-climate-severity-legend__sequence-step--cascade-active { border-color: rgba(248, 113, 113, 0.46); }
 .map-climate-severity-legend__sequence-step--hazard-unresolved { border-color: rgba(251, 191, 36, 0.42); }
 


### PR DESCRIPTION
Epsilon: Implements #703.

Summary:
- Extends the existing climate mitigation sequence with 1-2 secondary benefits per priority step.
- Reuses existing cascades, neighbor markers, selected cascade group, province loyalty, and contested/occupied state to surface logistics, culture, front, and neighbor-cascade benefits.
- Keeps the severity legend and mitigation sequence intact without duplicating UI, and shows quiet fallback copy when no secondary benefit is confirmed.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webClimateMitigationCrossDomainBenefits.test.js test/ui/climate/webClimateMitigationSequencePriority.test.js test/ui/climate/webClimateSeverityLegend.test.js
- npm test