### PR TITLE
Epsilon: summarize climate follow-up debt

### DIFF
--- a/test/ui/climate/webClimateFollowUpDebtSummary.test.js
+++ b/test/ui/climate/webClimateFollowUpDebtSummary.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('climate mitigation follow-up debt summarizes resolved partial and open outcomes', () => {
+  assert.match(webAppSource, /function buildClimateFollowUpDebtSummary/);
+  assert.match(webAppSource, /function renderClimateFollowUpDebtSummary/);
+  assert.match(webAppSource, /marker\.status === 'risk-reduced'/);
+  assert.match(webAppSource, /marker\.status === 'hazard-delayed'/);
+  assert.match(webAppSource, /marker\.status === 'hazard-unresolved' \|\| marker\.status === 'cascade-active'/);
+  assert.match(webAppSource, /Bénéfices obtenus/);
+  assert.match(webAppSource, /Conséquences ouvertes/);
+  assert.match(webAppSource, /Aucun bénéfice cross-domain confirmé/);
+  assert.match(webAppSource, /Aucune conséquence critique ouverte/);
+  assert.match(webAppSource, /climateFollowUpDebt = buildClimateFollowUpDebtSummary\(postCommitClimateMarkers, climateSeverityLegend\.mitigationSequence \?\? \[\]\)/);
+  assert.match(webAppSource, /renderClimateFollowUpDebtSummary\(climateFollowUpDebt\)/);
+
+  assert.match(stylesSource, /\.map-climate-follow-up-debt/);
+  assert.match(stylesSource, /\.map-climate-follow-up-debt--debt/);
+  assert.match(stylesSource, /\.map-climate-follow-up-debt--partial/);
+  assert.match(stylesSource, /\.map-climate-follow-up-debt--resolved/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -3742,6 +3742,59 @@ function buildClimateSeverityLegend(markers = [], densityControl = null, shell =
   };
 }
 
+function buildClimateFollowUpDebtSummary(markers = [], mitigationSequence = []) {
+  if (markers.length === 0) {
+    return {
+      state: 'empty',
+      successfulCount: 0,
+      partialCount: 0,
+      debtCount: 0,
+      benefits: [],
+      debts: [],
+      summary: 'Aucune dette climat post-résolution à suivre pour le moment.',
+    };
+  }
+
+  const successfulCount = markers.filter((marker) => marker.status === 'risk-reduced').length;
+  const partialMarkers = markers.filter((marker) => marker.status === 'hazard-delayed');
+  const debtMarkers = markers.filter((marker) => marker.status === 'hazard-unresolved' || marker.status === 'cascade-active');
+  const benefits = mitigationSequence
+    .flatMap((step) => step.secondaryBenefits ?? [])
+    .filter((benefit, index, all) => all.indexOf(benefit) === index)
+    .slice(0, 2);
+  const debts = debtMarkers
+    .map((marker) => `${marker.provinceLabel}: ${marker.summary}`)
+    .slice(0, 2);
+
+  return {
+    state: debtMarkers.length > 0 ? 'debt' : partialMarkers.length > 0 ? 'partial' : 'resolved',
+    successfulCount,
+    partialCount: partialMarkers.length,
+    debtCount: debtMarkers.length,
+    benefits,
+    debts,
+    summary: `${successfulCount} mitigation${successfulCount > 1 ? 's' : ''} réussie${successfulCount > 1 ? 's' : ''}, ${partialMarkers.length} partielle${partialMarkers.length > 1 ? 's' : ''}, ${debtMarkers.length} dette${debtMarkers.length > 1 ? 's' : ''} de suivi après résolution.`,
+  };
+}
+
+function renderClimateFollowUpDebtSummary(summary) {
+  if (summary.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <section class="map-climate-follow-up-debt map-climate-follow-up-debt--${summary.state}" aria-label="Résumé des dettes de suivi climatique après résolution">
+      <div>
+        <strong>Dette climat après résolution</strong>
+        <span>${summary.successfulCount} réussie${summary.successfulCount > 1 ? 's' : ''} · ${summary.partialCount} partielle${summary.partialCount > 1 ? 's' : ''} · ${summary.debtCount} ouverte${summary.debtCount > 1 ? 's' : ''}</span>
+      </div>
+      <p>${summary.summary}</p>
+      <small><b>Bénéfices obtenus</b> · ${summary.benefits.length > 0 ? summary.benefits.join(' · ') : 'Aucun bénéfice cross-domain confirmé.'}</small>
+      <small><b>Conséquences ouvertes</b> · ${summary.debts.length > 0 ? summary.debts.join(' · ') : 'Aucune conséquence critique ouverte; vérifier les mitigations partielles au prochain tour.'}</small>
+    </section>
+  `;
+}
+
 function renderClimateSeverityLegend(legend) {
   if (!legend.active || legend.entries.length === 0) {
     return '';
@@ -9957,6 +10010,7 @@ function render() {
     selectedProvinceId: state.selectedProvinceId,
   });
   const climateSeverityLegend = buildClimateSeverityLegend(postCommitClimateMarkers, climateMarkerDensity, shell);
+  const climateFollowUpDebt = buildClimateFollowUpDebtSummary(postCommitClimateMarkers, climateSeverityLegend.mitigationSequence ?? []);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -9985,6 +10039,7 @@ function render() {
           ${renderCumulativeClimateImpactSummary(cumulativeClimateImpact)}
           ${renderClimateMarkerDensityRollup(climateMarkerDensity)}
           ${renderSelectedClimateCascadeGroup(climateMarkerDensity.selectedCascadeGroup)}
+          ${renderClimateFollowUpDebtSummary(climateFollowUpDebt)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -360,6 +360,35 @@ button { font: inherit; }
 }
 .map-climate-cascade-group small { color: #fde68a; }
 
+.map-climate-follow-up-debt {
+  display: grid;
+  gap: 7px;
+  margin-top: 8px;
+  max-width: 72ch;
+  padding: 10px 12px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.58), rgba(51, 65, 85, 0.26));
+  border: 1px solid rgba(148, 163, 184, 0.24);
+}
+.map-climate-follow-up-debt--debt { border-color: rgba(248, 113, 113, 0.34); }
+.map-climate-follow-up-debt--partial { border-color: rgba(251, 191, 36, 0.32); }
+.map-climate-follow-up-debt--resolved { border-color: rgba(74, 222, 128, 0.28); }
+.map-climate-follow-up-debt div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-climate-follow-up-debt p,
+.map-climate-follow-up-debt span,
+.map-climate-follow-up-debt small {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-climate-follow-up-debt small { color: #bfdbfe; }
+
 .map-climate-severity-legend {
   display: grid;
   gap: 7px;


### PR DESCRIPTION
Epsilon: Implements #713.

Summary:
- Adds a post-resolution climate follow-up debt summary that distinguishes successful mitigation, partial mitigation, and open follow-up debt.
- Highlights benefits already gained from the existing cross-domain mitigation sequence versus remaining open climate consequences.
- Reuses current post-commit climate markers and mitigation sequence data so density/stacking behavior remains compatible.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webClimateFollowUpDebtSummary.test.js test/ui/climate/webClimateMitigationCrossDomainBenefits.test.js test/ui/climate/webClimateMitigationSequencePriority.test.js
- npm test