### PR TITLE
Beta: expose secondary corridor bottlenecks

### DIFF
--- a/test/ui/war/webAtlasWorldMapCanvas.test.js
+++ b/test/ui/war/webAtlasWorldMapCanvas.test.js
@@ -31,6 +31,7 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(webAppSource, /function buildAtlasFundedLogisticsPlans/);
   assert.match(webAppSource, /function buildAtlasCommittedFundingGaps/);
   assert.match(webAppSource, /function buildAtlasFundedCapacityProjections/);
+  assert.match(webAppSource, /function buildAtlasSecondaryBottlenecks/);
   assert.match(webAppSource, /function renderAtlasEconomyStressLegend/);
   assert.match(webAppSource, /atlas-world-economy-layer/);
   assert.match(webAppSource, /atlas-economy-stress-rollup/);
@@ -79,6 +80,12 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(webAppSource, /Revoir tour \+1/);
   assert.match(webAppSource, /priorité: compléter budget/);
   assert.match(webAppSource, /Aucune projection financée/);
+  assert.match(webAppSource, /Prochains goulets/);
+  assert.match(webAppSource, /Aucun goulet secondaire pertinent/);
+  assert.match(webAppSource, /nouveau goulet secondaire/);
+  assert.match(webAppSource, /encore saturé/);
+  assert.match(webAppSource, /résolu/);
+  assert.match(webAppSource, /ralentit le bénéfice financé/);
   assert.match(webAppSource, /atlas-logistics-route--forecast-\$\{forecast\?\.tone \?\? 'unknown'\}/);
   assert.match(webAppSource, /getRouteStressSummary\(route, tensionByCityId, cityNameById\)/);
   assert.match(stylesSource, /\.atlas-world-canvas/);
@@ -106,6 +113,9 @@ test('atlas world map canvas renders ocean terrain and relief as a dedicated map
   assert.match(stylesSource, /\.atlas-funded-capacity-projection/);
   assert.match(stylesSource, /\.atlas-funded-capacity-projection-item--saturated/);
   assert.match(stylesSource, /\.atlas-funded-capacity-projection-item--sufficient/);
+  assert.match(stylesSource, /\.atlas-secondary-bottleneck/);
+  assert.match(stylesSource, /\.atlas-secondary-bottleneck-item--secondary/);
+  assert.match(stylesSource, /\.atlas-secondary-bottleneck-item--resolved/);
   assert.match(stylesSource, /\.atlas-logistics-route--major/);
   assert.match(stylesSource, /\.atlas-economy-city--high/);
   assert.match(stylesSource, /\.atlas-economy-city__resources/);

--- a/web/app.js
+++ b/web/app.js
@@ -2097,6 +2097,66 @@ function buildAtlasFundedCapacityProjections(committedFundingGaps, supplyForecas
   };
 }
 
+function buildAtlasSecondaryBottlenecks(fundedCapacityProjections, supplyForecasts) {
+  if (fundedCapacityProjections.empty) {
+    return {
+      empty: true,
+      items: [],
+      summary: 'Aucun goulet secondaire pertinent',
+    };
+  }
+
+  const projectedRoutes = new Set(fundedCapacityProjections.items.map((item) => item.routeName));
+  const secondary = supplyForecasts.routes
+    .filter((forecast) => !projectedRoutes.has(forecast.routeName))
+    .map((forecast) => {
+      const isNewSecondary = forecast.tone === 'watch' || forecast.tone === 'uncertain';
+      const status = forecast.tone === 'overload'
+        ? 'encore saturé'
+        : isNewSecondary
+          ? 'nouveau goulet secondaire'
+          : 'résolu';
+      const cause = forecast.uncertain
+        ? 'données corridor incomplètes'
+        : forecast.highHubs > 0
+          ? `${forecast.highHubs} hub${forecast.highHubs > 1 ? 's' : ''} encore critique${forecast.highHubs > 1 ? 's' : ''}`
+          : forecast.resourceLoad >= 8
+            ? 'ressource encore fragile'
+            : forecast.tone === 'watch'
+              ? 'capacité limite après report'
+              : 'flux apaisé';
+      const impact = forecast.tone === 'overload'
+        ? 'pénurie aval probable'
+        : isNewSecondary
+          ? 'ralentit le bénéfice financé'
+          : 'aucun impact majeur';
+      const score = forecast.tone === 'overload'
+        ? 40 + forecast.resourceLoad
+        : isNewSecondary
+          ? 24 + forecast.resourceLoad
+          : 4;
+
+      return {
+        routeName: forecast.routeName,
+        corridor: forecast.corridor,
+        status,
+        cause,
+        impact,
+        score,
+      };
+    })
+    .sort((left, right) => right.score - left.score || left.routeName.localeCompare(right.routeName))
+    .slice(0, 3);
+
+  return {
+    empty: secondary.length === 0 || secondary.every((item) => item.status === 'résolu'),
+    items: secondary,
+    summary: secondary.length === 0 || secondary.every((item) => item.status === 'résolu')
+      ? 'Aucun goulet secondaire pertinent'
+      : `${secondary.filter((item) => item.status !== 'résolu').length} prochain${secondary.filter((item) => item.status !== 'résolu').length > 1 ? 's' : ''} goulet${secondary.filter((item) => item.status !== 'résolu').length > 1 ? 's' : ''}`,
+  };
+}
+
 function buildAtlasEconomyStressRollups(economyView) {
   if (!economyView) {
     return { legend: [], regions: [] };
@@ -2112,6 +2172,7 @@ function buildAtlasEconomyStressRollups(economyView) {
   const fundedPlans = buildAtlasFundedLogisticsPlans(actionBudget, budgetShortfalls);
   const committedFundingGaps = buildAtlasCommittedFundingGaps(fundedPlans);
   const fundedCapacityProjections = buildAtlasFundedCapacityProjections(committedFundingGaps, supplyForecasts);
+  const secondaryBottlenecks = buildAtlasSecondaryBottlenecks(fundedCapacityProjections, supplyForecasts);
   const toneRank = { critical: 3, strained: 2, healthy: 1 };
 
   for (const route of economyView.overlay.routes) {
@@ -2211,6 +2272,7 @@ function buildAtlasEconomyStressRollups(economyView) {
     fundedPlans,
     committedFundingGaps,
     fundedCapacityProjections,
+    secondaryBottlenecks,
   };
 }
 
@@ -2223,7 +2285,7 @@ function renderAtlasEconomyStressLegend(economyView) {
 
   return `
     <g class="atlas-economy-stress-rollup" aria-label="Légende économie atlas: stress logistique et régions économiques">
-      <rect class="atlas-economy-stress-rollup__panel" x="3" y="4" width="35" height="${71 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2) + (rollup.budgetShortfalls.items.length * 5.2) + (rollup.fundedPlans.plans.length * 5.4) + (rollup.committedFundingGaps.items.length * 5.4) + (rollup.fundedCapacityProjections.items.length * 5.4)}" rx="2.4"></rect>
+      <rect class="atlas-economy-stress-rollup__panel" x="3" y="4" width="35" height="${80 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2) + (rollup.budgetShortfalls.items.length * 5.2) + (rollup.fundedPlans.plans.length * 5.4) + (rollup.committedFundingGaps.items.length * 5.4) + (rollup.fundedCapacityProjections.items.length * 5.4) + (rollup.secondaryBottlenecks.items.length * 5.2)}" rx="2.4"></rect>
       <text class="atlas-economy-stress-rollup__title" x="5" y="8.3">Stress économie</text>
       ${rollup.legend.map((entry, index) => `
         <g class="atlas-economy-stress-legend atlas-economy-stress-legend--${entry.tone}">
@@ -2325,6 +2387,20 @@ function renderAtlasEconomyStressLegend(economyView) {
             <g class="atlas-funded-capacity-projection-item atlas-funded-capacity-projection-item--${projection.sufficient ? 'sufficient' : 'saturated'}" aria-label="Projection ${projection.routeName}: capacité ${projection.currentCapacity} vers ${projection.projectedCapacity}, ${projection.message}, ${projection.reviewTurn}">
               <text class="atlas-funded-capacity-projection-item__route" x="6.2" y="${y}">${projection.message} · ${projection.corridor} · ${projection.routeName}</text>
               <text class="atlas-funded-capacity-projection-item__detail" x="6.2" y="${y + 2.0}">capacité ${projection.currentCapacity}→${projection.projectedCapacity} · reste ${projection.fundingGap} · ${projection.priority} · ${projection.reviewTurn}</text>
+            </g>
+          `;
+        }).join('')}
+      </g>
+      <g class="atlas-secondary-bottleneck ${rollup.secondaryBottlenecks.empty ? 'is-empty' : ''}" aria-label="Prochains goulets après projection: ${rollup.secondaryBottlenecks.summary}">
+        <rect x="5" y="${73.2 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2) + (rollup.budgetShortfalls.items.length * 5.2) + (rollup.fundedPlans.plans.length * 5.4) + (rollup.committedFundingGaps.items.length * 5.4) + (rollup.fundedCapacityProjections.items.length * 5.4)}" width="30.5" height="${rollup.secondaryBottlenecks.empty ? 5.2 : 6.0 + (rollup.secondaryBottlenecks.items.length * 5.2)}" rx="1.4"></rect>
+        <text class="atlas-secondary-bottleneck__title" x="6.2" y="${75.7 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2) + (rollup.budgetShortfalls.items.length * 5.2) + (rollup.fundedPlans.plans.length * 5.4) + (rollup.committedFundingGaps.items.length * 5.4) + (rollup.fundedCapacityProjections.items.length * 5.4)}">Prochains goulets · ${rollup.secondaryBottlenecks.summary}</text>
+        ${rollup.secondaryBottlenecks.empty ? `<text class="atlas-secondary-bottleneck__empty" x="6.2" y="${78.0 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2) + (rollup.budgetShortfalls.items.length * 5.2) + (rollup.fundedPlans.plans.length * 5.4) + (rollup.committedFundingGaps.items.length * 5.4) + (rollup.fundedCapacityProjections.items.length * 5.4)}">Aucun goulet secondaire pertinent</text>` : ''}
+        ${rollup.secondaryBottlenecks.items.map((item, index) => {
+          const y = 79.3 + (rollup.regions.length * 8.1) + (rollup.forecasts.length * 5.4) + (rollup.interventions.length * 6.2) + (rollup.budgetShortfalls.items.length * 5.2) + (rollup.fundedPlans.plans.length * 5.4) + (rollup.committedFundingGaps.items.length * 5.4) + (rollup.fundedCapacityProjections.items.length * 5.4) + (index * 5.2);
+          return `
+            <g class="atlas-secondary-bottleneck-item atlas-secondary-bottleneck-item--${item.status === 'résolu' ? 'resolved' : item.status === 'encore saturé' ? 'saturated' : 'secondary'}" aria-label="Goulet ${index + 1} ${item.routeName}: ${item.status}, cause ${item.cause}, impact ${item.impact}">
+              <text class="atlas-secondary-bottleneck-item__route" x="6.2" y="${y}">${index + 1}. ${item.status} · ${item.corridor} · ${item.routeName}</text>
+              <text class="atlas-secondary-bottleneck-item__detail" x="6.2" y="${y + 2.0}">${item.cause} · ${item.impact}</text>
             </g>
           `;
         }).join('')}

--- a/web/styles.css
+++ b/web/styles.css
@@ -11200,3 +11200,35 @@ button { font: inherit; }
 .atlas-mediation-outcome--instable text { fill: #fde68a; }
 .atlas-mediation-outcome--contredit circle { stroke: rgba(251, 113, 133, 0.82); }
 .atlas-mediation-outcome--contredit text { fill: #fecdd3; }
+.atlas-secondary-bottleneck rect {
+  fill: rgba(88, 28, 135, 0.46);
+  stroke: rgba(196, 181, 253, 0.4);
+  stroke-width: 0.28;
+}
+.atlas-secondary-bottleneck.is-empty rect {
+  fill: rgba(15, 23, 42, 0.42);
+  stroke: rgba(148, 163, 184, 0.24);
+}
+.atlas-secondary-bottleneck__title {
+  fill: #ddd6fe;
+  font-size: 1.16px;
+  font-weight: 950;
+}
+.atlas-secondary-bottleneck__empty {
+  fill: #cbd5e1;
+  font-size: 1px;
+  font-weight: 780;
+}
+.atlas-secondary-bottleneck-item__route {
+  fill: #f8fafc;
+  font-size: 1.06px;
+  font-weight: 920;
+}
+.atlas-secondary-bottleneck-item__detail {
+  fill: #ddd6fe;
+  font-size: 0.94px;
+  font-weight: 760;
+}
+.atlas-secondary-bottleneck-item--saturated .atlas-secondary-bottleneck-item__detail { fill: #fecdd3; }
+.atlas-secondary-bottleneck-item--secondary .atlas-secondary-bottleneck-item__detail { fill: #fde68a; }
+.atlas-secondary-bottleneck-item--resolved .atlas-secondary-bottleneck-item__detail { fill: #bbf7d0; }


### PR DESCRIPTION
Beta: Implements #810.

## Summary
- Adds a compact atlas “Prochains goulets” section after funded capacity projections.
- Derives secondary bottlenecks from existing funded projections and supply forecasts, with rank, corridor, cause, and expected impact.
- Distinguishes resolved, still saturated, and new secondary bottleneck states.
- Keeps the empty state explicit when no relevant secondary bottleneck exists.

## Validation
- npm test (543 OK)
- targeted atlas world map tests (2 OK)
- node --check web/app.js
- git diff --check
