### PR TITLE
Gamma: warn on mediation signal conflicts

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -28,6 +28,8 @@ test('world map atlas renders culture influence zones from existing culture over
   assert.match(webAppSource, /zone\.mediation\.consequences\.appeasement/);
   assert.match(webAppSource, /function buildAtlasMediationCommitment/);
   assert.match(webAppSource, /zone\.commitment\.nextConsequence/);
+  assert.match(webAppSource, /function buildAtlasMediationSignalWarnings/);
+  assert.match(webAppSource, /renderCultureMediationSignalWarnings/);
 });
 
 test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
@@ -55,6 +57,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /incertaine/);
   assert.match(webAppSource, /inconnue/);
   assert.match(webAppSource, /coût politique/);
+  assert.match(webAppSource, /engagement trop optimiste/);
+  assert.match(webAppSource, /médiation hors culture locale/);
+  assert.match(webAppSource, /engagement cohérent/);
+  assert.match(webAppSource, /revérifier confiance/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -74,4 +80,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-border-zone--confidence-incertaine/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__commitment/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone--commitment-risk/);
+  assert.match(stylesSource, /\.culture-mediation-warnings/);
+  assert.match(stylesSource, /\.culture-mediation-warning--conflict/);
+  assert.match(stylesSource, /\.culture-mediation-warning--coherent/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -11385,6 +11385,86 @@ function renderCultureMapOverlay(cultureView) {
   `;
 }
 
+
+function buildAtlasMediationSignalWarnings(cultureView, selectedProvinceId = state.selectedProvinceId) {
+  const features = buildAtlasCultureFeatures({
+    ...cultureView,
+    selectedRegionId: selectedProvinceId,
+  });
+  const selectedEntries = cultureView.overlay.filter((entry) => entry.regionId === selectedProvinceId);
+  const selectedCultures = new Set(selectedEntries.map((entry) => entry.cultureName));
+  const selectedCohesion = Math.max(0, ...selectedEntries.map((entry) => entry.influenceScore ?? 0));
+  const selectedFocusWarning = features.borderZones
+    .filter((zone) => zone.regionId === selectedProvinceId)
+    .flatMap((zone) => {
+      const warnings = [];
+      if (zone.commitment.status === 'stable' && selectedCohesion < 50) {
+        warnings.push({
+          warningId: `${zone.borderId}:low-cohesion`,
+          state: 'conflict',
+          cultureName: zone.cultureName,
+          title: 'engagement trop optimiste',
+          detail: `cohésion locale ${selectedCohesion || 'faible'} · ${zone.commitment.label}`,
+          followUp: 'revérifier confiance',
+        });
+      }
+      if (!selectedCultures.has(zone.cultureName)) {
+        warnings.push({
+          warningId: `${zone.borderId}:missing-culture`,
+          state: 'conflict',
+          cultureName: zone.cultureName,
+          title: 'culture absente de la région',
+          detail: `${zone.mediation.option} cible ${zone.cultureName}`,
+          followUp: 'choisir frontière liée',
+        });
+      }
+      return warnings;
+    });
+  const crossRegionWarnings = features.borderZones
+    .filter((zone) => zone.regionId !== selectedProvinceId && !selectedCultures.has(zone.cultureName))
+    .slice(0, Math.max(0, 2 - selectedFocusWarning.length))
+    .map((zone) => ({
+      warningId: `${zone.borderId}:off-region`,
+      state: 'conflict',
+      cultureName: zone.cultureName,
+      title: 'médiation hors culture locale',
+      detail: `${zone.regionId} · ${zone.mediation.option}`,
+      followUp: 'lier à une culture visible',
+    }));
+  const warnings = [...selectedFocusWarning, ...crossRegionWarnings].slice(0, 2);
+
+  if (warnings.length === 0) {
+    return [{
+      warningId: `atlas-mediation:${selectedProvinceId}:coherent`,
+      state: 'coherent',
+      cultureName: selectedEntries[0]?.cultureName ?? 'culture locale',
+      title: 'engagement cohérent',
+      detail: selectedEntries.length > 0 ? 'signaux régionaux alignés' : 'aucun engagement actif',
+      followUp: selectedEntries.length > 0 ? 'maintenir suivi' : 'attendre médiation',
+    }];
+  }
+
+  return warnings;
+}
+
+function renderCultureMediationSignalWarnings(warnings) {
+  return `
+    <div class="culture-mediation-warnings" aria-label="Avertissements des engagements de médiation culturelle">
+      <div class="culture-mediation-warnings__header">
+        <strong>Engagements de médiation</strong>
+        <span>${warnings.length} signal${warnings.length > 1 ? 'aux' : ''}</span>
+      </div>
+      ${warnings.map((warning) => `
+        <article class="culture-mediation-warning culture-mediation-warning--${warning.state}">
+          <b>${warning.title}</b>
+          <span>${warning.cultureName} · ${warning.detail}</span>
+          <small>suivi: ${warning.followUp}</small>
+        </article>
+      `).join('')}
+    </div>
+  `;
+}
+
 function renderCultureSidePanel(cultureView) {
   if (state.activeOverlaySlot !== 'culture-overlay') {
     return null;
@@ -11415,6 +11495,7 @@ function renderCultureSidePanel(cultureView) {
     selectedMarker: focus,
     selectedCluster,
   });
+  const mediationWarnings = buildAtlasMediationSignalWarnings(cultureView, state.selectedProvinceId);
 
   return `
     <section class="panel overlay-panel overlay-panel--culture">
@@ -11438,6 +11519,7 @@ function renderCultureSidePanel(cultureView) {
       ${renderCultureDiscoveryUrgencyGroups(discoveryUrgencyGroups)}
       ${renderCultureInterventionPriorities(interventionPriorities)}
       ${renderCultureBlockerResolutionHistory(blockerHistory)}
+      ${renderCultureMediationSignalWarnings(mediationWarnings)}
       ${renderCultureClusterPinList(selectedCluster)}
       ${focus ? `
         <article class="culture-focus-card culture-focus-card--${getCultureTone(focus)}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -10904,3 +10904,34 @@ button { font: inherit; }
 }
 .atlas-cultural-border-zone--commitment-stable .atlas-cultural-border-zone__commitment { fill: #bbf7d0; }
 .atlas-cultural-border-zone--commitment-risk .atlas-cultural-border-zone__commitment { fill: #fed7aa; }
+.culture-mediation-warnings {
+  display: grid;
+  gap: 7px;
+  padding: 10px;
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.42);
+}
+.culture-mediation-warnings__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: #f8fafc;
+  font-size: 12px;
+}
+.culture-mediation-warnings__header span { color: #fde68a; font-size: 11px; }
+.culture-mediation-warning {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(2, 6, 23, 0.28);
+}
+.culture-mediation-warning b { color: #f8fafc; font-size: 12px; }
+.culture-mediation-warning span,
+.culture-mediation-warning small { color: #cbd5e1; font-size: 11px; line-height: 1.3; }
+.culture-mediation-warning--conflict { border-color: rgba(251, 113, 133, 0.32); background: rgba(127, 29, 29, 0.12); }
+.culture-mediation-warning--conflict b { color: #fecdd3; }
+.culture-mediation-warning--coherent { border-color: rgba(74, 222, 128, 0.26); background: rgba(20, 83, 45, 0.12); }
+.culture-mediation-warning--coherent b { color: #bbf7d0; }


### PR DESCRIPTION
Gamma: Implements #791.

## Summary
- add province-panel warnings comparing atlas mediation commitments with visible culture signals
- flag optimistic commitments over weak local cohesion and mediation that does not match the selected region culture
- include concise follow-up suggestions plus a coherent/no-active-conflict state

## Validation
- node --check web/app.js
- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/war/webAtlasWorldMapCanvas.test.js
- git diff --check
- npm test (533 OK)