### PR TITLE
Gamma: add atlas culture discoveries

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('world map atlas renders culture influence zones from existing culture overlay data', () => {
+  assert.match(webAppSource, /function buildAtlasCultureFeatures/);
+  assert.match(webAppSource, /cultureView\?\.overlay/);
+  assert.match(webAppSource, /getProvincePolygon\(entry\.regionId\)/);
+  assert.match(webAppSource, /getProvinceCenter\(entry\.regionId\)/);
+  assert.match(webAppSource, /atlas-culture-zone--\$\{zone\.tone\}/);
+  assert.match(webAppSource, /renderAtlasWorldCanvas\(shell, economyView, cultureView\)/);
+});
+
+test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
+  assert.match(webAppSource, /regionalDiscoveryLinks\.slice\(0, 2\)/);
+  assert.match(webAppSource, /atlas-discovery-site/);
+  assert.match(webAppSource, /data-atlas-discovery="\$\{site\.discoveryId\}"/);
+  assert.match(webAppSource, /Couche atlas culture et découvertes/);
+  assert.match(stylesSource, /\.atlas-culture-layer/);
+  assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
+  assert.match(stylesSource, /\.atlas-discovery-site path/);
+});

--- a/test/ui/war/webAtlasWorldMapCanvas.test.js
+++ b/test/ui/war/webAtlasWorldMapCanvas.test.js
@@ -20,7 +20,7 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(webAppSource, /atlasOceanGradient/);
   assert.match(webAppSource, /atlas-region--\$\{shape\.terrain\}/);
   assert.match(webAppSource, /map-layer--atlas/);
-  assert.match(webAppSource, /renderAtlasWorldCanvas\(shell, economyView\)/);
+  assert.match(webAppSource, /renderAtlasWorldCanvas\(shell, economyView, cultureView\)/);
   assert.match(webAppSource, /function renderAtlasWorldEconomyLayer/);
   assert.match(webAppSource, /atlas-world-economy-layer/);
   assert.match(webAppSource, /atlas-logistics-route/);

--- a/web/app.js
+++ b/web/app.js
@@ -561,11 +561,82 @@ function buildAtlasTerrainShapes(shell) {
   };
 }
 
-function renderAtlasWorldCanvas(shell, economyView = null) {
+function buildAtlasCultureFeatures(cultureView) {
+  const entries = cultureView?.overlay ?? [];
+  const dominantByRegion = new Map();
+
+  entries.forEach((entry) => {
+    const current = dominantByRegion.get(entry.regionId);
+    if (!current || entry.influenceScore > current.influenceScore) {
+      dominantByRegion.set(entry.regionId, entry);
+    }
+  });
+
+  const influenceZones = [...dominantByRegion.values()].map((entry) => ({
+    regionId: entry.regionId,
+    cultureName: entry.cultureName,
+    influenceTier: entry.influenceTier,
+    tone: getCultureTone(entry),
+    polygon: getProvincePolygon(entry.regionId),
+    center: getProvinceCenter(entry.regionId),
+    score: entry.influenceScore,
+  }));
+
+  const discoverySites = entries.flatMap((entry) => entry.regionalDiscoveryLinks.slice(0, 2).map((link, index) => ({
+    siteId: `${entry.regionId}:${entry.cultureId}:${link.discoveryId}:${index}`,
+    regionId: entry.regionId,
+    cultureName: entry.cultureName,
+    discoveryId: link.discoveryId,
+    tone: getCultureTone(entry),
+    center: getProvinceCenter(entry.regionId),
+    offset: (index - 0.5) * 2.8,
+  })));
+
+  return {
+    influenceZones,
+    cultureMarkers: influenceZones.filter((zone) => zone.influenceTier === 'dominant' || zone.influenceTier === 'strong'),
+    discoverySites,
+  };
+}
+
+function renderAtlasCultureLayer(cultureView) {
+  const features = buildAtlasCultureFeatures(cultureView);
+  const active = state.activeOverlaySlot === 'culture-overlay';
+
+  if (!features.influenceZones.length) {
+    return '';
+  }
+
+  return `
+    <g class="atlas-culture-layer ${active ? 'is-active' : 'is-muted'}" aria-label="Couche atlas culture et découvertes">
+      ${features.influenceZones.map((zone) => `
+        <polygon class="atlas-culture-zone atlas-culture-zone--${zone.tone} atlas-culture-zone--${zone.influenceTier}" points="${zone.polygon}" aria-label="Zone d’influence ${zone.cultureName}: ${zone.influenceTier}"></polygon>
+      `).join('')}
+      ${features.cultureMarkers.map((marker) => `
+        <g class="atlas-culture-marker atlas-culture-marker--${marker.tone}" data-atlas-culture-region="${marker.regionId}">
+          <circle cx="${marker.center.x}%" cy="${marker.center.y}%" r="${marker.influenceTier === 'dominant' ? 2.35 : 1.85}"></circle>
+          <text x="${marker.center.x}%" y="${marker.center.y + 0.82}%" text-anchor="middle">C</text>
+        </g>
+      `).join('')}
+      ${features.discoverySites.map((site) => {
+        const x = site.center.x + site.offset;
+        const y = site.center.y - 4.8;
+        return `
+          <g class="atlas-discovery-site atlas-discovery-site--${site.tone}" data-atlas-discovery="${site.discoveryId}">
+            <path d="M ${x} ${y - 1.05} L ${x + 1.05} ${y} L ${x} ${y + 1.05} L ${x - 1.05} ${y} Z"></path>
+            <title>${site.discoveryId} · ${site.cultureName}</title>
+          </g>
+        `;
+      }).join('')}
+    </g>
+  `;
+}
+
+function renderAtlasWorldCanvas(shell, economyView = null, cultureView = null) {
   const atlas = buildAtlasTerrainShapes(shell);
 
   return `
-    <svg class="atlas-world-canvas" viewBox="0 0 100 100" aria-label="Canevas atlas: océans, continents, îles et relief">
+    <svg class="atlas-world-canvas" viewBox="0 0 100 100" aria-label="Canevas atlas: océans, continents, îles, relief, cultures et découvertes">
       <defs>
         <linearGradient id="atlasOceanGradient" x1="0" x2="1" y1="0" y2="1">
           <stop offset="0%" stop-color="#0f3b57"></stop>
@@ -590,6 +661,7 @@ function renderAtlasWorldCanvas(shell, economyView = null) {
         <circle class="atlas-island atlas-island--${shape.terrain}" cx="${shape.center.x}" cy="${shape.center.y}" r="${shape.radius}" aria-label="Île ou archipel: ${shape.label}"></circle>
       `).join('')}
       ${renderAtlasWorldEconomyLayer(economyView)}
+      ${renderAtlasCultureLayer(cultureView)}
     </svg>
   `;
 }
@@ -10372,7 +10444,7 @@ function renderTacticalCoordinateGrid() {
 function getMapRenderLayers(shell, economyView, focusContext, cultureView, postCommitClimateMarkers = [], selectedClimateCascadeGroup = null, worldClimateLayer = null) {
   return [
     { key: 'backdrop', className: 'map-layer map-layer--backdrop', content: `<div class="map-backdrop"></div>${renderTacticalCoordinateGrid()}` },
-    { key: 'atlas', className: 'map-layer map-layer--atlas', content: renderAtlasWorldCanvas(shell, economyView) },
+    { key: 'atlas', className: 'map-layer map-layer--atlas', content: renderAtlasWorldCanvas(shell, economyView, cultureView) },
     { key: 'terrain', className: 'map-layer map-layer--terrain', content: renderTerrainDecor() },
     { key: 'surface', className: 'map-layer map-layer--surface', content: renderProvinceSurface(shell, focusContext) },
     { key: 'relations', className: 'map-layer map-layer--relations', content: renderStrategicRelations(shell) },

--- a/web/styles.css
+++ b/web/styles.css
@@ -9844,3 +9844,40 @@ button { font: inherit; }
   fill: #cbd5e1;
   font-size: 1.55px;
 }
+
+.atlas-culture-layer {
+  pointer-events: none;
+  opacity: 0.74;
+}
+.atlas-culture-layer.is-muted { opacity: 0.34; }
+.atlas-culture-zone {
+  fill: rgba(45, 212, 191, 0.12);
+  stroke: rgba(94, 234, 212, 0.2);
+  stroke-width: 0.38;
+  stroke-dasharray: 2 1.6;
+}
+.atlas-culture-zone--amber { fill: rgba(251, 191, 36, 0.12); stroke: rgba(251, 191, 36, 0.26); }
+.atlas-culture-zone--rose { fill: rgba(251, 113, 133, 0.1); stroke: rgba(251, 113, 133, 0.24); }
+.atlas-culture-zone--cyan { fill: rgba(34, 211, 238, 0.12); stroke: rgba(103, 232, 249, 0.26); }
+.atlas-culture-zone--dominant { stroke-width: 0.58; opacity: 0.92; }
+.atlas-culture-marker circle {
+  fill: rgba(15, 23, 42, 0.82);
+  stroke: rgba(167, 243, 208, 0.82);
+  stroke-width: 0.5;
+}
+.atlas-culture-marker text {
+  fill: #d1fae5;
+  font-size: 2.05px;
+  font-weight: 900;
+}
+.atlas-culture-marker--amber circle { stroke: rgba(253, 230, 138, 0.9); }
+.atlas-culture-marker--rose circle { stroke: rgba(254, 205, 211, 0.9); }
+.atlas-culture-marker--cyan circle { stroke: rgba(165, 243, 252, 0.9); }
+.atlas-discovery-site path {
+  fill: rgba(224, 242, 254, 0.86);
+  stroke: rgba(8, 47, 73, 0.9);
+  stroke-width: 0.32;
+}
+.atlas-discovery-site--amber path { fill: #fde68a; }
+.atlas-discovery-site--rose path { fill: #fecdd3; }
+.atlas-discovery-site--cyan path { fill: #a5f3fc; }


### PR DESCRIPTION
Gamma: Implements #717.

## Summary
- add an atlas culture layer with influence zones, strong/dominant culture markers, and discovery sites
- derive all atlas culture/discovery visuals from the existing culture overlay data and province geometry
- keep the layer compact/muted unless the culture overlay is active for atlas readability

## Validation
- node --check web/app.js
- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/war/webAtlasWorldMapCanvas.test.js
- git diff --check
- npm test (502 OK)