### PR TITLE
Epsilon: show climate action urgency timeline

### DIFF
--- a/test/ui/climate/webAtlasClimateActionUrgencyTimeline.test.js
+++ b/test/ui/climate/webAtlasClimateActionUrgencyTimeline.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas renders a compact urgency timeline from ranked climate action plans', () => {
+  assert.match(webAppSource, /function buildAtlasClimateActionUrgencyTimeline/);
+  assert.match(webAppSource, /function renderAtlasClimateActionUrgencyTimeline/);
+  assert.match(webAppSource, /left\.priorityRank - right\.priorityRank/);
+  assert.match(webAppSource, /Dépendance\/synergie/);
+  assert.match(webAppSource, /Synergie: prépare/);
+  assert.match(webAppSource, /Sans fenêtre proche/);
+  assert.match(webAppSource, /très exposée sans fenêtre d’action proche/);
+  assert.match(webAppSource, /Timeline climat: jouer/);
+  assert.match(webAppSource, /atlasClimateActionUrgencyTimeline = buildAtlasClimateActionUrgencyTimeline\(atlasClimateActionPlanRanking\)/);
+  assert.match(webAppSource, /renderAtlasClimateActionUrgencyTimeline\(atlasClimateActionUrgencyTimeline\)/);
+
+  assert.match(stylesSource, /\.map-world-climate-action-timeline/);
+  assert.match(stylesSource, /\.map-world-climate-action-timeline--alert/);
+  assert.match(stylesSource, /\.map-world-climate-action-timeline__step--critical/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -6051,6 +6051,80 @@ function renderAtlasClimateActionPlanRanking(view) {
   `;
 }
 
+function buildAtlasClimateActionUrgencyTimeline(rankingView) {
+  if (!rankingView || rankingView.state === 'empty' || rankingView.priorities.length === 0) {
+    return {
+      state: 'empty',
+      steps: [],
+      summary: 'Aucune timeline climat à afficher: priorité insuffisante.',
+    };
+  }
+
+  const ordered = rankingView.priorities
+    .slice()
+    .sort((left, right) => left.priorityRank - right.priorityRank || right.urgencyScore - left.urgencyScore || left.provinceLabel.localeCompare(right.provinceLabel));
+  const steps = ordered.map((plan, index) => {
+    const nextPlan = ordered[index + 1];
+    const dependency = nextPlan && plan.protectedRegions?.split('·').some((region) => nextPlan.protectedRegions?.includes(region.trim()))
+      ? `Synergie: prépare ${nextPlan.provinceLabel} via ${plan.protectedRegions}.`
+      : plan.badges?.includes('route protégée')
+        ? `Dépendance atlas: sécurise les routes avant ${plan.criticalSeason}.`
+        : 'Dépendance atlas: autonome mais à relire après le prochain plan.';
+    const exposureCount = plan.protectedRegions?.split('·').filter(Boolean).length ?? 1;
+    const noCloseWindowAlert = exposureCount >= 2 && plan.intensity !== 'critical'
+      ? `Alerte: ${plan.provinceLabel} reste très exposée sans fenêtre d’action proche.`
+      : '';
+
+    return {
+      provinceId: plan.provinceId,
+      provinceLabel: plan.provinceLabel,
+      priorityRank: plan.priorityRank,
+      intensity: plan.intensity,
+      deadline: plan.criticalSeason,
+      exposure: plan.protectedRegions,
+      action: plan.action,
+      reason: plan.mainReason,
+      expectedImpact: plan.expectedImpact,
+      dependency,
+      noCloseWindowAlert,
+    };
+  });
+
+  return {
+    state: steps.some((step) => step.noCloseWindowAlert) ? 'alert' : 'ready',
+    steps,
+    summary: `Timeline climat: jouer ${steps[0].provinceLabel} ensuite, puis suivre les dépendances atlas sans dupliquer le ranking.`,
+  };
+}
+
+function renderAtlasClimateActionUrgencyTimeline(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-action-timeline map-world-climate-action-timeline--${view.state}" aria-label="Timeline d’urgence des plans d’action climat">
+      <div class="map-world-climate-action-timeline__header">
+        <strong>Timeline d’urgence climat</strong>
+        <span>${view.steps[0]?.provinceLabel ?? 'à confirmer'} ensuite</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-action-timeline__list">
+        ${view.steps.map((step) => `
+          <li class="map-world-climate-action-timeline__step map-world-climate-action-timeline__step--${step.intensity}">
+            <b>${step.priorityRank}. ${step.deadline} · ${step.provinceLabel}</b>
+            <span>${step.action}</span>
+            <small><b>Pourquoi ensuite</b> · ${step.reason}</small>
+            <small><b>Exposition</b> · ${step.exposure}</small>
+            <small><b>Dépendance/synergie</b> · ${step.dependency}</small>
+            ${step.noCloseWindowAlert ? `<small class="map-world-climate-action-timeline__alert"><b>Sans fenêtre proche</b> · ${step.noCloseWindowAlert}</small>` : ''}
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateActionPlan(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -13199,6 +13273,7 @@ function render() {
   const atlasSeasonalPlanComparison = buildAtlasSeasonalMitigationPlanComparison(atlasSeasonalMitigationWindows);
   const atlasClimateActionPlan = buildAtlasClimateActionPlanFromComparison(atlasSeasonalPlanComparison);
   const atlasClimateActionPlanRanking = buildAtlasClimateActionPlanRanking(atlasClimateActionPlan);
+  const atlasClimateActionUrgencyTimeline = buildAtlasClimateActionUrgencyTimeline(atlasClimateActionPlanRanking);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -13235,6 +13310,7 @@ function render() {
           ${renderAtlasSeasonalMitigationPlanComparison(atlasSeasonalPlanComparison)}
           ${renderAtlasClimateActionPlan(atlasClimateActionPlan)}
           ${renderAtlasClimateActionPlanRanking(atlasClimateActionPlanRanking)}
+          ${renderAtlasClimateActionUrgencyTimeline(atlasClimateActionUrgencyTimeline)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -711,6 +711,49 @@ button { font: inherit; }
 }
 .map-world-climate-action-ranking__item--critical { border-color: rgba(248, 113, 113, 0.46); }
 .map-world-climate-action-ranking__item--elevated { border-color: rgba(251, 191, 36, 0.36); }
+.map-world-climate-action-timeline {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.68), rgba(120, 53, 15, 0.2));
+  border: 1px solid rgba(253, 186, 116, 0.28);
+}
+.map-world-climate-action-timeline--alert { border-color: rgba(248, 113, 113, 0.42); }
+.map-world-climate-action-timeline__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-action-timeline p,
+.map-world-climate-action-timeline span,
+.map-world-climate-action-timeline small {
+  color: #ffedd5;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-action-timeline__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-action-timeline__step {
+  position: relative;
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(253, 186, 116, 0.22);
+}
+.map-world-climate-action-timeline__step--critical { border-color: rgba(248, 113, 113, 0.46); }
+.map-world-climate-action-timeline__step--elevated { border-color: rgba(251, 191, 36, 0.36); }
+.map-world-climate-action-timeline__alert { color: #fecaca; }
 
 .map-climate-severity-legend {
   display: grid;


### PR DESCRIPTION
Epsilon: Implements #803.

Summary:
- Reuses the E8 climate action ranking to render a compact urgency timeline.
- Keeps deterministic order by priority rank/score/label while adding deadline, exposure, and dependency/synergy details.
- Flags highly exposed non-critical plans that lack a near action window so the timeline complements the ranking instead of duplicating it.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateActionUrgencyTimeline.test.js test/ui/climate/webAtlasClimateActionPlanRanking.test.js test/ui/climate/webAtlasClimateActionPlanConversion.test.js
- npm test