### PR TITLE
Alpha: create atlas world map canvas

### DIFF
--- a/test/ui/war/webAtlasWorldMapCanvas.test.js
+++ b/test/ui/war/webAtlasWorldMapCanvas.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas world map canvas reuses existing province geometry for continents and islands', () => {
+  assert.match(webAppSource, /function buildAtlasTerrainShapes/);
+  assert.match(webAppSource, /getProvinceGeometry\(province\.provinceId\)/);
+  assert.match(webAppSource, /getProvincePolygon\(province\.provinceId\)/);
+  assert.match(webAppSource, /getProvinceCenter\(province\.provinceId\)/);
+  assert.match(webAppSource, /const continents = shell\.provinces\.map/);
+  assert.match(webAppSource, /islands/);
+});
+
+test('atlas world map canvas renders ocean terrain and relief as a dedicated map layer', () => {
+  assert.match(webAppSource, /function renderAtlasWorldCanvas/);
+  assert.match(webAppSource, /atlas-world-canvas/);
+  assert.match(webAppSource, /atlasOceanGradient/);
+  assert.match(webAppSource, /atlas-region--\$\{shape\.terrain\}/);
+  assert.match(webAppSource, /map-layer--atlas/);
+  assert.match(stylesSource, /\.atlas-world-canvas/);
+  assert.match(stylesSource, /\.atlas-world-canvas__ocean-band/);
+  assert.match(stylesSource, /\.atlas-region__relief/);
+  assert.match(stylesSource, /\.atlas-island/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -514,6 +514,84 @@ function getProvincePolygon(provinceId) {
   return getProvinceGeometry(provinceId).polygon ?? '12,12 88,12 88,88 12,88';
 }
 
+function getAtlasTerrainKind(province) {
+  if (province.supplyLevel === 'collapsed') return 'marsh';
+  if (province.supplyLevel === 'disrupted') return 'highlands';
+  if (province.provinceId.includes('river')) return 'delta';
+  if (province.provinceId.includes('ridge')) return 'mountain';
+  if (province.provinceId.includes('plain')) return 'steppe';
+  if (province.provinceId.includes('watch')) return 'tundra';
+  if (province.provinceId.includes('reach')) return 'isles';
+  return 'heartland';
+}
+
+function buildAtlasTerrainShapes(shell) {
+  const continents = shell.provinces.map((province) => {
+    const geometry = getProvinceGeometry(province.provinceId);
+    const layout = geometry.layout ?? getProvinceLayout(province.provinceId);
+    return {
+      provinceId: province.provinceId,
+      label: province.label,
+      polygon: geometry.polygon ?? getProvincePolygon(province.provinceId),
+      center: getProvinceCenter(province.provinceId),
+      terrain: getAtlasTerrainKind(province),
+      fill: province.style.fill,
+      border: province.style.border,
+      relief: ['highlands', 'mountain'].includes(getAtlasTerrainKind(province)) ? 'relief' : 'soft',
+      island: layout.w < 18 || getAtlasTerrainKind(province) === 'isles',
+    };
+  });
+
+  const islands = continents
+    .filter((shape) => shape.island)
+    .map((shape) => ({
+      ...shape,
+      radius: shape.terrain === 'isles' ? 2.4 : 1.6,
+    }));
+
+  return {
+    continents,
+    islands,
+    oceanBands: [
+      { id: 'western-ocean', label: 'Mer d’Occident', path: 'M0,0 H21 C16,18 18,34 9,50 C18,68 13,84 22,100 H0 Z' },
+      { id: 'southern-ocean', label: 'Mer Australe', path: 'M0,82 C20,76 31,84 48,79 C68,74 80,82 100,76 V100 H0 Z' },
+      { id: 'eastern-sea', label: 'Mer des Brumes', path: 'M82,0 H100 V100 H90 C94,80 86,66 92,47 C84,31 91,15 82,0 Z' },
+    ],
+  };
+}
+
+function renderAtlasWorldCanvas(shell) {
+  const atlas = buildAtlasTerrainShapes(shell);
+
+  return `
+    <svg class="atlas-world-canvas" viewBox="0 0 100 100" aria-label="Canevas atlas: océans, continents, îles et relief">
+      <defs>
+        <linearGradient id="atlasOceanGradient" x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0%" stop-color="#0f3b57"></stop>
+          <stop offset="55%" stop-color="#12324a"></stop>
+          <stop offset="100%" stop-color="#071827"></stop>
+        </linearGradient>
+        <filter id="atlasReliefShadow" x="-20%" y="-20%" width="140%" height="140%">
+          <feDropShadow dx="0.6" dy="0.9" stdDeviation="0.7" flood-color="#020617" flood-opacity="0.42"></feDropShadow>
+        </filter>
+      </defs>
+      <rect class="atlas-world-canvas__ocean" width="100" height="100"></rect>
+      ${atlas.oceanBands.map((band) => `<path class="atlas-world-canvas__ocean-band" d="${band.path}" aria-label="${band.label}"></path>`).join('')}
+      <path class="atlas-world-canvas__current atlas-world-canvas__current--north" d="M8,20 C25,12 37,23 52,16 S82,12 94,23"></path>
+      <path class="atlas-world-canvas__current atlas-world-canvas__current--south" d="M5,73 C23,66 41,77 57,69 S82,61 96,70"></path>
+      ${atlas.continents.map((shape) => `
+        <g class="atlas-region atlas-region--${shape.terrain} atlas-region--${shape.relief}" data-atlas-province="${shape.provinceId}">
+          <polygon points="${shape.polygon}" style="--atlas-fill:${shape.fill};--atlas-border:${shape.border}"></polygon>
+          <path class="atlas-region__relief" d="M${Math.max(4, shape.center.x - 5)},${shape.center.y} q4,-3 8,0 t8,0"></path>
+        </g>
+      `).join('')}
+      ${atlas.islands.map((shape) => `
+        <circle class="atlas-island atlas-island--${shape.terrain}" cx="${shape.center.x}" cy="${shape.center.y}" r="${shape.radius}" aria-label="Île ou archipel: ${shape.label}"></circle>
+      `).join('')}
+    </svg>
+  `;
+}
+
 function getProvinceCenter(provinceId) {
   const geometry = getProvinceGeometry(provinceId);
 
@@ -9958,6 +10036,7 @@ function renderTacticalCoordinateGrid() {
 function getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null) {
   return [
     { key: 'backdrop', className: 'map-layer map-layer--backdrop', content: `<div class="map-backdrop"></div>${renderTacticalCoordinateGrid()}` },
+    { key: 'atlas', className: 'map-layer map-layer--atlas', content: renderAtlasWorldCanvas(shell) },
     { key: 'terrain', className: 'map-layer map-layer--terrain', content: renderTerrainDecor() },
     { key: 'surface', className: 'map-layer map-layer--surface', content: renderProvinceSurface(shell, focusContext) },
     { key: 'relations', className: 'map-layer map-layer--relations', content: renderStrategicRelations(shell) },

--- a/web/styles.css
+++ b/web/styles.css
@@ -1361,9 +1361,55 @@ button { font: inherit; }
 .map-layer--relations,
 .map-layer--surface,
 .map-layer--terrain,
+.map-layer--atlas,
 .map-layer--backdrop {
   z-index: 1;
 }
+.atlas-world-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.atlas-world-canvas__ocean {
+  fill: url(#atlasOceanGradient);
+}
+.atlas-world-canvas__ocean-band {
+  fill: rgba(14, 116, 144, 0.22);
+  stroke: rgba(125, 211, 252, 0.16);
+  stroke-width: 0.35;
+}
+.atlas-world-canvas__current {
+  fill: none;
+  stroke: rgba(186, 230, 253, 0.24);
+  stroke-width: 0.42;
+  stroke-dasharray: 2 2.6;
+}
+.atlas-region polygon {
+  fill: color-mix(in srgb, var(--atlas-fill) 52%, rgba(15, 23, 42, 0.22));
+  stroke: color-mix(in srgb, var(--atlas-border) 70%, rgba(226, 232, 240, 0.25));
+  stroke-width: 0.55;
+  filter: url(#atlasReliefShadow);
+  opacity: 0.78;
+}
+.atlas-region--mountain polygon,
+.atlas-region--highlands polygon { opacity: 0.86; }
+.atlas-region--delta polygon,
+.atlas-region--marsh polygon { opacity: 0.72; }
+.atlas-region__relief {
+  fill: none;
+  stroke: rgba(248, 250, 252, 0.24);
+  stroke-width: 0.45;
+  stroke-linecap: round;
+}
+.atlas-region--soft .atlas-region__relief { opacity: 0.28; }
+.atlas-island {
+  fill: rgba(203, 213, 225, 0.24);
+  stroke: rgba(226, 232, 240, 0.32);
+  stroke-width: 0.35;
+}
+
 .map-controls {
   position: absolute;
   top: 14px;


### PR DESCRIPTION
Alpha: Implements #715.

Summary:
- adds a dedicated atlas canvas layer behind the tactical map stack
- reuses existing province geometry for continent shapes, island markers, and province-linked terrain classes
- adds ocean bands, currents, and light relief styling without duplicating business/map logic

Validation:
- `node --check web/app.js`
- `npm test -- test/ui/war/webAtlasWorldMapCanvas.test.js test/ui/war/webProvinceWarOverlayOverflowSummary.test.js`
- `npm test` (498 passing)
- `git diff --check`