### PR TITLE
Delta: add atlas counterintelligence sweep planning

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -197,6 +197,22 @@ test('final intrigue exposure summary is visible before turn commit', () => {
   assert.match(stylesSource, /province-intrigue-final-commit-summary__item--trop-risqué/);
 });
 
+test('atlas counterintelligence sweep planning uses filtered signals without spoilers', () => {
+  assert.match(webAppSource, /function buildAtlasCounterintelligenceSweepPlan/);
+  assert.match(webAppSource, /function renderAtlasCounterintelligenceSweepPlan/);
+  assert.match(webAppSource, /Balayage contre-espionnage/);
+  assert.match(webAppSource, /Revérification discrète/);
+  assert.match(webAppSource, /Balayage prudent/);
+  assert.match(webAppSource, /Balayage prioritaire/);
+  assert.match(webAppSource, /réduction estimée modérée sans dévoiler la source/);
+  assert.match(webAppSource, /coût moyen · délai prudent/);
+  assert.match(webAppSource, /incertitude haute: confirmer la province avant action nominative/);
+  assert.match(webAppSource, /Aucun signal filtré ne justifie un balayage contre-espionnage ce tour/);
+  assert.match(webAppSource, /cellule, relais, cible et cause restent masqués/);
+  assert.match(stylesSource, /atlas-counterintelligence-plan/);
+  assert.match(stylesSource, /atlas-counterintelligence-card--shadow/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -8077,6 +8077,102 @@ function renderWorldMapIntrigueSignalRollup(rollup) {
   `;
 }
 
+
+function buildAtlasCounterintelligenceSweepPlan(signals) {
+  const filteredSignals = filterWorldMapIntrigueSignals(signals);
+  const sweepCandidates = filteredSignals
+    .map((signal) => {
+      const freshnessWeight = signal.freshness === 'recent' ? 18 : signal.freshness === 'uncertain' ? 16 : 10;
+      const certaintyWeight = signal.certainty === 'probable' ? 14 : signal.certainty === 'confirmed' ? 10 : 8;
+      const exposureWeight = signal.tone === 'danger' ? 18 : signal.tone === 'warning' ? 12 : signal.shadowZone ? 9 : 4;
+      const score = freshnessWeight + certaintyWeight + exposureWeight + (signal.probableSabotage ? 8 : 0);
+      const sweepMode = signal.freshness === 'stale'
+        ? 'Revérification discrète'
+        : signal.freshness === 'uncertain'
+          ? 'Balayage prudent'
+          : signal.certainty === 'probable'
+            ? 'Balayage prioritaire'
+            : 'Veille ciblée';
+      const expectedReduction = signal.tone === 'danger'
+        ? 'réduction estimée forte si le signal visible se confirme'
+        : signal.tone === 'warning' || signal.certainty === 'probable'
+          ? 'réduction estimée modérée sans dévoiler la source'
+          : 'réduction légère, utile pour clarifier la zone';
+      const costDelay = signal.freshness === 'stale'
+        ? 'coût bas · délai court'
+        : signal.freshness === 'uncertain'
+          ? 'coût moyen · délai prudent'
+          : 'coût moyen · action ce tour';
+      const uncertainty = signal.freshness === 'uncertain' || signal.shadowZone
+        ? 'incertitude haute: confirmer la province avant action nominative'
+        : signal.certainty === 'probable'
+          ? 'incertitude moyenne: cause et relais restent masqués'
+          : 'incertitude limitée aux détails non visibles';
+
+      return {
+        ...signal,
+        score,
+        sweepMode,
+        expectedReduction,
+        costDelay,
+        uncertainty,
+      };
+    })
+    .filter((signal) => signal.score >= 28 || signal.freshness !== 'stale' || signal.certainty === 'probable')
+    .sort((left, right) => right.score - left.score || left.locationName.localeCompare(right.locationName))
+    .slice(0, 3);
+
+  return {
+    empty: sweepCandidates.length === 0,
+    totalFiltered: filteredSignals.length,
+    candidates: sweepCandidates,
+    summary: sweepCandidates.length > 0
+      ? `${sweepCandidates.length} zone${sweepCandidates.length > 1 ? 's' : ''} de balayage contre-espionnage proposée${sweepCandidates.length > 1 ? 's' : ''} depuis les filtres atlas actifs.`
+      : 'Aucun signal filtré ne justifie un balayage contre-espionnage ce tour.',
+  };
+}
+
+function renderAtlasCounterintelligenceSweepPlan(plan) {
+  if (plan.empty) {
+    return `
+      <section class="atlas-counterintelligence-plan is-empty" aria-label="Plan de balayage contre-espionnage atlas">
+        <div class="atlas-counterintelligence-plan__header">
+          <strong>Balayage contre-espionnage</strong>
+          <span>aucune zone</span>
+        </div>
+        <p>${plan.summary}</p>
+        <small>Activez un filtre récent, ancien, incertain ou probable pour préparer une vérification sans révéler de cause cachée.</small>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="atlas-counterintelligence-plan" aria-label="Plan de balayage contre-espionnage atlas">
+      <div class="atlas-counterintelligence-plan__header">
+        <strong>Balayage contre-espionnage</strong>
+        <span>${plan.candidates.length}/${plan.totalFiltered} priorités</span>
+      </div>
+      <p>${plan.summary}</p>
+      <div class="atlas-counterintelligence-plan__list">
+        ${plan.candidates.map((candidate, index) => `
+          <button type="button" class="atlas-counterintelligence-card atlas-counterintelligence-card--${candidate.tone}" data-province-id="${candidate.locationId}" aria-label="Choisir ${candidate.locationName} pour ${candidate.sweepMode}: ${candidate.uncertainty}">
+            <div>
+              <b>#${index + 1} ${candidate.locationName}</b>
+              <span>${candidate.sweepMode} · ${candidate.freshnessLabel} · ${candidate.assurance}</span>
+            </div>
+            <dl>
+              <div><dt>Effet</dt><dd>${candidate.expectedReduction}</dd></div>
+              <div><dt>Coût / délai</dt><dd>${candidate.costDelay}</dd></div>
+              <div><dt>Incertitude</dt><dd>${candidate.uncertainty}</dd></div>
+            </dl>
+            <small>${candidate.priorityReason}; cellule, relais, cible et cause restent masqués.</small>
+          </button>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
 function renderCultureOpportunityEndTurnSummary(province, shell, focusContext, intrigueView = null) {
   const actionQueue = buildSelectedProvinceActionQueue(province, shell, focusContext, intrigueView);
   const cultureContext = getSelectedCultureContext(province.provinceId);
@@ -10152,6 +10248,7 @@ function renderIntrigueSidePanel(intrigueView) {
   const exposureMarkerRollup = buildIntrigueExposureMarkerRollup(exposureMarkers);
   const worldMapSignals = buildWorldMapIntrigueSignals(intrigueView, { ignoreFilters: true });
   const worldMapSignalRollup = buildWorldMapIntrigueSignalRollup(worldMapSignals);
+  const counterintelligencePlan = buildAtlasCounterintelligenceSweepPlan(worldMapSignals);
 
   return `
     <section class="panel overlay-panel overlay-panel--intrigue">
@@ -10171,6 +10268,7 @@ function renderIntrigueSidePanel(intrigueView) {
         <button type="button" class="intrigue-filter-chip ${intrigueView.filters.sabotage ? 'is-active' : ''}" data-intrigue-filter="sabotage">Sabotage</button>
       </section>
       ${renderWorldMapIntrigueSignalRollup(worldMapSignalRollup)}
+      ${renderAtlasCounterintelligenceSweepPlan(counterintelligencePlan)}
       ${renderIntrigueExposureMarkerRollup(exposureMarkerRollup)}
       <section class="intrigue-alert-panel intrigue-alert-panel--${intrigueView.alertPanel.tone}" aria-label="Lecture du niveau d'alerte">
         <div class="intrigue-alert-panel__header">

--- a/web/styles.css
+++ b/web/styles.css
@@ -2733,6 +2733,72 @@ button { font: inherit; }
 .world-map-intrigue-filter-chip b {
   color: #f8fafc;
 }
+.atlas-counterintelligence-plan {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(45, 212, 191, 0.28);
+  background: rgba(15, 23, 42, 0.5);
+}
+.atlas-counterintelligence-plan.is-empty {
+  border-color: rgba(148, 163, 184, 0.22);
+}
+.atlas-counterintelligence-plan__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.atlas-counterintelligence-plan__header span,
+.atlas-counterintelligence-plan p,
+.atlas-counterintelligence-plan small { color: #cbd5e1; }
+.atlas-counterintelligence-plan__list {
+  display: grid;
+  gap: 8px;
+}
+.atlas-counterintelligence-card {
+  display: grid;
+  gap: 7px;
+  width: 100%;
+  text-align: left;
+  padding: 9px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  color: #e2e8f0;
+  background: rgba(2, 6, 23, 0.26);
+  cursor: pointer;
+}
+.atlas-counterintelligence-card--danger { border-left: 3px solid rgba(248, 113, 113, 0.82); }
+.atlas-counterintelligence-card--warning { border-left: 3px solid rgba(251, 191, 36, 0.82); }
+.atlas-counterintelligence-card--shadow { border-left: 3px solid rgba(148, 163, 184, 0.72); }
+.atlas-counterintelligence-card--watch { border-left: 3px solid rgba(96, 165, 250, 0.72); }
+.atlas-counterintelligence-card:hover,
+.atlas-counterintelligence-card:focus-visible {
+  border-color: rgba(45, 212, 191, 0.6);
+  background: rgba(20, 83, 45, 0.26);
+}
+.atlas-counterintelligence-card div {
+  display: grid;
+  gap: 2px;
+}
+.atlas-counterintelligence-card div span { color: #bae6fd; font-size: 0.82rem; }
+.atlas-counterintelligence-card dl {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+}
+.atlas-counterintelligence-card dl div {
+  display: grid;
+  gap: 2px;
+}
+.atlas-counterintelligence-card dt {
+  color: #94a3b8;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.atlas-counterintelligence-card dd { margin: 0; color: #f8fafc; }
 .intrigue-exposure-marker-rollup {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Implements #742.

Summary:
- adds a fog-safe atlas counterintelligence sweep plan from the active intrigue signal filters
- prioritizes sweep zones by freshness, certainty, exposure risk, and probable sabotage without revealing hidden causes
- shows expected reduction, cost/delay, uncertainty, and an empty state when no filtered signal merits a sweep

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- npm test

Delta: Zeta, this PR is ready for validation before merge.