### PR TITLE
Gamma: add atlas mediation confidence

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -24,6 +24,8 @@ test('world map atlas renders culture influence zones from existing culture over
   assert.match(webAppSource, /Frontières instables|Médiations culturelles/);
   assert.match(webAppSource, /function buildAtlasCultureMediation/);
   assert.match(webAppSource, /zone\.mediation\.option/);
+  assert.match(webAppSource, /zone\.mediation\.confidence/);
+  assert.match(webAppSource, /zone\.mediation\.consequences\.appeasement/);
 });
 
 test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
@@ -43,6 +45,11 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /pacte de frontière/);
   assert.match(webAppSource, /si ignorée:/);
   assert.match(webAppSource, /frontières stables · données limitées/);
+  assert.match(webAppSource, /confiance \$\{zone\.mediation\.confidence\}/);
+  assert.match(webAppSource, /sûre/);
+  assert.match(webAppSource, /incertaine/);
+  assert.match(webAppSource, /inconnue/);
+  assert.match(webAppSource, /coût politique/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -57,4 +64,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-border-zone__mediation/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__risk/);
   assert.match(stylesSource, /\.atlas-cultural-border-zones\.is-stable rect/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__confidence/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__consequences/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone--confidence-incertaine/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1186,9 +1186,29 @@ function buildAtlasCultureMediation(zone) {
     découverte: ['protéger relais', 'découverte sécurisée', 'opportunité perdue'],
     'pression politique': ['conseil local', 'loyauté suivie', 'tension latente'],
   };
+  const consequenceByDriver = {
+    migration: ['apaisement du passage', 'tension déplacée', 'coût culturel modéré'],
+    'influence voisine': ['frontière clarifiée', 'pression voisine reportée', 'coût politique léger'],
+    événement: ['incident apaisé', 'tension vers relais', 'coût diplomatique'],
+    découverte: ['site sécurisé', 'attention déplacée', 'coût de protection'],
+    'pression politique': ['loyautés apaisées', 'tension latente déplacée', 'coût politique'],
+  };
   const [option, benefit, risk] = optionByDriver[zone.mainDriver] ?? optionByDriver['pression politique'];
+  const [appeasement, displacement, cost] = consequenceByDriver[zone.mainDriver] ?? consequenceByDriver['pression politique'];
+  const confidence = zone.selected || zone.drift.linkedToFocus
+    ? ['sûre', 'signal focalisé']
+    : zone.drift.causes.length >= 2
+      ? ['incertaine', 'causes multiples']
+      : ['inconnue', 'signal partiel'];
 
-  return { option, benefit, risk };
+  return {
+    option,
+    benefit,
+    risk,
+    confidence: confidence[0],
+    confidenceReason: confidence[1],
+    consequences: { appeasement, displacement, cost },
+  };
 }
 
 function renderAtlasCultureLayer(cultureView) {
@@ -1219,14 +1239,16 @@ function renderAtlasCultureLayer(cultureView) {
       `).join('')}
       ${features.borderZones.length > 0 ? `
         <g class="atlas-cultural-border-zones" aria-label="Synthèse des frontières culturelles instables et médiations">
-          <rect x="3" y="55" width="30" height="${9 + (features.borderZones.length * 7.2)}" rx="1.8"></rect>
+          <rect x="3" y="55" width="30" height="${11 + (features.borderZones.length * 10.4)}" rx="1.8"></rect>
           <text class="atlas-cultural-border-zones__title" x="5" y="58.4">Médiations culturelles</text>
           ${features.borderZones.map((zone, index) => `
-            <g class="atlas-cultural-border-zone atlas-cultural-border-zone--${zone.drift.state}" data-atlas-cultural-border="${zone.regionId}" aria-label="Frontière culturelle ${zone.cultureName}: moteur ${zone.mainDriver}, médiation ${zone.mediation.option}, bénéfice ${zone.mediation.benefit}, risque ${zone.mediation.risk}">
-              <text x="5" y="${62 + index * 7.2}">${zone.cultureName}</text>
-              <text class="atlas-cultural-border-zone__chips" x="5" y="${64 + index * 7.2}">${zone.chips.join(' · ')}</text>
-              <text class="atlas-cultural-border-zone__mediation" x="5" y="${66 + index * 7.2}">${zone.mediation.option} → ${zone.mediation.benefit}</text>
-              <text class="atlas-cultural-border-zone__risk" x="5" y="${67.8 + index * 7.2}">si ignorée: ${zone.mediation.risk}</text>
+            <g class="atlas-cultural-border-zone atlas-cultural-border-zone--${zone.drift.state} atlas-cultural-border-zone--confidence-${zone.mediation.confidence}" data-atlas-cultural-border="${zone.regionId}" aria-label="Frontière culturelle ${zone.cultureName}: moteur ${zone.mainDriver}, médiation ${zone.mediation.option}, confiance ${zone.mediation.confidence}, bénéfice ${zone.mediation.benefit}, risque ${zone.mediation.risk}, conséquences ${zone.mediation.consequences.appeasement}, ${zone.mediation.consequences.displacement}, ${zone.mediation.consequences.cost}">
+              <text x="5" y="${62 + index * 10.4}">${zone.cultureName}</text>
+              <text class="atlas-cultural-border-zone__chips" x="5" y="${64 + index * 10.4}">${zone.chips.join(' · ')}</text>
+              <text class="atlas-cultural-border-zone__mediation" x="5" y="${66 + index * 10.4}">${zone.mediation.option} → ${zone.mediation.benefit}</text>
+              <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 10.4}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
+              <text class="atlas-cultural-border-zone__consequences" x="5" y="${69.5 + index * 10.4}">${zone.mediation.consequences.appeasement} · ${zone.mediation.consequences.displacement} · ${zone.mediation.consequences.cost}</text>
+              <text class="atlas-cultural-border-zone__risk" x="5" y="${71.2 + index * 10.4}">si ignorée: ${zone.mediation.risk}</text>
             </g>
           `).join('')}
         </g>

--- a/web/styles.css
+++ b/web/styles.css
@@ -10712,3 +10712,16 @@ button { font: inherit; }
 .atlas-corridor-shortfall-item--overload .atlas-corridor-shortfall-item__action { fill: #fecdd3; }
 .atlas-corridor-shortfall-item--watch .atlas-corridor-shortfall-item__action { fill: #fde68a; }
 .atlas-corridor-shortfall-item--unknown .atlas-corridor-shortfall-item__action { fill: #ddd6fe; }
+.atlas-cultural-border-zone__confidence {
+  fill: #fef3c7;
+  font-size: 0.94px;
+  font-weight: 840;
+}
+.atlas-cultural-border-zone__consequences {
+  fill: #bbf7d0;
+  font-size: 0.9px;
+  font-weight: 760;
+}
+.atlas-cultural-border-zone--confidence-sûre .atlas-cultural-border-zone__confidence { fill: #bbf7d0; }
+.atlas-cultural-border-zone--confidence-incertaine .atlas-cultural-border-zone__confidence { fill: #fde68a; }
+.atlas-cultural-border-zone--confidence-inconnue .atlas-cultural-border-zone__confidence { fill: #ddd6fe; }


### PR DESCRIPTION
Gamma: Implements #771.

## Summary
- add readable confidence levels to atlas cultural mediation options
- summarize likely consequences for appeasement, tension displacement, and political/cultural cost
- distinguish sure, uncertain, and unknown estimates while keeping copy compact for unstable border zones

## Validation
- node --check web/app.js
- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/war/webAtlasWorldMapCanvas.test.js
- git diff --check
- npm test (527 OK)