### PR TITLE
Epsilon: compare atlas seasonal mitigation plans

### DIFF
--- a/test/ui/climate/webAtlasSeasonalMitigationPlanComparison.test.js
+++ b/test/ui/climate/webAtlasSeasonalMitigationPlanComparison.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas compares seasonal mitigation plans against climate cascades', () => {
+  assert.match(webAppSource, /function buildAtlasSeasonalMitigationPlanComparison/);
+  assert.match(webAppSource, /function renderAtlasSeasonalMitigationPlanComparison/);
+  assert.match(webAppSource, /seasonalWindows\.windows\.slice\(0, 3\)/);
+  assert.match(webAppSource, /avoidedCascade: window\.avoidedImpact/);
+  assert.match(webAppSource, /delayedCascade/);
+  assert.match(webAppSource, /probableCascade/);
+  assert.match(webAppSource, /Meilleur choix/);
+  assert.match(webAppSource, /Compromis principal/);
+  assert.match(webAppSource, /atlasSeasonalPlanComparison = buildAtlasSeasonalMitigationPlanComparison\(atlasSeasonalMitigationWindows\)/);
+  assert.match(webAppSource, /renderAtlasSeasonalMitigationPlanComparison\(atlasSeasonalPlanComparison\)/);
+  assert.match(webAppSource, /Plans saisonniers comparés/);
+  assert.match(webAppSource, /Encore probable/);
+
+  assert.match(stylesSource, /\.map-world-climate-plan-compare/);
+  assert.match(stylesSource, /\.map-world-climate-plan-compare--best/);
+  assert.match(stylesSource, /\.map-world-climate-plan-compare__item\.is-best/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -5412,6 +5412,77 @@ function buildAtlasSeasonalMitigationWindows(synergyView, worldClimateLayer) {
   };
 }
 
+function buildAtlasSeasonalMitigationPlanComparison(seasonalWindows) {
+  if (!seasonalWindows || seasonalWindows.windows.length === 0) {
+    return {
+      state: 'empty',
+      plans: [],
+      bestPlan: null,
+      summary: 'Aucun plan saisonnier comparable: fenêtre ou synergie insuffisante.',
+    };
+  }
+
+  const plans = seasonalWindows.windows.slice(0, 3).map((window, index) => {
+    const score = (window.intensity === 'critical' ? 3 : window.intensity === 'elevated' ? 2 : 1) * 10
+      + Math.max(0, 3 - window.urgencyRank)
+      + (window.badges.includes('route protégée') ? 2 : 0)
+      + (window.badges.includes('cascade évitée') ? 2 : 0);
+    const delayedCascade = window.intensity === 'critical'
+      ? 'Cascade retardée seulement si action immédiate.'
+      : 'Cascade retardée au prochain jalon saisonnier.';
+    const probableCascade = window.deferredConsequence.replace(/^Report: /, 'Probable si report: ');
+
+    return {
+      ...window,
+      planRank: index + 1,
+      score,
+      avoidedCascade: window.avoidedImpact,
+      delayedCascade,
+      probableCascade,
+      verdict: score >= 34 ? 'meilleur choix' : score >= 24 ? 'bon compromis' : 'compromis prudent',
+    };
+  });
+  const sorted = plans.slice().sort((left, right) => right.score - left.score || left.planRank - right.planRank);
+  const bestPlan = sorted[0] ?? null;
+  const hasClearBest = sorted.length > 1 ? (sorted[0].score - sorted[1].score) >= 4 : Boolean(bestPlan);
+
+  return {
+    state: hasClearBest ? 'best' : 'tradeoff',
+    plans,
+    bestPlan: hasClearBest ? bestPlan : null,
+    summary: hasClearBest
+      ? `Meilleur choix: ${bestPlan.provinceLabel} (${bestPlan.criticalSeason}) maximise cascades évitées et routes protégées.`
+      : `Compromis principal: ${plans.map((plan) => plan.provinceLabel).join(' vs ')} équilibrent saison critique, cascade retardée et risque encore probable.`,
+  };
+}
+
+function renderAtlasSeasonalMitigationPlanComparison(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-plan-compare map-world-climate-plan-compare--${view.state}" aria-label="Comparaison des plans saisonniers de mitigation climat">
+      <div class="map-world-climate-plan-compare__header">
+        <strong>Plans saisonniers comparés</strong>
+        <span>${view.bestPlan ? `Choix: ${view.bestPlan.provinceLabel}` : 'Compromis à arbitrer'}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-plan-compare__list">
+        ${view.plans.map((plan) => `
+          <li class="map-world-climate-plan-compare__item map-world-climate-plan-compare__item--${plan.intensity} ${view.bestPlan?.provinceId === plan.provinceId ? 'is-best' : ''}">
+            <b>${plan.planRank}. ${plan.provinceLabel}</b>
+            <span>${plan.action} · ${plan.verdict} · saison ${plan.criticalSeason}</span>
+            <small><b>Évitée</b> · ${plan.avoidedCascade}</small>
+            <small><b>Retardée</b> · ${plan.delayedCascade}</small>
+            <small><b>Encore probable</b> · ${plan.probableCascade}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasSeasonalMitigationWindows(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -12291,6 +12362,7 @@ function render() {
   const atlasClimateCascadeImpact = buildAtlasClimateCascadeImpactPreview(shell, worldClimateLayer);
   const atlasClimateMitigationSynergies = buildAtlasClimateMitigationSynergies(shell, atlasClimateCascadeImpact, worldClimateLayer);
   const atlasSeasonalMitigationWindows = buildAtlasSeasonalMitigationWindows(atlasClimateMitigationSynergies, worldClimateLayer);
+  const atlasSeasonalPlanComparison = buildAtlasSeasonalMitigationPlanComparison(atlasSeasonalMitigationWindows);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -12324,6 +12396,7 @@ function render() {
           ${renderAtlasClimateCascadeImpactPreview(atlasClimateCascadeImpact)}
           ${renderAtlasClimateMitigationSynergies(atlasClimateMitigationSynergies)}
           ${renderAtlasSeasonalMitigationWindows(atlasSeasonalMitigationWindows)}
+          ${renderAtlasSeasonalMitigationPlanComparison(atlasSeasonalPlanComparison)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -597,6 +597,49 @@ button { font: inherit; }
   color: #431407;
   background: #fcd34d;
 }
+.map-world-climate-plan-compare {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.66), rgba(30, 64, 175, 0.2));
+  border: 1px solid rgba(147, 197, 253, 0.26);
+}
+.map-world-climate-plan-compare--best { border-color: rgba(74, 222, 128, 0.42); }
+.map-world-climate-plan-compare--tradeoff { border-color: rgba(251, 191, 36, 0.34); }
+.map-world-climate-plan-compare__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-plan-compare p,
+.map-world-climate-plan-compare span,
+.map-world-climate-plan-compare small {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-plan-compare__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-plan-compare__item {
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(147, 197, 253, 0.22);
+}
+.map-world-climate-plan-compare__item--critical { border-color: rgba(248, 113, 113, 0.44); }
+.map-world-climate-plan-compare__item--elevated { border-color: rgba(251, 191, 36, 0.34); }
+.map-world-climate-plan-compare__item.is-best {
+  box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.32), 0 0 18px rgba(74, 222, 128, 0.16);
+}
 
 .map-climate-severity-legend {
   display: grid;


### PR DESCRIPTION
Epsilon: Implements #773.

Summary:
- Adds a compact atlas comparison of up to 3 seasonal mitigation plans derived from existing seasonal mitigation windows.
- Shows avoided, delayed, and still-probable climate cascades for each plan.
- Highlights a clear best choice when the score separates; otherwise explains the main tradeoff.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasSeasonalMitigationPlanComparison.test.js test/ui/climate/webAtlasSeasonalMitigationWindows.test.js test/ui/climate/webAtlasClimateMitigationSynergies.test.js
- npm test