### PR TITLE
Alpha: show military outcome trails

### DIFF
--- a/test/ui/war/webMilitaryOutcomeTrails.test.js
+++ b/test/ui/war/webMilitaryOutcomeTrails.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('military outcome trails summarize the most important after-action results', () => {
+  assert.match(webAppSource, /function buildMilitaryOutcomeTrailSummary/);
+  assert.match(webAppSource, /isMilitaryOutcomeMarkerVisible\(marker\)/);
+  assert.match(webAppSource, /militaryOutcomeSeverityRank/);
+  assert.match(webAppSource, /impactLabel/);
+  assert.match(webAppSource, /pression déplacée/);
+  assert.match(webAppSource, /risque résiduel/);
+  assert.match(webAppSource, /trails\.slice\(0, 3\)/);
+  assert.match(webAppSource, /groupedCount/);
+});
+
+test('military outcome trails render compact province-linked map controls', () => {
+  assert.match(webAppSource, /function renderMilitaryOutcomeTrailSummary/);
+  assert.match(webAppSource, /data-province-id="\$\{trail\.provinceId\}"/);
+  assert.match(webAppSource, /data-readiness-focus="\$\{trail\.provinceId\}"/);
+  assert.match(webAppSource, /résumé replié par filtres/);
+  assert.match(webAppSource, /renderMilitaryOutcomeTrailSummary\(state\.lastMilitaryOutcomeMarkers\)/);
+  assert.match(stylesSource, /\.military-outcome-trail/);
+  assert.match(stylesSource, /\.military-outcome-trail__item--worsened/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -796,6 +796,98 @@ function buildMilitaryFrontMarkerSummaries(markers = state.lastMilitaryOutcomeMa
     });
 }
 
+function buildMilitaryOutcomeTrailSummary(markers = state.lastMilitaryOutcomeMarkers) {
+  const visibleMarkers = markers.filter((marker) => isMilitaryOutcomeMarkerVisible(marker));
+  const sourceMarkers = visibleMarkers.length > 0 ? visibleMarkers : markers;
+
+  if (sourceMarkers.length === 0) {
+    return {
+      empty: true,
+      hiddenByFilters: false,
+      trails: [],
+      groupedCount: 0,
+      summary: 'Aucune suite militaire post-résolution à afficher.',
+    };
+  }
+
+  const trails = sourceMarkers
+    .map((marker) => {
+      const severity = militaryOutcomeSeverityRank[marker.tone] ?? 0;
+      const impactLabel = {
+        stabilized: 'stabilisé',
+        worsened: 'pression déplacée',
+        blocked: 'action bloquée',
+        risk: 'risque résiduel',
+      }[marker.tone] ?? 'suite militaire';
+      const nextStep = getMilitaryOutcomeUrgentAction(marker.tone);
+
+      return {
+        provinceId: marker.provinceId,
+        provinceLabel: marker.provinceLabel ?? marker.provinceId,
+        tone: marker.tone,
+        actionCode: marker.actionCode,
+        label: marker.label,
+        impactLabel,
+        detail: marker.changed ?? marker.summaryItem ?? marker.why,
+        nextStep,
+        severity,
+        turn: marker.turn,
+      };
+    })
+    .sort((left, right) => right.severity - left.severity || left.provinceLabel.localeCompare(right.provinceLabel));
+
+  const visibleTrails = trails.slice(0, 3);
+  const groupedCount = Math.max(0, trails.length - visibleTrails.length);
+
+  return {
+    empty: false,
+    hiddenByFilters: visibleMarkers.length === 0 && markers.length > 0,
+    trails: visibleTrails,
+    groupedCount,
+    summary: `${visibleTrails.length} suite${visibleTrails.length > 1 ? 's' : ''} militaire${visibleTrails.length > 1 ? 's' : ''} clé${visibleTrails.length > 1 ? 's' : ''} après résolution${groupedCount > 0 ? ` · ${groupedCount} regroupée${groupedCount > 1 ? 's' : ''}` : ''}.`,
+  };
+}
+
+function renderMilitaryOutcomeTrailSummary(markers = state.lastMilitaryOutcomeMarkers) {
+  const trailSummary = buildMilitaryOutcomeTrailSummary(markers);
+
+  if (trailSummary.empty) {
+    return `
+      <section class="military-outcome-trail is-empty" aria-label="Suites militaires post-résolution">
+        <div class="military-outcome-trail__header">
+          <span>Suites militaires</span>
+          <strong>Aucune suite</strong>
+        </div>
+        <p>${trailSummary.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="military-outcome-trail" aria-label="Suites militaires post-résolution">
+      <div class="military-outcome-trail__header">
+        <div>
+          <span>Suites militaires</span>
+          <strong>${trailSummary.summary}</strong>
+        </div>
+        ${trailSummary.hiddenByFilters ? '<small>résumé replié par filtres</small>' : '<small>top 3 visibles</small>'}
+      </div>
+      <div class="military-outcome-trail__list">
+        ${trailSummary.trails.map((trail) => `
+          <button type="button" class="military-outcome-trail__item military-outcome-trail__item--${trail.tone}" data-province-id="${trail.provinceId}" data-readiness-focus="${trail.provinceId}" aria-label="Suite militaire ${trail.provinceLabel}: ${trail.label}">
+            <div>
+              <strong>${trail.provinceLabel}</strong>
+              <code>${trail.actionCode}</code>
+            </div>
+            <p><b>${trail.label}</b> · ${trail.impactLabel}</p>
+            <small>${trail.nextStep}</small>
+          </button>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderMilitaryFrontMarkerSummaries(markers = state.lastMilitaryOutcomeMarkers) {
   const summaries = buildMilitaryFrontMarkerSummaries(markers);
 
@@ -10017,6 +10109,7 @@ function render() {
           <div class="map-stage" data-map-stage="true" tabindex="0" aria-label="Carte opérationnelle zoomable. Utilisez plus, moins, zéro ou C pour naviguer.">
             ${renderMapControls()}
             ${renderMilitaryOutcomeMarkerFilters(state.lastMilitaryOutcomeMarkers)}
+            ${renderMilitaryOutcomeTrailSummary(state.lastMilitaryOutcomeMarkers)}
             ${renderMilitaryFrontMarkerSummaries(state.lastMilitaryOutcomeMarkers)}
             <div class="map-viewport" style="transform:${getMapViewportTransform()};">
               ${renderMapLayerStack(shell, economyView, focusContext, cultureView, climateMarkerDensity.visibleMarkers, climateMarkerDensity.selectedCascadeGroup)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -1412,6 +1412,74 @@ button { font: inherit; }
 .military-outcome-filter__button--blocked.is-active { border-color: rgba(148, 163, 184, 0.48); color: #f8fafc; }
 .military-outcome-filter__button--risk.is-active { border-color: rgba(251, 191, 36, 0.52); color: #fde68a; }
 
+.military-outcome-trail {
+  position: absolute;
+  top: 112px;
+  right: 14px;
+  z-index: 8;
+  display: grid;
+  gap: 7px;
+  width: min(300px, calc(100% - 28px));
+  max-height: 180px;
+  overflow: auto;
+  padding: 9px;
+  border-radius: 16px;
+  background: rgba(8, 15, 28, 0.78);
+  border: 1px solid rgba(251, 191, 36, 0.2);
+  backdrop-filter: blur(10px);
+}
+.military-outcome-trail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-outcome-trail__header span,
+.military-outcome-trail__header small {
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.military-outcome-trail__header strong { color: #fde68a; font-size: 12px; }
+.military-outcome-trail p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.3;
+}
+.military-outcome-trail__list { display: grid; gap: 6px; }
+.military-outcome-trail__item {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 7px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.52);
+  border: 1px solid rgba(125, 211, 252, 0.16);
+  text-align: left;
+  cursor: pointer;
+}
+.military-outcome-trail__item:hover,
+.military-outcome-trail__item:focus-visible {
+  border-color: rgba(251, 191, 36, 0.52);
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.12);
+  outline: none;
+}
+.military-outcome-trail__item div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-outcome-trail__item strong { color: #f8fafc; }
+.military-outcome-trail__item code { color: #fde68a; font-size: 10px; }
+.military-outcome-trail__item small { color: var(--muted); font-size: 10px; }
+.military-outcome-trail__item--stabilized { border-color: rgba(74, 222, 128, 0.32); }
+.military-outcome-trail__item--worsened { border-color: rgba(251, 113, 133, 0.4); }
+.military-outcome-trail__item--blocked { border-color: rgba(148, 163, 184, 0.34); }
+.military-outcome-trail__item--risk { border-color: rgba(251, 191, 36, 0.36); }
+
 .military-front-marker-summary {
   position: absolute;
   top: 212px;
@@ -6535,6 +6603,74 @@ button { font: inherit; }
 .military-outcome-filter__button--worsened.is-active { border-color: rgba(251, 113, 133, 0.56); color: #fecdd3; }
 .military-outcome-filter__button--blocked.is-active { border-color: rgba(148, 163, 184, 0.48); color: #f8fafc; }
 .military-outcome-filter__button--risk.is-active { border-color: rgba(251, 191, 36, 0.52); color: #fde68a; }
+
+.military-outcome-trail {
+  position: absolute;
+  top: 112px;
+  right: 14px;
+  z-index: 8;
+  display: grid;
+  gap: 7px;
+  width: min(300px, calc(100% - 28px));
+  max-height: 180px;
+  overflow: auto;
+  padding: 9px;
+  border-radius: 16px;
+  background: rgba(8, 15, 28, 0.78);
+  border: 1px solid rgba(251, 191, 36, 0.2);
+  backdrop-filter: blur(10px);
+}
+.military-outcome-trail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-outcome-trail__header span,
+.military-outcome-trail__header small {
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.military-outcome-trail__header strong { color: #fde68a; font-size: 12px; }
+.military-outcome-trail p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.3;
+}
+.military-outcome-trail__list { display: grid; gap: 6px; }
+.military-outcome-trail__item {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 7px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.52);
+  border: 1px solid rgba(125, 211, 252, 0.16);
+  text-align: left;
+  cursor: pointer;
+}
+.military-outcome-trail__item:hover,
+.military-outcome-trail__item:focus-visible {
+  border-color: rgba(251, 191, 36, 0.52);
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.12);
+  outline: none;
+}
+.military-outcome-trail__item div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.military-outcome-trail__item strong { color: #f8fafc; }
+.military-outcome-trail__item code { color: #fde68a; font-size: 10px; }
+.military-outcome-trail__item small { color: var(--muted); font-size: 10px; }
+.military-outcome-trail__item--stabilized { border-color: rgba(74, 222, 128, 0.32); }
+.military-outcome-trail__item--worsened { border-color: rgba(251, 113, 133, 0.4); }
+.military-outcome-trail__item--blocked { border-color: rgba(148, 163, 184, 0.34); }
+.military-outcome-trail__item--risk { border-color: rgba(251, 191, 36, 0.36); }
 
 .military-front-marker-summary {
   position: absolute;


### PR DESCRIPTION
Alpha: Implements #709.

Summary:
- Adds compact after-action military outcome trails on the map after commit/resolution.
- Reuses existing post-commit military outcome markers, marker severity, visibility filters, and urgent-action copy; no hidden/fogged data is introduced.
- Shows the top 2-3 most important suites with province-linked controls and groups overflow instead of rendering a long list.

Tests:
- node --check web/app.js
- npm test -- test/ui/war/webMilitaryOutcomeTrails.test.js test/ui/war/webMilitaryFrontMarkerSummaries.test.js test/ui/war/webMilitaryOutcomeMarkerFilters.test.js
- npm test (494 tests)
- git diff --check

Zeta: PR prête pour revue. Merci de valider avant tout merge.
