### PR TITLE
Gamma: summarize atlas cultural borders

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -19,6 +19,9 @@ test('world map atlas renders culture influence zones from existing culture over
   assert.match(webAppSource, /function buildAtlasCultureDrift/);
   assert.match(webAppSource, /driftPreviews/);
   assert.match(webAppSource, /atlas-culture-drift--\$\{summary\.drift\.state\}/);
+  assert.match(webAppSource, /borderZones/);
+  assert.match(webAppSource, /atlas-cultural-border-zones/);
+  assert.match(webAppSource, /Frontières instables/);
 });
 
 test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
@@ -32,6 +35,9 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /atlas-discovery-site__link/);
   assert.match(webAppSource, /linkedToFocus/);
   assert.match(webAppSource, /summary\.drift\.causes\.join/);
+  assert.match(webAppSource, /mainDriver === 'migration'/);
+  assert.match(webAppSource, /protéger découverte/);
+  assert.match(webAppSource, /arbitrer influence/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -41,4 +47,6 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-culture-summary__drift/);
   assert.match(stylesSource, /\.atlas-culture-drift--migre/);
   assert.match(stylesSource, /\.atlas-culture-drift\.is-linked-focus path/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zones/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone--migre/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -971,6 +971,37 @@ function buildAtlasCultureFeatures(cultureView) {
   const driftPreviews = regionSummaries
     .filter((summary) => summary.drift.state !== 'stable' || summary.selected || summary.drift.linkedToFocus)
     .slice(0, 5);
+  const borderZones = regionSummaries
+    .filter((summary) => summary.drift.state !== 'stable' || summary.influenceLabel.includes('contestée'))
+    .map((summary) => {
+      const mainDriver = summary.drift.state === 'migre'
+        ? 'migration'
+        : summary.influenceLabel.includes('contestée')
+          ? 'influence voisine'
+          : summary.drift.causes.includes('repère actif')
+            ? 'événement'
+            : summary.drift.causes.some((cause) => cause.includes('découverte'))
+              ? 'découverte'
+              : 'pression politique';
+      const stabilization = mainDriver === 'découverte'
+        ? 'protéger découverte'
+        : mainDriver === 'événement'
+          ? 'suivre repère'
+          : mainDriver === 'migration'
+            ? 'stabiliser passage'
+            : mainDriver === 'influence voisine'
+              ? 'arbitrer influence'
+              : 'surveiller loyautés';
+
+      return {
+        ...summary,
+        borderId: `atlas-culture-border:${summary.regionId}`,
+        mainDriver,
+        stabilization,
+        chips: [mainDriver, summary.drift.label, stabilization].slice(0, 3),
+      };
+    })
+    .slice(0, 4);
 
   return {
     influenceZones,
@@ -979,6 +1010,7 @@ function buildAtlasCultureFeatures(cultureView) {
     focusedDiscovery: discoverySites.find((site) => site.focused) ?? null,
     regionSummaries,
     driftPreviews,
+    borderZones,
   };
 }
 
@@ -1008,6 +1040,18 @@ function renderAtlasCultureLayer(cultureView) {
           <text x="${summary.center.x + 4.2}%" y="${summary.center.y + 4.3}%">${summary.drift.causes.join(' · ')}</text>
         </g>
       `).join('')}
+      ${features.borderZones.length > 0 ? `
+        <g class="atlas-cultural-border-zones" aria-label="Synthèse des frontières culturelles instables">
+          <rect x="3" y="58" width="25" height="${7 + (features.borderZones.length * 5.2)}" rx="1.8"></rect>
+          <text class="atlas-cultural-border-zones__title" x="5" y="61.4">Frontières instables</text>
+          ${features.borderZones.map((zone, index) => `
+            <g class="atlas-cultural-border-zone atlas-cultural-border-zone--${zone.drift.state}" data-atlas-cultural-border="${zone.regionId}" aria-label="Frontière culturelle ${zone.cultureName}: moteur ${zone.mainDriver}, piste ${zone.stabilization}">
+              <text x="5" y="${65 + index * 5.2}">${zone.cultureName}</text>
+              <text class="atlas-cultural-border-zone__chips" x="5" y="${67 + index * 5.2}">${zone.chips.join(' · ')}</text>
+            </g>
+          `).join('')}
+        </g>
+      ` : ''}
       ${features.cultureMarkers.map((marker) => `
         <g class="atlas-culture-marker atlas-culture-marker--${marker.tone}" data-atlas-culture-region="${marker.regionId}">
           <circle cx="${marker.center.x}%" cy="${marker.center.y}%" r="${marker.influenceTier === 'dominant' ? 2.35 : 1.85}"></circle>

--- a/web/styles.css
+++ b/web/styles.css
@@ -10412,3 +10412,28 @@ button { font: inherit; }
   font-size: 1px;
   font-weight: 760;
 }
+.atlas-cultural-border-zones rect {
+  fill: rgba(2, 6, 23, 0.72);
+  stroke: rgba(251, 191, 36, 0.32);
+  stroke-width: 0.32;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.46));
+}
+.atlas-cultural-border-zones__title {
+  fill: #fde68a;
+  font-size: 1.55px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+}
+.atlas-cultural-border-zone text {
+  fill: #f8fafc;
+  font-size: 1.28px;
+  font-weight: 900;
+}
+.atlas-cultural-border-zone__chips {
+  fill: #cbd5e1;
+  font-size: 1.04px;
+  font-weight: 800;
+}
+.atlas-cultural-border-zone--migre .atlas-cultural-border-zone__chips { fill: #fde68a; }
+.atlas-cultural-border-zone--recule .atlas-cultural-border-zone__chips { fill: #fecdd3; }
+.atlas-cultural-border-zone--monte .atlas-cultural-border-zone__chips { fill: #bbf7d0; }


### PR DESCRIPTION
Gamma: Implements #751.

## Summary
- add a compact atlas summary for unstable cultural border zones
- derive each border driver from existing drift/overlap/discovery/event signals
- surface short stabilization pistes such as protecting discoveries, following events, stabilizing passages, or arbitrating influence

## Validation
- node --check web/app.js
- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/war/webAtlasWorldMapCanvas.test.js
- git diff --check
- npm test (517 OK)