### PR TITLE
Epsilon: rank atlas climate action plans

### DIFF
--- a/test/ui/climate/webAtlasClimateActionPlanRanking.test.js
+++ b/test/ui/climate/webAtlasClimateActionPlanRanking.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas ranks climate action plans by deadline severity and regional exposure', () => {
+  assert.match(webAppSource, /function getAtlasClimateActionPlanUrgencyScore/);
+  assert.match(webAppSource, /function buildAtlasClimateActionPlanRanking/);
+  assert.match(webAppSource, /function renderAtlasClimateActionPlanRanking/);
+  assert.match(webAppSource, /deadlineRank/);
+  assert.match(webAppSource, /severityRank/);
+  assert.match(webAppSource, /exposureRank/);
+  assert.match(webAppSource, /catastrophe\/cascade active avant la deadline/);
+  assert.match(webAppSource, /exposition régionale encore vulnérable/);
+  assert.match(webAppSource, /expectedImpact/);
+  assert.match(webAppSource, /sort\(\(left, right\) => right\.urgencyScore - left\.urgencyScore/);
+  assert.match(webAppSource, /atlasClimateActionPlanRanking = buildAtlasClimateActionPlanRanking\(atlasClimateActionPlan\)/);
+  assert.match(webAppSource, /renderAtlasClimateActionPlanRanking\(atlasClimateActionPlanRanking\)/);
+  assert.match(webAppSource, /Priorités plans climat/);
+  assert.match(webAppSource, /Impact attendu/);
+
+  assert.match(stylesSource, /\.map-world-climate-action-ranking/);
+  assert.match(stylesSource, /\.map-world-climate-action-ranking__item--critical/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -5976,6 +5976,81 @@ function buildAtlasClimateActionPlanFromComparison(planComparison) {
   };
 }
 
+function getAtlasClimateActionPlanUrgencyScore(plan, vulnerabilityCount = 0) {
+  const deadlineRank = /Printemps|Été|Automne|Hiver/i.test(plan.criticalSeason) ? 4 : 2;
+  const severityRank = plan.intensity === 'critical' ? 8 : plan.intensity === 'elevated' ? 5 : 2;
+  const exposureRank = (plan.badges?.includes('route protégée') ? 3 : 0) + (plan.protectedRegions?.split('·').length ?? 1) + vulnerabilityCount;
+  return deadlineRank + severityRank + exposureRank + Math.round((plan.score ?? 0) / 10);
+}
+
+function buildAtlasClimateActionPlanRanking(actionPlanView) {
+  if (!actionPlanView || actionPlanView.state === 'empty' || !actionPlanView.selectedPlan) {
+    return {
+      state: 'empty',
+      priorities: [],
+      summary: 'Aucun plan climat à classer par délai et exposition régionale.',
+    };
+  }
+
+  const candidates = [actionPlanView.selectedPlan, ...actionPlanView.vulnerablePlans]
+    .filter((plan, index, all) => plan && all.findIndex((candidate) => candidate.provinceId === plan.provinceId) === index)
+    .map((plan) => {
+      const vulnerabilityCount = actionPlanView.vulnerablePlans.some((candidate) => candidate.provinceId === plan.provinceId) ? 1 : 0;
+      const urgencyScore = getAtlasClimateActionPlanUrgencyScore(plan, vulnerabilityCount);
+      const mainReason = plan.intensity === 'critical'
+        ? 'catastrophe/cascade active avant la deadline'
+        : vulnerabilityCount > 0
+          ? 'exposition régionale encore vulnérable'
+          : plan.badges?.includes('route protégée')
+            ? 'route protégée et cascade évitable'
+            : 'deadline saisonnière à surveiller';
+
+      return {
+        ...plan,
+        urgencyScore,
+        mainReason,
+        expectedImpact: `${plan.avoidedCascade}; ${plan.protectedRegions} moins exposée${plan.protectedRegions?.includes('·') ? 's' : ''}.`,
+      };
+    })
+    .sort((left, right) => right.urgencyScore - left.urgencyScore || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 3)
+    .map((plan, index) => ({ ...plan, priorityRank: index + 1 }));
+
+  return {
+    state: candidates.length > 0 ? 'ready' : 'empty',
+    priorities: candidates,
+    summary: candidates.length > 0
+      ? `${candidates.length} plan${candidates.length > 1 ? 's' : ''} climat classé${candidates.length > 1 ? 's' : ''} par deadline, cascade active et exposition régionale.`
+      : 'Aucun plan climat à classer par délai et exposition régionale.',
+  };
+}
+
+function renderAtlasClimateActionPlanRanking(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-action-ranking" aria-label="Priorisation des plans d’action climat par urgence">
+      <div class="map-world-climate-action-ranking__header">
+        <strong>Priorités plans climat</strong>
+        <span>${view.priorities.length} classé${view.priorities.length > 1 ? 's' : ''}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-action-ranking__list">
+        ${view.priorities.map((plan) => `
+          <li class="map-world-climate-action-ranking__item map-world-climate-action-ranking__item--${plan.intensity}">
+            <b>${plan.priorityRank}. ${plan.provinceLabel}</b>
+            <span>${plan.action} · deadline ${plan.criticalSeason}</span>
+            <small><b>Raison</b> · ${plan.mainReason}</small>
+            <small><b>Impact attendu</b> · ${plan.expectedImpact}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateActionPlan(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -13123,6 +13198,7 @@ function render() {
   const atlasSeasonalMitigationWindows = buildAtlasSeasonalMitigationWindows(atlasClimateMitigationSynergies, worldClimateLayer);
   const atlasSeasonalPlanComparison = buildAtlasSeasonalMitigationPlanComparison(atlasSeasonalMitigationWindows);
   const atlasClimateActionPlan = buildAtlasClimateActionPlanFromComparison(atlasSeasonalPlanComparison);
+  const atlasClimateActionPlanRanking = buildAtlasClimateActionPlanRanking(atlasClimateActionPlan);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -13158,6 +13234,7 @@ function render() {
           ${renderAtlasSeasonalMitigationWindows(atlasSeasonalMitigationWindows)}
           ${renderAtlasSeasonalMitigationPlanComparison(atlasSeasonalPlanComparison)}
           ${renderAtlasClimateActionPlan(atlasClimateActionPlan)}
+          ${renderAtlasClimateActionPlanRanking(atlasClimateActionPlanRanking)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -673,6 +673,44 @@ button { font: inherit; }
   background: rgba(15, 23, 42, 0.54);
   border: 1px solid rgba(74, 222, 128, 0.24);
 }
+.map-world-climate-action-ranking {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.66), rgba(88, 28, 135, 0.22));
+  border: 1px solid rgba(216, 180, 254, 0.28);
+}
+.map-world-climate-action-ranking__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-action-ranking p,
+.map-world-climate-action-ranking span,
+.map-world-climate-action-ranking small {
+  color: #f3e8ff;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-action-ranking__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-action-ranking__item {
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(216, 180, 254, 0.22);
+}
+.map-world-climate-action-ranking__item--critical { border-color: rgba(248, 113, 113, 0.46); }
+.map-world-climate-action-ranking__item--elevated { border-color: rgba(251, 191, 36, 0.36); }
 
 .map-climate-severity-legend {
   display: grid;


### PR DESCRIPTION
Epsilon: Implements #793.

Summary:
- Adds atlas climate action plan priority ranking from the converted action plan view.
- Scores plans by seasonal deadline, active severity/cascade, and regional exposure/vulnerability.
- Shows top priorities with a short ranking reason and expected impact.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateActionPlanRanking.test.js test/ui/climate/webAtlasClimateActionPlanConversion.test.js test/ui/climate/webAtlasSeasonalMitigationPlanComparison.test.js
- npm test