### PR TITLE
Gamma: track culture blocker history

### DIFF
--- a/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
+++ b/src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
@@ -348,6 +348,56 @@ export function buildCultureDiscoveryUrgencyGroups({
 }
 
 
+
+export function buildCultureBlockerResolutionHistory({
+  priorityView = {},
+  previousHistory = [],
+  provinceId = 'province',
+  provinceLabel = provinceId,
+  turn = 0,
+} = {}) {
+  const priorities = priorityView.priorities ?? [];
+  const freshEntries = priorities
+    .filter((priority) => priority.blocker || priority.followUp || priority.resolutionGain)
+    .map((priority) => {
+      const status = priority.blocker
+        ? priority.conflict ? 'suivi nécessaire' : 'blocage levé'
+        : priority.followUp ? 'option débloquée' : 'gain reporté';
+      const source = priority.blocker?.shortReason ?? priority.followUp?.action ?? priority.sourceLabel;
+
+      return {
+        historyId: `culture-blocker-history:${provinceId}:${priority.priorityId}:${turn}`,
+        provinceId,
+        provinceLabel,
+        cultureName: priority.cultureName,
+        status,
+        source,
+        effect: priority.resolutionGain?.gain ?? priority.effect,
+        next: priority.resolutionGain?.next ?? priority.followUp?.reason ?? 'suivi culturel à confirmer',
+        risk: priority.resolutionGain?.riskAvoided ?? priority.waitRisk,
+        urgency: priority.urgency,
+        turn,
+        priority: (priority.urgency === 'urgent' ? 3 : 2) + (priority.blocker ? 2 : 0) + (priority.conflict ? 1 : 0),
+      };
+    });
+
+  const merged = [...freshEntries, ...previousHistory]
+    .filter((entry) => !entry.provinceId || entry.provinceId === provinceId)
+    .sort((left, right) => (right.turn ?? 0) - (left.turn ?? 0) || (right.priority ?? 0) - (left.priority ?? 0));
+  const seen = new Set();
+
+  return merged
+    .filter((entry) => {
+      const key = `${entry.provinceId}:${entry.cultureName}:${entry.source}:${entry.status}`;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .slice(0, 4);
+}
+
 export function buildCultureInterventionPriorities(groupView = {}) {
   const items = (groupView.groups ?? [])
     .flatMap((group) => (group.items ?? []).map((item) => ({ ...item, group: item.group ?? group.key })))

--- a/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
+++ b/test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCultureDiscoveryUrgencyGroups, buildCultureInterventionPriorities } from '../../../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
+import { buildCultureBlockerResolutionHistory, buildCultureDiscoveryUrgencyGroups, buildCultureInterventionPriorities } from '../../../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
 
 test('buildCultureDiscoveryUrgencyGroups orders urgent and active culture signals before background lore', () => {
   const groups = buildCultureDiscoveryUrgencyGroups({
@@ -163,4 +163,63 @@ test('buildCultureInterventionPriorities flags local priority conflicts', () => 
   assert.match(priorities.priorities[0].resolutionGain.gain, /tension réduite entre Compact d’Aurora et Ligues des Forges/);
   assert.equal(priorities.conflicts[0].label, 'Même province');
   assert.match(priorities.conflicts[0].summary, /concurrence/);
+});
+
+test('buildCultureBlockerResolutionHistory keeps recent resolved blockers and useful unlocks compact', () => {
+  const priorities = buildCultureInterventionPriorities({
+    groups: [{
+      key: 'urgent',
+      items: [
+        {
+          itemId: 'discovery:river:aurora',
+          kind: 'discovery',
+          group: 'urgent',
+          label: 'routes-célestes',
+          shortLabel: 'routes-célestes',
+          cultureName: 'Compact d’Aurora',
+          regionId: 'river-gate',
+          cause: 'Tension locale',
+          detail: 'route critique',
+          priority: 330,
+        },
+        {
+          itemId: 'discovery:river:aurora:catalogue',
+          kind: 'discovery',
+          group: 'active',
+          label: 'catalogues-publics',
+          shortLabel: 'catalogues-publics',
+          cultureName: 'Compact d’Aurora',
+          regionId: 'river-gate',
+          cause: 'Recherche active',
+          detail: 'suite utile',
+          priority: 220,
+        },
+      ],
+    }],
+  });
+
+  const history = buildCultureBlockerResolutionHistory({
+    priorityView: priorities,
+    previousHistory: [{
+      historyId: 'old',
+      provinceId: 'river-gate',
+      cultureName: 'Ancienne trace',
+      source: 'ancien signal',
+      status: 'gain reporté',
+      effect: 'ancienne option masquée',
+      next: 'ne devrait pas dominer',
+      risk: 'ancien risque',
+      turn: 1,
+      priority: 1,
+    }],
+    provinceId: 'river-gate',
+    provinceLabel: 'Porte du Fleuve',
+    turn: 4,
+  });
+
+  assert.equal(history[0].status, 'blocage levé');
+  assert.match(history[0].effect, /tension réduite/);
+  assert.match(history[0].next, /catalogues-publics/);
+  assert.match(history[0].risk, /risque social/);
+  assert.ok(history.length <= 4);
 });

--- a/test/ui/culture/webCultureUrgencyReasons.test.js
+++ b/test/ui/culture/webCultureUrgencyReasons.test.js
@@ -53,6 +53,7 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /cultureTensionCausePriority/);
   assert.match(webAppSource, /buildCultureDiscoveryUrgencyGroups/);
   assert.match(webAppSource, /buildCultureInterventionPriorities/);
+  assert.match(webAppSource, /buildCultureBlockerResolutionHistory/);
   assert.match(webAppSource, /renderCultureDiscoveryUrgencyGroups/);
   assert.match(webAppSource, /renderCultureInterventionPriorities/);
   assert.match(webAppSource, /Découvertes culturelles groupées par urgence/);
@@ -61,6 +62,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(webAppSource, /culture-intervention-priority__follow-up/);
   assert.match(webAppSource, /culture-intervention-priority__resolution-gain/);
   assert.match(webAppSource, /resolutionGain\.riskAvoided/);
+  assert.match(webAppSource, /culture-blocker-history/);
+  assert.match(webAppSource, /Blocages récents/);
   assert.match(webAppSource, /Urgence/);
   assert.match(webAppSource, /Cause floue/);
   assert.match(webAppSource, /urgence puis tendance/);
@@ -102,6 +105,8 @@ test('culture urgency badges render compact local timeline reasons', () => {
   assert.match(stylesSource, /\.culture-intervention-priority__blocker/);
   assert.match(stylesSource, /\.culture-intervention-priority__follow-up/);
   assert.match(stylesSource, /\.culture-intervention-priority__resolution-gain/);
+  assert.match(stylesSource, /\.culture-blocker-history/);
+  assert.match(stylesSource, /\.culture-blocker-history__item--urgent/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-rising/);
   assert.match(stylesSource, /\.culture-tension-marker-card--trend-unknown/);
   assert.match(stylesSource, /\.culture-opportunity-reminder__queue-confirmation/);

--- a/web/app.js
+++ b/web/app.js
@@ -18,7 +18,7 @@ import { buildIntrigueWebDemo } from '../src/ui/intrigue/buildIntrigueWebDemo.js
 import { buildIntrigueTurnReportDeltas } from '../src/ui/intrigue/buildIntrigueTurnReportDeltas.js';
 import { buildCultureMapRecommendations } from '../src/ui/culture/buildCultureMapRecommendations.js';
 import { buildCultureLocalTimeline } from '../src/ui/culture/buildCultureLocalTimeline.js';
-import { buildCultureDiscoveryUrgencyGroups, buildCultureInterventionPriorities } from '../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
+import { buildCultureBlockerResolutionHistory, buildCultureDiscoveryUrgencyGroups, buildCultureInterventionPriorities } from '../src/ui/culture/buildCultureDiscoveryUrgencyGroups.js';
 import { buildCultureConsequenceChips } from '../src/ui/culture/buildCultureConsequenceChips.js';
 import { buildCultureTurnReportDeltas } from '../src/ui/culture/buildCultureTurnReportDeltas.js';
 import { buildCultureUnlockHints } from '../src/ui/culture/buildCultureUnlockHints.js';
@@ -407,6 +407,7 @@ const state = {
   selectedLogisticsOutcomeRouteId: null,
   queuedCultureActions: [],
   cultureTensionMarkers: [],
+  cultureBlockerHistory: [],
   cultureTensionFilters: { eased: true, unresolved: true, escalated: true, opportunity: true },
   comparedCityIds: ['river-gate-city', 'crown-port'],
   comparisonProvinceIds: ['river-gate', 'crown-heart'],
@@ -8436,6 +8437,31 @@ function renderCultureInterventionPriorities(priorityView) {
   `;
 }
 
+function renderCultureBlockerResolutionHistory(history) {
+  if (!history.length) {
+    return '';
+  }
+
+  return `
+    <article class="culture-blocker-history" aria-label="Historique récent des blocages culturels">
+      <div class="culture-blocker-history__header">
+        <span>Blocages récents</span>
+        <strong>${history.length} trace${history.length > 1 ? 's' : ''} utile${history.length > 1 ? 's' : ''}</strong>
+      </div>
+      <ol>
+        ${history.map((entry) => `
+          <li class="culture-blocker-history__item culture-blocker-history__item--${entry.urgency}">
+            <b>${entry.status}</b>
+            <span>${entry.effect}</span>
+            <small>${entry.cultureName} · ${entry.source} · ${entry.next}</small>
+            <em>${entry.risk}</em>
+          </li>
+        `).join('')}
+      </ol>
+    </article>
+  `;
+}
+
 function renderCultureClusterPinList(cluster) {
   if (!cluster) {
     return '';
@@ -8594,6 +8620,26 @@ function buildPostCommitCultureTensionMarkers(shell) {
     const unlockHintsByAction = buildCultureUnlockHintsForActions(province, actionQueue, cultureContext);
     const report = buildCultureOpportunityReminders({ province, actionQueue, unlockHintsByAction });
     return buildCulturePostCommitTensionMarkers(province, report);
+  }).slice(0, 8);
+}
+
+function buildPostCommitCultureBlockerHistory(shell) {
+  const overlay = strategicMap.overlays.culture;
+  const clusters = buildCultureClusterSummaries(overlay);
+
+  return (shell.provinces ?? []).flatMap((province) => {
+    const selectedMarker = overlay.find((entry) => entry.regionId === province.provinceId) ?? null;
+    const selectedCluster = clusters.find((cluster) => cluster.regionIds.includes(province.provinceId)) ?? null;
+    const groups = buildCultureDiscoveryUrgencyGroups({ selectedMarker, selectedCluster });
+    const priorityView = buildCultureInterventionPriorities(groups);
+
+    return buildCultureBlockerResolutionHistory({
+      priorityView,
+      previousHistory: state.cultureBlockerHistory,
+      provinceId: province.provinceId,
+      provinceLabel: province.label,
+      turn: state.turn,
+    });
   }).slice(0, 8);
 }
 
@@ -8799,6 +8845,12 @@ function renderCultureSidePanel(cultureView) {
     selectedCluster,
   });
   const interventionPriorities = buildCultureInterventionPriorities(discoveryUrgencyGroups);
+  const blockerHistory = buildCultureBlockerResolutionHistory({
+    previousHistory: state.cultureBlockerHistory,
+    provinceId: state.selectedProvinceId,
+    provinceLabel: state.selectedProvinceId,
+    turn: state.turn,
+  });
   const recommendationView = buildCultureMapRecommendations({
     selectedRegionId: state.selectedProvinceId,
     selectedMarker: focus,
@@ -8831,6 +8883,7 @@ function renderCultureSidePanel(cultureView) {
       ${renderCultureLocalTimeline(localTimelineView)}
       ${renderCultureDiscoveryUrgencyGroups(discoveryUrgencyGroups)}
       ${renderCultureInterventionPriorities(interventionPriorities)}
+      ${renderCultureBlockerResolutionHistory(blockerHistory)}
       ${renderCultureClusterPinList(selectedCluster)}
       ${focus ? `
         <article class="culture-focus-card culture-focus-card--${getCultureTone(focus)}">
@@ -10024,6 +10077,7 @@ function advanceTurn() {
   const logisticsOutcomeMarkers = buildLogisticsOutcomeMarkers(shell, economyView);
 
   state.cultureTensionMarkers = buildPostCommitCultureTensionMarkers(shell);
+  state.cultureBlockerHistory = buildPostCommitCultureBlockerHistory(shell);
   state.queuedCultureActions = [];
   state.lastMilitaryOutcomeMarkers = militaryOutcomeMarker ? [militaryOutcomeMarker] : [];
   state.logisticsOutcomeMarkers = logisticsOutcomeMarkers;

--- a/web/styles.css
+++ b/web/styles.css
@@ -9490,6 +9490,7 @@ button { font: inherit; }
   font-size: 10px;
   line-height: 1.3;
 }
+
 .province-logistics-pressure-comparison {
   display: grid;
   gap: 8px;
@@ -9539,3 +9540,56 @@ button { font: inherit; }
   text-transform: uppercase;
 }
 .province-logistics-pressure-comparison__row span { color: #dbeafe; font-size: 11px; line-height: 1.3; }
+
+.culture-blocker-history {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.culture-blocker-history__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.culture-blocker-history__header span {
+  color: #bae6fd;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-blocker-history__header strong { color: #e0f2fe; font-size: 12px; }
+.culture-blocker-history ol {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.culture-blocker-history__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.42);
+  border-left: 3px solid rgba(45, 212, 191, 0.58);
+}
+.culture-blocker-history__item--urgent { border-left-color: rgba(251, 113, 133, 0.72); }
+.culture-blocker-history__item b {
+  color: #a7f3d0;
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+.culture-blocker-history__item span { color: #f8fafc; font-size: 12px; font-weight: 800; }
+.culture-blocker-history__item small,
+.culture-blocker-history__item em {
+  color: #cbd5e1;
+  font-size: 10px;
+  line-height: 1.3;
+  font-style: normal;
+}


### PR DESCRIPTION
Gamma: Implements #711.

## Summary
- add compact culture blocker resolution history entries for recently resolved blockers/unlocks
- preserve only recent important province traces so old noise does not pollute details
- render a province culture “Blocages récents” panel reusing existing blocker/unlock/gain data

## Validation
- node --check web/app.js
- node --check src/ui/culture/buildCultureDiscoveryUrgencyGroups.js
- node --check src/ui/culture/buildCultureOpportunityReminders.js
- npm test -- test/ui/culture/buildCultureDiscoveryUrgencyGroups.test.js test/ui/culture/buildCultureOpportunityReminders.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/culture/buildCultureUnlockHints.test.js
- git diff --check
- npm test (493 OK)