### PR TITLE
Beta: triage atlas corridor budget shortfalls

### DIFF
--- a/test/ui/war/webAtlasWorldMapCanvas.test.js
+++ b/test/ui/war/webAtlasWorldMapCanvas.test.js
@@ -27,6 +27,7 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(webAppSource, /function buildAtlasSupplyRouteCapacityForecast/);
   assert.match(webAppSource, /function buildAtlasCorridorInterventionOptions/);
   assert.match(webAppSource, /function buildAtlasCorridorActionBudget/);
+  assert.match(webAppSource, /function buildAtlasCorridorBudgetShortfalls/);
   assert.match(webAppSource, /function renderAtlasEconomyStressLegend/);
   assert.match(webAppSource, /atlas-world-economy-layer/);
   assert.match(webAppSource, /atlas-economy-stress-rollup/);
@@ -50,6 +51,12 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(webAppSource, /Compromis:/);
   assert.match(webAppSource, /aucune intervention sûre/);
   assert.match(webAppSource, /coût inconnu/);
+  assert.match(webAppSource, /Manques budget/);
+  assert.match(webAppSource, /Aucun corridor sous-financé/);
+  assert.match(webAppSource, /impact aval/);
+  assert.match(webAppSource, /action minimale/);
+  assert.match(webAppSource, /rediriger ressources/);
+  assert.match(webAppSource, /réduire objectif/);
   assert.match(webAppSource, /atlas-logistics-route--forecast-\$\{forecast\?\.tone \?\? 'unknown'\}/);
   assert.match(webAppSource, /getRouteStressSummary\(route, tensionByCityId, cityNameById\)/);
   assert.match(stylesSource, /\.atlas-world-canvas/);
@@ -67,6 +74,8 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(stylesSource, /\.atlas-corridor-intervention__rank/);
   assert.match(stylesSource, /\.atlas-corridor-budget/);
   assert.match(stylesSource, /\.atlas-corridor-budget__tradeoff/);
+  assert.match(stylesSource, /\.atlas-corridor-shortfall/);
+  assert.match(stylesSource, /\.atlas-corridor-shortfall-item--overload/);
   assert.match(stylesSource, /\.atlas-logistics-route--major/);
   assert.match(stylesSource, /\.atlas-economy-city--high/);
   assert.match(stylesSource, /\.atlas-economy-city__resources/);

--- a/web/app.js
+++ b/web/app.js
@@ -1470,6 +1470,58 @@ function buildAtlasCorridorActionBudget(interventions, actionCapacity = 3) {
   };
 }
 
+function buildAtlasCorridorBudgetShortfalls(actionBudget) {
+  if (actionBudget.empty || actionBudget.deferred.length === 0) {
+    return {
+      empty: true,
+      items: [],
+      summary: 'Aucun corridor sous-financé',
+    };
+  }
+
+  const items = actionBudget.deferred
+    .map((option) => {
+      const downstreamImpact = option.unknown
+        ? 12
+        : option.tone === 'overload'
+          ? 40 + (option.expectedGain ?? 0) * 4
+          : option.tone === 'watch'
+            ? 24 + (option.expectedGain ?? 0) * 3
+            : 10;
+      const minimumAction = option.unknown
+        ? 'réduire objectif'
+        : option.actionCost !== null && option.actionCost > actionBudget.remaining
+          ? 'rediriger ressources'
+          : option.tone === 'overload'
+            ? 'financer'
+            : 'reporter';
+      const expectedEffect = option.unknown
+        ? `${option.corridor}: clarifier routes/cités touchées`
+        : option.tone === 'overload'
+          ? `${option.routeName}: éviter pénurie aval`
+          : option.tone === 'watch'
+            ? `${option.routeName}: contenir tension cité`
+            : `${option.routeName}: report faible impact`;
+
+      return {
+        ...option,
+        downstreamImpact,
+        minimumAction,
+        expectedEffect,
+      };
+    })
+    .sort((left, right) => right.downstreamImpact - left.downstreamImpact || left.routeName.localeCompare(right.routeName))
+    .slice(0, 3);
+
+  return {
+    empty: items.length === 0,
+    items,
+    summary: items.length === 0
+      ? 'Aucun corridor sous-financé'
+      : `${items.length} manque${items.length > 1 ? 's' : ''} budgétaire${items.length > 1 ? 's' : ''} priorisé${items.length > 1 ? 's' : ''}`,
+  };
+}
+
 function buildAtlasEconomyStressRollups(economyView) {
   if (!economyView) {
     return { legend: [], regions: [] };
@@ -1481,6 +1533,7 @@ function buildAtlasEconomyStressRollups(economyView) {
   const supplyForecasts = buildAtlasSupplyCapacityForecasts(economyView);
   const interventionOptions = buildAtlasCorridorInterventionOptions(supplyForecasts);
   const actionBudget = buildAtlasCorridorActionBudget(interventionOptions);
+  const budgetShortfalls = buildAtlasCorridorBudgetShortfalls(actionBudget);
   const toneRank = { critical: 3, strained: 2, healthy: 1 };
 
   for (const route of economyView.overlay.routes) {
@@ -1576,6 +1629,7 @@ function buildAtlasEconomyStressRollups(economyView) {
     forecasts: supplyForecasts.routes,
     interventions: interventionOptions,
     actionBudget,
+    budgetShortfalls,
   };
 }
 
@@ -1588,7 +1642,7 @@ function renderAtlasEconomyStressLegend(economyView) {
 
   return `
     <g class="atlas-economy-stress-rollup" aria-label="Légende économie atlas: stress logistique et régions économiques">
-      <rect class="atlas-economy-stress-rollup__panel" x="3" y="4" width="35" height="${34 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}" rx="2.4"></rect>
+      <rect class="atlas-economy-stress-rollup__panel" x="3" y="4" width="35" height="${43 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2) + (rollup.budgetShortfalls.items.length * 5.2)}" rx="2.4"></rect>
       <text class="atlas-economy-stress-rollup__title" x="5" y="8.3">Stress économie</text>
       ${rollup.legend.map((entry, index) => `
         <g class="atlas-economy-stress-legend atlas-economy-stress-legend--${entry.tone}">
@@ -1637,6 +1691,20 @@ function renderAtlasEconomyStressLegend(economyView) {
         <text class="atlas-corridor-budget__selected" x="6.2" y="${36.4 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}">Retenir: ${rollup.actionBudget.selectedLabel} · gain +${rollup.actionBudget.selectedGain}</text>
         <text class="atlas-corridor-budget__deferred" x="6.2" y="${38.4 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}">Reporter: ${rollup.actionBudget.deferredLabel}</text>
         <text class="atlas-corridor-budget__tradeoff" x="6.2" y="${40.2 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}">Compromis: ${rollup.actionBudget.tradeoff}</text>
+      </g>
+      <g class="atlas-corridor-shortfall ${rollup.budgetShortfalls.empty ? 'is-empty' : ''}" aria-label="Manques budgétaires corridors: ${rollup.budgetShortfalls.summary}">
+        <rect x="5" y="${42.2 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}" width="30.5" height="${rollup.budgetShortfalls.empty ? 4.8 : 5.6 + (rollup.budgetShortfalls.items.length * 5.2)}" rx="1.4"></rect>
+        <text class="atlas-corridor-shortfall__title" x="6.2" y="${44.7 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}">Manques budget · ${rollup.budgetShortfalls.summary}</text>
+        ${rollup.budgetShortfalls.empty ? `<text class="atlas-corridor-shortfall__empty" x="6.2" y="${47.0 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2)}">Aucun corridor sous-financé</text>` : ''}
+        ${rollup.budgetShortfalls.items.map((item, index) => {
+          const y = 48.2 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2) + (index * 5.2);
+          return `
+            <g class="atlas-corridor-shortfall-item atlas-corridor-shortfall-item--${item.tone}" aria-label="Manque ${item.routeName}: impact aval ${item.downstreamImpact}, action minimale ${item.minimumAction}, effet ${item.expectedEffect}">
+              <text class="atlas-corridor-shortfall-item__route" x="6.2" y="${y}">${item.corridor} · ${item.routeName}</text>
+              <text class="atlas-corridor-shortfall-item__action" x="6.2" y="${y + 2.0}">${item.minimumAction} · ${item.expectedEffect}</text>
+            </g>
+          `;
+        }).join('')}
       </g>
     </g>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -10603,3 +10603,35 @@ button { font: inherit; }
   font-size: 1.04px;
   font-weight: 800;
 }
+.atlas-corridor-shortfall rect {
+  fill: rgba(69, 26, 3, 0.52);
+  stroke: rgba(251, 191, 36, 0.42);
+  stroke-width: 0.28;
+}
+.atlas-corridor-shortfall.is-empty rect {
+  fill: rgba(15, 23, 42, 0.44);
+  stroke: rgba(148, 163, 184, 0.26);
+}
+.atlas-corridor-shortfall__title {
+  fill: #fde68a;
+  font-size: 1.18px;
+  font-weight: 950;
+}
+.atlas-corridor-shortfall__empty {
+  fill: #cbd5e1;
+  font-size: 1px;
+  font-weight: 780;
+}
+.atlas-corridor-shortfall-item__route {
+  fill: #f8fafc;
+  font-size: 1.08px;
+  font-weight: 920;
+}
+.atlas-corridor-shortfall-item__action {
+  fill: #fed7aa;
+  font-size: 0.98px;
+  font-weight: 780;
+}
+.atlas-corridor-shortfall-item--overload .atlas-corridor-shortfall-item__action { fill: #fecdd3; }
+.atlas-corridor-shortfall-item--watch .atlas-corridor-shortfall-item__action { fill: #fde68a; }
+.atlas-corridor-shortfall-item--unknown .atlas-corridor-shortfall-item__action { fill: #ddd6fe; }


### PR DESCRIPTION
Beta: Implements #770.

## Summary
- Adds compact atlas triage for under-funded corridor budget shortfalls.
- Sorts deferred corridor interventions by downstream impact and shows the minimum useful action: finance, defer, reduce objective, or redirect resources.
- Shows the expected effect on affected routes/cities without adding another simulator or noisy map layer.
- Keeps the empty state explicit when no corridor is under-funded.

## Validation
- npm test (523 OK)
- targeted atlas world map tests (2 OK)
- node --check web/app.js
- git diff --check
