### PR TITLE
Epsilon: preview atlas seasonal mitigation windows

### DIFF
--- a/test/ui/climate/webAtlasSeasonalMitigationWindows.test.js
+++ b/test/ui/climate/webAtlasSeasonalMitigationWindows.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas climate mitigation synergies expose compact seasonal windows', () => {
+  assert.match(webAppSource, /function buildAtlasSeasonalMitigationWindows/);
+  assert.match(webAppSource, /function renderAtlasSeasonalMitigationWindows/);
+  assert.match(webAppSource, /synergyView\.synergies/);
+  assert.match(webAppSource, /worldClimateLayer\.timeline\.entries/);
+  assert.match(webAppSource, /criticalSeason = synergy\.season/);
+  assert.match(webAppSource, /deferredConsequence = synergy\.intensity === 'critical'/);
+  assert.match(webAppSource, /Impact évité/);
+  assert.match(webAppSource, /Si reportée/);
+  assert.match(webAppSource, /Aucune fenêtre saisonnière critique/);
+  assert.match(webAppSource, /aucune saison critique nette/);
+  assert.match(webAppSource, /atlasSeasonalMitigationWindows = buildAtlasSeasonalMitigationWindows\(atlasClimateMitigationSynergies, worldClimateLayer\)/);
+  assert.match(webAppSource, /renderAtlasSeasonalMitigationWindows\(atlasSeasonalMitigationWindows\)/);
+
+  assert.match(stylesSource, /\.map-world-climate-window/);
+  assert.match(stylesSource, /\.map-world-climate-window--urgent/);
+  assert.match(stylesSource, /\.map-world-climate-window__badges/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -5339,6 +5339,89 @@ function buildAtlasClimateMitigationSynergies(shell, cascadePreview, worldClimat
   };
 }
 
+function buildAtlasSeasonalMitigationWindows(synergyView, worldClimateLayer) {
+  if (!synergyView || synergyView.synergies.length === 0) {
+    return {
+      state: 'empty',
+      windows: [],
+      summary: 'Aucune fenêtre saisonnière critique: pas de synergie notable à prioriser.',
+    };
+  }
+
+  const timelineByProvinceId = new Map(worldClimateLayer.timeline.entries.map((entry) => [entry.provinceId, entry]));
+  const windows = synergyView.synergies
+    .map((synergy) => {
+      const timelineEntry = timelineByProvinceId.get(synergy.provinceId);
+      const criticalSeason = synergy.season ?? timelineEntry?.season ?? worldClimateLayer.timeline.targetSeason;
+      const urgencyRank = synergy.intensity === 'critical' ? 0 : synergy.intensity === 'elevated' ? 1 : 2;
+      const deferredConsequence = synergy.intensity === 'critical'
+        ? `Report: ${synergy.routeImpact} peut subir la cascade suivante avant ${criticalSeason}.`
+        : synergy.intensity === 'elevated'
+          ? `Report: l’anomalie de ${criticalSeason} réduit la marge de mitigation sur ${synergy.protectedRegions}.`
+          : `Report: fenêtre utile mais non critique; relire au prochain toggle saison.`;
+
+      return {
+        provinceId: synergy.provinceId,
+        provinceLabel: synergy.provinceLabel,
+        action: synergy.action,
+        intensity: synergy.intensity,
+        urgencyRank,
+        criticalSeason,
+        avoidedImpact: synergy.avoidedCascade,
+        protectedRegions: synergy.protectedRegions,
+        deferredConsequence,
+        badges: ['fenêtre saisonnière', ...synergy.badges].slice(0, 4),
+      };
+    })
+    .filter((entry) => entry.criticalSeason && entry.avoidedImpact)
+    .sort((left, right) => left.urgencyRank - right.urgencyRank || left.criticalSeason.localeCompare(right.criticalSeason) || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 3);
+
+  return {
+    state: windows.length === 0 ? 'quiet' : windows.some((window) => window.intensity === 'critical') ? 'urgent' : 'ready',
+    windows,
+    summary: windows.length === 0
+      ? 'Les synergies existent mais aucune saison critique nette ne justifie un panneau supplémentaire.'
+      : `${windows.length} fenêtre${windows.length > 1 ? 's' : ''} saisonnière${windows.length > 1 ? 's' : ''} lie${windows.length > 1 ? 'nt' : ''} mitigation, impact évité et conséquence du report.`,
+  };
+}
+
+function renderAtlasSeasonalMitigationWindows(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  if (view.state === 'quiet') {
+    return `
+      <section class="map-world-climate-window map-world-climate-window--quiet" aria-label="Fenêtres saisonnières de mitigation climat atlas">
+        <strong>Fenêtres saisonnières</strong>
+        <p>${view.summary}</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="map-world-climate-window map-world-climate-window--${view.state}" aria-label="Fenêtres saisonnières de mitigation climat atlas">
+      <div class="map-world-climate-window__header">
+        <strong>Fenêtres saisonnières</strong>
+        <span>${view.windows.length} priorité${view.windows.length > 1 ? 's' : ''} climat</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-window__list">
+        ${view.windows.map((window) => `
+          <li class="map-world-climate-window__item map-world-climate-window__item--${window.intensity}">
+            <b>${window.provinceLabel}</b>
+            <span>${window.action} · saison critique: ${window.criticalSeason}</span>
+            <small><b>Impact évité</b> · ${window.avoidedImpact}</small>
+            <small><b>Si reportée</b> · ${window.deferredConsequence}</small>
+            <div class="map-world-climate-window__badges">${window.badges.map((badge) => `<small>${badge}</small>`).join('')}</div>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateMitigationSynergies(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -12141,6 +12224,7 @@ function render() {
   const worldClimateLayer = buildWorldClimateLayer(shell, state.seasonIndex, state.atlasClimateForecastMode);
   const atlasClimateCascadeImpact = buildAtlasClimateCascadeImpactPreview(shell, worldClimateLayer);
   const atlasClimateMitigationSynergies = buildAtlasClimateMitigationSynergies(shell, atlasClimateCascadeImpact, worldClimateLayer);
+  const atlasSeasonalMitigationWindows = buildAtlasSeasonalMitigationWindows(atlasClimateMitigationSynergies, worldClimateLayer);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -12173,6 +12257,7 @@ function render() {
           ${renderWorldClimateLayerSummary(worldClimateLayer)}
           ${renderAtlasClimateCascadeImpactPreview(atlasClimateCascadeImpact)}
           ${renderAtlasClimateMitigationSynergies(atlasClimateMitigationSynergies)}
+          ${renderAtlasSeasonalMitigationWindows(atlasSeasonalMitigationWindows)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -545,6 +545,58 @@ button { font: inherit; }
   color: #052e16;
   background: #86efac;
 }
+.map-world-climate-window {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.64), rgba(120, 53, 15, 0.22));
+  border: 1px solid rgba(251, 191, 36, 0.26);
+}
+.map-world-climate-window--urgent { border-color: rgba(248, 113, 113, 0.44); }
+.map-world-climate-window--quiet { border-color: rgba(148, 163, 184, 0.2); }
+.map-world-climate-window__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-window p,
+.map-world-climate-window span,
+.map-world-climate-window small {
+  color: #fef3c7;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-window__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-window__item {
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(251, 191, 36, 0.24);
+}
+.map-world-climate-window__item--critical { border-color: rgba(248, 113, 113, 0.46); }
+.map-world-climate-window__item--elevated { border-color: rgba(251, 191, 36, 0.38); }
+.map-world-climate-window__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 5px;
+}
+.map-world-climate-window__badges small {
+  padding: 3px 7px;
+  border-radius: 999px;
+  color: #431407;
+  background: #fcd34d;
+}
 
 .map-climate-severity-legend {
   display: grid;


### PR DESCRIPTION
Epsilon: Implements #763.

Summary:
- Adds a compact atlas seasonal mitigation window preview that reuses climate synergies and cascade previews.
- Shows each priority mitigation with critical season, avoided impact, and likely consequence if delayed.
- Keeps quiet/empty states when no critical season or notable synergy is available, avoiding a duplicate timeline.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasSeasonalMitigationWindows.test.js test/ui/climate/webAtlasClimateMitigationSynergies.test.js test/ui/climate/webAtlasClimateCascadeImpactPreviews.test.js
- npm test