### PR TITLE
Delta: mark residual intelligence blind spots

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -296,6 +296,21 @@ test('atlas counterintelligence summarizes coverage after assignment orders', ()
   assert.match(stylesSource, /atlas-counterintelligence-post-order-coverage__grid/);
 });
 
+test('atlas counterintelligence marks residual blind spots after sweep summaries', () => {
+  assert.match(webAppSource, /residualBlindSpots/);
+  assert.match(webAppSource, /Angles morts résiduels/);
+  assert.match(webAppSource, /Angles morts résiduels de renseignement fog-safe/);
+  assert.match(webAppSource, /non couvert/);
+  assert.match(webAppSource, /couverture trop faible/);
+  assert.match(webAppSource, /couverture expirante\/contestée/);
+  assert.match(webAppSource, /sévérité/);
+  assert.match(webAppSource, /Ajouter un balayage court ou déplacer une veille stable/);
+  assert.match(webAppSource, /Aucun angle mort résiduel visible/);
+  assert.match(webAppSource, /État vide: aucune province ne reste aveugle ou fragile après ces ordres/);
+  assert.match(stylesSource, /atlas-counterintelligence-blind-spots/);
+  assert.match(stylesSource, /atlas-counterintelligence-blind-spots__item--haute/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -10099,10 +10099,45 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
   const postOrderCoverageSummary = assignmentOrders.length > 0
     ? `${coveredOrderZones.length} zone${coveredOrderZones.length > 1 ? 's' : ''} couverte${coveredOrderZones.length > 1 ? 's' : ''} après ordre; ${uncoveredRiskZones.length} zone${uncoveredRiskZones.length > 1 ? 's' : ''} à risque non couverte${uncoveredRiskZones.length > 1 ? 's' : ''}; ${fragileAssignments.length} affectation${fragileAssignments.length > 1 ? 's' : ''} fragile${fragileAssignments.length > 1 ? 's' : ''} à résoudre.`
     : 'Aucun résumé post-ordre disponible tant qu’aucun ordre de balayage n’est préparé.';
+  const residualBlindSpots = [
+    ...uncoveredRiskZones.map((zone) => ({
+      locationName: zone.locationName,
+      failureType: 'non couvert',
+      severity: 'haute',
+      severityRank: 1,
+      detail: zone.detail,
+      nextAction: 'Ajouter un balayage court ou déplacer une veille stable.',
+    })),
+    ...assignmentOrders
+      .filter((order) => order.coveredZone.includes('partielle'))
+      .map((order) => ({
+        locationName: order.locationName,
+        failureType: 'couverture trop faible',
+        severity: order.safetyStatus === 'unsafe' ? 'haute' : 'moyenne',
+        severityRank: order.safetyStatus === 'unsafe' ? 1 : 2,
+        detail: `${order.coveredZone} · ${order.residualRisk}`,
+        nextAction: 'Renforcer par une équipe légère avant confirmation définitive.',
+      })),
+    ...fragileAssignments.map((zone) => ({
+      locationName: zone.locationName,
+      failureType: 'couverture expirante/contestée',
+      severity: 'moyenne',
+      severityRank: 2,
+      detail: zone.detail,
+      nextAction: 'Résoudre le conflit d’affectation ou replanifier le créneau.',
+    })),
+  ]
+    .sort((left, right) => left.severityRank - right.severityRank || left.locationName.localeCompare(right.locationName))
+    .slice(0, 4);
+  const residualBlindSpotSummary = residualBlindSpots.length > 0
+    ? `${residualBlindSpots.length} angle${residualBlindSpots.length > 1 ? 's' : ''} mort${residualBlindSpots.length > 1 ? 's' : ''} résiduel${residualBlindSpots.length > 1 ? 's' : ''}: ${residualBlindSpots.filter((spot) => spot.failureType === 'non couvert').length} non couvert${residualBlindSpots.filter((spot) => spot.failureType === 'non couvert').length > 1 ? 's' : ''}, ${residualBlindSpots.filter((spot) => spot.failureType === 'couverture trop faible').length} couverture${residualBlindSpots.filter((spot) => spot.failureType === 'couverture trop faible').length > 1 ? 's' : ''} trop faible${residualBlindSpots.filter((spot) => spot.failureType === 'couverture trop faible').length > 1 ? 's' : ''}, ${residualBlindSpots.filter((spot) => spot.failureType === 'couverture expirante/contestée').length} contesté${residualBlindSpots.filter((spot) => spot.failureType === 'couverture expirante/contestée').length > 1 ? 's' : ''}.`
+    : 'Aucun angle mort résiduel visible: la couverture actuelle suffit selon les signaux atlas.';
   const postOrderCoverage = {
     coveredOrderZones,
     fragileAssignments,
     uncoveredRiskZones,
+    residualBlindSpots,
+    residualBlindSpotSummary,
     summary: postOrderCoverageSummary,
   };
   const exposureCooldownSummary = sweepCandidates.length > 0
@@ -10205,6 +10240,13 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
               : '<small>Aucun conflit d’affectation restant à résoudre.</small>'}
           </div>
         </div>
+      </section>
+      <section class="atlas-counterintelligence-blind-spots" aria-label="Angles morts résiduels de renseignement fog-safe">
+        <strong>Angles morts résiduels</strong>
+        <p>${plan.postOrderCoverage.residualBlindSpotSummary}</p>
+        ${plan.postOrderCoverage.residualBlindSpots.length > 0
+          ? `<ul>${plan.postOrderCoverage.residualBlindSpots.map((spot) => `<li class="atlas-counterintelligence-blind-spots__item atlas-counterintelligence-blind-spots__item--${spot.severity}"><b>${spot.locationName}</b> · ${spot.failureType} · sévérité ${spot.severity}<small>${spot.detail} · ${spot.nextAction}</small></li>`).join('')}</ul>`
+          : '<small>État vide: aucune province ne reste aveugle ou fragile après ces ordres.</small>'}
       </section>
       <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">
         <strong>Conflits de planning</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3156,6 +3156,29 @@ button { font: inherit; }
   padding-left: 17px;
   color: #f8fafc;
 }
+.atlas-counterintelligence-blind-spots {
+  display: grid;
+  gap: 7px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(168, 85, 247, 0.26);
+  background: rgba(59, 7, 100, 0.18);
+}
+.atlas-counterintelligence-blind-spots p,
+.atlas-counterintelligence-blind-spots small { margin: 0; color: #e9d5ff; }
+.atlas-counterintelligence-blind-spots ul {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding-left: 18px;
+  color: #f8fafc;
+}
+.atlas-counterintelligence-blind-spots__item--haute { color: #fecaca; }
+.atlas-counterintelligence-blind-spots__item--moyenne { color: #fde68a; }
+.atlas-counterintelligence-blind-spots li small {
+  display: block;
+  margin-top: 2px;
+}
 .atlas-counterintelligence-schedule-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Implements #812.

Summary:
- derives residual intelligence blind spots from existing sweep orders, coverage summaries, and intrigue risk signals
- shows compact atlas entries for uncovered, too-weak, and expiring/contested coverage with severity and next action
- keeps all copy fog-safe without exposing hidden actors, cells, relays, causes, targets, or exact threat details

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- git diff --check HEAD~1..HEAD
- npm test

Delta: Zeta, this PR is ready for validation before merge.