### PR TITLE
Beta: compare logistics pressure outcomes

### DIFF
--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -11,6 +11,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /buildProvinceLogisticsBottleneckPriorities/);
   assert.match(webAppSource, /buildProvinceLogisticsInterventionTradeoff/);
   assert.match(webAppSource, /buildProvinceLogisticsInterventionSequence/);
+  assert.match(webAppSource, /buildProvinceLogisticsPressureComparison/);
+  assert.match(webAppSource, /renderProvinceLogisticsPressureComparison/);
   assert.match(webAppSource, /province-logistics-bottleneck-warning/);
   assert.match(webAppSource, /province-logistics-bottleneck-priorities/);
   assert.match(webAppSource, /Priorités aval/);
@@ -19,6 +21,12 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Compromis d’intervention logistique/);
   assert.match(webAppSource, /Séquence recommandée d’interventions logistiques/);
   assert.match(webAppSource, /Séquence recommandée/);
+  assert.match(webAppSource, /Prévu vs résolu/);
+  assert.match(webAppSource, /Comparaison pression logistique prévue et résolue/);
+  assert.match(webAppSource, /Reste à traiter/);
+  assert.match(webAppSource, /goulot amélioré/);
+  assert.match(webAppSource, /pénurie persistante/);
+  assert.match(webAppSource, /nouvelle contrainte aval/);
   assert.match(webAppSource, /alternative équivalente/);
   assert.match(webAppSource, /ordre dépendant du choix militaire/);
   assert.match(webAppSource, /ordre dépendant du choix culturel\/production/);
@@ -126,6 +134,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(stylesSource, /province-logistics-bottleneck-priorities/);
   assert.match(stylesSource, /province-logistics-bottleneck-tradeoff/);
   assert.match(stylesSource, /province-logistics-intervention-sequence/);
+  assert.match(stylesSource, /province-logistics-pressure-comparison/);
+  assert.match(stylesSource, /province-logistics-pressure-comparison__row--improved/);
+  assert.match(stylesSource, /province-logistics-pressure-comparison__row--danger/);
   assert.match(stylesSource, /province-logistics-bottleneck-priority--high/);
   assert.match(stylesSource, /province-logistics-bottleneck-priority--medium/);
   assert.match(stylesSource, /province-logistics-bottleneck--low/);

--- a/web/app.js
+++ b/web/app.js
@@ -2093,6 +2093,90 @@ function buildProvinceLogisticsBottleneckWarnings(province, economyView, compari
   }];
 }
 
+function buildProvinceLogisticsPressureComparison(province, economyView) {
+  if (!province || !economyView) {
+    return null;
+  }
+
+  const planned = buildProvinceLogisticsBottleneckPriorities(buildProvinceLogisticsBottleneckComparison(province, economyView));
+  const outcomeMarker = getLogisticsOutcomeMarkerForFocusedProvince(province.provinceId);
+  const resolvedDetails = sortLogisticsOutcomeDetails(outcomeMarker?.details ?? []);
+  const detailByRouteId = new Map(resolvedDetails.map((detail) => [detail.routeId, detail]));
+  const rows = planned.slice(0, 3).map((entry) => {
+    const detail = detailByRouteId.get(entry.routeId) ?? resolvedDetails.find((candidate) => candidate.routeLabel === entry.routeName) ?? null;
+    const status = detail?.status ?? 'planned-only';
+    const delta = status === 'resolved' || status === 'reduced'
+      ? 'goulot amélioré'
+      : status === 'new-bottleneck'
+        ? 'nouvelle contrainte aval'
+        : status === 'unresolved'
+          ? 'pénurie persistante'
+          : 'reste à traiter';
+    const tone = status === 'resolved' || status === 'reduced'
+      ? 'improved'
+      : status === 'new-bottleneck' || status === 'unresolved'
+        ? 'danger'
+        : 'pending';
+
+    return {
+      routeId: entry.routeId,
+      routeName: entry.routeName,
+      planned: `${entry.headline}: ${entry.downstreamImpact}`,
+      resolved: detail ? `${detail.label}: ${detail.detail}` : 'Pas encore confirmé par les marqueurs post-résolution.',
+      nextStep: tone === 'improved'
+        ? 'Préparer le relais vers le prochain goulot.'
+        : tone === 'danger'
+          ? 'Replanifier avant le prochain tour.'
+          : 'Conserver dans la file de suivi.',
+      delta,
+      tone,
+    };
+  });
+
+  if (rows.length === 0 && !outcomeMarker) {
+    return null;
+  }
+
+  return {
+    hasNotableDelta: rows.some((row) => row.tone !== 'pending'),
+    summary: rows.some((row) => row.tone === 'danger')
+      ? 'Écart logistique notable: une pression reste ou se déplace.'
+      : rows.some((row) => row.tone === 'improved')
+        ? 'Plan confirmé: une pression logistique s’améliore.'
+        : 'Pression prévue en attente de résolution.',
+    rows,
+  };
+}
+
+function renderProvinceLogisticsPressureComparison(province, economyView) {
+  const comparison = buildProvinceLogisticsPressureComparison(province, economyView);
+
+  if (!comparison) {
+    return '';
+  }
+
+  return `
+    <section class="province-logistics-pressure-comparison ${comparison.hasNotableDelta ? 'has-notable-delta' : 'is-discreet'}" aria-label="Comparaison pression logistique prévue et résolue">
+      <div class="province-logistics-pressure-comparison__header">
+        <strong>Prévu vs résolu</strong>
+        <span>${comparison.summary}</span>
+      </div>
+      ${comparison.rows.length > 0 ? `
+        <ol>
+          ${comparison.rows.map((row) => `
+            <li class="province-logistics-pressure-comparison__row province-logistics-pressure-comparison__row--${row.tone}">
+              <strong>${row.routeName}</strong>
+              <div><b>Prévu</b><span>${row.planned}</span></div>
+              <div><b>Résolu</b><span>${row.resolved}</span></div>
+              <div><b>Reste à traiter</b><span>${row.delta} · ${row.nextStep}</span></div>
+            </li>
+          `).join('')}
+        </ol>
+      ` : '<small>Aucun écart notable sur les routes suivies.</small>'}
+    </section>
+  `;
+}
+
 function renderProvinceLogisticsBottleneckComparison(province, economyView) {
   const comparisons = buildProvinceLogisticsBottleneckComparison(province, economyView);
   const warnings = buildProvinceLogisticsBottleneckWarnings(province, economyView, comparisons);
@@ -7064,6 +7148,7 @@ function renderActiveProvince(shell, economyView = null, intrigueView = null) {
       </div>
       ${renderProvinceEconomyConsequences(province, economyView)}
       ${renderProvinceEconomyTurnReport(province, economyView)}
+      ${renderProvinceLogisticsPressureComparison(province, economyView)}
       ${renderProvinceLogisticsBottleneckComparison(province, economyView)}
       ${renderFocusedLogisticsOutcomeGroup(province)}
       ${renderProvinceLogisticsChoicePreview(province, economyView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -9473,3 +9473,52 @@ button { font: inherit; }
   font-size: 10px;
   line-height: 1.3;
 }
+.province-logistics-pressure-comparison {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 11px;
+  border-radius: 17px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.62), rgba(8, 47, 73, 0.26));
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.province-logistics-pressure-comparison.is-discreet { opacity: 0.82; }
+.province-logistics-pressure-comparison.has-notable-delta { border-color: rgba(56, 189, 248, 0.3); }
+.province-logistics-pressure-comparison__header {
+  display: grid;
+  gap: 2px;
+}
+.province-logistics-pressure-comparison__header strong { color: #f8fafc; }
+.province-logistics-pressure-comparison__header span { color: #bae6fd; font-size: 12px; }
+.province-logistics-pressure-comparison ol {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.province-logistics-pressure-comparison__row {
+  display: grid;
+  gap: 5px;
+  padding: 8px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.province-logistics-pressure-comparison__row--improved { border-color: rgba(74, 222, 128, 0.34); }
+.province-logistics-pressure-comparison__row--danger { border-color: rgba(251, 113, 133, 0.42); }
+.province-logistics-pressure-comparison__row--pending { border-color: rgba(125, 211, 252, 0.22); }
+.province-logistics-pressure-comparison__row > strong { color: #e0f2fe; }
+.province-logistics-pressure-comparison__row div {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr);
+  gap: 6px;
+  align-items: start;
+}
+.province-logistics-pressure-comparison__row b {
+  color: #93c5fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-logistics-pressure-comparison__row span { color: #dbeafe; font-size: 11px; line-height: 1.3; }


### PR DESCRIPTION
Beta: Implements #710.

## Summary
- Adds a concise “Prévu vs résolu” logistics pressure comparison in selected province details.
- Reuses existing bottleneck priorities and post-resolution logistics outcome groups to show planned pressure, resolved outcome, and what remains to treat.
- Highlights useful deltas: improved bottleneck, persistent shortage, new downstream constraint, while keeping no-delta cases discreet.

## Validation
- npm test (495 OK)
- targeted economy UI tests (7 OK)
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js web/app.js
- git diff --check
