### PR TITLE
Delta: add atlas intrigue signal filters

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -197,6 +197,23 @@ test('final intrigue exposure summary is visible before turn commit', () => {
   assert.match(stylesSource, /province-intrigue-final-commit-summary__item--trop-risqué/);
 });
 
+test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
+  assert.match(webAppSource, /atlasIntrigueSignalFilters/);
+  assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);
+  assert.match(webAppSource, /function filterWorldMapIntrigueSignals/);
+  assert.match(webAppSource, /data-atlas-intrigue-signal-filter="\$\{key\}"/);
+  assert.match(webAppSource, /state\.atlasIntrigueSignalFilters\[key\] = !state\.atlasIntrigueSignalFilters\[key\]/);
+  assert.match(webAppSource, /Récents/);
+  assert.match(webAppSource, /Anciens/);
+  assert.match(webAppSource, /Incertains/);
+  assert.match(webAppSource, /Probables/);
+  assert.match(webAppSource, /information ancienne à revérifier avant action directe/);
+  assert.match(webAppSource, /incertitude élevée: action risquée sans vérification/);
+  assert.match(webAppSource, /signal probable à prioriser sans révéler la source/);
+  assert.match(stylesSource, /world-map-intrigue-filter-chip/);
+  assert.match(stylesSource, /world-map-intrigue-filter-chip\.is-active/);
+});
+
 test('world map intrigue signals show presence risk shadows and probable sabotage safely', () => {
   assert.match(webAppSource, /function buildWorldMapIntrigueSignals/);
   assert.match(webAppSource, /function renderWorldMapIntrigueSignals/);
@@ -205,6 +222,7 @@ test('world map intrigue signals show presence risk shadows and probable sabotag
   assert.match(webAppSource, /Résumé intrigue carte monde fog-safe/);
   assert.match(webAppSource, /présence forte/);
   assert.match(webAppSource, /risque sabotage probable/);
+  assert.match(webAppSource, /\$\{signal\.freshnessLabel\} · \$\{signal\.riskLabel\}/);
   assert.match(webAppSource, /zone d’ombre conservée/);
   assert.match(webAppSource, /les cellules, relais, objectifs et causes cachées restent masqués/);
   assert.match(webAppSource, /aucun détail caché révélé/);

--- a/web/app.js
+++ b/web/app.js
@@ -435,6 +435,12 @@ const state = {
     increased: false,
     hidden: false,
   },
+  atlasIntrigueSignalFilters: {
+    recent: false,
+    stale: false,
+    uncertain: false,
+    probable: false,
+  },
   acceptedRecommendedMilitaryAction: null,
   lastMilitaryOutcomeMarkers: [],
   militaryOutcomeMarkerFilters: {
@@ -7421,10 +7427,25 @@ function renderPostCommitIntrigueExposureMarkers(markers) {
 }
 
 
-function buildWorldMapIntrigueSignals(intrigueView = null) {
-  const entries = intrigueView?.map?.entries ?? [];
+function getActiveAtlasIntrigueSignalFilters() {
+  return Object.entries(state.atlasIntrigueSignalFilters)
+    .filter(([, active]) => active)
+    .map(([key]) => key);
+}
 
-  return entries.map((entry) => {
+function filterWorldMapIntrigueSignals(signals) {
+  const activeFilters = getActiveAtlasIntrigueSignalFilters();
+
+  if (activeFilters.length === 0) {
+    return signals;
+  }
+
+  return signals.filter((signal) => activeFilters.some((filter) => signal.filterTags.includes(filter)));
+}
+
+function buildWorldMapIntrigueSignals(intrigueView = null, options = {}) {
+  const entries = intrigueView?.map?.entries ?? [];
+  const signals = entries.map((entry) => {
     const presenceLabels = {
       high: 'présence forte',
       medium: 'présence probable',
@@ -7449,6 +7470,34 @@ function buildWorldMapIntrigueSignals(intrigueView = null) {
       : shadowZone
         ? '??'
         : 'I';
+    const freshness = entry.sabotageRiskLevel === 'high' || entry.metrics.exposedCellCount > 0 || hasSabotageSignal
+      ? 'recent'
+      : shadowZone
+        ? 'uncertain'
+        : 'stale';
+    const freshnessLabels = {
+      recent: 'récent',
+      stale: 'ancien',
+      uncertain: 'incertain',
+    };
+    const certainty = assurance === 'confirmé'
+      ? 'confirmed'
+      : assurance === 'probable'
+        ? 'probable'
+        : 'uncertain';
+    const filterTags = [freshness];
+
+    if (certainty === 'probable') {
+      filterTags.push('probable');
+    }
+
+    const priorityReason = freshness === 'stale'
+      ? 'information ancienne à revérifier avant action directe'
+      : freshness === 'uncertain'
+        ? 'incertitude élevée: action risquée sans vérification'
+        : certainty === 'probable'
+          ? 'signal probable à prioriser sans révéler la source'
+          : 'signal récent lisible par données visibles';
     const tone = entry.sabotageRiskLevel === 'high'
       ? 'danger'
       : entry.sabotageRiskLevel === 'medium' || entry.presenceLevel === 'high'
@@ -7467,32 +7516,47 @@ function buildWorldMapIntrigueSignals(intrigueView = null) {
       tone,
       glyph,
       assurance,
+      certainty,
+      freshness,
+      freshnessLabel: freshnessLabels[freshness],
+      filterTags,
+      priorityReason,
       presenceLabel: presenceLabels[entry.presenceLevel] ?? presenceLabels.none,
       riskLabel: riskLabels[entry.sabotageRiskLevel] ?? riskLabels.none,
       shadowZone,
       probableSabotage: hasSabotageSignal,
-      copy: `${presenceLabels[entry.presenceLevel] ?? presenceLabels.none} · ${riskLabels[entry.sabotageRiskLevel] ?? riskLabels.none} · assurance ${assurance}${shadowZone ? ' · zone d’ombre conservée' : ''}`,
-      ariaLabel: `Signal intrigue monde en ${entry.locationName}: ${presenceLabels[entry.presenceLevel] ?? presenceLabels.none}; ${riskLabels[entry.sabotageRiskLevel] ?? riskLabels.none}; assurance ${assurance}; aucun détail caché révélé`,
+      copy: `${freshnessLabels[freshness]} · ${presenceLabels[entry.presenceLevel] ?? presenceLabels.none} · ${riskLabels[entry.sabotageRiskLevel] ?? riskLabels.none} · assurance ${assurance}${shadowZone ? ' · zone d’ombre conservée' : ''} · ${priorityReason}`,
+      ariaLabel: `Signal intrigue monde en ${entry.locationName}: ${freshnessLabels[freshness]}; ${presenceLabels[entry.presenceLevel] ?? presenceLabels.none}; ${riskLabels[entry.sabotageRiskLevel] ?? riskLabels.none}; assurance ${assurance}; aucun détail caché révélé`,
     };
   }).sort((left, right) => {
     const rank = { danger: 1, warning: 2, shadow: 3, watch: 4 };
     return rank[left.tone] - rank[right.tone] || left.locationName.localeCompare(right.locationName);
   }).slice(0, 6);
+
+  return options.ignoreFilters ? signals : filterWorldMapIntrigueSignals(signals);
 }
 
 function buildWorldMapIntrigueSignalRollup(signals) {
+  const filteredSignals = filterWorldMapIntrigueSignals(signals);
   const counts = {
     danger: signals.filter((signal) => signal.tone === 'danger').length,
     warning: signals.filter((signal) => signal.tone === 'warning').length,
     shadow: signals.filter((signal) => signal.shadowZone).length,
     probableSabotage: signals.filter((signal) => signal.probableSabotage).length,
+    recent: signals.filter((signal) => signal.freshness === 'recent').length,
+    stale: signals.filter((signal) => signal.freshness === 'stale').length,
+    uncertain: signals.filter((signal) => signal.freshness === 'uncertain').length,
+    probable: signals.filter((signal) => signal.certainty === 'probable').length,
   };
+  const activeFilters = getActiveAtlasIntrigueSignalFilters();
 
   return {
     counts,
+    activeFilters,
+    filteredCount: filteredSignals.length,
     totalCount: signals.length,
     summary: signals.length > 0
-      ? `${signals.length} signal${signals.length > 1 ? 's' : ''} intrigue monde visible${signals.length > 1 ? 's' : ''}: ${counts.probableSabotage} sabotage${counts.probableSabotage > 1 ? 's' : ''} probable${counts.probableSabotage > 1 ? 's' : ''}, ${counts.shadow} zone${counts.shadow > 1 ? 's' : ''} d’ombre.`
+      ? `${filteredSignals.length}/${signals.length} signal${signals.length > 1 ? 's' : ''} intrigue atlas visible${filteredSignals.length > 1 ? 's' : ''}: ${counts.recent} récent${counts.recent > 1 ? 's' : ''}, ${counts.stale} ancien${counts.stale > 1 ? 's' : ''}, ${counts.uncertain} incertain${counts.uncertain > 1 ? 's' : ''}, ${counts.probable} probable${counts.probable > 1 ? 's' : ''}.`
       : 'Aucun signal intrigue monde visible avec les filtres actuels.',
   };
 }
@@ -7509,7 +7573,7 @@ function renderWorldMapIntrigueSignals(signals) {
           <title>${signal.copy}</title>
           <circle class="world-map-intrigue-signal__aura" cx="${signal.center.x}%" cy="${signal.center.y}%" r="${signal.probableSabotage ? 4.9 : 3.9}"></circle>
           <text class="world-map-intrigue-signal__glyph" x="${signal.center.x}%" y="${signal.center.y + 1.05}%" text-anchor="middle">${signal.glyph}</text>
-          <text class="world-map-intrigue-signal__label" x="${signal.center.x + 4.2}%" y="${signal.center.y - 1.2}%" text-anchor="start">${signal.riskLabel}</text>
+          <text class="world-map-intrigue-signal__label" x="${signal.center.x + 4.2}%" y="${signal.center.y - 1.2}%" text-anchor="start">${signal.freshnessLabel} · ${signal.riskLabel}</text>
           <text class="world-map-intrigue-signal__copy" x="${signal.center.x + 4.2}%" y="${signal.center.y + 2.0}%" text-anchor="start">${signal.presenceLabel} · ${signal.assurance}</text>
         </g>
       `).join('')}
@@ -7529,6 +7593,18 @@ function renderWorldMapIntrigueSignalRollup(rollup) {
         <span>${rollup.counts.probableSabotage} sabotage${rollup.counts.probableSabotage > 1 ? 's' : ''} probable${rollup.counts.probableSabotage > 1 ? 's' : ''}</span>
       </div>
       <p>${rollup.summary}</p>
+      <div class="world-map-intrigue-filter-chips" aria-label="Filtres atlas intrigue par fraîcheur et certitude">
+        ${[
+          ['recent', 'Récents'],
+          ['stale', 'Anciens'],
+          ['uncertain', 'Incertains'],
+          ['probable', 'Probables'],
+        ].map(([key, label]) => `
+          <button type="button" class="world-map-intrigue-filter-chip ${state.atlasIntrigueSignalFilters[key] ? 'is-active' : ''}" data-atlas-intrigue-signal-filter="${key}" aria-pressed="${state.atlasIntrigueSignalFilters[key]}">
+            ${label} <b>${rollup.counts[key]}</b>
+          </button>
+        `).join('')}
+      </div>
       <small>${rollup.counts.shadow} zone${rollup.counts.shadow > 1 ? 's' : ''} d’ombre conservée${rollup.counts.shadow > 1 ? 's' : ''}; les cellules, relais, objectifs et causes cachées restent masqués.</small>
     </section>
   `;
@@ -9607,7 +9683,7 @@ function renderIntrigueSidePanel(intrigueView) {
 
   const exposureMarkers = buildPostCommitIntrigueExposureMarkers(intrigueView, { ignoreFilters: true });
   const exposureMarkerRollup = buildIntrigueExposureMarkerRollup(exposureMarkers);
-  const worldMapSignals = buildWorldMapIntrigueSignals(intrigueView);
+  const worldMapSignals = buildWorldMapIntrigueSignals(intrigueView, { ignoreFilters: true });
   const worldMapSignalRollup = buildWorldMapIntrigueSignalRollup(worldMapSignals);
 
   return `
@@ -11425,6 +11501,14 @@ function render() {
     element.addEventListener('click', () => {
       const key = element.dataset.intrigueExposureFilter;
       state.intrigueExposureOutcomeFilters[key] = !state.intrigueExposureOutcomeFilters[key];
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-atlas-intrigue-signal-filter]').forEach((element) => {
+    element.addEventListener('click', () => {
+      const key = element.dataset.atlasIntrigueSignalFilter;
+      state.atlasIntrigueSignalFilters[key] = !state.atlasIntrigueSignalFilters[key];
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -2688,6 +2688,32 @@ button { font: inherit; }
 .world-map-intrigue-rollup__header span,
 .world-map-intrigue-rollup p,
 .world-map-intrigue-rollup small { color: #cbd5e1; }
+.world-map-intrigue-filter-chips {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+.world-map-intrigue-filter-chip {
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+  align-items: center;
+  padding: 7px 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  color: #e2e8f0;
+  background: rgba(2, 6, 23, 0.24);
+  cursor: pointer;
+}
+.world-map-intrigue-filter-chip.is-active,
+.world-map-intrigue-filter-chip:hover,
+.world-map-intrigue-filter-chip:focus-visible {
+  border-color: rgba(129, 140, 248, 0.68);
+  background: rgba(49, 46, 129, 0.42);
+}
+.world-map-intrigue-filter-chip b {
+  color: #f8fafc;
+}
 .intrigue-exposure-marker-rollup {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Implements #732.

Summary:
- add atlas intrigue signal filters for recent, stale, uncertain, and probable signals
- reuse existing fog-safe freshness/certainty concepts in the world-map intrigue signal rollup
- highlight stale and uncertain signals with short non-spoilery priority reasons
- keep hidden cells, targets, relays, objectives, and causes masked

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Closes #732