### PR TITLE
Epsilon: convert atlas mitigation comparison to action plan

### DIFF
--- a/test/ui/climate/webAtlasClimateActionPlanConversion.test.js
+++ b/test/ui/climate/webAtlasClimateActionPlanConversion.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas converts seasonal mitigation comparisons into climate action plans', () => {
+  assert.match(webAppSource, /function buildAtlasClimateActionPlanFromComparison/);
+  assert.match(webAppSource, /function renderAtlasClimateActionPlan/);
+  assert.match(webAppSource, /planComparison\.bestPlan \?\? planComparison\.plans/);
+  assert.match(webAppSource, /vulnerablePlans = planComparison\.plans\.filter/);
+  assert.match(webAppSource, /Plan d’action proposé/);
+  assert.match(webAppSource, /Saison\/fenêtre/);
+  assert.match(webAppSource, /Régions touchées/);
+  assert.match(webAppSource, /Cascade évitée\/réduite/);
+  assert.match(webAppSource, /Coût\/compromis/);
+  assert.match(webAppSource, /Vulnérable/);
+  assert.match(webAppSource, /atlasClimateActionPlan = buildAtlasClimateActionPlanFromComparison\(atlasSeasonalPlanComparison\)/);
+  assert.match(webAppSource, /renderAtlasClimateActionPlan\(atlasClimateActionPlan\)/);
+
+  assert.match(stylesSource, /\.map-world-climate-action-plan/);
+  assert.match(stylesSource, /\.map-world-climate-action-plan--warning/);
+  assert.match(stylesSource, /\.map-world-climate-action-plan__card/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -5610,6 +5610,55 @@ function buildAtlasSeasonalMitigationPlanComparison(seasonalWindows) {
   };
 }
 
+function buildAtlasClimateActionPlanFromComparison(planComparison) {
+  if (!planComparison || planComparison.plans.length === 0) {
+    return {
+      state: 'empty',
+      selectedPlan: null,
+      vulnerablePlans: [],
+      summary: 'Aucun plan d’action climat à convertir depuis l’atlas.',
+    };
+  }
+
+  const selectedPlan = planComparison.bestPlan ?? planComparison.plans.slice().sort((left, right) => right.score - left.score || left.planRank - right.planRank)[0];
+  const vulnerablePlans = planComparison.plans.filter((plan) => /probable|Report|cascade suivante/i.test(plan.probableCascade) && plan.provinceId !== selectedPlan?.provinceId);
+
+  return {
+    state: selectedPlan ? (vulnerablePlans.length > 0 ? 'warning' : 'ready') : 'empty',
+    selectedPlan,
+    vulnerablePlans,
+    summary: selectedPlan
+      ? `Plan d’action proposé: ${selectedPlan.action} sur ${selectedPlan.provinceLabel}, fenêtre ${selectedPlan.criticalSeason}.`
+      : 'Aucun plan saisonnier assez clair pour devenir une action atlas.',
+  };
+}
+
+function renderAtlasClimateActionPlan(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  const plan = view.selectedPlan;
+
+  return `
+    <section class="map-world-climate-action-plan map-world-climate-action-plan--${view.state}" aria-label="Plan d’action climatique converti depuis la comparaison saisonnière">
+      <div class="map-world-climate-action-plan__header">
+        <strong>Plan d’action climat</strong>
+        <span>${plan.provinceLabel} · ${plan.criticalSeason}</span>
+      </div>
+      <p>${view.summary}</p>
+      <div class="map-world-climate-action-plan__card">
+        <b>${plan.action}</b>
+        <small><b>Saison/fenêtre</b> · ${plan.criticalSeason}</small>
+        <small><b>Régions touchées</b> · ${plan.protectedRegions}</small>
+        <small><b>Cascade évitée/réduite</b> · ${plan.avoidedCascade}</small>
+        <small><b>Coût/compromis</b> · ${plan.verdict}; ${plan.delayedCascade}</small>
+        ${view.vulnerablePlans.length > 0 ? `<small><b>Vulnérable</b> · ${view.vulnerablePlans.map((vulnerable) => `${vulnerable.provinceLabel}: ${vulnerable.probableCascade}`).join(' · ')}</small>` : ''}
+      </div>
+    </section>
+  `;
+}
+
 function renderAtlasSeasonalMitigationPlanComparison(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -12628,6 +12677,7 @@ function render() {
   const atlasClimateMitigationSynergies = buildAtlasClimateMitigationSynergies(shell, atlasClimateCascadeImpact, worldClimateLayer);
   const atlasSeasonalMitigationWindows = buildAtlasSeasonalMitigationWindows(atlasClimateMitigationSynergies, worldClimateLayer);
   const atlasSeasonalPlanComparison = buildAtlasSeasonalMitigationPlanComparison(atlasSeasonalMitigationWindows);
+  const atlasClimateActionPlan = buildAtlasClimateActionPlanFromComparison(atlasSeasonalPlanComparison);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -12662,6 +12712,7 @@ function render() {
           ${renderAtlasClimateMitigationSynergies(atlasClimateMitigationSynergies)}
           ${renderAtlasSeasonalMitigationWindows(atlasSeasonalMitigationWindows)}
           ${renderAtlasSeasonalMitigationPlanComparison(atlasSeasonalPlanComparison)}
+          ${renderAtlasClimateActionPlan(atlasClimateActionPlan)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -640,6 +640,39 @@ button { font: inherit; }
 .map-world-climate-plan-compare__item.is-best {
   box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.32), 0 0 18px rgba(74, 222, 128, 0.16);
 }
+.map-world-climate-action-plan {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.66), rgba(20, 83, 45, 0.24));
+  border: 1px solid rgba(74, 222, 128, 0.3);
+}
+.map-world-climate-action-plan--warning { border-color: rgba(251, 191, 36, 0.42); }
+.map-world-climate-action-plan__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-action-plan p,
+.map-world-climate-action-plan span,
+.map-world-climate-action-plan small {
+  color: #dcfce7;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-action-plan__card {
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.54);
+  border: 1px solid rgba(74, 222, 128, 0.24);
+}
 
 .map-climate-severity-legend {
   display: grid;


### PR DESCRIPTION
Epsilon: Implements #783.

Summary:
- Converts the atlas seasonal mitigation comparison into a concrete climate action plan summary.
- Presents selected plan details: season/window, touched regions, avoided/reduced cascade, and main cost/tradeoff.
- Flags vulnerable alternate plans that still expose an untreated cascade, with an empty state when no plan is relevant.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateActionPlanConversion.test.js test/ui/climate/webAtlasSeasonalMitigationPlanComparison.test.js test/ui/climate/webAtlasSeasonalMitigationWindows.test.js
- npm test