### PR TITLE
Epsilon: flag under-ready climate execution gaps

### DIFF
--- a/test/ui/climate/webAtlasClimateUnderReadyExecutionGaps.test.js
+++ b/test/ui/climate/webAtlasClimateUnderReadyExecutionGaps.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas flags urgent climate plans whose execution readiness is under-prepared', () => {
+  assert.match(webAppSource, /function buildAtlasClimateUnderReadyExecutionGaps/);
+  assert.match(webAppSource, /function renderAtlasClimateUnderReadyExecutionGaps/);
+  assert.match(webAppSource, /region\.status === 'insufficient' \|\| region\.status === 'too-late'/);
+  assert.match(webAppSource, /gapType = region\.status === 'too-late'/);
+  assert.match(webAppSource, /délai/);
+  assert.match(webAppSource, /capacité/);
+  assert.match(webAppSource, /ressource/);
+  assert.match(webAppSource, /dépendance régionale/);
+  assert.match(webAppSource, /Manque concret/);
+  assert.match(webAppSource, /Risque exécution/);
+  assert.match(webAppSource, /aucun avertissement ajouté/);
+  assert.match(webAppSource, /atlasClimateUnderReadyExecutionGaps = buildAtlasClimateUnderReadyExecutionGaps\(atlasClimateMitigationReadiness\)/);
+  assert.match(webAppSource, /renderAtlasClimateUnderReadyExecutionGaps\(atlasClimateUnderReadyExecutionGaps\)/);
+
+  assert.match(stylesSource, /\.map-world-climate-under-ready/);
+  assert.match(stylesSource, /\.map-world-climate-under-ready__item--insufficient/);
+  assert.match(stylesSource, /\.map-world-climate-under-ready__item--too-late/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -6538,6 +6538,84 @@ function buildAtlasClimateMitigationReadinessComparison(timelineView) {
   };
 }
 
+function buildAtlasClimateUnderReadyExecutionGaps(readinessView) {
+  if (!readinessView || readinessView.state === 'empty' || readinessView.regions.length === 0) {
+    return {
+      state: 'empty',
+      gaps: [],
+      summary: 'Aucun déficit d’exécution climat urgent à signaler.',
+    };
+  }
+
+  const gaps = readinessView.regions
+    .filter((region) => region.status === 'insufficient' || region.status === 'too-late' || (region.status === 'just-in-time' && /cascade active|serré/i.test(region.cascadeRisk + region.timingProblem)))
+    .map((region) => {
+      const gapType = region.status === 'too-late'
+        ? 'délai'
+        : region.mitigationAvailable.includes('insuffisante')
+          ? 'capacité'
+          : region.exposure?.includes('·')
+            ? 'dépendance régionale'
+            : 'ressource';
+      const severityScore = (region.status === 'too-late' ? 40 : region.status === 'insufficient' ? 30 : 20)
+        + (region.exposure?.split('·').length ?? 1)
+        + (/cascade active|catastrophe/i.test(region.cascadeRisk) ? 5 : 0);
+
+      return {
+        provinceId: region.provinceId,
+        provinceLabel: region.provinceLabel,
+        status: region.status,
+        gapType,
+        severityScore,
+        deadline: region.deadline,
+        shortfall: gapType === 'délai'
+          ? `${region.deadline}: fenêtre d’action probablement manquée.`
+          : gapType === 'capacité'
+            ? `${region.mitigationAvailable}: besoins régionaux non couverts.`
+            : gapType === 'dépendance régionale'
+              ? `${region.exposure}: dépendances régionales à sécuriser avant l’action.`
+              : `${region.mitigationAvailable}: ressource d’exécution à confirmer.`,
+        consequence: region.timingProblem,
+      };
+    })
+    .sort((left, right) => right.severityScore - left.severityScore || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 3);
+
+  return {
+    state: gaps.length > 0 ? 'warning' : 'clear',
+    gaps,
+    summary: gaps.length > 0
+      ? `${gaps.length} déficit${gaps.length > 1 ? 's' : ''} d’exécution climat urgent${gaps.length > 1 ? 's' : ''} à résoudre avant validation.`
+      : 'Les plans urgents affichés sont suffisamment prêts; aucun avertissement ajouté.',
+  };
+}
+
+function renderAtlasClimateUnderReadyExecutionGaps(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-under-ready" aria-label="Déficits d’exécution des plans climat urgents">
+      <div class="map-world-climate-under-ready__header">
+        <strong>Plans climat sous-prêts</strong>
+        <span>${view.gaps.length} déficit${view.gaps.length > 1 ? 's' : ''}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-under-ready__list">
+        ${view.gaps.map((gap) => `
+          <li class="map-world-climate-under-ready__item map-world-climate-under-ready__item--${gap.status}">
+            <b>${gap.provinceLabel}</b>
+            <span>${gap.deadline} · écart ${gap.gapType}</span>
+            <small><b>Manque concret</b> · ${gap.shortfall}</small>
+            <small><b>Risque exécution</b> · ${gap.consequence}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateMitigationReadinessComparison(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -13834,6 +13912,7 @@ function render() {
   const atlasClimateActionPlanRanking = buildAtlasClimateActionPlanRanking(atlasClimateActionPlan);
   const atlasClimateActionUrgencyTimeline = buildAtlasClimateActionUrgencyTimeline(atlasClimateActionPlanRanking);
   const atlasClimateMitigationReadiness = buildAtlasClimateMitigationReadinessComparison(atlasClimateActionUrgencyTimeline);
+  const atlasClimateUnderReadyExecutionGaps = buildAtlasClimateUnderReadyExecutionGaps(atlasClimateMitigationReadiness);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -13872,6 +13951,7 @@ function render() {
           ${renderAtlasClimateActionPlanRanking(atlasClimateActionPlanRanking)}
           ${renderAtlasClimateActionUrgencyTimeline(atlasClimateActionUrgencyTimeline)}
           ${renderAtlasClimateMitigationReadinessComparison(atlasClimateMitigationReadiness)}
+          ${renderAtlasClimateUnderReadyExecutionGaps(atlasClimateUnderReadyExecutionGaps)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -796,6 +796,47 @@ button { font: inherit; }
 .map-world-climate-readiness__item--just-in-time { border-color: rgba(251, 191, 36, 0.38); }
 .map-world-climate-readiness__item--insufficient,
 .map-world-climate-readiness__item--too-late { border-color: rgba(248, 113, 113, 0.48); }
+.map-world-climate-under-ready {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(127, 29, 29, 0.24));
+  border: 1px solid rgba(248, 113, 113, 0.38);
+}
+.map-world-climate-under-ready__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-under-ready p,
+.map-world-climate-under-ready span,
+.map-world-climate-under-ready small {
+  color: #fee2e2;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-under-ready__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-under-ready__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.56);
+  border: 1px solid rgba(248, 113, 113, 0.28);
+}
+.map-world-climate-under-ready__item--just-in-time { border-color: rgba(251, 191, 36, 0.42); }
+.map-world-climate-under-ready__item--insufficient,
+.map-world-climate-under-ready__item--too-late { border-color: rgba(248, 113, 113, 0.52); }
 
 .map-climate-severity-legend {
   display: grid;


### PR DESCRIPTION
Epsilon: Implements #823.

Summary:
- Adds under-ready execution gap detection on top of the E10 climate readiness comparison.
- Flags urgent plans with insufficient/too-late/very tight readiness and identifies the main gap: delay, capacity, resource, or regional dependency.
- Shows only the top 2-3 concrete deficits and stays quiet when urgent plans are sufficiently ready.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateUnderReadyExecutionGaps.test.js test/ui/climate/webAtlasClimateMitigationReadinessComparison.test.js test/ui/climate/webAtlasClimateActionUrgencyTimeline.test.js
- npm test