### PR TITLE
Delta: warn on intrigue queue conflicts

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -292,3 +292,19 @@ test('safe intrigue responses compare exposure timing without breaking fog', () 
   assert.match(stylesSource, /province-intrigue-response-option--mitigated/);
   assert.match(stylesSource, /province-intrigue-response-option--danger/);
 });
+
+test('intrigue responses warn about queued map choice conflicts without leaking fog', () => {
+  assert.match(webAppSource, /function buildIntrigueQueuedMapChoiceConflicts/);
+  assert.match(webAppSource, /function renderIntrigueQueuedMapChoiceConflicts/);
+  assert.match(webAppSource, /collectQueuedMapChoiceConflictSources/);
+  assert.match(webAppSource, /attention: conflit avec/);
+  assert.match(webAppSource, /ressource détournée/);
+  assert.match(webAppSource, /délai consommé/);
+  assert.match(webAppSource, /exposition accrue/);
+  assert.match(webAppSource, /attention: conflit possible sous brouillard/);
+  assert.match(webAppSource, /ne pas inférer cellule, cible, relais ni objectif caché/);
+  assert.match(webAppSource, /Conflits fog-safe entre réponses intrigue et choix carte en file/);
+  assert.match(webAppSource, /renderIntrigueQueuedMapChoiceConflicts\(province, intrigueView\)/);
+  assert.match(stylesSource, /province-intrigue-queue-conflicts/);
+  assert.match(stylesSource, /province-intrigue-queue-conflict--masked/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -4351,6 +4351,114 @@ function renderSafeIntrigueResponseTimingComparison(province, intrigueView) {
   `;
 }
 
+function collectQueuedMapChoiceConflictSources(province, queuedMapChoices = state) {
+  const selectedProvinceId = province?.provinceId;
+  const logistics = (queuedMapChoices.queuedLogisticsActions ?? [])
+    .filter((entry) => entry.provinceId !== selectedProvinceId)
+    .map((entry) => ({
+      type: 'logistics',
+      label: entry.label ?? entry.target ?? 'choix logistique en file',
+      code: entry.actionId ?? entry.routeId ?? 'LOG',
+      priority: entry.status === 'conflict' || entry.status === 'risky' ? 1 : 3,
+      conflictType: 'ressource détournée',
+      detail: entry.downstreamEffect ?? 'un ordre logistique visible peut détourner la réserve avant la réponse intrigue.',
+    }));
+  const climate = (queuedMapChoices.queuedClimateInterventions ?? [])
+    .filter((entry) => entry.provinceId !== selectedProvinceId)
+    .map((entry) => ({
+      type: 'climate',
+      label: entry.label ?? 'intervention climat en file',
+      code: entry.actionCode ?? 'CLIMATE',
+      priority: entry.missedDeadline ? 1 : 2,
+      conflictType: entry.missedDeadline ? 'fenêtre de brouillard de guerre qui se referme' : 'délai consommé',
+      detail: entry.tradeoff ?? entry.expectedResult ?? 'l’intervention consomme une fenêtre d’action lisible avant la réponse intrigue.',
+    }));
+  const culture = (queuedMapChoices.queuedCultureActions ?? [])
+    .filter((entry) => entry.provinceId !== selectedProvinceId)
+    .map((entry) => ({
+      type: 'culture',
+      label: entry.label ?? 'choix culturel en file',
+      code: entry.actionCode ?? 'CULTURE',
+      priority: entry.status === 'risky' || entry.status === 'blocked' ? 1 : 2,
+      conflictType: 'exposition accrue',
+      detail: entry.mainRisk ?? entry.expectedResult ?? 'un ordre public peut hausser le bruit visible avant la réponse intrigue.',
+    }));
+
+  return logistics.concat(climate, culture)
+    .sort((left, right) => left.priority - right.priority || left.label.localeCompare(right.label))
+    .slice(0, 3);
+}
+
+function buildIntrigueQueuedMapChoiceConflicts(province, intrigueView, queuedMapChoices = state) {
+  const options = buildSafeIntrigueResponseTimingOptions(province, intrigueView);
+  const entry = (intrigueView?.map?.entries ?? []).find((candidate) => candidate.locationId === province?.provinceId) ?? null;
+  const sources = collectQueuedMapChoiceConflictSources(province, queuedMapChoices);
+
+  if (options.length === 0 || sources.length === 0) {
+    return [];
+  }
+
+  const fogLimited = !entry?.showSecondaryDetails && (entry?.metrics?.exposedCellCount ?? 0) === 0 && entry?.sabotageRiskLevel !== 'high';
+  const primaryOption = options.find((option) => option.tone === 'danger') ?? options[0];
+
+  if (fogLimited) {
+    return [{
+      tone: 'masked',
+      priority: 1,
+      label: 'attention: conflit possible sous brouillard',
+      sourceLabel: 'choix de carte masqué',
+      sourceCode: primaryOption.code,
+      responseLabel: primaryOption.label,
+      detail: 'La file contient un choix ailleurs, mais le brouillard masque le lien exact: ne pas inférer cellule, cible, relais ni objectif caché.',
+    }];
+  }
+
+  return sources.map((source, index) => {
+    const option = options[index] ?? primaryOption;
+    return {
+      tone: source.priority <= 1 || option.tone === 'danger' ? 'danger' : 'warning',
+      priority: source.priority + (option.tone === 'danger' ? 0 : 1),
+      label: `attention: conflit avec ${source.label}`,
+      sourceLabel: source.label,
+      sourceCode: source.code,
+      responseLabel: option.label,
+      detail: `${source.conflictType}: ${source.detail} Réponse concernée: ${option.label}; seuls les impacts visibles de file, délai, exposition et ressource sont comparés.`,
+    };
+  })
+    .sort((left, right) => left.priority - right.priority || left.label.localeCompare(right.label))
+    .slice(0, 2);
+}
+
+function renderIntrigueQueuedMapChoiceConflicts(province, intrigueView, queuedMapChoices = state) {
+  const conflicts = buildIntrigueQueuedMapChoiceConflicts(province, intrigueView, queuedMapChoices);
+
+  if (conflicts.length === 0) {
+    return '';
+  }
+
+  return `
+    <section class="province-intrigue-queue-conflicts" aria-label="Conflits fog-safe entre réponses intrigue et choix carte en file">
+      <div class="province-intrigue-queue-conflicts__header">
+        <strong>Conflits avec la file carte</strong>
+        <span>${conflicts.length} avertissement${conflicts.length > 1 ? 's' : ''}</span>
+      </div>
+      <div class="province-intrigue-queue-conflict-list">
+        ${conflicts.map((conflict) => `
+          <article class="province-intrigue-queue-conflict province-intrigue-queue-conflict--${conflict.tone}">
+            <div>
+              <b>${conflict.label}</b>
+              <code>${conflict.sourceCode}</code>
+            </div>
+            <p>${conflict.detail}</p>
+            <small>${conflict.responseLabel} · ${conflict.sourceLabel}</small>
+          </article>
+        `).join('')}
+      </div>
+      <small>Lecture fog-safe: avertit seulement sur les conflits déductibles; cellule, cible, relais et état caché restent masqués.</small>
+    </section>
+  `;
+}
+
 function buildProvinceIntrigueRiskWarnings(province, actionQueue, intrigueView) {
   const drillDown = findProvinceIntrigueDrillDown(province, intrigueView);
   const selectedResponse = drillDown?.quickResponses?.find((response) => response.code === drillDown.recommendedResponseCode)
@@ -6785,6 +6893,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       ${renderProvinceActionRecommendations(province, focusContext, intrigueView)}
       ${renderProvinceIntrigueExposureTimelineHints(province, intrigueView)}
       ${renderSafeIntrigueResponseTimingComparison(province, intrigueView)}
+      ${renderIntrigueQueuedMapChoiceConflicts(province, intrigueView)}
       ${renderConflictOutcomePreview(province, shell)}
       ${renderSelectedProvinceConflictNextAction(province, shell, focusContext, intrigueView)}
       ${renderQueuedMilitaryMapActionConfirmation(province, shell, intrigueView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -8023,7 +8023,52 @@ button { font: inherit; }
   color: #e0f2fe;
 }
 
-
+.province-intrigue-queue-conflicts {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.62), rgba(88, 28, 135, 0.24));
+  border: 1px solid rgba(216, 180, 254, 0.18);
+}
+.province-intrigue-queue-conflicts__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-queue-conflicts__header span,
+.province-intrigue-queue-conflicts > small,
+.province-intrigue-queue-conflict small {
+  color: var(--muted);
+}
+.province-intrigue-queue-conflict-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+.province-intrigue-queue-conflict {
+  padding: 9px 10px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.32);
+  border-left: 3px solid rgba(250, 204, 21, 0.74);
+}
+.province-intrigue-queue-conflict--danger { border-left-color: rgba(248, 113, 113, 0.84); }
+.province-intrigue-queue-conflict--warning { border-left-color: rgba(250, 204, 21, 0.78); }
+.province-intrigue-queue-conflict--masked { border-left-color: rgba(148, 163, 184, 0.62); }
+.province-intrigue-queue-conflict div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.province-intrigue-queue-conflict code {
+  color: #f5d0fe;
+  font-size: 0.72rem;
+}
+.province-intrigue-queue-conflict p {
+  margin: 5px 0;
+  color: #f8fafc;
+}
 
 .province-climate-hazard-blockers {
   margin-top: 12px;


### PR DESCRIPTION
Delta: Implements #702.

Summary:
- Adds fog-safe warnings when safe intrigue responses conflict with queued map choices elsewhere.
- Compares visible queue conflicts for delay consumed, exposure increase, diverted resources, and fog windows closing.
- Keeps masked cases non-spoilery and adds UI/test coverage for visible and fog-limited conflicts.

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check HEAD~1..HEAD
- npm test
