### PR TITLE
Delta: add fog-safe world map intrigue signals

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -197,6 +197,23 @@ test('final intrigue exposure summary is visible before turn commit', () => {
   assert.match(stylesSource, /province-intrigue-final-commit-summary__item--trop-risqué/);
 });
 
+test('world map intrigue signals show presence risk shadows and probable sabotage safely', () => {
+  assert.match(webAppSource, /function buildWorldMapIntrigueSignals/);
+  assert.match(webAppSource, /function renderWorldMapIntrigueSignals/);
+  assert.match(webAppSource, /function renderWorldMapIntrigueSignalRollup/);
+  assert.match(webAppSource, /Signaux intrigue sur la carte monde fog-safe/);
+  assert.match(webAppSource, /Résumé intrigue carte monde fog-safe/);
+  assert.match(webAppSource, /présence forte/);
+  assert.match(webAppSource, /risque sabotage probable/);
+  assert.match(webAppSource, /zone d’ombre conservée/);
+  assert.match(webAppSource, /les cellules, relais, objectifs et causes cachées restent masqués/);
+  assert.match(webAppSource, /aucun détail caché révélé/);
+  assert.match(webAppSource, /renderWorldMapIntrigueSignals\(worldMapSignals\)/);
+  assert.match(stylesSource, /world-map-intrigue-signal/);
+  assert.match(stylesSource, /world-map-intrigue-signal--shadow/);
+  assert.match(stylesSource, /world-map-intrigue-rollup/);
+});
+
 test('post-commit intrigue exposure markers stay fog-safe on the map', () => {
   assert.match(webAppSource, /function buildPostCommitIntrigueExposureMarkers/);
   assert.match(webAppSource, /function renderPostCommitIntrigueExposureMarkers/);

--- a/web/app.js
+++ b/web/app.js
@@ -7106,6 +7106,120 @@ function renderPostCommitIntrigueExposureMarkers(markers) {
   `;
 }
 
+
+function buildWorldMapIntrigueSignals(intrigueView = null) {
+  const entries = intrigueView?.map?.entries ?? [];
+
+  return entries.map((entry) => {
+    const presenceLabels = {
+      high: 'présence forte',
+      medium: 'présence probable',
+      low: 'présence faible',
+      none: 'présence inconnue',
+    };
+    const riskLabels = {
+      high: 'risque sabotage probable',
+      medium: 'risque sabotage possible',
+      low: 'risque sabotage faible',
+      none: 'risque non confirmé',
+    };
+    const hasSabotageSignal = entry.metrics.sabotageOperationCount > 0 || ['high', 'medium'].includes(entry.sabotageRiskLevel);
+    const shadowZone = !entry.showSecondaryDetails || (entry.metrics.exposedCellCount === 0 && entry.presenceLevel !== 'high');
+    const assurance = entry.metrics.exposedCellCount > 0 || entry.showSecondaryDetails
+      ? 'confirmé'
+      : hasSabotageSignal
+        ? 'probable'
+        : 'zone d’ombre';
+    const glyph = hasSabotageSignal
+      ? 'S?'
+      : shadowZone
+        ? '??'
+        : 'I';
+    const tone = entry.sabotageRiskLevel === 'high'
+      ? 'danger'
+      : entry.sabotageRiskLevel === 'medium' || entry.presenceLevel === 'high'
+        ? 'warning'
+        : shadowZone
+          ? 'shadow'
+          : 'watch';
+
+    return {
+      locationId: entry.locationId,
+      locationName: entry.locationName,
+      center: {
+        x: clampVisualMetric(entry.center.x - 4.8, 4, 94),
+        y: clampVisualMetric(entry.center.y - 5.1, 6, 94),
+      },
+      tone,
+      glyph,
+      assurance,
+      presenceLabel: presenceLabels[entry.presenceLevel] ?? presenceLabels.none,
+      riskLabel: riskLabels[entry.sabotageRiskLevel] ?? riskLabels.none,
+      shadowZone,
+      probableSabotage: hasSabotageSignal,
+      copy: `${presenceLabels[entry.presenceLevel] ?? presenceLabels.none} · ${riskLabels[entry.sabotageRiskLevel] ?? riskLabels.none} · assurance ${assurance}${shadowZone ? ' · zone d’ombre conservée' : ''}`,
+      ariaLabel: `Signal intrigue monde en ${entry.locationName}: ${presenceLabels[entry.presenceLevel] ?? presenceLabels.none}; ${riskLabels[entry.sabotageRiskLevel] ?? riskLabels.none}; assurance ${assurance}; aucun détail caché révélé`,
+    };
+  }).sort((left, right) => {
+    const rank = { danger: 1, warning: 2, shadow: 3, watch: 4 };
+    return rank[left.tone] - rank[right.tone] || left.locationName.localeCompare(right.locationName);
+  }).slice(0, 6);
+}
+
+function buildWorldMapIntrigueSignalRollup(signals) {
+  const counts = {
+    danger: signals.filter((signal) => signal.tone === 'danger').length,
+    warning: signals.filter((signal) => signal.tone === 'warning').length,
+    shadow: signals.filter((signal) => signal.shadowZone).length,
+    probableSabotage: signals.filter((signal) => signal.probableSabotage).length,
+  };
+
+  return {
+    counts,
+    totalCount: signals.length,
+    summary: signals.length > 0
+      ? `${signals.length} signal${signals.length > 1 ? 's' : ''} intrigue monde visible${signals.length > 1 ? 's' : ''}: ${counts.probableSabotage} sabotage${counts.probableSabotage > 1 ? 's' : ''} probable${counts.probableSabotage > 1 ? 's' : ''}, ${counts.shadow} zone${counts.shadow > 1 ? 's' : ''} d’ombre.`
+      : 'Aucun signal intrigue monde visible avec les filtres actuels.',
+  };
+}
+
+function renderWorldMapIntrigueSignals(signals) {
+  if (!signals.length) {
+    return '';
+  }
+
+  return `
+    <g class="world-map-intrigue-signal-layer" aria-label="Signaux intrigue sur la carte monde fog-safe">
+      ${signals.map((signal) => `
+        <g class="world-map-intrigue-signal world-map-intrigue-signal--${signal.tone} ${signal.shadowZone ? 'has-shadow-zone' : ''}" data-intrigue-location="${signal.locationId}" tabindex="0" aria-label="${signal.ariaLabel}">
+          <title>${signal.copy}</title>
+          <circle class="world-map-intrigue-signal__aura" cx="${signal.center.x}%" cy="${signal.center.y}%" r="${signal.probableSabotage ? 4.9 : 3.9}"></circle>
+          <text class="world-map-intrigue-signal__glyph" x="${signal.center.x}%" y="${signal.center.y + 1.05}%" text-anchor="middle">${signal.glyph}</text>
+          <text class="world-map-intrigue-signal__label" x="${signal.center.x + 4.2}%" y="${signal.center.y - 1.2}%" text-anchor="start">${signal.riskLabel}</text>
+          <text class="world-map-intrigue-signal__copy" x="${signal.center.x + 4.2}%" y="${signal.center.y + 2.0}%" text-anchor="start">${signal.presenceLabel} · ${signal.assurance}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
+function renderWorldMapIntrigueSignalRollup(rollup) {
+  if (rollup.totalCount === 0) {
+    return '';
+  }
+
+  return `
+    <section class="world-map-intrigue-rollup" aria-label="Résumé intrigue carte monde fog-safe">
+      <div class="world-map-intrigue-rollup__header">
+        <strong>Intrigue carte monde</strong>
+        <span>${rollup.counts.probableSabotage} sabotage${rollup.counts.probableSabotage > 1 ? 's' : ''} probable${rollup.counts.probableSabotage > 1 ? 's' : ''}</span>
+      </div>
+      <p>${rollup.summary}</p>
+      <small>${rollup.counts.shadow} zone${rollup.counts.shadow > 1 ? 's' : ''} d’ombre conservée${rollup.counts.shadow > 1 ? 's' : ''}; les cellules, relais, objectifs et causes cachées restent masqués.</small>
+    </section>
+  `;
+}
+
 function renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const cultureContext = getSelectedCultureContext(province.provinceId);
@@ -9041,11 +9155,12 @@ function renderEconomyMapOverlay(economyView) {
 
 function renderIntrigueMapOverlay(intrigueView) {
   const postCommitMarkers = buildPostCommitIntrigueExposureMarkers(intrigueView);
+  const worldMapSignals = buildWorldMapIntrigueSignals(intrigueView);
 
   if (state.activeOverlaySlot !== 'intrigue-overlay') {
     const criticalSignals = intrigueView.map.entries.filter((entry) => entry.sabotageRiskLevel === 'high' || entry.metrics.exposedCellCount > 0);
 
-    if (criticalSignals.length === 0 && postCommitMarkers.length === 0) {
+    if (criticalSignals.length === 0 && postCommitMarkers.length === 0 && worldMapSignals.every((signal) => signal.tone === 'watch')) {
       return '';
     }
 
@@ -9057,6 +9172,7 @@ function renderIntrigueMapOverlay(intrigueView) {
             <text class="intrigue-critical-signal__code" x="${entry.center.x + 3.8}%" y="${entry.center.y - 2.6}%">${entry.threatGlyph.code}</text>
           </g>
         `).join('')}
+        ${renderWorldMapIntrigueSignals(worldMapSignals.filter((signal) => signal.tone !== 'watch'))}
         ${renderPostCommitIntrigueExposureMarkers(postCommitMarkers)}
       </svg>
     `;
@@ -9112,6 +9228,7 @@ function renderIntrigueMapOverlay(intrigueView) {
         ${threatGlyphMarkup}
       </g>
       ${hotspotMarkup}
+      ${renderWorldMapIntrigueSignals(worldMapSignals)}
       ${renderPostCommitIntrigueExposureMarkers(postCommitMarkers)}
     </svg>
   `;
@@ -9124,6 +9241,8 @@ function renderIntrigueSidePanel(intrigueView) {
 
   const exposureMarkers = buildPostCommitIntrigueExposureMarkers(intrigueView, { ignoreFilters: true });
   const exposureMarkerRollup = buildIntrigueExposureMarkerRollup(exposureMarkers);
+  const worldMapSignals = buildWorldMapIntrigueSignals(intrigueView);
+  const worldMapSignalRollup = buildWorldMapIntrigueSignalRollup(worldMapSignals);
 
   return `
     <section class="panel overlay-panel overlay-panel--intrigue">
@@ -9142,6 +9261,7 @@ function renderIntrigueSidePanel(intrigueView) {
         <button type="button" class="intrigue-filter-chip ${intrigueView.filters.alerts ? 'is-active' : ''}" data-intrigue-filter="alerts">Alertes</button>
         <button type="button" class="intrigue-filter-chip ${intrigueView.filters.sabotage ? 'is-active' : ''}" data-intrigue-filter="sabotage">Sabotage</button>
       </section>
+      ${renderWorldMapIntrigueSignalRollup(worldMapSignalRollup)}
       ${renderIntrigueExposureMarkerRollup(exposureMarkerRollup)}
       <section class="intrigue-alert-panel intrigue-alert-panel--${intrigueView.alertPanel.tone}" aria-label="Lecture du niveau d'alerte">
         <div class="intrigue-alert-panel__header">

--- a/web/styles.css
+++ b/web/styles.css
@@ -2512,6 +2512,56 @@ button { font: inherit; }
   stroke-width: 0.72;
   filter: drop-shadow(0 0 10px rgba(216, 180, 254, 0.68));
 }
+.world-map-intrigue-signal { cursor: help; }
+.world-map-intrigue-signal__aura {
+  fill: rgba(15, 23, 42, 0.86);
+  stroke: rgba(226, 232, 240, 0.72);
+  stroke-width: 0.34;
+  filter: drop-shadow(0 0 7px rgba(129, 140, 248, 0.28));
+}
+.world-map-intrigue-signal--danger .world-map-intrigue-signal__aura { stroke: rgba(248, 113, 113, 0.9); fill: rgba(127, 29, 29, 0.58); }
+.world-map-intrigue-signal--warning .world-map-intrigue-signal__aura { stroke: rgba(251, 191, 36, 0.88); fill: rgba(120, 53, 15, 0.52); }
+.world-map-intrigue-signal--shadow .world-map-intrigue-signal__aura { stroke: rgba(148, 163, 184, 0.7); stroke-dasharray: 1.2 1.1; }
+.world-map-intrigue-signal--watch .world-map-intrigue-signal__aura { stroke: rgba(96, 165, 250, 0.72); }
+.world-map-intrigue-signal.has-shadow-zone .world-map-intrigue-signal__aura { filter: drop-shadow(0 0 8px rgba(148, 163, 184, 0.32)); }
+.world-map-intrigue-signal__glyph {
+  fill: #f8fafc;
+  font-size: 2.9px;
+  font-weight: 900;
+  pointer-events: none;
+}
+.world-map-intrigue-signal__label {
+  fill: #f8fafc;
+  font-size: 2.35px;
+  font-weight: 800;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.72);
+  stroke-width: 0.45px;
+}
+.world-map-intrigue-signal__copy {
+  fill: #dbeafe;
+  font-size: 1.95px;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.72);
+  stroke-width: 0.4px;
+}
+.world-map-intrigue-rollup {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(129, 140, 248, 0.28);
+  background: rgba(30, 41, 59, 0.48);
+}
+.world-map-intrigue-rollup__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.world-map-intrigue-rollup__header span,
+.world-map-intrigue-rollup p,
+.world-map-intrigue-rollup small { color: #cbd5e1; }
 .intrigue-exposure-marker-rollup {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Implements #718.

Summary:
- add fog-safe world-map intrigue signal badges for presence, shadow zones, risk, and probable sabotage
- show a world-map intrigue rollup in the intrigue side panel
- surface non-spoilery signals even when the intrigue overlay is not the active map layer
- keep hidden cells, relays, targets, objectives, and causes masked

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Closes #718