### PR TITLE
Alpha: summarize atlas commitment coverage

### DIFF
--- a/test/ui/war/webAtlasMilitaryCommitmentCoverage.test.js
+++ b/test/ui/war/webAtlasMilitaryCommitmentCoverage.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military commitment coverage aggregates staged commitments by front state', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryCommitmentCoverageSummary\(commitment, conflicts, shell, features\)/);
+  assert.match(webAppSource, /committedStages/);
+  assert.match(webAppSource, /coveredProvinceIds/);
+  assert.match(webAppSource, /uncoveredFronts = shell\.provinces/);
+  assert.match(webAppSource, /province\.contested && !coveredProvinceIds\.has\(province\.provinceId\)/);
+  assert.match(webAppSource, /front actif sans engagement direct/);
+});
+
+test('atlas military commitment coverage summarizes active commitments conflicts priority and deadline', () => {
+  assert.match(webAppSource, /Actifs/);
+  assert.match(webAppSource, /Conflits/);
+  assert.match(webAppSource, /Priorité/);
+  assert.match(webAppSource, /Échéance/);
+  assert.match(webAppSource, /échéance \$\{commitment\.selectedOption\.delay\}/);
+  assert.match(webAppSource, /Contradictoire:/);
+  assert.match(webAppSource, /renderAtlasMilitaryCommitmentCoverageSummary\(commitmentCoverage\)/);
+});
+
+test('atlas military commitment coverage renders compact map panel and empty state', () => {
+  assert.match(webAppSource, /atlas-military-commitment-coverage/);
+  assert.match(webAppSource, /Aucun engagement militaire staged actif à agréger par front/);
+  assert.match(webAppSource, /Non couvert:/);
+  assert.match(stylesSource, /\.atlas-military-commitment-coverage__panel/);
+  assert.match(stylesSource, /\.atlas-military-coverage-row--uncovered/);
+  assert.match(stylesSource, /\.atlas-military-coverage-row--conflict/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1096,7 +1096,109 @@ function renderAtlasMilitaryCommitmentFrontConflicts(conflicts) {
   `;
 }
 
+function buildAtlasMilitaryCommitmentCoverageSummary(commitment, conflicts, shell, features) {
+  const pressureByProvinceId = new Map(shell.provinces.map((province) => [province.provinceId, getAtlasMilitaryPressureScore(province)]));
+  const targetProvince = getAtlasCommitmentTargetProvince(commitment, shell);
+  const committedStages = commitment?.stages?.filter((stage) => stage.status === 'à engager').length ?? 0;
+  const activeStages = commitment?.stages?.length ?? 0;
+  const coveredProvinceIds = new Set(targetProvince ? [targetProvince.provinceId] : []);
+  const uncoveredFronts = shell.provinces
+    .filter((province) => province.contested && !coveredProvinceIds.has(province.provinceId))
+    .map((province) => ({
+      provinceId: province.provinceId,
+      label: province.label,
+      pressure: pressureByProvinceId.get(province.provinceId) ?? 0,
+      reason: 'front actif sans engagement direct',
+    }))
+    .sort((left, right) => right.pressure - left.pressure || left.label.localeCompare(right.label));
+
+  const contradictoryFronts = (conflicts?.conflicts ?? [])
+    .filter((conflict) => conflict.severity === 'haute' || conflict.label.includes('stabilisée'))
+    .map((conflict) => ({
+      conflictId: conflict.conflictId,
+      label: conflict.provinceLabel,
+      reason: conflict.label,
+      priority: conflict.priority,
+    }));
+
+  const frontPriority = uncoveredFronts[0]
+    ?? (targetProvince ? {
+      provinceId: targetProvince.provinceId,
+      label: targetProvince.label,
+      pressure: pressureByProvinceId.get(targetProvince.provinceId) ?? 0,
+      reason: 'front couvert par engagement préparé',
+    } : null);
+
+  const nextDeadline = commitment?.selectedOption?.delay
+    ? `échéance ${commitment.selectedOption.delay}`
+    : 'échéance non planifiée';
+  const rows = [
+    {
+      key: 'active',
+      label: 'Actifs',
+      value: `${activeStages} étape${activeStages > 1 ? 's' : ''} · ${committedStages} à engager`,
+      tone: activeStages > 0 ? 'covered' : 'uncovered',
+    },
+    {
+      key: 'conflicts',
+      label: 'Conflits',
+      value: `${conflicts?.conflicts?.length ?? 0} détecté${(conflicts?.conflicts?.length ?? 0) > 1 ? 's' : ''}`,
+      tone: conflicts?.conflicts?.length ? 'conflict' : 'covered',
+    },
+    {
+      key: 'priority',
+      label: 'Priorité',
+      value: frontPriority ? `${frontPriority.label} · ${frontPriority.reason}` : 'aucun front visible',
+      tone: uncoveredFronts.length ? 'uncovered' : 'covered',
+    },
+    {
+      key: 'deadline',
+      label: 'Échéance',
+      value: nextDeadline,
+      tone: nextDeadline.includes('long') ? 'uncovered' : 'covered',
+    },
+  ];
+
+  return {
+    rows,
+    uncoveredFronts: uncoveredFronts.slice(0, 2),
+    contradictoryFronts: contradictoryFronts.slice(0, 2),
+    summary: activeStages > 0
+      ? `${activeStages} étape${activeStages > 1 ? 's' : ''}; ${uncoveredFronts.length} front${uncoveredFronts.length > 1 ? 's' : ''} non couvert${uncoveredFronts.length > 1 ? 's' : ''}; ${conflicts?.conflicts?.length ?? 0} conflit${(conflicts?.conflicts?.length ?? 0) > 1 ? 's' : ''}.`
+      : 'Aucun engagement militaire staged actif à agréger par front.',
+    empty: activeStages === 0,
+  };
+}
+
+function renderAtlasMilitaryCommitmentCoverageSummary(coverage) {
+  const extraCount = Math.min(2, (coverage.uncoveredFronts?.length ?? 0) + (coverage.contradictoryFronts?.length ?? 0));
+  const height = coverage.empty ? 8 : 8 + (coverage.rows.length * 3.1) + (extraCount * 2.7);
+  const extraRows = [
+    ...(coverage.uncoveredFronts ?? []).map((front) => ({ tone: 'uncovered', label: `Non couvert: ${front.label}` })),
+    ...(coverage.contradictoryFronts ?? []).map((front) => ({ tone: 'conflict', label: `Contradictoire: ${front.label}` })),
+  ].slice(0, 2);
+
+  return `
+    <g class="atlas-military-commitment-coverage" aria-label="Synthèse couverture engagements militaires par front: ${coverage.summary}">
+      <rect class="atlas-military-commitment-coverage__panel" x="3" y="61" width="38" height="${height}" rx="2.5"></rect>
+      <text class="atlas-military-commitment-coverage__title" x="5" y="64.4">Couverture engagements</text>
+      ${coverage.empty ? `<text class="atlas-military-commitment-coverage__empty" x="5" y="68">${coverage.summary}</text>` : `
+        ${coverage.rows.map((row, index) => `
+          <g class="atlas-military-coverage-row atlas-military-coverage-row--${row.tone}" data-atlas-coverage-row="${row.key}">
+            <text class="atlas-military-coverage-row__label" x="5" y="${68 + index * 3.1}">${row.label}</text>
+            <text class="atlas-military-coverage-row__value" x="14" y="${68 + index * 3.1}">${row.value}</text>
+          </g>
+        `).join('')}
+        ${extraRows.map((row, index) => `
+          <text class="atlas-military-coverage-extra atlas-military-coverage-extra--${row.tone}" x="5" y="${81.2 + index * 2.7}">${row.label}</text>
+        `).join('')}
+      `}
+    </g>
+  `;
+}
+
 function buildAtlasMilitaryFeatures(shell) {
+
 
 
 
@@ -1167,6 +1269,7 @@ function renderAtlasMilitaryLayer(shell) {
   const outcomeForecasts = buildAtlasMilitaryOperationOutcomeForecasts(operationSequence);
   const stagedCommitment = buildAtlasMilitaryStagedCommitment(outcomeForecasts);
   const commitmentConflicts = buildAtlasMilitaryCommitmentFrontConflicts(stagedCommitment, shell, features);
+  const commitmentCoverage = buildAtlasMilitaryCommitmentCoverageSummary(stagedCommitment, commitmentConflicts, shell, features);
 
   if (!features.routes.length && !features.riskZones.length) {
     return `
@@ -1193,6 +1296,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryOperationSequence(operationSequence)}
       ${renderAtlasMilitaryOperationOutcomeForecasts(outcomeForecasts)}
       ${renderAtlasMilitaryStagedCommitment(stagedCommitment)}
+      ${renderAtlasMilitaryCommitmentCoverageSummary(commitmentCoverage)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `
         <g class="atlas-military-risk atlas-military-risk--${zone.tone}" data-atlas-risk-province="${zone.provinceId}" aria-label="Zone militaire ${zone.label}: pression ${zone.pressure}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -10370,6 +10370,7 @@ button { font: inherit; }
 .atlas-conflict-comparison,
 .atlas-military-outcome-forecasts,
 .atlas-military-staged-commitment,
+.atlas-military-commitment-coverage,
 .atlas-military-commitment-conflicts {
   pointer-events: auto;
 }
@@ -10542,6 +10543,44 @@ button { font: inherit; }
 .atlas-military-staged-commitment__empty {
   fill: #cbd5e1;
   font-size: 0.96px;
+}
+.atlas-military-commitment-coverage__panel {
+  fill: rgba(15, 23, 42, 0.77);
+  stroke: rgba(129, 140, 248, 0.36);
+  stroke-width: 0.35;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-commitment-coverage__title,
+.atlas-military-coverage-row text,
+.atlas-military-coverage-extra,
+.atlas-military-commitment-coverage__empty {
+  fill: #e0e7ff;
+  font-size: 1.18px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.86);
+  stroke-width: 0.32;
+}
+.atlas-military-coverage-row__label {
+  fill: #c7d2fe;
+}
+.atlas-military-coverage-row__value {
+  fill: #f8fafc;
+}
+.atlas-military-coverage-row--uncovered .atlas-military-coverage-row__value,
+.atlas-military-coverage-extra--uncovered {
+  fill: #fde68a;
+}
+.atlas-military-coverage-row--conflict .atlas-military-coverage-row__value,
+.atlas-military-coverage-extra--conflict {
+  fill: #fecdd3;
+}
+.atlas-military-coverage-row--covered .atlas-military-coverage-row__value {
+  fill: #bbf7d0;
+}
+.atlas-military-commitment-coverage__empty {
+  fill: #cbd5e1;
+  font-size: 0.98px;
 }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);


### PR DESCRIPTION
Alpha: Implements #799.

Summary:
- aggregates staged military commitments against visible atlas front state
- adds a compact coverage panel with active stages, detected conflicts, priority front, and deadline
- highlights uncovered contested fronts and contradictory commitment/front reads without duplicating the A8 conflict panel
- keeps the change scoped to map/atlas UI helpers and styles

Validation:
- `node --check web/app.js`
- `npm test -- test/ui/war/webAtlasMilitaryCommitmentCoverage.test.js test/ui/war/webAtlasMilitaryCommitmentConflicts.test.js`
- `npm test` (541 passing)
- `git diff --check`