### PR TITLE
Beta: compare atlas corridor interventions

### DIFF
--- a/test/ui/war/webAtlasWorldMapCanvas.test.js
+++ b/test/ui/war/webAtlasWorldMapCanvas.test.js
@@ -25,6 +25,7 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(webAppSource, /function buildAtlasEconomyStressRollups/);
   assert.match(webAppSource, /function buildAtlasSupplyCapacityForecasts/);
   assert.match(webAppSource, /function buildAtlasSupplyRouteCapacityForecast/);
+  assert.match(webAppSource, /function buildAtlasCorridorInterventionOptions/);
   assert.match(webAppSource, /function renderAtlasEconomyStressLegend/);
   assert.match(webAppSource, /atlas-world-economy-layer/);
   assert.match(webAppSource, /atlas-economy-stress-rollup/);
@@ -38,6 +39,10 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(webAppSource, /Capacité prochain tour/);
   assert.match(webAppSource, /risque surcharge prochain tour/);
   assert.match(webAppSource, /prévision incertaine/);
+  assert.match(webAppSource, /Comparer interventions/);
+  assert.match(webAppSource, /gain inconnu/);
+  assert.match(webAppSource, /pénurie évitée élevée/);
+  assert.match(webAppSource, /ex æquo/);
   assert.match(webAppSource, /atlas-logistics-route--forecast-\$\{forecast\?\.tone \?\? 'unknown'\}/);
   assert.match(webAppSource, /getRouteStressSummary\(route, tensionByCityId, cityNameById\)/);
   assert.match(stylesSource, /\.atlas-world-canvas/);
@@ -51,6 +56,8 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(stylesSource, /\.atlas-supply-forecast--overload/);
   assert.match(stylesSource, /\.atlas-supply-forecast__title/);
   assert.match(stylesSource, /\.atlas-logistics-route--forecast-uncertain/);
+  assert.match(stylesSource, /\.atlas-corridor-intervention--overload/);
+  assert.match(stylesSource, /\.atlas-corridor-intervention__rank/);
   assert.match(stylesSource, /\.atlas-logistics-route--major/);
   assert.match(stylesSource, /\.atlas-economy-city--high/);
   assert.match(stylesSource, /\.atlas-economy-city__resources/);

--- a/web/app.js
+++ b/web/app.js
@@ -1016,6 +1016,9 @@ function buildAtlasSupplyRouteCapacityForecast(route, stress, tensionByCityId) {
     delta,
     tone,
     uncertain,
+    highHubs,
+    mediumHubs,
+    resourceLoad,
     label: uncertain
       ? `${route.routeName}: prévision incertaine`
       : `${route.routeName}: ${currentCapacity}→${projectedCapacity}`,
@@ -1085,6 +1088,66 @@ function buildAtlasSupplyCapacityForecasts(economyView) {
   };
 }
 
+function buildAtlasCorridorInterventionOptions(supplyForecasts) {
+  const options = supplyForecasts.routes.map((forecast) => {
+    const expectedGain = forecast.uncertain
+      ? null
+      : forecast.tone === 'overload'
+        ? Math.max(2, Math.abs(forecast.delta) + 1)
+        : forecast.tone === 'watch'
+          ? 1
+          : forecast.tone === 'recovery'
+            ? 0
+            : null;
+    const riskAvoided = forecast.uncertain
+      ? 'risque à qualifier'
+      : forecast.tone === 'overload'
+        ? 'pénurie évitée élevée'
+        : forecast.tone === 'watch'
+          ? 'pénurie évitée moyenne'
+          : 'risque déjà contenu';
+    const constraint = forecast.uncertain
+      ? 'données de flux incomplètes'
+      : forecast.highHubs > 0
+        ? `${forecast.highHubs} hub${forecast.highHubs > 1 ? 's' : ''} critique${forecast.highHubs > 1 ? 's' : ''}`
+        : forecast.resourceLoad >= 8
+          ? 'charge ressource élevée'
+          : forecast.mediumHubs > 0
+            ? 'hub sous tension modérée'
+            : 'contrainte faible';
+    const score = forecast.uncertain
+      ? 0
+      : (expectedGain * 10)
+        + (forecast.tone === 'overload' ? 12 : forecast.tone === 'watch' ? 6 : 1)
+        + Math.min(6, forecast.resourceLoad);
+
+    return {
+      optionId: `atlas-intervention:${forecast.routeId}`,
+      routeName: forecast.routeName,
+      corridor: forecast.corridor,
+      tone: forecast.uncertain ? 'unknown' : forecast.tone,
+      expectedGain,
+      gainLabel: forecast.uncertain ? 'gain inconnu' : `+${expectedGain} capacité attendue`,
+      riskAvoided,
+      constraint,
+      score,
+      unknown: forecast.uncertain,
+    };
+  })
+    .sort((left, right) => right.score - left.score || left.routeName.localeCompare(right.routeName))
+    .slice(0, 3);
+
+  return options.map((option, index, entries) => ({
+    ...option,
+    rankLabel: option.unknown
+      ? '?'
+      : index > 0 && option.score === entries[index - 1].score
+        ? `≈${index}`
+        : `${index + 1}`,
+    tieLabel: index > 0 && option.score === entries[index - 1].score ? 'ex æquo' : '',
+  }));
+}
+
 function buildAtlasEconomyStressRollups(economyView) {
   if (!economyView) {
     return { legend: [], regions: [] };
@@ -1094,6 +1157,7 @@ function buildAtlasEconomyStressRollups(economyView) {
   const cityNameById = Object.fromEntries(economyView.overlay.cities.map((city) => [city.cityId, city.cityName]));
   const corridorMap = new Map();
   const supplyForecasts = buildAtlasSupplyCapacityForecasts(economyView);
+  const interventionOptions = buildAtlasCorridorInterventionOptions(supplyForecasts);
   const toneRank = { critical: 3, strained: 2, healthy: 1 };
 
   for (const route of economyView.overlay.routes) {
@@ -1187,6 +1251,7 @@ function buildAtlasEconomyStressRollups(economyView) {
     ],
     regions,
     forecasts: supplyForecasts.routes,
+    interventions: interventionOptions,
   };
 }
 
@@ -1199,7 +1264,7 @@ function renderAtlasEconomyStressLegend(economyView) {
 
   return `
     <g class="atlas-economy-stress-rollup" aria-label="Légende économie atlas: stress logistique et régions économiques">
-      <rect class="atlas-economy-stress-rollup__panel" x="3" y="4" width="35" height="${20 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4)}" rx="2.4"></rect>
+      <rect class="atlas-economy-stress-rollup__panel" x="3" y="4" width="35" height="${24 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}" rx="2.4"></rect>
       <text class="atlas-economy-stress-rollup__title" x="5" y="8.3">Stress économie</text>
       ${rollup.legend.map((entry, index) => `
         <g class="atlas-economy-stress-legend atlas-economy-stress-legend--${entry.tone}">
@@ -1227,6 +1292,18 @@ function renderAtlasEconomyStressLegend(economyView) {
             <rect x="5" y="${y - 2.8}" width="30.5" height="4.7" rx="1.2"></rect>
             <text class="atlas-supply-forecast__route" x="6.2" y="${y - 0.6}">${forecast.label} · ${forecast.status}</text>
             <text class="atlas-supply-forecast__action" x="6.2" y="${y + 1.2}">${forecast.action}</text>
+          </g>
+        `;
+      }).join('')}
+      <text class="atlas-corridor-intervention__title" x="5" y="${26 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4)}">Comparer interventions</text>
+      ${rollup.interventions.map((option, index) => {
+        const y = 30 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (index * 6.2);
+        return `
+          <g class="atlas-corridor-intervention atlas-corridor-intervention--${option.tone}" aria-label="Intervention ${option.routeName}: ${option.gainLabel}, ${option.riskAvoided}, contrainte ${option.constraint}">
+            <rect x="5" y="${y - 3.1}" width="30.5" height="5.5" rx="1.2"></rect>
+            <text class="atlas-corridor-intervention__rank" x="6.2" y="${y - 0.8}">${option.rankLabel}</text>
+            <text class="atlas-corridor-intervention__route" x="8.2" y="${y - 0.8}">${option.corridor} · ${option.routeName}${option.tieLabel ? ` · ${option.tieLabel}` : ''}</text>
+            <text class="atlas-corridor-intervention__detail" x="6.2" y="${y + 1.2}">${option.gainLabel} · ${option.riskAvoided} · ${option.constraint}</text>
           </g>
         `;
       }).join('')}

--- a/web/styles.css
+++ b/web/styles.css
@@ -10292,3 +10292,33 @@ button { font: inherit; }
 .atlas-economy-region-rollup__forecast--recovery { fill: #a5f3fc; }
 .atlas-economy-region-rollup__forecast--watch { fill: #fde68a; }
 .atlas-economy-region-rollup__forecast--uncertain { fill: #ddd6fe; }
+.atlas-corridor-intervention__title {
+  fill: #f8fafc;
+  font-size: 1.65px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+}
+.atlas-corridor-intervention rect {
+  fill: rgba(15, 23, 42, 0.62);
+  stroke: rgba(148, 163, 184, 0.24);
+  stroke-width: 0.24;
+}
+.atlas-corridor-intervention--overload rect { stroke: rgba(251, 113, 133, 0.78); fill: rgba(127, 29, 29, 0.4); }
+.atlas-corridor-intervention--watch rect { stroke: rgba(251, 191, 36, 0.62); fill: rgba(120, 53, 15, 0.32); }
+.atlas-corridor-intervention--recovery rect { stroke: rgba(103, 232, 249, 0.48); fill: rgba(14, 116, 144, 0.26); }
+.atlas-corridor-intervention--unknown rect { stroke: rgba(196, 181, 253, 0.68); fill: rgba(76, 29, 149, 0.3); }
+.atlas-corridor-intervention__rank {
+  fill: #f8fafc;
+  font-size: 1.25px;
+  font-weight: 950;
+}
+.atlas-corridor-intervention__route {
+  fill: #e0f2fe;
+  font-size: 1.12px;
+  font-weight: 900;
+}
+.atlas-corridor-intervention__detail {
+  fill: #cbd5e1;
+  font-size: 1px;
+  font-weight: 760;
+}


### PR DESCRIPTION
Beta: Implements #750.

## Summary
- Adds a compact atlas comparison for logistics corridor interventions.
- Ranks options by expected capacity gain, shortage risk avoided, and visible constraint.
- Reuses the existing atlas supply forecast/stress data instead of adding a new logistics model.
- Keeps unknown and tied intervention states explicit with `?` and `ex æquo` labels.

## Validation
- npm test (513 OK)
- targeted atlas world map tests (2 OK)
- node --check web/app.js
- git diff --check
