### PR TITLE
Epsilon: add world map climate seasons

### DIFF
--- a/test/ui/climate/webClimateCascadeGroupHighlights.test.js
+++ b/test/ui/climate/webClimateCascadeGroupHighlights.test.js
@@ -15,7 +15,7 @@ test('aggregated climate markers expose selected cascade groups while urgent mar
   assert.match(webAppSource, /Le groupe met en évidence les provinces du risque principal/);
   assert.match(webAppSource, /has-climate-cascade-group/);
   assert.match(webAppSource, /is-climate-cascade-group-primary/);
-  assert.match(webAppSource, /renderMapLayerStack\(shell, economyView, focusContext, cultureView, climateMarkerDensity\.visibleMarkers, climateMarkerDensity\.selectedCascadeGroup\)/);
+  assert.match(webAppSource, /renderMapLayerStack\(shell, economyView, focusContext, cultureView, climateMarkerDensity\.visibleMarkers, climateMarkerDensity\.selectedCascadeGroup, worldClimateLayer\)/);
   assert.match(webAppSource, /marker\.status === 'cascade-active' \|\| marker\.status === 'hazard-unresolved'/);
 
   assert.match(stylesSource, /\.map-climate-cascade-group/);

--- a/test/ui/climate/webClimateMarkerDensityControls.test.js
+++ b/test/ui/climate/webClimateMarkerDensityControls.test.js
@@ -16,7 +16,7 @@ test('climate post-commit markers have density controls that preserve urgent thr
   assert.match(webAppSource, /Priorité conservée aux cascades et aléas non résolus/);
   assert.match(webAppSource, /climateMarkerDensity = buildClimateMarkerDensityControl\(postCommitClimateMarkers, \{/);
   assert.match(webAppSource, /renderClimateMarkerDensityRollup\(climateMarkerDensity\)/);
-  assert.match(webAppSource, /renderMapLayerStack\(shell, economyView, focusContext, cultureView, climateMarkerDensity\.visibleMarkers, climateMarkerDensity\.selectedCascadeGroup\)/);
+  assert.match(webAppSource, /renderMapLayerStack\(shell, economyView, focusContext, cultureView, climateMarkerDensity\.visibleMarkers, climateMarkerDensity\.selectedCascadeGroup, worldClimateLayer\)/);
 
   assert.match(stylesSource, /\.map-climate-density/);
   assert.match(stylesSource, /\.map-climate-density--grouped/);

--- a/test/ui/climate/webPostCommitClimateImpactMarkers.test.js
+++ b/test/ui/climate/webPostCommitClimateImpactMarkers.test.js
@@ -18,7 +18,7 @@ test('map exposes compact post-commit climate impact markers and detail copy', (
   assert.match(webAppSource, /has-climate-post-commit/);
   assert.match(webAppSource, /province-node__climate-marker/);
   assert.match(webAppSource, /marqueur climat post-résolution/);
-  assert.match(webAppSource, /renderProvinceCard\(province, focusContext, postCommitClimateMarkers, selectedClimateCascadeGroup\)/);
+  assert.match(webAppSource, /renderProvinceCard\(province, focusContext, postCommitClimateMarkers, selectedClimateCascadeGroup, worldClimateLayer\)/);
   assert.match(webAppSource, /renderPostCommitClimateMarkerDetail\(province, buildPostCommitClimateImpactMarkers/);
 
   assert.match(stylesSource, /\.province-node\.has-climate-post-commit/);

--- a/test/ui/climate/webWorldMapClimateSeasons.test.js
+++ b/test/ui/climate/webWorldMapClimateSeasons.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('world map climate layer exposes seasons biomes anomalies and disasters without replacing marker density', () => {
+  assert.match(webAppSource, /function getWorldClimateBiomeLabel/);
+  assert.match(webAppSource, /function getWorldClimateSeasonCue/);
+  assert.match(webAppSource, /function buildWorldClimateLayer/);
+  assert.match(webAppSource, /function renderWorldClimateLayerSummary/);
+  assert.match(webAppSource, /province\.biome \?\? 'temperate'/);
+  assert.match(webAppSource, /seasonLabels\[seasonIndex\]/);
+  assert.match(webAppSource, /hazard\.riskLevel === 'high' \|\| riskLevel === 'critical'/);
+  assert.match(webAppSource, /Catastrophe visible/);
+  assert.match(webAppSource, /Anomalie climat/);
+  assert.match(webAppSource, /Biome saisonnier/);
+  assert.match(webAppSource, /state\.activeOverlaySlot !== 'climate-overlay'/);
+  assert.match(webAppSource, /worldClimateLayer = buildWorldClimateLayer\(shell, state\.seasonIndex\)/);
+  assert.match(webAppSource, /renderWorldClimateLayerSummary\(worldClimateLayer\)/);
+  assert.match(webAppSource, /renderMapLayerStack\(shell, economyView, focusContext, cultureView, climateMarkerDensity\.visibleMarkers, climateMarkerDensity\.selectedCascadeGroup, worldClimateLayer\)/);
+  assert.match(webAppSource, /renderProvinceCard\(province, focusContext, postCommitClimateMarkers, selectedClimateCascadeGroup, worldClimateLayer\)/);
+  assert.match(webAppSource, /data-world-climate/);
+
+  assert.match(stylesSource, /\.map-world-climate/);
+  assert.match(stylesSource, /\.map-world-climate__item--disaster/);
+  assert.match(stylesSource, /\.province-node\.has-world-climate/);
+  assert.match(stylesSource, /\.province-node__world-climate/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1378,7 +1378,7 @@ function renderProvinceWarOverlayOverflowSummary(summary) {
   `;
 }
 
-function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null) {
+function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null, worldClimateLayer = null) {
   const layout = province.geometry.layout ?? getProvinceLayout(province.provinceId);
   const badges = province.badges.map((badge) => `<span class="province-badge">${badge}</span>`).join('');
   const isNeighbor = focusContext.neighborIds.has(province.provinceId);
@@ -1391,17 +1391,19 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
   const logisticsOutcomeMarker = getLogisticsOutcomeMarkerForProvince(province.provinceId);
   const climateMarker = postCommitClimateMarkers.find((marker) => marker.provinceId === province.provinceId) ?? null;
   const climateCascadeGroupMarker = selectedClimateCascadeGroup?.markers.find((marker) => marker.provinceId === province.provinceId) ?? null;
+  const worldClimateEntry = worldClimateLayer?.entries.find((entry) => entry.provinceId === province.provinceId) ?? null;
   const warOverlayOverflow = buildProvinceWarOverlayOverflowSummary(province, { readinessTone, militaryOutcomeMarker, logisticsOutcomeMarker });
   const isReadinessHighlight = Boolean(readinessTone);
   const isMilitaryOutcomeHighlight = Boolean(militaryOutcomeMarker);
   const isLogisticsOutcomeHighlight = Boolean(logisticsOutcomeMarker);
   const isClimateOutcomeHighlight = Boolean(climateMarker);
   const isClimateCascadeGroupHighlight = Boolean(climateCascadeGroupMarker);
-  const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && !isReadinessHighlight && !isMilitaryOutcomeHighlight && !isLogisticsOutcomeHighlight && !isClimateOutcomeHighlight && !isClimateCascadeGroupHighlight && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince || state.readinessFocusProvinceId);
+  const isWorldClimateHighlight = Boolean(worldClimateEntry && state.activeOverlaySlot === 'climate-overlay');
+  const isMuted = !isSelected && !isFocused && !isHovered && !isNeighbor && !isReadinessHighlight && !isMilitaryOutcomeHighlight && !isLogisticsOutcomeHighlight && !isClimateOutcomeHighlight && !isClimateCascadeGroupHighlight && !isWorldClimateHighlight && (focusContext.selectedProvince || focusContext.focusedProvince || focusContext.hoveredProvince || state.readinessFocusProvinceId);
   const tacticalState = province.contested ? 'front contesté' : province.occupied ? 'occupation' : 'contrôle stable';
   const readinessLabel = readinessTone === 'danger' ? 'menace immédiate' : readinessTone === 'warning' ? 'préparation insuffisante' : readinessTone === 'ready' ? 'opportunité tactique' : null;
   const economyBlockerLabel = economyBlocker ? `${economyBlocker.blocker}: ${economyBlocker.summary}` : null;
-  const selectionSignal = climateMarker ? 'CLIMAT' : climateCascadeGroupMarker ? 'GROUPE' : economyBlocker ? 'BLOCAGE' : isMilitaryOutcomeHighlight ? 'RÉSOLU' : isReadinessHighlight ? 'ALERTE' : isSelected ? 'ACTIF' : isHovered ? 'SURVOL' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
+  const selectionSignal = climateMarker ? 'CLIMAT' : climateCascadeGroupMarker ? 'GROUPE' : worldClimateEntry ? 'SAISON' : economyBlocker ? 'BLOCAGE' : isMilitaryOutcomeHighlight ? 'RÉSOLU' : isReadinessHighlight ? 'ALERTE' : isSelected ? 'ACTIF' : isHovered ? 'SURVOL' : isFocused ? 'FOCUS' : isNeighbor ? 'VOISIN' : 'SCAN';
   const classes = [
     'province-node',
     isSelected ? 'is-selected' : '',
@@ -1419,6 +1421,9 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
     climateMarker ? `has-climate-post-commit--${climateMarker.status}` : '',
     climateCascadeGroupMarker ? 'has-climate-cascade-group' : '',
     climateCascadeGroupMarker?.provinceId === selectedClimateCascadeGroup?.primaryProvinceId ? 'is-climate-cascade-group-primary' : '',
+    isWorldClimateHighlight ? 'has-world-climate' : '',
+    isWorldClimateHighlight ? `has-world-climate--${worldClimateEntry.tone}` : '',
+    isWorldClimateHighlight ? `has-world-biome--${worldClimateEntry.biome}` : '',
     readinessTone ? `is-readiness-${readinessTone}` : '',
     isMuted ? 'is-muted' : '',
     province.contested ? 'is-contested' : '',
@@ -1435,8 +1440,9 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
       data-economy-blocker="${economyBlockerLabel ?? ''}"
       data-military-outcome="${militaryOutcomeMarker?.label ?? ''}"
       data-logistics-outcome="${logisticsOutcomeMarker?.label ?? ''}"
-      data-climate-outcome="${climateMarker?.label ?? climateCascadeGroupMarker?.label ?? ''}"
-      title="${climateMarker ? `${climateMarker.label} — ${climateMarker.summary}` : climateCascadeGroupMarker ? `${selectedClimateCascadeGroup.label}: ${climateCascadeGroupMarker.summary}` : logisticsOutcomeMarker ? `${logisticsOutcomeMarker.label}: ${logisticsOutcomeMarker.detail}` : economyBlocker ? `${economyBlocker.summary} — ${economyBlocker.effect}` : militaryOutcomeMarker ? `${militaryOutcomeMarker.label} — ${militaryOutcomeMarker.changed}` : province.label}"
+      data-climate-outcome="${climateMarker?.label ?? climateCascadeGroupMarker?.label ?? worldClimateEntry?.label ?? ''}"
+      data-world-climate="${worldClimateEntry ? `${worldClimateEntry.biome}:${worldClimateEntry.tone}` : ''}"
+      title="${climateMarker ? `${climateMarker.label} — ${climateMarker.summary}` : climateCascadeGroupMarker ? `${selectedClimateCascadeGroup.label}: ${climateCascadeGroupMarker.summary}` : worldClimateEntry ? `${worldClimateEntry.label}: ${worldClimateEntry.summary}` : logisticsOutcomeMarker ? `${logisticsOutcomeMarker.label}: ${logisticsOutcomeMarker.detail}` : economyBlocker ? `${economyBlocker.summary} — ${economyBlocker.effect}` : militaryOutcomeMarker ? `${militaryOutcomeMarker.label} — ${militaryOutcomeMarker.changed}` : province.label}"
       style="left:${layout.x}%;top:${layout.y}%;width:${layout.w}%;height:${layout.h}%;--province-fill:${province.style.fill};--province-border:${province.style.border};--province-shape:${getProvinceShape(province.provinceId)};"
       aria-pressed="${province.selectionState.selected}"
       aria-label="${province.label}, ${climateMarker ? `marqueur climat post-résolution: ${climateMarker.label}, ${climateMarker.summary}` : logisticsOutcomeMarker ? `résultat logistique post-commit: ${logisticsOutcomeMarker.label}, ${logisticsOutcomeMarker.detail}` : economyBlocker ? `blocage économie/logistique: ${economyBlocker.summary}, ${economyBlocker.effect}` : militaryOutcomeMarker ? `issue militaire post-commit: ${militaryOutcomeMarker.label}, ${militaryOutcomeMarker.changed}` : readinessLabel ? `cible préparation conflit: ${readinessLabel}` : tacticalState}, approvisionnement ${province.supplyTone}, loyauté ${province.loyalty}"
@@ -1449,6 +1455,7 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
       ${economyBlocker ? `<span class="province-node__economy-blocker"><b>${economyBlocker.blocker}</b>${economyBlocker.summary}<small>${economyBlocker.effect}</small></span>` : ''}
       ${renderProvinceLogisticsOutcomeMarker(logisticsOutcomeMarker)}
       ${climateMarker ? `<span class="province-node__climate-marker"><b>${climateMarker.label}</b>${climateMarker.summary}<small>${climateMarker.detail}</small></span>` : ''}
+      ${isWorldClimateHighlight ? `<span class="province-node__world-climate"><b>${worldClimateEntry.label}</b>${worldClimateEntry.summary}<small>${worldClimateEntry.detail}</small></span>` : ''}
       <span class="province-node__badges">${badges}</span>
       ${renderPostCommitMilitaryOutcomeMarker(militaryOutcomeMarker)}
       ${renderProvinceWarOverlayOverflowSummary(warOverlayOverflow)}
@@ -3916,6 +3923,98 @@ function buildClimateSeverityLegend(markers = [], densityControl = null, shell =
       ? `${groupedCount} marqueur${groupedCount > 1 ? 's' : ''} agrégé${groupedCount > 1 ? 's' : ''}; la sévérité explique les piles sans ouvrir chaque province.`
       : 'Sévérité climat lisible directement sur les marqueurs visibles.',
   };
+}
+
+function getWorldClimateBiomeLabel(biome) {
+  return {
+    continental: 'Continental',
+    temperate: 'Tempéré',
+    arid: 'Aride',
+    coastal: 'Côtier',
+    tropical: 'Tropical',
+  }[biome] ?? 'Mixte';
+}
+
+function getWorldClimateSeasonCue(province, seasonIndex = state.seasonIndex) {
+  const season = seasonLabels[seasonIndex] ?? seasonLabels[0];
+  const biome = province.biome ?? 'temperate';
+  const riskLevel = getProvinceClimateRiskLevel(province);
+  const hazard = province.hazards?.[0] ?? null;
+  const disaster = hazard && (hazard.riskLevel === 'high' || riskLevel === 'critical')
+    ? `${hazard.type} ${hazard.riskLevel}`
+    : null;
+  const anomaly = hazard && hazard.riskLevel === 'moderate'
+    ? `${hazard.type} sous surveillance`
+    : riskLevel === 'strained'
+      ? 'stress saisonnier'
+      : null;
+  const seasonalPressure = [
+    biome === 'continental' ? 'gel tardif possible' : biome === 'coastal' ? 'crues littorales surveillées' : 'reprise végétale',
+    biome === 'arid' ? 'sécheresse probable' : biome === 'tropical' ? 'mousson active' : 'chaleur modérée',
+    biome === 'temperate' ? 'récoltes exposées' : biome === 'continental' ? 'premiers froids' : 'instabilité de transition',
+    biome === 'continental' ? 'gel et cols difficiles' : biome === 'coastal' ? 'tempêtes côtières' : 'pression hivernale',
+  ][seasonIndex] ?? 'saison lisible';
+  const tone = disaster ? 'disaster' : anomaly ? 'anomaly' : riskLevel === 'stable' ? 'seasonal' : 'watch';
+
+  return {
+    provinceId: province.provinceId,
+    provinceLabel: province.label,
+    biome,
+    biomeLabel: getWorldClimateBiomeLabel(biome),
+    season,
+    seasonalPressure,
+    anomaly,
+    disaster,
+    tone,
+    label: disaster ? 'Catastrophe visible' : anomaly ? 'Anomalie climat' : 'Biome saisonnier',
+    summary: `${getWorldClimateBiomeLabel(biome)} · ${season}: ${seasonalPressure}.`,
+    detail: disaster ? `Catastrophe: ${disaster}.` : anomaly ? `Anomalie: ${anomaly}.` : `Variation saisonnière sans surcharge: risque ${riskLevel}.`,
+  };
+}
+
+function buildWorldClimateLayer(shell, seasonIndex = state.seasonIndex) {
+  const entries = shell.provinces.map((province) => getWorldClimateSeasonCue(province, seasonIndex));
+  const disasterCount = entries.filter((entry) => entry.disaster).length;
+  const anomalyCount = entries.filter((entry) => entry.anomaly && !entry.disaster).length;
+  const biomeCount = new Set(entries.map((entry) => entry.biome)).size;
+
+  return {
+    entries,
+    season: seasonLabels[seasonIndex] ?? seasonLabels[0],
+    biomeCount,
+    disasterCount,
+    anomalyCount,
+    summary: `${biomeCount} biomes visibles en ${seasonLabels[seasonIndex] ?? seasonLabels[0]} · ${disasterCount} catastrophe${disasterCount > 1 ? 's' : ''} · ${anomalyCount} anomalie${anomalyCount > 1 ? 's' : ''}.`,
+  };
+}
+
+function renderWorldClimateLayerSummary(layer) {
+  if (state.activeOverlaySlot !== 'climate-overlay') {
+    return '';
+  }
+
+  const highlighted = layer.entries
+    .filter((entry) => entry.disaster || entry.anomaly)
+    .slice(0, 3);
+
+  return `
+    <section class="map-world-climate" aria-label="Lecture monde des saisons biomes et catastrophes">
+      <div class="map-world-climate__header">
+        <strong>Carte monde climat · ${layer.season}</strong>
+        <span>${layer.biomeCount} biomes · ${layer.disasterCount} catastrophes · ${layer.anomalyCount} anomalies</span>
+      </div>
+      <p>${layer.summary}</p>
+      <ul class="map-world-climate__list">
+        ${(highlighted.length > 0 ? highlighted : layer.entries.slice(0, 3)).map((entry) => `
+          <li class="map-world-climate__item map-world-climate__item--${entry.tone}">
+            <b>${entry.provinceLabel}</b>
+            <span>${entry.summary}</span>
+            <small>${entry.detail}</small>
+          </li>
+        `).join('')}
+      </ul>
+    </section>
+  `;
 }
 
 function buildClimateFollowUpDebtSummary(markers = [], mitigationSequence = []) {
@@ -9955,7 +10054,7 @@ function renderTacticalCoordinateGrid() {
   `;
 }
 
-function getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null) {
+function getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null, worldClimateLayer = null) {
   return [
     { key: 'backdrop', className: 'map-layer map-layer--backdrop', content: `<div class="map-backdrop"></div>${renderTacticalCoordinateGrid()}` },
     { key: 'terrain', className: 'map-layer map-layer--terrain', content: renderTerrainDecor() },
@@ -9965,12 +10064,12 @@ function getMapRenderLayers(shell, economyView, focusContext, cultureView, postC
     { key: 'anchors', className: 'map-layer map-layer--anchors', content: renderMapAnchorShells() },
     { key: 'economy', className: 'map-layer map-layer--economy', content: `${renderEconomyMapOverlay(economyView)}${renderCultureMapOverlay(cultureView)}` },
     { key: 'hud', className: 'map-layer map-layer--hud', content: `${renderCityQuickPanel(economyView)}<div class="focus-hint">${focusContext.selectedProvince ? `Sélection active, ${focusContext.selectedProvince.label}` : 'Survolez une province pour déplacer le focus'}</div>` },
-    { key: 'interactions', className: 'map-layer map-layer--interactions', content: `${shell.provinces.map((province) => renderProvinceCard(province, focusContext, postCommitClimateMarkers, selectedClimateCascadeGroup)).join('')}${renderProvincePopup(shell)}` },
+    { key: 'interactions', className: 'map-layer map-layer--interactions', content: `${shell.provinces.map((province) => renderProvinceCard(province, focusContext, postCommitClimateMarkers, selectedClimateCascadeGroup, worldClimateLayer)).join('')}${renderProvincePopup(shell)}` },
   ];
 }
 
-function renderMapLayerStack(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null) {
-  return getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers, selectedClimateCascadeGroup)
+function renderMapLayerStack(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null, worldClimateLayer = null) {
+  return getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers, selectedClimateCascadeGroup, worldClimateLayer)
     .map((layer) => `<div class="${layer.className}" data-map-layer="${layer.key}">${layer.content}</div>`)
     .join('');
 }
@@ -10229,6 +10328,7 @@ function render() {
   });
   const climateSeverityLegend = buildClimateSeverityLegend(postCommitClimateMarkers, climateMarkerDensity, shell);
   const climateFollowUpDebt = buildClimateFollowUpDebtSummary(postCommitClimateMarkers, climateSeverityLegend.mitigationSequence ?? []);
+  const worldClimateLayer = buildWorldClimateLayer(shell, state.seasonIndex);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -10258,6 +10358,7 @@ function render() {
           ${renderClimateMarkerDensityRollup(climateMarkerDensity)}
           ${renderSelectedClimateCascadeGroup(climateMarkerDensity.selectedCascadeGroup)}
           ${renderClimateFollowUpDebtSummary(climateFollowUpDebt)}
+          ${renderWorldClimateLayerSummary(worldClimateLayer)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">
@@ -10293,7 +10394,7 @@ function render() {
             ${renderMilitaryOutcomeTrailSummary(state.lastMilitaryOutcomeMarkers)}
             ${renderMilitaryFrontMarkerSummaries(state.lastMilitaryOutcomeMarkers)}
             <div class="map-viewport" style="transform:${getMapViewportTransform()};">
-              ${renderMapLayerStack(shell, economyView, focusContext, cultureView, climateMarkerDensity.visibleMarkers, climateMarkerDensity.selectedCascadeGroup)}
+              ${renderMapLayerStack(shell, economyView, focusContext, cultureView, climateMarkerDensity.visibleMarkers, climateMarkerDensity.selectedCascadeGroup, worldClimateLayer)}
               ${renderIntrigueMapOverlay(intrigueView)}
             </div>
             ${renderBottomTray(economyView, intrigueView, cultureView)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -389,6 +389,50 @@ button { font: inherit; }
 }
 .map-climate-follow-up-debt small { color: #bfdbfe; }
 
+.map-world-climate {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.64), rgba(20, 83, 45, 0.22));
+  border: 1px solid rgba(125, 211, 252, 0.22);
+}
+.map-world-climate__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate p,
+.map-world-climate span,
+.map-world-climate small {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.map-world-climate__item {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+.map-world-climate__item--disaster { border-color: rgba(248, 113, 113, 0.42); }
+.map-world-climate__item--anomaly,
+.map-world-climate__item--watch { border-color: rgba(251, 191, 36, 0.34); }
+.map-world-climate__item--seasonal { border-color: rgba(74, 222, 128, 0.28); }
+
 .map-climate-severity-legend {
   display: grid;
   gap: 7px;
@@ -1154,6 +1198,42 @@ button { font: inherit; }
 }
 .province-node__climate-marker small {
   color: #bae6fd;
+  font-size: 9px;
+}
+.province-node.has-world-climate::before {
+  border-style: dashed;
+  border-color: rgba(125, 211, 252, 0.58);
+  box-shadow: inset 0 0 18px rgba(14, 165, 233, 0.12), 0 0 0 3px rgba(125, 211, 252, 0.08);
+}
+.province-node.has-world-climate--disaster::before { border-color: rgba(248, 113, 113, 0.72); }
+.province-node.has-world-climate--anomaly::before,
+.province-node.has-world-climate--watch::before { border-color: rgba(251, 191, 36, 0.66); }
+.province-node.has-world-biome--arid { filter: drop-shadow(0 0 12px rgba(251, 191, 36, 0.16)); }
+.province-node.has-world-biome--tropical,
+.province-node.has-world-biome--coastal { filter: drop-shadow(0 0 12px rgba(45, 212, 191, 0.14)); }
+.province-node__world-climate {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 2px;
+  max-width: 24ch;
+  margin-top: 6px;
+  padding: 6px 7px;
+  border-radius: 10px;
+  background: rgba(8, 15, 28, 0.72);
+  border: 1px solid rgba(125, 211, 252, 0.32);
+  color: #bfdbfe;
+  font-size: 10px;
+  line-height: 1.25;
+}
+.province-node__world-climate b {
+  color: #f8fafc;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.province-node__world-climate small {
+  color: #bbf7d0;
   font-size: 9px;
 }
 .economy-route.has-economy-blocker .economy-route__halo,


### PR DESCRIPTION
Epsilon: Implements #719.

Summary:
- Adds a world-climate layer for the climate overlay that surfaces seasonal biome cues, anomalies, and disaster risks from existing province climate data.
- Adds compact map node cues and a world-climate summary without replacing existing climate marker density or cascade grouping behavior.
- Keeps disasters/anomalies highlighted while low-risk biome/season variation stays concise.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webWorldMapClimateSeasons.test.js test/ui/climate/webClimateCascadeGroupHighlights.test.js test/ui/climate/webClimateMarkerDensityControls.test.js test/ui/climate/webPostCommitClimateImpactMarkers.test.js
- npm test