### PR TITLE
Delta: preview sweep schedule conflicts

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -238,6 +238,20 @@ test('atlas counterintelligence warns about missed sweep windows safely', () => 
   assert.match(stylesSource, /atlas-counterintelligence-window-risk/);
 });
 
+test('atlas counterintelligence previews schedule conflicts safely', () => {
+  assert.match(webAppSource, /scheduleConflicts/);
+  assert.match(webAppSource, /Conflits de planning/);
+  assert.match(webAppSource, /Conflits de calendrier contre-espionnage fog-safe/);
+  assert.match(webAppSource, /chevauchement de balayage/);
+  assert.match(webAppSource, /arrive trop tard/);
+  assert.match(webAppSource, /zone sensible sans couverture/);
+  assert.match(webAppSource, /Déplacer ce balayage au créneau suivant/);
+  assert.match(webAppSource, /Monter ce balayage en priorité ou remplacer une veille stable/);
+  assert.match(webAppSource, /aucune identité ni cause cachée révélée/);
+  assert.match(webAppSource, /Aucun conflit de planning visible entre balayages filtrés/);
+  assert.match(stylesSource, /atlas-counterintelligence-schedule-conflicts/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -9224,11 +9224,54 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
     uncertain: sweepCandidates.filter((candidate) => candidate.coverageLevel === 'uncertain'),
     uncovered: filteredSignals.filter((signal) => !candidateIds.has(signal.locationId)),
   };
-  const missedWindowRisks = sweepCandidates
+  const scheduledSweeps = sweepCandidates.map((candidate, index) => ({
+    ...candidate,
+    plannedTurnOffset: candidate.missedWindowRiskLevel === 'urgent' ? 0 : index === 0 ? 0 : index,
+  }));
+  const missedWindowRisks = scheduledSweeps
     .filter((candidate) => ['urgent', 'closing', 'uncertain'].includes(candidate.missedWindowRiskLevel));
   const missedWindowSummary = missedWindowRisks.length > 0
     ? `${missedWindowRisks.length} fenêtre${missedWindowRisks.length > 1 ? 's' : ''} de balayage à risque si vous attendez: ${missedWindowRisks.filter((candidate) => candidate.missedWindowRiskLevel === 'urgent').length} critique${missedWindowRisks.filter((candidate) => candidate.missedWindowRiskLevel === 'urgent').length > 1 ? 's' : ''}, ${missedWindowRisks.filter((candidate) => candidate.missedWindowRiskLevel === 'closing').length} en fermeture, ${missedWindowRisks.filter((candidate) => candidate.missedWindowRiskLevel === 'uncertain').length} incertaine${missedWindowRisks.filter((candidate) => candidate.missedWindowRiskLevel === 'uncertain').length > 1 ? 's' : ''}.`
     : 'Aucune fenêtre manquée probable avec les signaux filtrés actuels.';
+  const scheduleConflicts = [];
+  scheduledSweeps.forEach((candidate, index) => {
+    const overlapping = scheduledSweeps.find((other, otherIndex) => otherIndex < index && other.plannedTurnOffset === candidate.plannedTurnOffset);
+    if (overlapping) {
+      scheduleConflicts.push({
+        type: 'overlap',
+        tone: 'warning',
+        locationName: candidate.locationName,
+        label: 'chevauchement de balayage',
+        detail: `Même créneau que ${overlapping.locationName}; prioriser le signal le plus frais sans dévoiler la cause.`,
+        alternative: candidate.score > overlapping.score ? 'Déplacer l’autre balayage au créneau suivant.' : 'Déplacer ce balayage au créneau suivant.',
+      });
+    }
+
+    if (['urgent', 'closing'].includes(candidate.missedWindowRiskLevel) && candidate.plannedTurnOffset > 0) {
+      scheduleConflicts.push({
+        type: 'late',
+        tone: 'danger',
+        locationName: candidate.locationName,
+        label: 'arrive trop tard',
+        detail: `${candidate.missedWindowLabel}: le créneau prévu peut réduire l’utilité de la réponse.`,
+        alternative: 'Monter ce balayage en priorité ou remplacer une veille stable.',
+      });
+    }
+  });
+  coveragePreview.uncovered
+    .filter((signal) => signal.tone === 'danger' || signal.tone === 'warning' || signal.certainty === 'probable')
+    .slice(0, 2)
+    .forEach((signal) => scheduleConflicts.push({
+      type: 'gap',
+      tone: signal.tone === 'danger' ? 'danger' : 'warning',
+      locationName: signal.locationName,
+      label: 'zone sensible sans couverture',
+      detail: `${signal.freshnessLabel} · ${signal.riskLabel}; aucune identité ni cause cachée révélée.`,
+      alternative: 'Remplacer une veille stable par une vérification courte sur cette zone.',
+    }));
+  const scheduleConflictSummary = scheduleConflicts.length > 0
+    ? `${scheduleConflicts.length} conflit${scheduleConflicts.length > 1 ? 's' : ''} de planning détecté${scheduleConflicts.length > 1 ? 's' : ''}: ${scheduleConflicts.filter((conflict) => conflict.type === 'overlap').length} chevauchement${scheduleConflicts.filter((conflict) => conflict.type === 'overlap').length > 1 ? 's' : ''}, ${scheduleConflicts.filter((conflict) => conflict.type === 'late').length} retard${scheduleConflicts.filter((conflict) => conflict.type === 'late').length > 1 ? 's' : ''}, ${scheduleConflicts.filter((conflict) => conflict.type === 'gap').length} zone${scheduleConflicts.filter((conflict) => conflict.type === 'gap').length > 1 ? 's' : ''} sans couverture.`
+    : 'Aucun conflit de planning visible entre balayages filtrés.';
   const exposureCooldownSummary = sweepCandidates.length > 0
     ? `${sweepCandidates.filter((candidate) => candidate.tone === 'danger').length} risque${sweepCandidates.filter((candidate) => candidate.tone === 'danger').length > 1 ? 's' : ''} d’exposition haut${sweepCandidates.filter((candidate) => candidate.tone === 'danger').length > 1 ? 's' : ''}; cooldown visible estimé sans cause cachée.`
     : 'Aucun risque d’exposition ou cooldown supplémentaire proposé.';
@@ -9236,10 +9279,12 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
   return {
     empty: sweepCandidates.length === 0,
     totalFiltered: filteredSignals.length,
-    candidates: sweepCandidates,
+    candidates: scheduledSweeps,
     coveragePreview,
     missedWindowRisks,
     missedWindowSummary,
+    scheduleConflicts,
+    scheduleConflictSummary,
     exposureCooldownSummary,
     summary: sweepCandidates.length > 0
       ? `${sweepCandidates.length} zone${sweepCandidates.length > 1 ? 's' : ''} de balayage contre-espionnage proposée${sweepCandidates.length > 1 ? 's' : ''} depuis les filtres atlas actifs.`
@@ -9259,6 +9304,7 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
         <small>Activez un filtre récent, ancien, incertain ou probable pour préparer une vérification sans révéler de cause cachée.</small>
         <small>${plan.exposureCooldownSummary}</small>
         <small>${plan.missedWindowSummary}</small>
+        <small>${plan.scheduleConflictSummary}</small>
       </section>
     `;
   }
@@ -9276,6 +9322,13 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
         <span><b>${plan.coveragePreview.uncovered.length}</b> non couvert${plan.coveragePreview.uncovered.length > 1 ? 's' : ''}</span>
       </div>
       <small>${plan.exposureCooldownSummary}</small>
+      <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">
+        <strong>Conflits de planning</strong>
+        <p>${plan.scheduleConflictSummary}</p>
+        ${plan.scheduleConflicts.length > 0
+          ? `<ul>${plan.scheduleConflicts.map((conflict) => `<li class="atlas-counterintelligence-schedule-conflicts__item atlas-counterintelligence-schedule-conflicts__item--${conflict.tone}"><b>${conflict.locationName}</b> · ${conflict.label}: ${conflict.detail}<small>${conflict.alternative}</small></li>`).join('')}</ul>`
+          : '<small>Aucun chevauchement, retard critique ou trou de couverture sensible avec les filtres actifs.</small>'}
+      </section>
       <section class="atlas-counterintelligence-window-risk" aria-label="Risque de fenêtre manquée fog-safe">
         <strong>Fenêtres à ne pas manquer</strong>
         <p>${plan.missedWindowSummary}</p>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2964,6 +2964,29 @@ button { font: inherit; }
   color: #f8fafc;
   font-size: 1rem;
 }
+.atlas-counterintelligence-schedule-conflicts {
+  display: grid;
+  gap: 6px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(251, 113, 133, 0.26);
+  background: rgba(127, 29, 29, 0.18);
+}
+.atlas-counterintelligence-schedule-conflicts p,
+.atlas-counterintelligence-schedule-conflicts small { margin: 0; color: #fecdd3; }
+.atlas-counterintelligence-schedule-conflicts ul {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding-left: 18px;
+  color: #f8fafc;
+}
+.atlas-counterintelligence-schedule-conflicts__item--danger { color: #fecaca; }
+.atlas-counterintelligence-schedule-conflicts__item--warning { color: #fde68a; }
+.atlas-counterintelligence-schedule-conflicts li small {
+  display: block;
+  margin-top: 2px;
+}
 .atlas-counterintelligence-window-risk {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Implements #772.

Summary:
- adds fog-safe schedule conflict previews for counterintelligence sweeps
- flags overlapping sweeps, late sweep slots, and sensitive filtered regions left uncovered
- proposes safe alternatives such as moving a sweep, prioritizing urgent coverage, or replacing a stable watch without revealing hidden causes or actors

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check HEAD~1..HEAD
- npm test

Delta: Zeta, this PR is ready for validation before merge.