### PR TITLE
Alpha: add atlas conflict route playback

### DIFF
--- a/test/ui/war/webAtlasConflictRoutePlayback.test.js
+++ b/test/ui/war/webAtlasConflictRoutePlayback.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas conflict playback derives deterministic route history from existing front pressure', () => {
+  assert.match(webAppSource, /atlasConflictPlaybackStep: 1/);
+  assert.match(webAppSource, /function buildAtlasConflictRoutePlaybackSteps\(route\)/);
+  assert.match(webAppSource, /previousPressure = Math\.max\(0, route\.pressure - trend\)/);
+  assert.match(webAppSource, /projectedPressure = Math\.max\(0, route\.pressure \+ Math\.round\(trend \* 0\.7\)\)/);
+  assert.match(webAppSource, /function buildAtlasConflictRoutePlayback\(routes, activeStep = state\.atlasConflictPlaybackStep\)/);
+  assert.doesNotMatch(webAppSource, /fetch\(|XMLHttpRequest|WebSocket/);
+});
+
+test('atlas conflict playback exposes short scrub controls and empty state', () => {
+  assert.match(webAppSource, /atlas-conflict-playback/);
+  assert.match(webAppSource, /data-atlas-conflict-playback-step/);
+  assert.match(webAppSource, /Tour -1/);
+  assert.match(webAppSource, /Actuel/);
+  assert.match(webAppSource, /Projection/);
+  assert.match(webAppSource, /Aucun historique militaire pertinent|Aucun front actif à rejouer/);
+  assert.match(webAppSource, /state\.atlasConflictPlaybackStep = Math\.max\(0, Math\.min\(2/);
+});
+
+test('atlas conflict playback styling stays compact and non-permanent', () => {
+  assert.match(stylesSource, /\.atlas-conflict-playback__panel/);
+  assert.match(stylesSource, /\.atlas-conflict-playback-step\.is-active/);
+  assert.match(stylesSource, /\.atlas-campaign-route--rising path:first-child/);
+  assert.match(stylesSource, /\.atlas-campaign-route--falling path:first-child/);
+  assert.doesNotMatch(stylesSource, /@keyframes atlas-conflict|animation:\s*atlas-conflict/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -442,6 +442,7 @@ const state = {
     probable: false,
   },
   atlasClimateForecastMode: 'current',
+  atlasConflictPlaybackStep: 1,
   acceptedRecommendedMilitaryAction: null,
   lastMilitaryOutcomeMarkers: [],
   militaryOutcomeMarkerFilters: {
@@ -469,6 +470,7 @@ function applyMapScenario(scenario) {
   state.turn = 1;
   state.seasonIndex = 0;
   state.atlasClimateForecastMode = 'current';
+  state.atlasConflictPlaybackStep = 1;
   state.mapZoom = 1;
   state.mapPanX = 0;
   state.mapPanY = 0;
@@ -586,6 +588,85 @@ function getAtlasMilitaryRouteTone(route) {
   return route.pressure >= 74 ? 'risk' : 'watch';
 }
 
+function getAtlasConflictRouteTrend(route) {
+  if (route.contested) return 14;
+  if (route.occupied) return 8;
+  if (route.pressure >= 74) return 6;
+  return -5;
+}
+
+function buildAtlasConflictRoutePlaybackSteps(route) {
+  const trend = getAtlasConflictRouteTrend(route);
+  const previousPressure = Math.max(0, route.pressure - trend);
+  const projectedPressure = Math.max(0, route.pressure + Math.round(trend * 0.7));
+  const direction = projectedPressure > route.pressure ? 'rising' : projectedPressure < route.pressure ? 'falling' : 'steady';
+
+  return [
+    {
+      step: 0,
+      key: 'previous',
+      label: 'Tour -1',
+      pressure: previousPressure,
+      delta: route.pressure - previousPressure,
+      direction: route.pressure > previousPressure ? 'rising' : route.pressure < previousPressure ? 'falling' : 'steady',
+    },
+    {
+      step: 1,
+      key: 'current',
+      label: 'Actuel',
+      pressure: route.pressure,
+      delta: route.pressure - previousPressure,
+      direction,
+    },
+    {
+      step: 2,
+      key: 'projected',
+      label: 'Projection',
+      pressure: projectedPressure,
+      delta: projectedPressure - route.pressure,
+      direction,
+    },
+  ];
+}
+
+function buildAtlasConflictRoutePlayback(routes, activeStep = state.atlasConflictPlaybackStep) {
+  const safeStep = Math.max(0, Math.min(2, Number(activeStep) || 0));
+  const playbackRoutes = routes
+    .map((route) => {
+      const steps = buildAtlasConflictRoutePlaybackSteps(route);
+      const active = steps[safeStep] ?? steps[1];
+      return {
+        ...route,
+        playbackSteps: steps,
+        activePlayback: active,
+        playbackDirection: active.direction,
+      };
+    })
+    .filter((route) => route.playbackSteps.some((step) => step.delta !== 0));
+
+  return {
+    activeStep: safeStep,
+    steps: [
+      { step: 0, label: 'Tour -1' },
+      { step: 1, label: 'Actuel' },
+      { step: 2, label: 'Projection' },
+    ],
+    routes: playbackRoutes,
+    empty: playbackRoutes.length === 0,
+  };
+}
+
+function getAtlasConflictPlaybackSummary(playback) {
+  if (playback.empty) {
+    return 'Aucun historique de front actif à rejouer.';
+  }
+
+  const rising = playback.routes.filter((route) => route.activePlayback.direction === 'rising').length;
+  const falling = playback.routes.filter((route) => route.activePlayback.direction === 'falling').length;
+  const steady = playback.routes.length - rising - falling;
+  return `${playback.steps[playback.activeStep].label}: ${rising} pression${rising > 1 ? 's' : ''} en hausse, ${falling} en baisse, ${steady} stable${steady > 1 ? 's' : ''}.`;
+}
+
 function buildAtlasMilitaryFeatures(shell) {
   const pressureByProvinceId = new Map(shell.provinces.map((province) => [province.provinceId, getAtlasMilitaryPressureScore(province)]));
   const routes = buildProvinceRelations(shell)
@@ -646,31 +727,50 @@ function buildAtlasMilitaryFeatures(shell) {
 
 function renderAtlasMilitaryLayer(shell) {
   const features = buildAtlasMilitaryFeatures(shell);
+  const playback = buildAtlasConflictRoutePlayback(features.routes);
+  const playbackSummary = getAtlasConflictPlaybackSummary(playback);
 
   if (!features.routes.length && !features.riskZones.length) {
-    return '';
+    return `
+      <g class="atlas-military-layer atlas-military-layer--empty" aria-label="Lecture militaire atlas vide">
+        <text class="atlas-conflict-playback-empty" x="50" y="92" text-anchor="middle">Aucun front actif à rejouer</text>
+      </g>
+    `;
   }
 
   return `
     <g class="atlas-military-layer" aria-label="Axes militaires atlas: routes de campagne, pression directionnelle et risques résiduels">
+      <g class="atlas-conflict-playback" aria-label="Lecture courte des changements de pression: ${playbackSummary}">
+        <rect class="atlas-conflict-playback__panel" x="61" y="5" width="36" height="18" rx="2.4"></rect>
+        <text class="atlas-conflict-playback__title" x="63" y="9.2">Replay fronts</text>
+        <text class="atlas-conflict-playback__summary" x="63" y="20.1">${playbackSummary}</text>
+        ${playback.steps.map((step, index) => `
+          <g class="atlas-conflict-playback-step ${playback.activeStep === step.step ? 'is-active' : ''}" data-atlas-conflict-playback-step="${step.step}" aria-label="Afficher ${step.label}">
+            <rect x="${63 + index * 10.4}" y="11" width="9.2" height="4.7" rx="1.5"></rect>
+            <text x="${67.6 + index * 10.4}" y="14.1" text-anchor="middle">${step.label}</text>
+          </g>
+        `).join('')}
+      </g>
       ${features.riskZones.map((zone) => `
         <g class="atlas-military-risk atlas-military-risk--${zone.tone}" data-atlas-risk-province="${zone.provinceId}" aria-label="Zone militaire ${zone.label}: pression ${zone.pressure}">
           <polygon points="${zone.polygon}"></polygon>
           <text x="${zone.center.x}%" y="${zone.center.y - 3.5}%" text-anchor="middle">${zone.tone === 'front' ? 'FRONT' : zone.tone === 'occupation' ? 'OCC' : 'RISQUE'}</text>
         </g>
       `).join('')}
-      ${features.routes.map((route) => {
+      ${playback.routes.map((route) => {
         const path = `M${route.origin.x},${route.origin.y} Q${route.control.x},${route.control.y} ${route.destination.x},${route.destination.y}`;
         const arrowX = (route.control.x + route.destination.x) / 2;
         const arrowY = (route.control.y + route.destination.y) / 2;
+        const deltaPrefix = route.activePlayback.delta > 0 ? '+' : '';
         return `
-          <g class="atlas-campaign-route atlas-campaign-route--${route.tone}" data-atlas-campaign-route="${route.routeId}" aria-label="Axe ${route.sourceLabel} vers ${route.targetLabel}: pression ${route.pressure}">
+          <g class="atlas-campaign-route atlas-campaign-route--${route.tone} atlas-campaign-route--${route.playbackDirection}" data-atlas-campaign-route="${route.routeId}" aria-label="Axe ${route.sourceLabel} vers ${route.targetLabel}: ${route.activePlayback.label}, pression ${route.activePlayback.pressure}, delta ${deltaPrefix}${route.activePlayback.delta}">
             <path d="${path}" pathLength="100"></path>
             <path class="atlas-campaign-route__arrow" d="M${arrowX - 1.15},${arrowY - 0.85} L${arrowX + 1.35},${arrowY} L${arrowX - 1.15},${arrowY + 0.85} Z"></path>
-            <text x="${route.control.x}" y="${route.control.y - 1.6}" text-anchor="middle">${route.contested ? 'Front' : route.occupied ? 'Occupation' : 'Pression'}</text>
+            <text x="${route.control.x}" y="${route.control.y - 1.6}" text-anchor="middle">${route.activePlayback.label} ${deltaPrefix}${route.activePlayback.delta}</text>
           </g>
         `;
       }).join('')}
+      ${playback.empty ? `<text class="atlas-conflict-playback-empty" x="50" y="92" text-anchor="middle">Aucun historique militaire pertinent</text>` : ''}
       ${features.overflowCount > 0 ? `<text class="atlas-military-overflow" x="82" y="88" text-anchor="middle">+${features.overflowCount} axes agrégés</text>` : ''}
     </g>
   `;
@@ -11884,6 +11984,13 @@ function render() {
     element.addEventListener('click', () => {
       state.atlasClimateForecastMode = element.dataset.atlasClimateForecastMode ?? 'current';
       state.activeOverlaySlot = 'climate-overlay';
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-atlas-conflict-playback-step]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.atlasConflictPlaybackStep = Math.max(0, Math.min(2, Number(element.dataset.atlasConflictPlaybackStep) || 0));
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -9931,6 +9931,40 @@ button { font: inherit; }
   pointer-events: none;
   opacity: 0.9;
 }
+.atlas-conflict-playback {
+  pointer-events: auto;
+}
+.atlas-conflict-playback__panel {
+  fill: rgba(15, 23, 42, 0.78);
+  stroke: rgba(248, 113, 113, 0.32);
+  stroke-width: 0.35;
+}
+.atlas-conflict-playback__title,
+.atlas-conflict-playback__summary,
+.atlas-conflict-playback-step text,
+.atlas-conflict-playback-empty {
+  fill: #fee2e2;
+  font-size: 1.55px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.86);
+  stroke-width: 0.42;
+}
+.atlas-conflict-playback__summary {
+  fill: #fde68a;
+  font-size: 1.28px;
+}
+.atlas-conflict-playback-step rect {
+  fill: rgba(127, 29, 29, 0.42);
+  stroke: rgba(248, 113, 113, 0.38);
+  stroke-width: 0.28;
+  cursor: pointer;
+}
+.atlas-conflict-playback-step.is-active rect {
+  fill: rgba(248, 113, 113, 0.54);
+  stroke: rgba(254, 226, 226, 0.72);
+}
+.atlas-conflict-playback-step.is-active text { fill: #fff7ed; }
 .atlas-military-risk polygon {
   fill: rgba(251, 191, 36, 0.08);
   stroke: rgba(253, 230, 138, 0.26);
@@ -9975,6 +10009,9 @@ button { font: inherit; }
   stroke: rgba(125, 211, 252, 0.5);
   stroke-width: 0.52;
 }
+.atlas-campaign-route--rising path:first-child { stroke-dasharray: 5 1.5; }
+.atlas-campaign-route--falling path:first-child { opacity: 0.58; stroke-dasharray: 2 2.8; }
+.atlas-campaign-route--steady path:first-child { stroke-dasharray: 3 2.2; }
 .atlas-campaign-route__arrow {
   fill: #fecdd3;
   stroke: rgba(127, 29, 29, 0.88);


### PR DESCRIPTION
Alpha: Implements #739.

Summary:
- adds a compact atlas front replay panel with Tour -1 / Actuel / Projection scrub steps
- derives deterministic route pressure deltas from existing atlas campaign route pressure and front/occupation state, without network or hidden data sources
- updates route arrows/labels by selected step and provides empty-state copy when no relevant route history exists

Validation:
- `node --check web/app.js`
- `npm test -- test/ui/war/webAtlasConflictRoutePlayback.test.js test/ui/war/webAtlasCampaignFrontRoutes.test.js`
- `npm test` (511 passing)
- `git diff --check`