### PR TITLE
Alpha: stage atlas military operation commitments

### DIFF
--- a/test/ui/war/webAtlasMilitaryStagedCommitments.test.js
+++ b/test/ui/war/webAtlasMilitaryStagedCommitments.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas staged commitments select a military forecast without leaving the map', () => {
+  assert.match(webAppSource, /selectedAtlasMilitaryOutcomeOptionId: null/);
+  assert.match(webAppSource, /data-atlas-military-outcome-option/);
+  assert.match(webAppSource, /state\.selectedAtlasMilitaryOutcomeOptionId = element\.dataset\.atlasMilitaryOutcomeOption/);
+  assert.match(webAppSource, /function buildAtlasMilitaryStagedCommitment\(forecasts, selectedOptionId = state\.selectedAtlasMilitaryOutcomeOptionId\)/);
+  assert.match(webAppSource, /forecasts\.options\.find\(\(option\) => option\.optionId === selectedOptionId\)/);
+});
+
+test('atlas staged commitments prepare two or three readable commitment stages', () => {
+  assert.match(webAppSource, /Repérer/);
+  assert.match(webAppSource, /Engager/);
+  assert.match(webAppSource, /Suivi|Réserve/);
+  assert.match(webAppSource, /costRisk/);
+  assert.match(webAppSource, /territory/);
+  assert.match(webAppSource, /effect/);
+  assert.match(webAppSource, /prévisionnel/);
+  assert.match(webAppSource, /à engager/);
+  assert.match(webAppSource, /renderAtlasMilitaryStagedCommitment\(stagedCommitment\)/);
+});
+
+test('atlas staged commitments expose unavailable state and selected styling', () => {
+  assert.match(webAppSource, /Engagement indisponible: aucune prévision militaire pertinente/);
+  assert.match(webAppSource, /atlas-military-staged-commitment__empty/);
+  assert.match(stylesSource, /\.atlas-military-staged-commitment__panel/);
+  assert.match(stylesSource, /\.atlas-military-commitment-stage--commit rect/);
+  assert.match(stylesSource, /\.atlas-military-outcome-option\.is-selected circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -444,6 +444,7 @@ const state = {
   atlasClimateForecastMode: 'current',
   atlasConflictPlaybackStep: 1,
   atlasConflictComparisonMode: 'current',
+  selectedAtlasMilitaryOutcomeOptionId: null,
   acceptedRecommendedMilitaryAction: null,
   lastMilitaryOutcomeMarkers: [],
   militaryOutcomeMarkerFilters: {
@@ -473,6 +474,7 @@ function applyMapScenario(scenario) {
   state.atlasClimateForecastMode = 'current';
   state.atlasConflictPlaybackStep = 1;
   state.atlasConflictComparisonMode = 'current';
+  state.selectedAtlasMilitaryOutcomeOptionId = null;
   state.mapZoom = 1;
   state.mapPanX = 0;
   state.mapPanY = 0;
@@ -905,12 +907,13 @@ function buildAtlasMilitaryOperationOutcomeForecasts(sequence) {
 
 function renderAtlasMilitaryOperationOutcomeForecasts(forecasts) {
   const height = forecasts.empty ? 9 : 11 + (forecasts.options.length * 4.8);
+  const selectedOptionId = state.selectedAtlasMilitaryOutcomeOptionId ?? forecasts.options[0]?.optionId ?? null;
   return `
     <g class="atlas-military-outcome-forecasts" aria-label="Prévisions comparées des opérations militaires: ${forecasts.summary}">
       <rect class="atlas-military-outcome-forecasts__panel" x="42" y="54" width="55" height="${height}" rx="2.5"></rect>
       <text class="atlas-military-outcome-forecasts__title" x="44" y="58.3">Issues probables</text>
       ${forecasts.empty ? `<text class="atlas-military-outcome-forecasts__empty" x="44" y="63">${forecasts.summary}</text>` : forecasts.options.map((option, index) => `
-        <g class="atlas-military-outcome-option atlas-military-outcome-option--${option.tone}" data-atlas-military-outcome-option="${option.optionId}" tabindex="0" aria-label="${option.label}: ${option.frontChange}, ${option.risk}, délai ${option.delay}. ${option.detail}">
+        <g class="atlas-military-outcome-option atlas-military-outcome-option--${option.tone} ${selectedOptionId === option.optionId ? 'is-selected' : ''}" data-atlas-military-outcome-option="${option.optionId}" tabindex="0" aria-label="${option.label}: ${option.frontChange}, ${option.risk}, délai ${option.delay}. ${option.detail}">
           <circle cx="45.1" cy="${63 + index * 4.8}" r="1.15"></circle>
           <text class="atlas-military-outcome-option__line" x="47" y="${62.4 + index * 4.8}">${option.label}: ${option.frontChange} · ${option.risk}</text>
           <text class="atlas-military-outcome-option__detail" x="47" y="${64.5 + index * 4.8}">délai ${option.delay} · ${option.detail}</text>
@@ -921,7 +924,81 @@ function renderAtlasMilitaryOperationOutcomeForecasts(forecasts) {
   `;
 }
 
+function buildAtlasMilitaryStagedCommitment(forecasts, selectedOptionId = state.selectedAtlasMilitaryOutcomeOptionId) {
+  if (!forecasts || forecasts.empty || !forecasts.options.length) {
+    return {
+      selectedOption: null,
+      stages: [],
+      summary: 'Engagement indisponible: aucune prévision militaire pertinente.',
+      empty: true,
+    };
+  }
+
+  const selectedOption = forecasts.options.find((option) => option.optionId === selectedOptionId) ?? forecasts.options[0];
+  const stages = [
+    {
+      stageId: `${selectedOption.optionId}:recon`,
+      status: 'prévisionnel',
+      label: 'Repérer',
+      costRisk: 'coût faible / risque lecture incomplète',
+      territory: selectedOption.target,
+      effect: `confirmer ${selectedOption.frontChange}`,
+    },
+    {
+      stageId: `${selectedOption.optionId}:commit`,
+      status: 'à engager',
+      label: 'Engager',
+      costRisk: `${selectedOption.overextension} / ${selectedOption.risk}`,
+      territory: selectedOption.target,
+      effect: selectedOption.label,
+    },
+    selectedOption.delay === 'long'
+      ? {
+        stageId: `${selectedOption.optionId}:reserve`,
+        status: 'prévisionnel',
+        label: 'Réserve',
+        costRisk: 'coût moyen / délai long',
+        territory: selectedOption.target,
+        effect: 'tenir la fenêtre ouverte',
+      }
+      : {
+        stageId: `${selectedOption.optionId}:followup`,
+        status: 'prévisionnel',
+        label: 'Suivi',
+        costRisk: `risque ${selectedOption.risk}`,
+        territory: selectedOption.target,
+        effect: `vérifier ${selectedOption.frontChange}`,
+      },
+  ].slice(0, 3);
+
+  return {
+    selectedOption,
+    stages,
+    summary: `Engagement préparé: ${selectedOption.label} sur ${selectedOption.target}; ${stages.length} étapes, ${selectedOption.delay}.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryStagedCommitment(commitment) {
+  const height = commitment.empty ? 8 : 7 + (commitment.stages.length * 4.1);
+  return `
+    <g class="atlas-military-staged-commitment" aria-label="Engagement militaire par étapes: ${commitment.summary}">
+      <rect class="atlas-military-staged-commitment__panel" x="42" y="80" width="55" height="${height}" rx="2.5"></rect>
+      <text class="atlas-military-staged-commitment__title" x="44" y="83.3">Engagement préparé</text>
+      ${commitment.empty ? `<text class="atlas-military-staged-commitment__empty" x="44" y="86.5">${commitment.summary}</text>` : commitment.stages.map((stage, index) => `
+        <g class="atlas-military-commitment-stage atlas-military-commitment-stage--${stage.status === 'à engager' ? 'commit' : 'preview'}" data-atlas-commitment-stage="${stage.stageId}" aria-label="${stage.label}: ${stage.status}, ${stage.territory}, ${stage.effect}, ${stage.costRisk}">
+          <rect x="44" y="${84.8 + index * 4.1}" width="4.4" height="2.7" rx="0.9"></rect>
+          <text class="atlas-military-commitment-stage__label" x="49.5" y="${85.9 + index * 4.1}">${index + 1}. ${stage.label} · ${stage.status}</text>
+          <text class="atlas-military-commitment-stage__detail" x="49.5" y="${87.4 + index * 4.1}">${stage.territory}: ${stage.effect}</text>
+          <text class="atlas-military-commitment-stage__risk" x="49.5" y="${88.9 + index * 4.1}">${stage.costRisk}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function buildAtlasMilitaryFeatures(shell) {
+
 
 
   const pressureByProvinceId = new Map(shell.provinces.map((province) => [province.provinceId, getAtlasMilitaryPressureScore(province)]));
@@ -988,6 +1065,7 @@ function renderAtlasMilitaryLayer(shell) {
   const comparison = buildAtlasConflictRouteComparison(playback);
   const operationSequence = buildAtlasMilitaryOperationSequence(playback, comparison);
   const outcomeForecasts = buildAtlasMilitaryOperationOutcomeForecasts(operationSequence);
+  const stagedCommitment = buildAtlasMilitaryStagedCommitment(outcomeForecasts);
 
   if (!features.routes.length && !features.riskZones.length) {
     return `
@@ -1013,6 +1091,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasConflictRouteComparison(comparison)}
       ${renderAtlasMilitaryOperationSequence(operationSequence)}
       ${renderAtlasMilitaryOperationOutcomeForecasts(outcomeForecasts)}
+      ${renderAtlasMilitaryStagedCommitment(stagedCommitment)}
       ${features.riskZones.map((zone) => `
         <g class="atlas-military-risk atlas-military-risk--${zone.tone}" data-atlas-risk-province="${zone.provinceId}" aria-label="Zone militaire ${zone.label}: pression ${zone.pressure}">
           <polygon points="${zone.polygon}"></polygon>
@@ -13311,6 +13390,13 @@ function render() {
   document.querySelectorAll('[data-atlas-conflict-comparison-mode]').forEach((element) => {
     element.addEventListener('click', () => {
       state.atlasConflictComparisonMode = element.dataset.atlasConflictComparisonMode ?? 'current';
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-atlas-military-outcome-option]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.selectedAtlasMilitaryOutcomeOptionId = element.dataset.atlasMilitaryOutcomeOption ?? null;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -10246,7 +10246,8 @@ button { font: inherit; }
 }
 .atlas-conflict-playback,
 .atlas-conflict-comparison,
-.atlas-military-outcome-forecasts {
+.atlas-military-outcome-forecasts,
+.atlas-military-staged-commitment {
   pointer-events: auto;
 }
 .atlas-conflict-playback__panel {
@@ -10372,6 +10373,10 @@ button { font: inherit; }
 .atlas-military-outcome-option--danger circle { fill: rgba(248, 113, 113, 0.78); }
 .atlas-military-outcome-option--gain circle { fill: rgba(74, 222, 128, 0.76); }
 .atlas-military-outcome-option--delay circle { fill: rgba(251, 191, 36, 0.76); }
+.atlas-military-outcome-option.is-selected circle {
+  stroke: rgba(255, 255, 255, 0.92);
+  stroke-width: 0.44;
+}
 .atlas-military-outcome-option__detail,
 .atlas-military-outcome-forecasts__empty {
   fill: #cbd5e1;
@@ -10380,6 +10385,40 @@ button { font: inherit; }
 .atlas-military-outcome-option:focus .atlas-military-outcome-option__detail,
 .atlas-military-outcome-option:hover .atlas-military-outcome-option__detail {
   fill: #f8fafc;
+}
+.atlas-military-staged-commitment__panel {
+  fill: rgba(12, 74, 110, 0.74);
+  stroke: rgba(56, 189, 248, 0.34);
+  stroke-width: 0.35;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-staged-commitment__title,
+.atlas-military-commitment-stage text,
+.atlas-military-staged-commitment__empty {
+  fill: #e0f2fe;
+  font-size: 1.36px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.86);
+  stroke-width: 0.36;
+}
+.atlas-military-commitment-stage rect {
+  fill: rgba(125, 211, 252, 0.46);
+  stroke: rgba(224, 242, 254, 0.58);
+  stroke-width: 0.22;
+}
+.atlas-military-commitment-stage--commit rect {
+  fill: rgba(74, 222, 128, 0.58);
+  stroke: rgba(187, 247, 208, 0.72);
+}
+.atlas-military-commitment-stage__detail {
+  fill: #bae6fd;
+  font-size: 1.04px;
+}
+.atlas-military-commitment-stage__risk,
+.atlas-military-staged-commitment__empty {
+  fill: #cbd5e1;
+  font-size: 0.96px;
 }
 .atlas-military-risk polygon {
   fill: rgba(251, 191, 36, 0.08);


### PR DESCRIPTION
Alpha: Implements #779.

Summary:
- adds atlas staged commitments derived from selected military outcome forecasts
- lets the player pick a forecast option and view 2-3 readable commitment stages in-map
- distinguishes forecast/prep stages from the step to engage, with cost/risk, territory/front, and expected effect
- keeps an empty state when no relevant military forecast exists

Validation:
- `node --check web/app.js`
- `npm test -- test/ui/war/webAtlasMilitaryStagedCommitments.test.js test/ui/war/webAtlasMilitaryOutcomeForecasts.test.js`
- `npm test` (531 passing)
- `git diff --check`