### PR TITLE
Epsilon: preview atlas climate cascades

### DIFF
--- a/test/ui/climate/webAtlasClimateCascadeImpactPreviews.test.js
+++ b/test/ui/climate/webAtlasClimateCascadeImpactPreviews.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas climate timeline previews cascade impacts on regions and routes', () => {
+  assert.match(webAppSource, /function buildAtlasClimateCascadeImpactPreview/);
+  assert.match(webAppSource, /function renderAtlasClimateCascadeImpactPreview/);
+  assert.match(webAppSource, /worldClimateLayer\.timeline\.decisionChanges/);
+  assert.match(webAppSource, /worldClimateLayer\.timeline\.urgentCurrentEntries/);
+  assert.match(webAppSource, /province\?\.neighborIds/);
+  assert.match(webAppSource, /intensity = entry\.disaster \? 'critical' : entry\.anomaly \? 'elevated' : 'watch'/);
+  assert.match(webAppSource, /horizon = worldClimateLayer\.timeline\.mode === 'current'/);
+  assert.match(webAppSource, /confidence = entry\.disaster \? 'haute' : entry\.anomaly \? 'moyenne' : 'prudente'/);
+  assert.match(webAppSource, /Aucune cascade climat pertinente prévue/);
+  assert.match(webAppSource, /Routes<\/b> · \$\{impact\.routeImpact\}/);
+  assert.match(webAppSource, /atlasClimateCascadeImpact = buildAtlasClimateCascadeImpactPreview\(shell, worldClimateLayer\)/);
+  assert.match(webAppSource, /renderAtlasClimateCascadeImpactPreview\(atlasClimateCascadeImpact\)/);
+
+  assert.match(stylesSource, /\.map-world-climate-cascade/);
+  assert.match(stylesSource, /\.map-world-climate-cascade--critical/);
+  assert.match(stylesSource, /\.map-world-climate-cascade__item--elevated/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -4671,6 +4671,93 @@ function renderAtlasClimateForecastToggles(layer) {
   `;
 }
 
+function buildAtlasClimateCascadeImpactPreview(shell, worldClimateLayer) {
+  const provinceById = new Map(shell.provinces.map((province) => [province.provinceId, province]));
+  const impactedEntries = worldClimateLayer.timeline.decisionChanges
+    .concat(worldClimateLayer.timeline.mode === 'short-alert' ? worldClimateLayer.timeline.urgentCurrentEntries : [])
+    .filter((entry, index, all) => all.findIndex((candidate) => candidate.provinceId === entry.provinceId) === index)
+    .filter((entry) => entry.disaster || entry.anomaly || entry.tone === 'watch' || entry.changedDecision);
+
+  const impacts = impactedEntries.map((entry) => {
+    const province = provinceById.get(entry.provinceId);
+    const linkedRoutes = (province?.neighborIds ?? [])
+      .map((neighborId) => provinceById.get(neighborId))
+      .filter(Boolean)
+      .slice(0, 2);
+    const intensity = entry.disaster ? 'critical' : entry.anomaly ? 'elevated' : 'watch';
+    const horizon = worldClimateLayer.timeline.mode === 'current'
+      ? 'maintenant'
+      : worldClimateLayer.timeline.mode === 'next-season'
+        ? `prochaine saison (${worldClimateLayer.timeline.targetSeason})`
+        : 'court terme';
+    const confidence = entry.disaster ? 'haute' : entry.anomaly ? 'moyenne' : 'prudente';
+
+    return {
+      provinceId: entry.provinceId,
+      provinceLabel: entry.provinceLabel,
+      intensity,
+      horizon,
+      confidence,
+      regionImpact: entry.disaster
+        ? `${entry.provinceLabel}: catastrophe susceptible de propager des coûts régionaux.`
+        : entry.anomaly
+          ? `${entry.provinceLabel}: anomalie à relire avant arbitrage régional.`
+          : `${entry.provinceLabel}: variation saisonnière utile mais non critique.`,
+      routeImpact: linkedRoutes.length > 0
+        ? linkedRoutes.map((neighbor) => `${entry.provinceLabel} → ${neighbor.label}`).join(' · ')
+        : 'Aucune route voisine exposée.',
+      reason: entry.decisionReason ?? entry.detail,
+    };
+  })
+    .sort((left, right) => ({ critical: 0, elevated: 1, watch: 2 }[left.intensity] ?? 3) - ({ critical: 0, elevated: 1, watch: 2 }[right.intensity] ?? 3)
+      || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 3);
+
+  return {
+    state: impacts.length === 0 ? 'empty' : impacts.some((impact) => impact.intensity === 'critical') ? 'critical' : 'watch',
+    impacts,
+    summary: impacts.length === 0
+      ? 'Aucune cascade climat pertinente prévue pour les routes ou régions suivies.'
+      : `${impacts.length} cascade${impacts.length > 1 ? 's' : ''} climat à surveiller sur routes/régions · horizon ${worldClimateLayer.timeline.targetSeason}.`,
+  };
+}
+
+function renderAtlasClimateCascadeImpactPreview(preview) {
+  if (state.activeOverlaySlot !== 'climate-overlay') {
+    return '';
+  }
+
+  if (preview.state === 'empty') {
+    return `
+      <section class="map-world-climate-cascade map-world-climate-cascade--empty" aria-label="Aperçu des cascades climat atlas">
+        <strong>Cascades climat atlas</strong>
+        <p>${preview.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="map-world-climate-cascade map-world-climate-cascade--${preview.state}" aria-label="Aperçu des cascades climat atlas">
+      <div class="map-world-climate-cascade__header">
+        <strong>Cascades climat atlas</strong>
+        <span>${preview.impacts.length} impact${preview.impacts.length > 1 ? 's' : ''} route/région</span>
+      </div>
+      <p>${preview.summary}</p>
+      <ol class="map-world-climate-cascade__list">
+        ${preview.impacts.map((impact) => `
+          <li class="map-world-climate-cascade__item map-world-climate-cascade__item--${impact.intensity}">
+            <b>${impact.provinceLabel}</b>
+            <span>${impact.regionImpact}</span>
+            <small><b>Routes</b> · ${impact.routeImpact}</small>
+            <small><b>Horizon</b> · ${impact.horizon} · confiance ${impact.confidence}</small>
+            <small>${impact.reason}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderWorldClimateLayerSummary(layer) {
   if (state.activeOverlaySlot !== 'climate-overlay') {
     return '';
@@ -11261,6 +11348,7 @@ function render() {
   const climateSeverityLegend = buildClimateSeverityLegend(postCommitClimateMarkers, climateMarkerDensity, shell);
   const climateFollowUpDebt = buildClimateFollowUpDebtSummary(postCommitClimateMarkers, climateSeverityLegend.mitigationSequence ?? []);
   const worldClimateLayer = buildWorldClimateLayer(shell, state.seasonIndex, state.atlasClimateForecastMode);
+  const atlasClimateCascadeImpact = buildAtlasClimateCascadeImpactPreview(shell, worldClimateLayer);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -11291,6 +11379,7 @@ function render() {
           ${renderSelectedClimateCascadeGroup(climateMarkerDensity.selectedCascadeGroup)}
           ${renderClimateFollowUpDebtSummary(climateFollowUpDebt)}
           ${renderWorldClimateLayerSummary(worldClimateLayer)}
+          ${renderAtlasClimateCascadeImpactPreview(atlasClimateCascadeImpact)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -451,6 +451,48 @@ button { font: inherit; }
   background: #7dd3fc;
   border-color: rgba(186, 230, 253, 0.74);
 }
+.map-world-climate-cascade {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.64), rgba(88, 28, 135, 0.2));
+  border: 1px solid rgba(216, 180, 254, 0.22);
+}
+.map-world-climate-cascade--critical { border-color: rgba(248, 113, 113, 0.42); }
+.map-world-climate-cascade--watch { border-color: rgba(251, 191, 36, 0.34); }
+.map-world-climate-cascade--empty { border-color: rgba(148, 163, 184, 0.22); }
+.map-world-climate-cascade__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-cascade p,
+.map-world-climate-cascade span,
+.map-world-climate-cascade small {
+  color: #e9d5ff;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-cascade__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-cascade__item {
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(216, 180, 254, 0.2);
+}
+.map-world-climate-cascade__item--critical { border-color: rgba(248, 113, 113, 0.44); }
+.map-world-climate-cascade__item--elevated { border-color: rgba(251, 191, 36, 0.34); }
+.map-world-climate-cascade__item--watch { border-color: rgba(125, 211, 252, 0.24); }
 
 .map-climate-severity-legend {
   display: grid;


### PR DESCRIPTION
Epsilon: Implements #743.

Summary:
- Adds an atlas climate cascade preview connected to the existing climate forecast timeline and toggles.
- Shows which regions and neighboring routes may be impacted next, with intensity, horizon, and confidence kept compact.
- Keeps an explicit empty state when no relevant regional/route cascade is forecast.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateCascadeImpactPreviews.test.js test/ui/climate/webAtlasClimateForecastToggles.test.js test/ui/climate/webWorldMapClimateSeasons.test.js
- npm test