### PR TITLE
Epsilon: show atlas climate mitigation synergies

### DIFF
--- a/test/ui/climate/webAtlasClimateMitigationSynergies.test.js
+++ b/test/ui/climate/webAtlasClimateMitigationSynergies.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas climate mitigation synergies reuse cascade previews for compact multi-effect badges', () => {
+  assert.match(webAppSource, /function buildAtlasClimateMitigationSynergies/);
+  assert.match(webAppSource, /function renderAtlasClimateMitigationSynergies/);
+  assert.match(webAppSource, /cascadePreview\.impacts/);
+  assert.match(webAppSource, /buildProvinceClimateRiskReductionForecast\(province, shell\)/);
+  assert.match(webAppSource, /buildClimateInterventionQueuePlan\(province, forecast\)/);
+  assert.match(webAppSource, /cascade évitée/);
+  assert.match(webAppSource, /route protégée/);
+  assert.match(webAppSource, /saison critique/);
+  assert.match(webAppSource, /région prioritaire/);
+  assert.match(webAppSource, /aucun bruit visuel ajouté/);
+  assert.match(webAppSource, /atlasClimateMitigationSynergies = buildAtlasClimateMitigationSynergies\(shell, atlasClimateCascadeImpact, worldClimateLayer\)/);
+  assert.match(webAppSource, /renderAtlasClimateMitigationSynergies\(atlasClimateMitigationSynergies\)/);
+  assert.match(webAppSource, /map-world-climate-synergy__badges/);
+
+  assert.match(stylesSource, /\.map-world-climate-synergy/);
+  assert.match(stylesSource, /\.map-world-climate-synergy--priority/);
+  assert.match(stylesSource, /\.map-world-climate-synergy__badges/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -4894,6 +4894,106 @@ function buildAtlasClimateCascadeImpactPreview(shell, worldClimateLayer) {
   };
 }
 
+function buildAtlasClimateMitigationSynergies(shell, cascadePreview, worldClimateLayer) {
+  if (!shell || !cascadePreview || cascadePreview.impacts.length === 0) {
+    return {
+      state: 'empty',
+      synergies: [],
+      summary: 'Aucune synergie climat notable à afficher sur l’atlas.',
+    };
+  }
+
+  const provinceById = new Map(shell.provinces.map((province) => [province.provinceId, province]));
+  const timelineByProvinceId = new Map(worldClimateLayer.timeline.entries.map((entry) => [entry.provinceId, entry]));
+  const synergies = cascadePreview.impacts
+    .map((impact) => {
+      const province = provinceById.get(impact.provinceId);
+      if (!province) {
+        return null;
+      }
+
+      const forecast = buildProvinceClimateRiskReductionForecast(province, shell);
+      const plan = buildClimateInterventionQueuePlan(province, forecast);
+      const timelineEntry = timelineByProvinceId.get(impact.provinceId);
+      const linkedRegions = province.neighborIds
+        .map((provinceId) => provinceById.get(provinceId)?.label)
+        .filter(Boolean)
+        .slice(0, 2);
+      const avoidedCascade = forecast.selectedInterventionPreview.avoidedCascade;
+      const badges = [
+        avoidedCascade ? 'cascade évitée' : null,
+        impact.routeImpact !== 'Aucune route voisine exposée.' ? 'route protégée' : null,
+        timelineEntry?.season ? `saison critique: ${timelineEntry.season}` : null,
+        impact.intensity === 'critical' ? 'région prioritaire' : null,
+      ].filter(Boolean);
+
+      return {
+        provinceId: province.provinceId,
+        provinceLabel: province.label,
+        action: plan.actionLabel,
+        disabled: plan.disabled,
+        intensity: impact.intensity,
+        badges: badges.slice(0, 4),
+        protectedRegions: linkedRegions.length > 0 ? linkedRegions.join(' · ') : province.label,
+        routeImpact: impact.routeImpact,
+        avoidedCascade,
+        season: timelineEntry?.season ?? worldClimateLayer.timeline.targetSeason,
+        summary: `${plan.actionLabel}: protège ${linkedRegions.length > 0 ? linkedRegions.join(' / ') : province.label} et réduit ${avoidedCascade}.`,
+      };
+    })
+    .filter(Boolean)
+    .filter((entry) => entry.badges.length > 1 || entry.intensity === 'critical')
+    .sort((left, right) => ({ critical: 0, elevated: 1, watch: 2 }[left.intensity] ?? 3) - ({ critical: 0, elevated: 1, watch: 2 }[right.intensity] ?? 3)
+      || Number(left.disabled) - Number(right.disabled)
+      || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 3);
+
+  return {
+    state: synergies.length === 0 ? 'quiet' : synergies.some((entry) => entry.intensity === 'critical') ? 'priority' : 'ready',
+    synergies,
+    summary: synergies.length === 0
+      ? 'Les cascades prévues n’ont pas encore de synergie de mitigation assez nette; aucun bruit visuel ajouté.'
+      : `${synergies.length} synergie${synergies.length > 1 ? 's' : ''} climat relie${synergies.length > 1 ? 'nt' : ''} interventions, régions protégées et cascades évitées.`,
+  };
+}
+
+function renderAtlasClimateMitigationSynergies(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  if (view.state === 'quiet') {
+    return `
+      <section class="map-world-climate-synergy map-world-climate-synergy--quiet" aria-label="Synergies de mitigation climat atlas">
+        <strong>Synergies climat</strong>
+        <p>${view.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="map-world-climate-synergy map-world-climate-synergy--${view.state}" aria-label="Synergies de mitigation climat atlas">
+      <div class="map-world-climate-synergy__header">
+        <strong>Synergies climat</strong>
+        <span>${view.synergies.length} mitigation${view.synergies.length > 1 ? 's' : ''} multi-effet</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-synergy__list">
+        ${view.synergies.map((entry) => `
+          <li class="map-world-climate-synergy__item map-world-climate-synergy__item--${entry.intensity}">
+            <b>${entry.provinceLabel}</b>
+            <span>${entry.summary}</span>
+            <div class="map-world-climate-synergy__badges">
+              ${entry.badges.map((badge) => `<small>${badge}</small>`).join('')}
+            </div>
+            <small><b>Routes/régions</b> · ${entry.routeImpact} · régions protégées: ${entry.protectedRegions}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateCascadeImpactPreview(preview) {
   if (state.activeOverlaySlot !== 'climate-overlay') {
     return '';
@@ -11619,6 +11719,7 @@ function render() {
   const climateFollowUpDebt = buildClimateFollowUpDebtSummary(postCommitClimateMarkers, climateSeverityLegend.mitigationSequence ?? []);
   const worldClimateLayer = buildWorldClimateLayer(shell, state.seasonIndex, state.atlasClimateForecastMode);
   const atlasClimateCascadeImpact = buildAtlasClimateCascadeImpactPreview(shell, worldClimateLayer);
+  const atlasClimateMitigationSynergies = buildAtlasClimateMitigationSynergies(shell, atlasClimateCascadeImpact, worldClimateLayer);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -11650,6 +11751,7 @@ function render() {
           ${renderClimateFollowUpDebtSummary(climateFollowUpDebt)}
           ${renderWorldClimateLayerSummary(worldClimateLayer)}
           ${renderAtlasClimateCascadeImpactPreview(atlasClimateCascadeImpact)}
+          ${renderAtlasClimateMitigationSynergies(atlasClimateMitigationSynergies)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -493,6 +493,58 @@ button { font: inherit; }
 .map-world-climate-cascade__item--critical { border-color: rgba(248, 113, 113, 0.44); }
 .map-world-climate-cascade__item--elevated { border-color: rgba(251, 191, 36, 0.34); }
 .map-world-climate-cascade__item--watch { border-color: rgba(125, 211, 252, 0.24); }
+.map-world-climate-synergy {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.64), rgba(6, 78, 59, 0.22));
+  border: 1px solid rgba(110, 231, 183, 0.24);
+}
+.map-world-climate-synergy--priority { border-color: rgba(74, 222, 128, 0.44); }
+.map-world-climate-synergy--quiet { border-color: rgba(148, 163, 184, 0.2); }
+.map-world-climate-synergy__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-synergy p,
+.map-world-climate-synergy span,
+.map-world-climate-synergy small {
+  color: #d1fae5;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-synergy__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-synergy__item {
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(110, 231, 183, 0.22);
+}
+.map-world-climate-synergy__item--critical { border-color: rgba(74, 222, 128, 0.48); }
+.map-world-climate-synergy__item--elevated { border-color: rgba(251, 191, 36, 0.34); }
+.map-world-climate-synergy__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin: 5px 0;
+}
+.map-world-climate-synergy__badges small {
+  padding: 3px 7px;
+  border-radius: 999px;
+  color: #052e16;
+  background: #86efac;
+}
 
 .map-climate-severity-legend {
   display: grid;


### PR DESCRIPTION
Epsilon: Implements #753.

Summary:
- Adds an atlas climate mitigation synergy view that reuses cascade impact previews instead of introducing a separate model.
- Links existing climate interventions to protected regions/routes, affected seasons, and avoided cascades.
- Keeps synergy badges compact (`cascade évitée`, `route protégée`, `saison critique`, `région prioritaire`) and stays quiet when no notable synergy exists.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateMitigationSynergies.test.js test/ui/climate/webAtlasClimateCascadeImpactPreviews.test.js test/ui/climate/webAtlasClimateForecastToggles.test.js
- npm test