### PR TITLE
Epsilon: compare climate urgency with readiness

### DIFF
--- a/test/ui/climate/webAtlasClimateMitigationReadinessComparison.test.js
+++ b/test/ui/climate/webAtlasClimateMitigationReadinessComparison.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas compares climate urgency timelines against mitigation readiness', () => {
+  assert.match(webAppSource, /function buildAtlasClimateMitigationReadinessComparison/);
+  assert.match(webAppSource, /function renderAtlasClimateMitigationReadinessComparison/);
+  assert.match(webAppSource, /ready/);
+  assert.match(webAppSource, /just-in-time/);
+  assert.match(webAppSource, /insufficient/);
+  assert.match(webAppSource, /too-late/);
+  assert.match(webAppSource, /deadline, mitigation disponible et risque de cascade/);
+  assert.match(webAppSource, /Timing prioritaire/);
+  assert.match(webAppSource, /Problème timing/);
+  assert.match(webAppSource, /atlasClimateMitigationReadiness = buildAtlasClimateMitigationReadinessComparison\(atlasClimateActionUrgencyTimeline\)/);
+  assert.match(webAppSource, /renderAtlasClimateMitigationReadinessComparison\(atlasClimateMitigationReadiness\)/);
+
+  assert.match(stylesSource, /\.map-world-climate-readiness/);
+  assert.match(stylesSource, /\.map-world-climate-readiness--timing-risk/);
+  assert.match(stylesSource, /\.map-world-climate-readiness__item--just-in-time/);
+  assert.match(stylesSource, /\.map-world-climate-readiness__item--insufficient/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -6456,6 +6456,82 @@ function buildAtlasClimateActionUrgencyTimeline(rankingView) {
   };
 }
 
+function buildAtlasClimateMitigationReadinessComparison(timelineView) {
+  if (!timelineView || timelineView.state === 'empty' || timelineView.steps.length === 0) {
+    return {
+      state: 'empty',
+      regions: [],
+      summary: 'Aucun plan urgent en attente: readiness climat non affichée.',
+    };
+  }
+
+  const regions = timelineView.steps.map((step) => {
+    const readinessStatus = step.intensity === 'critical' && step.noCloseWindowAlert
+      ? 'too-late'
+      : step.intensity === 'critical'
+        ? 'just-in-time'
+        : step.noCloseWindowAlert
+          ? 'insufficient'
+          : 'ready';
+    const mitigationAvailable = readinessStatus === 'ready'
+      ? 'mitigation prête'
+      : readinessStatus === 'just-in-time'
+        ? 'mitigation juste-à-temps'
+        : readinessStatus === 'insufficient'
+          ? 'capacité insuffisante avant fenêtre'
+          : 'fenêtre dépassée';
+    const timingProblem = readinessStatus === 'insufficient' || readinessStatus === 'too-late'
+      ? 'Timing prioritaire: la capacité disponible arrive après l’exposition régionale.'
+      : readinessStatus === 'just-in-time'
+        ? 'Timing serré: jouer maintenant évite le basculement cascade.'
+        : 'Timing couvert: la mitigation précède la cascade probable.';
+
+    return {
+      provinceId: step.provinceId,
+      provinceLabel: step.provinceLabel,
+      status: readinessStatus,
+      deadline: step.deadline,
+      mitigationAvailable,
+      cascadeRisk: step.reason,
+      exposure: step.exposure,
+      timingProblem,
+    };
+  });
+
+  return {
+    state: regions.some((region) => region.status === 'too-late' || region.status === 'insufficient') ? 'timing-risk' : 'ready',
+    regions,
+    summary: `${regions.length} région${regions.length > 1 ? 's' : ''} compare${regions.length > 1 ? 'nt' : ''} deadline, mitigation disponible et risque de cascade.`,
+  };
+}
+
+function renderAtlasClimateMitigationReadinessComparison(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-readiness map-world-climate-readiness--${view.state}" aria-label="Comparaison readiness mitigation climat atlas">
+      <div class="map-world-climate-readiness__header">
+        <strong>Readiness mitigation climat</strong>
+        <span>${view.state === 'timing-risk' ? 'timing à risque' : 'timing couvert'}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-readiness__list">
+        ${view.regions.map((region) => `
+          <li class="map-world-climate-readiness__item map-world-climate-readiness__item--${region.status}">
+            <b>${region.provinceLabel}</b>
+            <span>${region.deadline} · ${region.mitigationAvailable}</span>
+            <small><b>Cascade</b> · ${region.cascadeRisk}</small>
+            <small><b>Exposition</b> · ${region.exposure}</small>
+            <small><b>Problème timing</b> · ${region.timingProblem}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateActionUrgencyTimeline(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -13724,6 +13800,7 @@ function render() {
   const atlasClimateActionPlan = buildAtlasClimateActionPlanFromComparison(atlasSeasonalPlanComparison);
   const atlasClimateActionPlanRanking = buildAtlasClimateActionPlanRanking(atlasClimateActionPlan);
   const atlasClimateActionUrgencyTimeline = buildAtlasClimateActionUrgencyTimeline(atlasClimateActionPlanRanking);
+  const atlasClimateMitigationReadiness = buildAtlasClimateMitigationReadinessComparison(atlasClimateActionUrgencyTimeline);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -13761,6 +13838,7 @@ function render() {
           ${renderAtlasClimateActionPlan(atlasClimateActionPlan)}
           ${renderAtlasClimateActionPlanRanking(atlasClimateActionPlanRanking)}
           ${renderAtlasClimateActionUrgencyTimeline(atlasClimateActionUrgencyTimeline)}
+          ${renderAtlasClimateMitigationReadinessComparison(atlasClimateMitigationReadiness)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -754,6 +754,48 @@ button { font: inherit; }
 .map-world-climate-action-timeline__step--critical { border-color: rgba(248, 113, 113, 0.46); }
 .map-world-climate-action-timeline__step--elevated { border-color: rgba(251, 191, 36, 0.36); }
 .map-world-climate-action-timeline__alert { color: #fecaca; }
+.map-world-climate-readiness {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.68), rgba(20, 83, 45, 0.2));
+  border: 1px solid rgba(110, 231, 183, 0.28);
+}
+.map-world-climate-readiness--timing-risk { border-color: rgba(248, 113, 113, 0.42); }
+.map-world-climate-readiness__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-readiness p,
+.map-world-climate-readiness span,
+.map-world-climate-readiness small {
+  color: #d1fae5;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-readiness__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-readiness__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(110, 231, 183, 0.22);
+}
+.map-world-climate-readiness__item--just-in-time { border-color: rgba(251, 191, 36, 0.38); }
+.map-world-climate-readiness__item--insufficient,
+.map-world-climate-readiness__item--too-late { border-color: rgba(248, 113, 113, 0.48); }
 
 .map-climate-severity-legend {
   display: grid;


### PR DESCRIPTION
Epsilon: Implements #813.

Summary:
- Adds an atlas mitigation readiness comparison derived from the climate urgency timeline.
- Classifies regions as ready, just-in-time, insufficient, or too-late using deadline, available mitigation, exposure, and cascade risk.
- Highlights when timing is the primary problem so the panel complements severity/ranking views.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateMitigationReadinessComparison.test.js test/ui/climate/webAtlasClimateActionUrgencyTimeline.test.js test/ui/climate/webAtlasClimateActionPlanRanking.test.js
- npm test