### PR TITLE
Gamma: show cultural rebound windows

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -32,6 +32,8 @@ test('world map atlas renders culture influence zones from existing culture over
   assert.match(webAppSource, /renderCultureMediationSignalWarnings/);
   assert.match(webAppSource, /outcomeStatus/);
   assert.match(webAppSource, /atlas-mediation-outcome/);
+  assert.match(webAppSource, /reboundWindow/);
+  assert.match(webAppSource, /atlas-cultural-rebound-window/);
 });
 
 test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
@@ -49,7 +51,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /protéger découverte/);
   assert.match(webAppSource, /arbitrer influence/);
   assert.match(webAppSource, /pacte de frontière/);
-  assert.match(webAppSource, /risque restant:/);
+  assert.match(webAppSource, /reboundWindow\.label/);
   assert.match(webAppSource, /aucun engagement · frontières stables/);
   assert.match(webAppSource, /confiance \$\{zone\.mediation\.confidence\}/);
   assert.match(webAppSource, /engagement stable/);
@@ -65,7 +67,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /réviser engagement/);
   assert.match(webAppSource, /renforcer suivi/);
   assert.match(webAppSource, /conserver médiation/);
-  assert.match(webAppSource, /risque restant:/);
+  assert.match(webAppSource, /stabilisation possible/);
+  assert.match(webAppSource, /rechute probable/);
+  assert.match(webAppSource, /fenêtre manquée/);
+  assert.match(webAppSource, /aucune fenêtre active/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -91,4 +96,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-mediation-outcome--améliore/);
   assert.match(stylesSource, /\.atlas-mediation-outcome--instable/);
   assert.match(stylesSource, /\.atlas-mediation-outcome--contredit/);
+  assert.match(stylesSource, /\.atlas-cultural-rebound-window--favorable/);
+  assert.match(stylesSource, /\.atlas-cultural-rebound-window--risky/);
+  assert.match(stylesSource, /\.atlas-cultural-rebound-window--missed/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1619,6 +1619,26 @@ function buildAtlasMediationCommitment(zone) {
   const residualRisk = outcomeStatus === 'améliore'
     ? zone.mediation.consequences.cost
     : zone.mediation.risk;
+  const reboundWindow = outcomeStatus === 'améliore'
+    ? {
+        state: 'favorable',
+        label: 'stabilisation possible',
+        reason: `${remainingConfidence} · ${nextConsequence}`,
+        action: 'négocier maintenant',
+      }
+    : outcomeStatus === 'contredit'
+      ? {
+          state: 'missed',
+          label: 'fenêtre manquée',
+          reason: `${zone.drift.label} · ${residualRisk}`,
+          action: 'réviser médiation',
+        }
+      : {
+          state: 'risky',
+          label: 'rechute probable',
+          reason: `${remainingConfidence} · ${zone.drift.label}`,
+          action: 'renforcer relais',
+        };
 
   return {
     status,
@@ -1628,6 +1648,7 @@ function buildAtlasMediationCommitment(zone) {
     outcomeStatus,
     nextAction,
     residualRisk,
+    reboundWindow,
     label: status === 'stable' ? 'engagement stable' : 'engagement à risque',
   };
 }
@@ -1664,6 +1685,18 @@ function renderAtlasCultureLayer(cultureView) {
           <text x="${zone.center.x + 2}%" y="${zone.center.y + 6.4}%">${zone.commitment.outcomeStatus} · ${zone.commitment.nextAction}</text>
         </g>
       `).join('')}
+      ${features.borderZones.length > 0 ? features.borderZones.map((zone) => `
+        <g class="atlas-cultural-rebound-window atlas-cultural-rebound-window--${zone.commitment.reboundWindow.state}" data-atlas-cultural-rebound-window="${zone.regionId}" aria-label="Fenêtre culturelle ${zone.cultureName}: ${zone.commitment.reboundWindow.label}, pourquoi ${zone.commitment.reboundWindow.reason}, action ${zone.commitment.reboundWindow.action}">
+          <rect x="${Math.min(82, zone.center.x + 3)}" y="${Math.min(88, zone.center.y + 8)}" width="15.8" height="4.8" rx="1.5"></rect>
+          <text x="${Math.min(83, zone.center.x + 4)}%" y="${Math.min(90, zone.center.y + 10.1)}%">${zone.commitment.reboundWindow.label}</text>
+          <text class="atlas-cultural-rebound-window__action" x="${Math.min(83, zone.center.x + 4)}%" y="${Math.min(92, zone.center.y + 12)}%">${zone.commitment.reboundWindow.action}</text>
+        </g>
+      `).join('') : `
+        <g class="atlas-cultural-rebound-window is-empty" aria-label="Aucune fenêtre de rebond culturel active">
+          <rect x="66" y="86" width="28" height="6" rx="1.6"></rect>
+          <text x="68%" y="89.8%">aucune fenêtre active</text>
+        </g>
+      `}
       ${features.borderZones.length > 0 ? `
         <g class="atlas-cultural-border-zones" aria-label="Synthèse des frontières culturelles instables et médiations">
           <rect x="3" y="55" width="30" height="${12 + (features.borderZones.length * 12.2)}" rx="1.8"></rect>
@@ -1676,7 +1709,7 @@ function renderAtlasCultureLayer(cultureView) {
               <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 12.2}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
               <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 12.2}">${zone.commitment.label} · ${zone.commitment.outcomeStatus} · reste ${zone.commitment.remainingConfidence}</text>
               <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 12.2}">prochain: ${zone.commitment.nextConsequence} · action: ${zone.commitment.nextAction}</text>
-              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 12.2}">risque restant: ${zone.commitment.residualRisk}</text>
+              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 12.2}">${zone.commitment.reboundWindow.label}: ${zone.commitment.reboundWindow.action}</text>
             </g>
           `).join('')}
         </g>

--- a/web/styles.css
+++ b/web/styles.css
@@ -11301,3 +11301,25 @@ button { font: inherit; }
 .atlas-secondary-bottleneck-item--saturated .atlas-secondary-bottleneck-item__detail { fill: #fecdd3; }
 .atlas-secondary-bottleneck-item--secondary .atlas-secondary-bottleneck-item__detail { fill: #fde68a; }
 .atlas-secondary-bottleneck-item--resolved .atlas-secondary-bottleneck-item__detail { fill: #bbf7d0; }
+.atlas-cultural-rebound-window rect {
+  fill: rgba(15, 23, 42, 0.78);
+  stroke: rgba(224, 242, 254, 0.32);
+  stroke-width: 0.26;
+}
+.atlas-cultural-rebound-window text {
+  fill: #e0f2fe;
+  font-size: 0.95px;
+  font-weight: 900;
+}
+.atlas-cultural-rebound-window__action {
+  fill: #cbd5e1;
+  font-size: 0.86px;
+  font-weight: 780;
+}
+.atlas-cultural-rebound-window--favorable rect { stroke: rgba(74, 222, 128, 0.74); fill: rgba(20, 83, 45, 0.42); }
+.atlas-cultural-rebound-window--favorable text { fill: #bbf7d0; }
+.atlas-cultural-rebound-window--risky rect { stroke: rgba(251, 191, 36, 0.72); fill: rgba(120, 53, 15, 0.38); }
+.atlas-cultural-rebound-window--risky text { fill: #fde68a; }
+.atlas-cultural-rebound-window--missed rect { stroke: rgba(251, 113, 133, 0.72); fill: rgba(127, 29, 29, 0.38); }
+.atlas-cultural-rebound-window--missed text { fill: #fecdd3; }
+.atlas-cultural-rebound-window.is-empty rect { stroke: rgba(148, 163, 184, 0.28); fill: rgba(15, 23, 42, 0.52); }


### PR DESCRIPTION
Gamma: Implements #811.

## Summary
- derive rebound windows from mediation outcome, remaining confidence, drift, and next consequence
- show favorable, risky, missed, and empty rebound-window states on the culture atlas
- keep copy short and action-oriented without adding a global calendar

## Validation
- node --check web/app.js
- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/war/webAtlasWorldMapCanvas.test.js
- git diff --check
- npm test (547 OK)