### PR TITLE
Alpha: highlight atlas commitment debt

### DIFF
--- a/test/ui/war/webAtlasMilitaryCommitmentDebt.test.js
+++ b/test/ui/war/webAtlasMilitaryCommitmentDebt.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military commitment debt reuses coverage and staged commitment data', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryCommitmentDebtSummary\(coverage, commitment, shell\)/);
+  assert.match(webAppSource, /coverage\?\.uncoveredFronts/);
+  assert.match(webAppSource, /coverage\?\.contradictoryFronts/);
+  assert.match(webAppSource, /getAtlasCommitmentTargetProvince\(commitment, shell\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryCommitmentDebtSummary\(commitmentDebt\)/);
+  assert.doesNotMatch(webAppSource, /new WarModel|simulateWar|hiddenDebt/);
+});
+
+test('atlas military commitment debt lists active threat partial and absent coverage reasons', () => {
+  assert.match(webAppSource, /pression élevée non couverte/);
+  assert.match(webAppSource, /menace active encore non couverte/);
+  assert.match(webAppSource, /soutien engagé ailleurs|soutien engagé sur front stabilisé/);
+  assert.match(webAppSource, /tone: 'absent'/);
+  assert.match(webAppSource, /tone: 'threat'/);
+  assert.match(webAppSource, /tone: 'partial'/);
+  assert.match(webAppSource, /priority: 70 \+ front\.pressure/);
+});
+
+test('atlas military commitment debt renders compact atlas panel markers and empty state', () => {
+  assert.match(webAppSource, /atlas-military-commitment-debt/);
+  assert.match(webAppSource, /Dette engagement/);
+  assert.match(webAppSource, /DETTE/);
+  assert.match(webAppSource, /Dette d’engagement nulle: tous les fronts actifs visibles sont couverts/);
+  assert.match(stylesSource, /\.atlas-military-commitment-debt__panel/);
+  assert.match(stylesSource, /\.atlas-military-debt-marker--absent circle/);
+  assert.match(stylesSource, /\.atlas-military-debt-row--partial circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1197,7 +1197,94 @@ function renderAtlasMilitaryCommitmentCoverageSummary(coverage) {
   `;
 }
 
+function buildAtlasMilitaryCommitmentDebtSummary(coverage, commitment, shell) {
+  const pressureByProvinceId = new Map(shell.provinces.map((province) => [province.provinceId, getAtlasMilitaryPressureScore(province)]));
+  const targetProvince = getAtlasCommitmentTargetProvince(commitment, shell);
+  const coveredProvinceIds = new Set(targetProvince ? [targetProvince.provinceId] : []);
+  const debtByProvinceId = new Map();
+
+  (coverage?.uncoveredFronts ?? []).forEach((front) => {
+    debtByProvinceId.set(front.provinceId, {
+      debtId: `uncovered:${front.provinceId}`,
+      provinceId: front.provinceId,
+      label: front.label,
+      tone: 'absent',
+      severity: 'haute',
+      priority: 70 + front.pressure,
+      reason: front.pressure >= 70 ? 'pression élevée non couverte' : 'front actif sans engagement',
+    });
+  });
+
+  shell.provinces
+    .filter((province) => province.contested && !coveredProvinceIds.has(province.provinceId))
+    .forEach((province) => {
+      const pressure = pressureByProvinceId.get(province.provinceId) ?? 0;
+      if (pressure < 55 || debtByProvinceId.has(province.provinceId)) return;
+      debtByProvinceId.set(province.provinceId, {
+        debtId: `threat:${province.provinceId}`,
+        provinceId: province.provinceId,
+        label: province.label,
+        tone: 'threat',
+        severity: 'moyenne',
+        priority: 52 + pressure,
+        reason: 'menace active encore non couverte',
+      });
+    });
+
+  (coverage?.contradictoryFronts ?? []).forEach((front) => {
+    debtByProvinceId.set(front.conflictId, {
+      debtId: `contradictory:${front.conflictId}`,
+      provinceId: null,
+      label: front.label,
+      tone: 'partial',
+      severity: 'moyenne',
+      priority: front.priority,
+      reason: front.reason.includes('stabilisée') ? 'soutien engagé sur front stabilisé' : 'soutien engagé ailleurs',
+    });
+  });
+
+  const debts = [...debtByProvinceId.values()]
+    .sort((left, right) => right.priority - left.priority || left.label.localeCompare(right.label))
+    .slice(0, 3)
+    .map((debt) => ({
+      ...debt,
+      center: debt.provinceId ? getProvinceCenter(debt.provinceId) : null,
+    }));
+
+  return {
+    debts,
+    summary: debts.length > 0
+      ? `${debts.length} dette${debts.length > 1 ? 's' : ''} d’engagement: ${debts.map((debt) => debt.label).join(', ')}.`
+      : 'Dette d’engagement nulle: tous les fronts actifs visibles sont couverts.',
+    empty: debts.length === 0,
+  };
+}
+
+function renderAtlasMilitaryCommitmentDebtSummary(debtSummary) {
+  const height = debtSummary.empty ? 8 : 8 + (debtSummary.debts.length * 3.9);
+  return `
+    <g class="atlas-military-commitment-debt" aria-label="Dette d’engagement militaire restante: ${debtSummary.summary}">
+      <rect class="atlas-military-commitment-debt__panel" x="61" y="25" width="36" height="${height}" rx="2.4"></rect>
+      <text class="atlas-military-commitment-debt__title" x="63" y="28.4">Dette engagement</text>
+      ${debtSummary.empty ? `<text class="atlas-military-commitment-debt__empty" x="63" y="32">${debtSummary.summary}</text>` : debtSummary.debts.map((debt, index) => `
+        <g class="atlas-military-debt-row atlas-military-debt-row--${debt.tone}" data-atlas-commitment-debt="${debt.debtId}" aria-label="${debt.label}: ${debt.reason}, priorité ${debt.priority}">
+          <circle cx="63.9" cy="${32 + index * 3.9}" r="0.9"></circle>
+          <text class="atlas-military-debt-row__label" x="65.5" y="${31.4 + index * 3.9}">${debt.label} · ${debt.severity}</text>
+          <text class="atlas-military-debt-row__reason" x="65.5" y="${33.1 + index * 3.9}">${debt.reason}</text>
+        </g>
+      `).join('')}
+      ${debtSummary.debts.filter((debt) => debt.center).map((debt) => `
+        <g class="atlas-military-debt-marker atlas-military-debt-marker--${debt.tone}" data-atlas-commitment-debt-marker="${debt.debtId}" aria-label="Dette ${debt.label}: ${debt.reason}">
+          <circle cx="${debt.center.x}%" cy="${debt.center.y}%" r="1.45"></circle>
+          <text x="${debt.center.x}%" y="${debt.center.y - 2.1}%" text-anchor="middle">DETTE</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function buildAtlasMilitaryFeatures(shell) {
+
 
 
 
@@ -1270,6 +1357,7 @@ function renderAtlasMilitaryLayer(shell) {
   const stagedCommitment = buildAtlasMilitaryStagedCommitment(outcomeForecasts);
   const commitmentConflicts = buildAtlasMilitaryCommitmentFrontConflicts(stagedCommitment, shell, features);
   const commitmentCoverage = buildAtlasMilitaryCommitmentCoverageSummary(stagedCommitment, commitmentConflicts, shell, features);
+  const commitmentDebt = buildAtlasMilitaryCommitmentDebtSummary(commitmentCoverage, stagedCommitment, shell);
 
   if (!features.routes.length && !features.riskZones.length) {
     return `
@@ -1297,6 +1385,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryOperationOutcomeForecasts(outcomeForecasts)}
       ${renderAtlasMilitaryStagedCommitment(stagedCommitment)}
       ${renderAtlasMilitaryCommitmentCoverageSummary(commitmentCoverage)}
+      ${renderAtlasMilitaryCommitmentDebtSummary(commitmentDebt)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `
         <g class="atlas-military-risk atlas-military-risk--${zone.tone}" data-atlas-risk-province="${zone.provinceId}" aria-label="Zone militaire ${zone.label}: pression ${zone.pressure}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -10441,6 +10441,7 @@ button { font: inherit; }
 .atlas-military-outcome-forecasts,
 .atlas-military-staged-commitment,
 .atlas-military-commitment-coverage,
+.atlas-military-commitment-debt,
 .atlas-military-commitment-conflicts {
   pointer-events: auto;
 }
@@ -10651,6 +10652,51 @@ button { font: inherit; }
 .atlas-military-commitment-coverage__empty {
   fill: #cbd5e1;
   font-size: 0.98px;
+}
+.atlas-military-commitment-debt__panel {
+  fill: rgba(24, 24, 27, 0.78);
+  stroke: rgba(251, 191, 36, 0.38);
+  stroke-width: 0.35;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-commitment-debt__title,
+.atlas-military-debt-row text,
+.atlas-military-commitment-debt__empty {
+  fill: #fef3c7;
+  font-size: 1.22px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.86);
+  stroke-width: 0.32;
+}
+.atlas-military-debt-row circle {
+  fill: rgba(251, 191, 36, 0.82);
+  stroke: rgba(254, 243, 199, 0.74);
+  stroke-width: 0.22;
+}
+.atlas-military-debt-row--absent circle,
+.atlas-military-debt-marker--absent circle { fill: rgba(248, 113, 113, 0.84); }
+.atlas-military-debt-row--partial circle,
+.atlas-military-debt-marker--partial circle { fill: rgba(251, 191, 36, 0.82); }
+.atlas-military-debt-row--threat circle,
+.atlas-military-debt-marker--threat circle { fill: rgba(244, 114, 182, 0.78); }
+.atlas-military-debt-row__reason,
+.atlas-military-commitment-debt__empty {
+  fill: #fde68a;
+  font-size: 0.92px;
+}
+.atlas-military-debt-marker circle {
+  stroke: rgba(254, 243, 199, 0.82);
+  stroke-width: 0.35;
+  filter: drop-shadow(0 0 3px rgba(251, 191, 36, 0.6));
+}
+.atlas-military-debt-marker text {
+  fill: #fef3c7;
+  font-size: 1.05px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.34;
 }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);


### PR DESCRIPTION
Alpha: Implements #809.

Summary:
- derives remaining commitment debt from existing staged commitments, coverage summaries, conflicts, and visible front pressure
- highlights uncovered active fronts, partial/contradictory support, and active threats without adding a new source of truth
- renders a compact atlas debt panel and small map markers with clear empty state

Validation:
- `node --check web/app.js`
- `npm test -- test/ui/war/webAtlasMilitaryCommitmentDebt.test.js test/ui/war/webAtlasMilitaryCommitmentCoverage.test.js`
- `npm test` (546 passing)
- `git diff --check`