### PR TITLE
Alpha: compare atlas military outcome forecasts

### DIFF
--- a/test/ui/war/webAtlasMilitaryOutcomeForecasts.test.js
+++ b/test/ui/war/webAtlasMilitaryOutcomeForecasts.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas operation outcome forecasts reuse visible operation sequence data', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryOperationOutcomeForecasts\(sequence\)/);
+  assert.match(webAppSource, /focusedStep = sequence\.steps\[0\]/);
+  assert.match(webAppSource, /focusedStep\.effect/);
+  assert.match(webAppSource, /focusedStep\.risk/);
+  assert.match(webAppSource, /focusedStep\.reason/);
+  assert.doesNotMatch(webAppSource, /new WarModel|simulateWar|hiddenForecast|secretForecast/);
+});
+
+test('atlas operation outcome forecasts compare multiple options with gain risk and delay', () => {
+  assert.match(webAppSource, /Percée rapide/);
+  assert.match(webAppSource, /Tenir et fixer/);
+  assert.match(webAppSource, /Réserve prudente/);
+  assert.match(webAppSource, /frontChange/);
+  assert.match(webAppSource, /overextension/);
+  assert.match(webAppSource, /delay/);
+  assert.match(webAppSource, /surextension/);
+  assert.match(webAppSource, /renderAtlasMilitaryOperationOutcomeForecasts\(outcomeForecasts\)/);
+});
+
+test('atlas operation outcome forecasts render one-line options plus focus details and empty state', () => {
+  assert.match(webAppSource, /atlas-military-outcome-option__line/);
+  assert.match(webAppSource, /atlas-military-outcome-option__detail/);
+  assert.match(webAppSource, /tabindex="0"/);
+  assert.match(webAppSource, /Prévisions indisponibles: aucune opération militaire candidate visible/);
+  assert.match(stylesSource, /\.atlas-military-outcome-forecasts__panel/);
+  assert.match(stylesSource, /\.atlas-military-outcome-option:focus \.atlas-military-outcome-option__detail/);
+  assert.match(stylesSource, /\.atlas-military-outcome-option--gain circle/);
+  assert.match(stylesSource, /\.atlas-military-outcome-option--danger circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -860,7 +860,69 @@ function renderAtlasMilitaryOperationSequence(sequence) {
   `;
 }
 
+function buildAtlasMilitaryOperationOutcomeForecasts(sequence) {
+  if (!sequence || sequence.empty || !sequence.steps.length) {
+    return {
+      options: [],
+      summary: 'Prévisions indisponibles: aucune opération militaire candidate visible.',
+      empty: true,
+    };
+  }
+
+  const focusedStep = sequence.steps[0];
+  const templates = [
+    { key: 'push', label: 'Percée rapide', gain: 14, overextension: 'élevée', delay: 'court', riskBias: 2 },
+    { key: 'hold', label: 'Tenir et fixer', gain: 7, overextension: 'modérée', delay: 'moyen', riskBias: 1 },
+    { key: 'reserve', label: 'Réserve prudente', gain: -3, overextension: 'faible', delay: 'long', riskBias: -1 },
+  ];
+
+  const options = templates.map((template, index) => {
+    const danger = focusedStep.tone === 'danger' ? 2 : 0;
+    const gain = template.gain - danger + Math.max(0, Math.min(3, Math.round(focusedStep.priority / 55)));
+    const riskScore = Math.max(1, Math.min(5, 3 + template.riskBias + danger));
+    const frontChange = gain > 8 ? `front +${gain}` : gain >= 0 ? `front +${gain}` : `front ${gain}`;
+    const risk = riskScore >= 5 ? 'surextension critique' : riskScore >= 4 ? 'surextension élevée' : riskScore >= 3 ? 'surextension contrôlée' : 'surextension basse';
+    return {
+      optionId: `forecast:${focusedStep.stepId}:${template.key}`,
+      label: template.label,
+      target: focusedStep.target,
+      frontChange,
+      overextension: template.overextension,
+      delay: template.delay,
+      risk,
+      detail: `${focusedStep.effect}; risque ${focusedStep.risk}; raison ${focusedStep.reason}.`,
+      tone: riskScore >= 5 ? 'danger' : gain >= 8 ? 'gain' : gain < 0 ? 'delay' : 'balanced',
+      rank: index + 1,
+    };
+  });
+
+  return {
+    options,
+    summary: `Prévisions ${focusedStep.target}: ${options.map((option) => `${option.label} ${option.frontChange}`).join(' · ')}`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryOperationOutcomeForecasts(forecasts) {
+  const height = forecasts.empty ? 9 : 11 + (forecasts.options.length * 4.8);
+  return `
+    <g class="atlas-military-outcome-forecasts" aria-label="Prévisions comparées des opérations militaires: ${forecasts.summary}">
+      <rect class="atlas-military-outcome-forecasts__panel" x="42" y="54" width="55" height="${height}" rx="2.5"></rect>
+      <text class="atlas-military-outcome-forecasts__title" x="44" y="58.3">Issues probables</text>
+      ${forecasts.empty ? `<text class="atlas-military-outcome-forecasts__empty" x="44" y="63">${forecasts.summary}</text>` : forecasts.options.map((option, index) => `
+        <g class="atlas-military-outcome-option atlas-military-outcome-option--${option.tone}" data-atlas-military-outcome-option="${option.optionId}" tabindex="0" aria-label="${option.label}: ${option.frontChange}, ${option.risk}, délai ${option.delay}. ${option.detail}">
+          <circle cx="45.1" cy="${63 + index * 4.8}" r="1.15"></circle>
+          <text class="atlas-military-outcome-option__line" x="47" y="${62.4 + index * 4.8}">${option.label}: ${option.frontChange} · ${option.risk}</text>
+          <text class="atlas-military-outcome-option__detail" x="47" y="${64.5 + index * 4.8}">délai ${option.delay} · ${option.detail}</text>
+          <title>${option.target}: ${option.detail}</title>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function buildAtlasMilitaryFeatures(shell) {
+
 
   const pressureByProvinceId = new Map(shell.provinces.map((province) => [province.provinceId, getAtlasMilitaryPressureScore(province)]));
   const routes = buildProvinceRelations(shell)
@@ -925,6 +987,7 @@ function renderAtlasMilitaryLayer(shell) {
   const playbackSummary = getAtlasConflictPlaybackSummary(playback);
   const comparison = buildAtlasConflictRouteComparison(playback);
   const operationSequence = buildAtlasMilitaryOperationSequence(playback, comparison);
+  const outcomeForecasts = buildAtlasMilitaryOperationOutcomeForecasts(operationSequence);
 
   if (!features.routes.length && !features.riskZones.length) {
     return `
@@ -949,6 +1012,7 @@ function renderAtlasMilitaryLayer(shell) {
       </g>
       ${renderAtlasConflictRouteComparison(comparison)}
       ${renderAtlasMilitaryOperationSequence(operationSequence)}
+      ${renderAtlasMilitaryOperationOutcomeForecasts(outcomeForecasts)}
       ${features.riskZones.map((zone) => `
         <g class="atlas-military-risk atlas-military-risk--${zone.tone}" data-atlas-risk-province="${zone.provinceId}" aria-label="Zone militaire ${zone.label}: pression ${zone.pressure}">
           <polygon points="${zone.polygon}"></polygon>

--- a/web/styles.css
+++ b/web/styles.css
@@ -10179,7 +10179,8 @@ button { font: inherit; }
   opacity: 0.9;
 }
 .atlas-conflict-playback,
-.atlas-conflict-comparison {
+.atlas-conflict-comparison,
+.atlas-military-outcome-forecasts {
   pointer-events: auto;
 }
 .atlas-conflict-playback__panel {
@@ -10280,6 +10281,39 @@ button { font: inherit; }
 .atlas-military-operation-sequence__empty {
   fill: #cbd5e1;
   font-size: 1.05px;
+}
+.atlas-military-outcome-forecasts__panel {
+  fill: rgba(8, 47, 73, 0.74);
+  stroke: rgba(125, 211, 252, 0.32);
+  stroke-width: 0.35;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-outcome-forecasts__title,
+.atlas-military-outcome-option text,
+.atlas-military-outcome-forecasts__empty {
+  fill: #e0f2fe;
+  font-size: 1.42px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.86);
+  stroke-width: 0.38;
+}
+.atlas-military-outcome-option circle {
+  fill: rgba(125, 211, 252, 0.72);
+  stroke: rgba(224, 242, 254, 0.72);
+  stroke-width: 0.24;
+}
+.atlas-military-outcome-option--danger circle { fill: rgba(248, 113, 113, 0.78); }
+.atlas-military-outcome-option--gain circle { fill: rgba(74, 222, 128, 0.76); }
+.atlas-military-outcome-option--delay circle { fill: rgba(251, 191, 36, 0.76); }
+.atlas-military-outcome-option__detail,
+.atlas-military-outcome-forecasts__empty {
+  fill: #cbd5e1;
+  font-size: 1.05px;
+}
+.atlas-military-outcome-option:focus .atlas-military-outcome-option__detail,
+.atlas-military-outcome-option:hover .atlas-military-outcome-option__detail {
+  fill: #f8fafc;
 }
 .atlas-military-risk polygon {
   fill: rgba(251, 191, 36, 0.08);


### PR DESCRIPTION
Alpha: Implements #769.

Summary:
- adds compact atlas outcome forecasts for candidate military operations
- compares multiple options with front gain/loss, overextension risk, and delay estimates from existing operation sequence data
- keeps one-line option copy with focus/hover details and clean unavailable copy when no visible operation candidate exists

Validation:
- `node --check web/app.js`
- `npm test -- test/ui/war/webAtlasMilitaryOutcomeForecasts.test.js test/ui/war/webAtlasMilitaryOperationSequence.test.js`
- `npm test` (526 passing)
- `git diff --check`