### PR TITLE
Beta: add atlas corridor action budgeting

### DIFF
--- a/test/ui/war/webAtlasWorldMapCanvas.test.js
+++ b/test/ui/war/webAtlasWorldMapCanvas.test.js
@@ -26,6 +26,7 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(webAppSource, /function buildAtlasSupplyCapacityForecasts/);
   assert.match(webAppSource, /function buildAtlasSupplyRouteCapacityForecast/);
   assert.match(webAppSource, /function buildAtlasCorridorInterventionOptions/);
+  assert.match(webAppSource, /function buildAtlasCorridorActionBudget/);
   assert.match(webAppSource, /function renderAtlasEconomyStressLegend/);
   assert.match(webAppSource, /atlas-world-economy-layer/);
   assert.match(webAppSource, /atlas-economy-stress-rollup/);
@@ -43,6 +44,12 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(webAppSource, /gain inconnu/);
   assert.match(webAppSource, /pénurie évitée élevée/);
   assert.match(webAppSource, /ex æquo/);
+  assert.match(webAppSource, /Budget corridor/);
+  assert.match(webAppSource, /Retenir:/);
+  assert.match(webAppSource, /Reporter:/);
+  assert.match(webAppSource, /Compromis:/);
+  assert.match(webAppSource, /aucune intervention sûre/);
+  assert.match(webAppSource, /coût inconnu/);
   assert.match(webAppSource, /atlas-logistics-route--forecast-\$\{forecast\?\.tone \?\? 'unknown'\}/);
   assert.match(webAppSource, /getRouteStressSummary\(route, tensionByCityId, cityNameById\)/);
   assert.match(stylesSource, /\.atlas-world-canvas/);
@@ -58,6 +65,8 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(stylesSource, /\.atlas-logistics-route--forecast-uncertain/);
   assert.match(stylesSource, /\.atlas-corridor-intervention--overload/);
   assert.match(stylesSource, /\.atlas-corridor-intervention__rank/);
+  assert.match(stylesSource, /\.atlas-corridor-budget/);
+  assert.match(stylesSource, /\.atlas-corridor-budget__tradeoff/);
   assert.match(stylesSource, /\.atlas-logistics-route--major/);
   assert.match(stylesSource, /\.atlas-economy-city--high/);
   assert.match(stylesSource, /\.atlas-economy-city__resources/);

--- a/web/app.js
+++ b/web/app.js
@@ -1295,6 +1295,60 @@ function buildAtlasCorridorInterventionOptions(supplyForecasts) {
   }));
 }
 
+function buildAtlasCorridorActionBudget(interventions, actionCapacity = 3) {
+  const selected = [];
+  const deferred = [];
+  let remaining = actionCapacity;
+
+  for (const option of interventions) {
+    const actionCost = option.unknown
+      ? null
+      : option.tone === 'overload' && option.constraint.includes('critique')
+        ? 2
+        : 1;
+    const budgetedOption = {
+      ...option,
+      actionCost,
+      budgetLabel: actionCost === null ? 'coût inconnu' : `${actionCost} action${actionCost > 1 ? 's' : ''}`,
+    };
+
+    if (actionCost !== null && actionCost <= remaining && option.expectedGain > 0) {
+      selected.push(budgetedOption);
+      remaining -= actionCost;
+    } else {
+      deferred.push(budgetedOption);
+    }
+  }
+
+  const selectedGain = selected.reduce((total, option) => total + (option.expectedGain ?? 0), 0);
+  const deferredRisk = deferred.find((option) => option.tone === 'overload')
+    ?? deferred.find((option) => option.unknown)
+    ?? deferred[0]
+    ?? null;
+  const selectedLabel = selected.length > 0
+    ? selected.map((option) => option.routeName).join(' + ')
+    : 'aucune intervention sûre';
+  const deferredLabel = deferred.length > 0
+    ? deferred.slice(0, 2).map((option) => option.routeName).join(' + ')
+    : 'aucun report';
+  const tradeoff = deferredRisk
+    ? `Reporter ${deferredRisk.routeName}: ${deferredRisk.riskAvoided}`
+    : 'Budget couvre les options lisibles';
+
+  return {
+    capacity: actionCapacity,
+    used: actionCapacity - remaining,
+    remaining,
+    selected,
+    deferred,
+    selectedGain,
+    selectedLabel,
+    deferredLabel,
+    tradeoff,
+    empty: interventions.length === 0,
+  };
+}
+
 function buildAtlasEconomyStressRollups(economyView) {
   if (!economyView) {
     return { legend: [], regions: [] };
@@ -1305,6 +1359,7 @@ function buildAtlasEconomyStressRollups(economyView) {
   const corridorMap = new Map();
   const supplyForecasts = buildAtlasSupplyCapacityForecasts(economyView);
   const interventionOptions = buildAtlasCorridorInterventionOptions(supplyForecasts);
+  const actionBudget = buildAtlasCorridorActionBudget(interventionOptions);
   const toneRank = { critical: 3, strained: 2, healthy: 1 };
 
   for (const route of economyView.overlay.routes) {
@@ -1399,6 +1454,7 @@ function buildAtlasEconomyStressRollups(economyView) {
     regions,
     forecasts: supplyForecasts.routes,
     interventions: interventionOptions,
+    actionBudget,
   };
 }
 
@@ -1411,7 +1467,7 @@ function renderAtlasEconomyStressLegend(economyView) {
 
   return `
     <g class="atlas-economy-stress-rollup" aria-label="Légende économie atlas: stress logistique et régions économiques">
-      <rect class="atlas-economy-stress-rollup__panel" x="3" y="4" width="35" height="${24 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}" rx="2.4"></rect>
+      <rect class="atlas-economy-stress-rollup__panel" x="3" y="4" width="35" height="${34 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}" rx="2.4"></rect>
       <text class="atlas-economy-stress-rollup__title" x="5" y="8.3">Stress économie</text>
       ${rollup.legend.map((entry, index) => `
         <g class="atlas-economy-stress-legend atlas-economy-stress-legend--${entry.tone}">
@@ -1454,6 +1510,13 @@ function renderAtlasEconomyStressLegend(economyView) {
           </g>
         `;
       }).join('')}
+      <g class="atlas-corridor-budget ${rollup.actionBudget.empty ? 'is-empty' : ''}" aria-label="Budget de corridor: ${rollup.actionBudget.used}/${rollup.actionBudget.capacity} actions, sélection ${rollup.actionBudget.selectedLabel}, reports ${rollup.actionBudget.deferredLabel}">
+        <rect x="5" y="${31.8 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}" width="30.5" height="8.6" rx="1.4"></rect>
+        <text class="atlas-corridor-budget__title" x="6.2" y="${34.2 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}">Budget corridor ${rollup.actionBudget.used}/${rollup.actionBudget.capacity}</text>
+        <text class="atlas-corridor-budget__selected" x="6.2" y="${36.4 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}">Retenir: ${rollup.actionBudget.selectedLabel} · gain +${rollup.actionBudget.selectedGain}</text>
+        <text class="atlas-corridor-budget__deferred" x="6.2" y="${38.4 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}">Reporter: ${rollup.actionBudget.deferredLabel}</text>
+        <text class="atlas-corridor-budget__tradeoff" x="6.2" y="${40.2 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}">Compromis: ${rollup.actionBudget.tradeoff}</text>
+      </g>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -10455,3 +10455,32 @@ button { font: inherit; }
 .atlas-cultural-border-zone--migre .atlas-cultural-border-zone__chips { fill: #fde68a; }
 .atlas-cultural-border-zone--recule .atlas-cultural-border-zone__chips { fill: #fecdd3; }
 .atlas-cultural-border-zone--monte .atlas-cultural-border-zone__chips { fill: #bbf7d0; }
+.atlas-corridor-budget rect {
+  fill: rgba(8, 47, 73, 0.54);
+  stroke: rgba(125, 211, 252, 0.42);
+  stroke-width: 0.28;
+}
+.atlas-corridor-budget.is-empty rect {
+  fill: rgba(15, 23, 42, 0.46);
+  stroke: rgba(148, 163, 184, 0.26);
+}
+.atlas-corridor-budget__title {
+  fill: #f8fafc;
+  font-size: 1.28px;
+  font-weight: 950;
+}
+.atlas-corridor-budget__selected {
+  fill: #bbf7d0;
+  font-size: 1.02px;
+  font-weight: 820;
+}
+.atlas-corridor-budget__deferred {
+  fill: #fed7aa;
+  font-size: 1px;
+  font-weight: 780;
+}
+.atlas-corridor-budget__tradeoff {
+  fill: #ddd6fe;
+  font-size: 0.98px;
+  font-weight: 780;
+}


### PR DESCRIPTION
Beta: Implements #760.

## Summary
- Adds a compact atlas corridor action budget derived from existing intervention comparisons.
- Shows which logistics interventions fit into a limited action capacity, which are deferred, and the main trade-off.
- Reuses existing capacity gain, shortage-risk, constraint, tie, and unknown-state signals without adding a new economy simulator.
- Keeps empty/unknown selections quiet and explicit.

## Validation
- npm test (518 OK)
- targeted atlas world map tests (2 OK)
- node --check web/app.js
- git diff --check
