### PR TITLE
Alpha: add atlas campaign front routes

### DIFF
--- a/test/ui/war/webAtlasCampaignFrontRoutes.test.js
+++ b/test/ui/war/webAtlasCampaignFrontRoutes.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas campaign layer derives military pressure from existing province/front data', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryFeatures\(shell\)/);
+  assert.match(webAppSource, /buildProvinceRelations\(shell\)/);
+  assert.match(webAppSource, /province\.contested/);
+  assert.match(webAppSource, /province\.occupied/);
+  assert.match(webAppSource, /province\.supplyLevel/);
+  assert.match(webAppSource, /getProvinceCenter\(source\.provinceId\)/);
+  assert.doesNotMatch(webAppSource, /hiddenMilitary|foggedMilitary|secretMilitary/);
+});
+
+test('atlas campaign layer keeps world-scale military signals compact and aggregated', () => {
+  assert.match(webAppSource, /function renderAtlasMilitaryLayer\(shell\)/);
+  assert.match(webAppSource, /atlas-campaign-route/);
+  assert.match(webAppSource, /atlas-campaign-route__arrow/);
+  assert.match(webAppSource, /atlas-military-risk/);
+  assert.match(webAppSource, /slice\(0, 3\)/);
+  assert.match(webAppSource, /overflowCount/);
+  assert.match(webAppSource, /axes agrégés/);
+});
+
+test('atlas campaign routes and pressure arrows have dedicated styling', () => {
+  assert.match(stylesSource, /\.atlas-military-layer/);
+  assert.match(stylesSource, /\.atlas-campaign-route path:first-child/);
+  assert.match(stylesSource, /\.atlas-campaign-route__arrow/);
+  assert.match(stylesSource, /\.atlas-military-risk--front polygon/);
+  assert.match(stylesSource, /\.atlas-military-overflow/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -561,6 +561,113 @@ function buildAtlasTerrainShapes(shell) {
   };
 }
 
+function getAtlasMilitaryPressureScore(province) {
+  let score = 0;
+  if (province.contested) score += 80;
+  if (province.occupied) score += 58;
+  if (province.supplyLevel === 'collapsed') score += 26;
+  if (province.supplyLevel === 'disrupted') score += 18;
+  if (province.loyalty < 45) score += 14;
+  score += Math.min(18, Math.max(0, province.strategicValue ?? 0) * 2);
+  return score;
+}
+
+function getAtlasMilitaryRouteTone(route) {
+  if (route.contested) return 'front';
+  if (route.occupied) return 'occupation';
+  return route.pressure >= 74 ? 'risk' : 'watch';
+}
+
+function buildAtlasMilitaryFeatures(shell) {
+  const pressureByProvinceId = new Map(shell.provinces.map((province) => [province.provinceId, getAtlasMilitaryPressureScore(province)]));
+  const routes = buildProvinceRelations(shell)
+    .map((relation) => {
+      const originProvince = shell.provinces.find((province) => province.provinceId === relation.relationId.split('::')[0]);
+      const destinationProvince = shell.provinces.find((province) => province.provinceId === relation.relationId.split('::')[1]);
+      const originScore = pressureByProvinceId.get(originProvince?.provinceId) ?? 0;
+      const destinationScore = pressureByProvinceId.get(destinationProvince?.provinceId) ?? 0;
+      const pressure = Math.max(originScore, destinationScore) + (relation.contested ? 18 : relation.occupied ? 10 : 0);
+      const source = originScore >= destinationScore ? originProvince : destinationProvince;
+      const target = originScore >= destinationScore ? destinationProvince : originProvince;
+
+      if (!source || !target || pressure < 38) {
+        return null;
+      }
+
+      const controlX = ((relation.origin.x + relation.destination.x) / 2) + (relation.contested ? 1.2 : -0.8);
+      const controlY = ((relation.origin.y + relation.destination.y) / 2) - (relation.occupied ? 2.1 : 1.2);
+
+      return {
+        routeId: relation.relationId,
+        sourceId: source.provinceId,
+        targetId: target.provinceId,
+        sourceLabel: source.label,
+        targetLabel: target.label,
+        origin: getProvinceCenter(source.provinceId),
+        destination: getProvinceCenter(target.provinceId),
+        control: { x: controlX, y: controlY },
+        pressure,
+        contested: relation.contested,
+        occupied: relation.occupied,
+        tone: getAtlasMilitaryRouteTone({ ...relation, pressure }),
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => right.pressure - left.pressure || left.routeId.localeCompare(right.routeId));
+
+  const dominantRoutes = routes.slice(0, 3);
+  const riskZones = shell.provinces
+    .map((province) => ({
+      provinceId: province.provinceId,
+      label: province.label,
+      center: getProvinceCenter(province.provinceId),
+      polygon: getProvincePolygon(province.provinceId),
+      pressure: pressureByProvinceId.get(province.provinceId) ?? 0,
+      tone: province.contested ? 'front' : province.occupied ? 'occupation' : province.supplyLevel === 'collapsed' ? 'risk' : 'watch',
+    }))
+    .filter((zone) => zone.pressure >= 42)
+    .sort((left, right) => right.pressure - left.pressure || left.label.localeCompare(right.label))
+    .slice(0, 3);
+
+  return {
+    routes: dominantRoutes,
+    overflowCount: Math.max(0, routes.length - dominantRoutes.length),
+    riskZones,
+  };
+}
+
+function renderAtlasMilitaryLayer(shell) {
+  const features = buildAtlasMilitaryFeatures(shell);
+
+  if (!features.routes.length && !features.riskZones.length) {
+    return '';
+  }
+
+  return `
+    <g class="atlas-military-layer" aria-label="Axes militaires atlas: routes de campagne, pression directionnelle et risques résiduels">
+      ${features.riskZones.map((zone) => `
+        <g class="atlas-military-risk atlas-military-risk--${zone.tone}" data-atlas-risk-province="${zone.provinceId}" aria-label="Zone militaire ${zone.label}: pression ${zone.pressure}">
+          <polygon points="${zone.polygon}"></polygon>
+          <text x="${zone.center.x}%" y="${zone.center.y - 3.5}%" text-anchor="middle">${zone.tone === 'front' ? 'FRONT' : zone.tone === 'occupation' ? 'OCC' : 'RISQUE'}</text>
+        </g>
+      `).join('')}
+      ${features.routes.map((route) => {
+        const path = `M${route.origin.x},${route.origin.y} Q${route.control.x},${route.control.y} ${route.destination.x},${route.destination.y}`;
+        const arrowX = (route.control.x + route.destination.x) / 2;
+        const arrowY = (route.control.y + route.destination.y) / 2;
+        return `
+          <g class="atlas-campaign-route atlas-campaign-route--${route.tone}" data-atlas-campaign-route="${route.routeId}" aria-label="Axe ${route.sourceLabel} vers ${route.targetLabel}: pression ${route.pressure}">
+            <path d="${path}" pathLength="100"></path>
+            <path class="atlas-campaign-route__arrow" d="M${arrowX - 1.15},${arrowY - 0.85} L${arrowX + 1.35},${arrowY} L${arrowX - 1.15},${arrowY + 0.85} Z"></path>
+            <text x="${route.control.x}" y="${route.control.y - 1.6}" text-anchor="middle">${route.contested ? 'Front' : route.occupied ? 'Occupation' : 'Pression'}</text>
+          </g>
+        `;
+      }).join('')}
+      ${features.overflowCount > 0 ? `<text class="atlas-military-overflow" x="82" y="88" text-anchor="middle">+${features.overflowCount} axes agrégés</text>` : ''}
+    </g>
+  `;
+}
+
 function buildAtlasCultureFeatures(cultureView) {
   const entries = cultureView?.overlay ?? [];
   const dominantByRegion = new Map();
@@ -662,6 +769,7 @@ function renderAtlasWorldCanvas(shell, economyView = null, cultureView = null) {
       `).join('')}
       ${renderAtlasWorldEconomyLayer(economyView)}
       ${renderAtlasCultureLayer(cultureView)}
+      ${renderAtlasMilitaryLayer(shell)}
     </svg>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -9881,3 +9881,61 @@ button { font: inherit; }
 .atlas-discovery-site--amber path { fill: #fde68a; }
 .atlas-discovery-site--rose path { fill: #fecdd3; }
 .atlas-discovery-site--cyan path { fill: #a5f3fc; }
+.atlas-military-layer {
+  pointer-events: none;
+  opacity: 0.9;
+}
+.atlas-military-risk polygon {
+  fill: rgba(251, 191, 36, 0.08);
+  stroke: rgba(253, 230, 138, 0.26);
+  stroke-width: 0.4;
+  stroke-dasharray: 1.2 1.4;
+}
+.atlas-military-risk--front polygon {
+  fill: rgba(127, 29, 29, 0.18);
+  stroke: rgba(248, 113, 113, 0.48);
+}
+.atlas-military-risk--occupation polygon {
+  fill: rgba(71, 85, 105, 0.18);
+  stroke: rgba(203, 213, 225, 0.42);
+}
+.atlas-military-risk text,
+.atlas-campaign-route text,
+.atlas-military-overflow {
+  fill: #fee2e2;
+  font-size: 1.65px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.88);
+  stroke-width: 0.46;
+}
+.atlas-campaign-route path:first-child {
+  fill: none;
+  stroke: rgba(248, 113, 113, 0.86);
+  stroke-width: 0.74;
+  stroke-linecap: round;
+  stroke-dasharray: 4 2;
+  filter: drop-shadow(0 0 3px rgba(127, 29, 29, 0.58));
+}
+.atlas-campaign-route--occupation path:first-child {
+  stroke: rgba(203, 213, 225, 0.72);
+  stroke-dasharray: 2.6 1.8;
+}
+.atlas-campaign-route--risk path:first-child {
+  stroke: rgba(251, 191, 36, 0.78);
+}
+.atlas-campaign-route--watch path:first-child {
+  stroke: rgba(125, 211, 252, 0.5);
+  stroke-width: 0.52;
+}
+.atlas-campaign-route__arrow {
+  fill: #fecdd3;
+  stroke: rgba(127, 29, 29, 0.88);
+  stroke-width: 0.22;
+}
+.atlas-campaign-route--risk .atlas-campaign-route__arrow { fill: #fde68a; }
+.atlas-campaign-route--watch .atlas-campaign-route__arrow { fill: #bae6fd; }
+.atlas-military-overflow {
+  fill: #fde68a;
+}


### PR DESCRIPTION
Alpha: Implements #729.

Summary:
- adds an atlas military layer for campaign routes, major front/occupation pressure, direction arrows, and compact residual risk zones
- derives signals from existing shell province/front relation data, supply, loyalty, and strategic value without adding a hidden military data source
- caps dominant routes and risk zones to three and aggregates overflow for world-scale readability

Validation:
- `node --check web/app.js`
- `npm test -- test/ui/war/webAtlasCampaignFrontRoutes.test.js test/ui/war/webAtlasWorldMapCanvas.test.js`
- `npm test` (506 passing)
- `git diff --check`