### PR TITLE
Gamma: track mediation outcome status

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -30,6 +30,8 @@ test('world map atlas renders culture influence zones from existing culture over
   assert.match(webAppSource, /zone\.commitment\.nextConsequence/);
   assert.match(webAppSource, /function buildAtlasMediationSignalWarnings/);
   assert.match(webAppSource, /renderCultureMediationSignalWarnings/);
+  assert.match(webAppSource, /outcomeStatus/);
+  assert.match(webAppSource, /atlas-mediation-outcome/);
 });
 
 test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
@@ -47,7 +49,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /protéger découverte/);
   assert.match(webAppSource, /arbitrer influence/);
   assert.match(webAppSource, /pacte de frontière/);
-  assert.match(webAppSource, /si ignorée:/);
+  assert.match(webAppSource, /risque restant:/);
   assert.match(webAppSource, /aucun engagement · frontières stables/);
   assert.match(webAppSource, /confiance \$\{zone\.mediation\.confidence\}/);
   assert.match(webAppSource, /engagement stable/);
@@ -60,7 +62,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /engagement trop optimiste/);
   assert.match(webAppSource, /médiation hors culture locale/);
   assert.match(webAppSource, /engagement cohérent/);
-  assert.match(webAppSource, /revérifier confiance/);
+  assert.match(webAppSource, /réviser engagement/);
+  assert.match(webAppSource, /renforcer suivi/);
+  assert.match(webAppSource, /conserver médiation/);
+  assert.match(webAppSource, /risque restant:/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -83,4 +88,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.culture-mediation-warnings/);
   assert.match(stylesSource, /\.culture-mediation-warning--conflict/);
   assert.match(stylesSource, /\.culture-mediation-warning--coherent/);
+  assert.match(stylesSource, /\.atlas-mediation-outcome--améliore/);
+  assert.match(stylesSource, /\.atlas-mediation-outcome--instable/);
+  assert.match(stylesSource, /\.atlas-mediation-outcome--contredit/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1517,12 +1517,28 @@ function buildAtlasMediationCommitment(zone) {
       : zone.mainDriver === 'événement'
         ? 'phase repère'
         : 'phase suivi';
+  const outcomeStatus = status === 'stable'
+    ? 'améliore'
+    : remainingConfidence === 'faible'
+      ? 'contredit'
+      : 'instable';
+  const nextAction = outcomeStatus === 'améliore'
+    ? 'conserver médiation'
+    : outcomeStatus === 'contredit'
+      ? 'réviser engagement'
+      : 'renforcer suivi';
+  const residualRisk = outcomeStatus === 'améliore'
+    ? zone.mediation.consequences.cost
+    : zone.mediation.risk;
 
   return {
     status,
     remainingConfidence,
     nextConsequence,
     phase,
+    outcomeStatus,
+    nextAction,
+    residualRisk,
     label: status === 'stable' ? 'engagement stable' : 'engagement à risque',
   };
 }
@@ -1553,6 +1569,12 @@ function renderAtlasCultureLayer(cultureView) {
           <text x="${summary.center.x + 4.2}%" y="${summary.center.y + 4.3}%">${summary.drift.causes.join(' · ')}</text>
         </g>
       `).join('')}
+      ${features.borderZones.map((zone) => `
+        <g class="atlas-mediation-outcome atlas-mediation-outcome--${zone.commitment.outcomeStatus}" data-atlas-mediation-outcome="${zone.regionId}" aria-label="Suivi médiation ${zone.cultureName}: signal ${zone.commitment.outcomeStatus}, impact ${zone.commitment.nextConsequence}, risque ${zone.commitment.residualRisk}, prochaine action ${zone.commitment.nextAction}">
+          <circle cx="${zone.center.x}%" cy="${zone.center.y + 6}%" r="1.55"></circle>
+          <text x="${zone.center.x + 2}%" y="${zone.center.y + 6.4}%">${zone.commitment.outcomeStatus} · ${zone.commitment.nextAction}</text>
+        </g>
+      `).join('')}
       ${features.borderZones.length > 0 ? `
         <g class="atlas-cultural-border-zones" aria-label="Synthèse des frontières culturelles instables et médiations">
           <rect x="3" y="55" width="30" height="${12 + (features.borderZones.length * 12.2)}" rx="1.8"></rect>
@@ -1563,9 +1585,9 @@ function renderAtlasCultureLayer(cultureView) {
               <text class="atlas-cultural-border-zone__chips" x="5" y="${64 + index * 12.2}">${zone.chips.join(' · ')}</text>
               <text class="atlas-cultural-border-zone__mediation" x="5" y="${66 + index * 12.2}">${zone.mediation.option} → ${zone.mediation.benefit}</text>
               <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 12.2}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
-              <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 12.2}">${zone.commitment.label} · reste ${zone.commitment.remainingConfidence} · ${zone.commitment.phase}</text>
-              <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 12.2}">prochain: ${zone.commitment.nextConsequence} · coût: ${zone.mediation.consequences.cost}</text>
-              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 12.2}">si ignorée: ${zone.mediation.risk}</text>
+              <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 12.2}">${zone.commitment.label} · ${zone.commitment.outcomeStatus} · reste ${zone.commitment.remainingConfidence}</text>
+              <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 12.2}">prochain: ${zone.commitment.nextConsequence} · action: ${zone.commitment.nextAction}</text>
+              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 12.2}">risque restant: ${zone.commitment.residualRisk}</text>
             </g>
           `).join('')}
         </g>
@@ -11914,8 +11936,8 @@ function buildAtlasMediationSignalWarnings(cultureView, selectedProvinceId = sta
           state: 'conflict',
           cultureName: zone.cultureName,
           title: 'engagement trop optimiste',
-          detail: `cohésion locale ${selectedCohesion || 'faible'} · ${zone.commitment.label}`,
-          followUp: 'revérifier confiance',
+          detail: `cohésion locale ${selectedCohesion || 'faible'} · ${zone.commitment.outcomeStatus}`,
+          followUp: zone.commitment.nextAction,
         });
       }
       if (!selectedCultures.has(zone.cultureName)) {
@@ -11938,8 +11960,8 @@ function buildAtlasMediationSignalWarnings(cultureView, selectedProvinceId = sta
       state: 'conflict',
       cultureName: zone.cultureName,
       title: 'médiation hors culture locale',
-      detail: `${zone.regionId} · ${zone.mediation.option}`,
-      followUp: 'lier à une culture visible',
+      detail: `${zone.regionId} · ${zone.commitment.outcomeStatus}`,
+      followUp: zone.commitment.nextAction,
     }));
   const warnings = [...selectedFocusWarning, ...crossRegionWarnings].slice(0, 2);
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -11154,3 +11154,22 @@ button { font: inherit; }
 }
 .atlas-funded-capacity-projection-item--saturated .atlas-funded-capacity-projection-item__detail { fill: #fed7aa; }
 .atlas-funded-capacity-projection-item--sufficient .atlas-funded-capacity-projection-item__detail { fill: #bbf7d0; }
+.atlas-mediation-outcome circle {
+  fill: rgba(15, 23, 42, 0.78);
+  stroke: rgba(224, 242, 254, 0.62);
+  stroke-width: 0.32;
+}
+.atlas-mediation-outcome text {
+  fill: #e0f2fe;
+  font-size: 1.05px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.84);
+  stroke-width: 0.3;
+}
+.atlas-mediation-outcome--améliore circle { stroke: rgba(74, 222, 128, 0.82); }
+.atlas-mediation-outcome--améliore text { fill: #bbf7d0; }
+.atlas-mediation-outcome--instable circle { stroke: rgba(251, 191, 36, 0.82); }
+.atlas-mediation-outcome--instable text { fill: #fde68a; }
+.atlas-mediation-outcome--contredit circle { stroke: rgba(251, 113, 133, 0.82); }
+.atlas-mediation-outcome--contredit text { fill: #fecdd3; }


### PR DESCRIPTION
Gamma: Implements #801.

## Summary
- add compact atlas outcome badges for engaged cultural mediations by region
- classify mediation signals as improving, unstable, or contradictory with expected impact, residual risk, and next action
- keep existing G8 conflict warnings visible while reusing the same commitment/mediation data path

## Validation
- node --check web/app.js
- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/war/webAtlasWorldMapCanvas.test.js
- git diff --check
- npm test (542 OK)