### PR TITLE
Alpha: prioritize atlas commitment debt

### DIFF
--- a/test/ui/war/webAtlasMilitaryCommitmentDebtPriorities.test.js
+++ b/test/ui/war/webAtlasMilitaryCommitmentDebtPriorities.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military commitment debt priorities reuse visible debt coverage and delay data', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryCommitmentDebtPriorities\(debtSummary, coverage, commitment\)/);
+  assert.match(webAppSource, /getAtlasCommitmentDelayPressure\(commitment\?\.selectedOption\?\.delay\)/);
+  assert.match(webAppSource, /coverage\?\.uncoveredFronts/);
+  assert.match(webAppSource, /debtSummary\.debts/);
+  assert.match(webAppSource, /renderAtlasMilitaryCommitmentDebtPriorities\(commitmentPriority\)/);
+  assert.doesNotMatch(webAppSource, /new WarModel|simulateWar|hiddenPriority/);
+});
+
+test('atlas military commitment debt priorities combine pressure coverage gap and degradation window', () => {
+  assert.match(webAppSource, /pressureScore = Math\.max\(0, Math\.round\(debt\.priority \/ 3\)\)/);
+  assert.match(webAppSource, /coverageGap = debt\.tone === 'absent'/);
+  assert.match(webAppSource, /urgencyScore = pressureScore \+ coverageGap \+ delayPressure\.score/);
+  assert.match(webAppSource, /fenêtre courte/);
+  assert.match(webAppSource, /couverture insuffisante/);
+  assert.match(webAppSource, /pression élevée/);
+  assert.match(webAppSource, /soutien partiel/);
+});
+
+test('atlas military commitment debt priorities render short ranking and quiet empty state', () => {
+  assert.match(webAppSource, /Priorité dette/);
+  assert.match(webAppSource, /atlas-military-commitment-priority/);
+  assert.match(webAppSource, /P\$\{index \+ 1\}/);
+  assert.match(webAppSource, /Aucune dette prioritaire: tous les fronts visibles sont couverts ou non urgents/);
+  assert.match(stylesSource, /\.atlas-military-commitment-priority__panel/);
+  assert.match(stylesSource, /\.atlas-military-priority-row--critical rect/);
+  assert.match(stylesSource, /\.atlas-military-priority-marker--high circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1283,7 +1283,81 @@ function renderAtlasMilitaryCommitmentDebtSummary(debtSummary) {
   `;
 }
 
+function getAtlasCommitmentDelayPressure(delay) {
+  if (delay === 'court') return { score: 22, label: 'fenêtre courte' };
+  if (delay === 'moyen') return { score: 12, label: 'fenêtre moyenne' };
+  if (delay === 'long') return { score: 4, label: 'fenêtre longue' };
+  return { score: 8, label: 'délai incertain' };
+}
+
+function buildAtlasMilitaryCommitmentDebtPriorities(debtSummary, coverage, commitment) {
+  if (!debtSummary || debtSummary.empty || !debtSummary.debts.length) {
+    return {
+      priorities: [],
+      summary: 'Aucune dette prioritaire: tous les fronts visibles sont couverts ou non urgents.',
+      empty: true,
+    };
+  }
+
+  const delayPressure = getAtlasCommitmentDelayPressure(commitment?.selectedOption?.delay);
+  const uncoveredIds = new Set((coverage?.uncoveredFronts ?? []).map((front) => front.provinceId));
+  const priorities = debtSummary.debts
+    .map((debt) => {
+      const coverageGap = debt.tone === 'absent' || uncoveredIds.has(debt.provinceId) ? 24 : debt.tone === 'partial' ? 14 : 8;
+      const pressureScore = Math.max(0, Math.round(debt.priority / 3));
+      const urgencyScore = pressureScore + coverageGap + delayPressure.score;
+      const reason = debt.tone === 'absent'
+        ? `couverture insuffisante · ${debt.reason}`
+        : debt.tone === 'threat'
+          ? `pression élevée · ${debt.reason}`
+          : `soutien partiel · ${debt.reason}`;
+      return {
+        priorityId: `priority:${debt.debtId}`,
+        label: debt.label,
+        tone: urgencyScore >= 75 ? 'critical' : urgencyScore >= 58 ? 'high' : 'watch',
+        urgencyScore,
+        reason,
+        delayLabel: delayPressure.label,
+        center: debt.center,
+      };
+    })
+    .sort((left, right) => right.urgencyScore - left.urgencyScore || left.label.localeCompare(right.label))
+    .slice(0, 3);
+
+  return {
+    priorities,
+    summary: priorities.length > 0
+      ? `Priorité dette: ${priorities.map((priority, index) => `${index + 1}. ${priority.label}`).join(' · ')}.`
+      : 'Aucune dette prioritaire: pas de dette active visible.',
+    empty: priorities.length === 0,
+  };
+}
+
+function renderAtlasMilitaryCommitmentDebtPriorities(prioritySummary) {
+  const height = prioritySummary.empty ? 7.5 : 7 + (prioritySummary.priorities.length * 3.9);
+  return `
+    <g class="atlas-military-commitment-priority" aria-label="Priorités de dette d’engagement militaire: ${prioritySummary.summary}">
+      <rect class="atlas-military-commitment-priority__panel" x="61" y="46" width="36" height="${height}" rx="2.4"></rect>
+      <text class="atlas-military-commitment-priority__title" x="63" y="49.2">Priorité dette</text>
+      ${prioritySummary.empty ? `<text class="atlas-military-commitment-priority__empty" x="63" y="52.6">${prioritySummary.summary}</text>` : prioritySummary.priorities.map((priority, index) => `
+        <g class="atlas-military-priority-row atlas-military-priority-row--${priority.tone}" data-atlas-commitment-priority="${priority.priorityId}" aria-label="${index + 1}. ${priority.label}: score ${priority.urgencyScore}, ${priority.reason}, ${priority.delayLabel}">
+          <rect x="63" y="${51 + index * 3.9}" width="3.6" height="2.6" rx="0.8"></rect>
+          <text class="atlas-military-priority-row__label" x="67.2" y="${52 + index * 3.9}">${index + 1}. ${priority.label} · ${priority.urgencyScore}</text>
+          <text class="atlas-military-priority-row__reason" x="67.2" y="${53.7 + index * 3.9}">${priority.reason} · ${priority.delayLabel}</text>
+        </g>
+      `).join('')}
+      ${prioritySummary.priorities.filter((priority) => priority.center).map((priority, index) => `
+        <g class="atlas-military-priority-marker atlas-military-priority-marker--${priority.tone}" data-atlas-commitment-priority-marker="${priority.priorityId}" aria-label="Priorité ${index + 1} ${priority.label}: ${priority.reason}">
+          <circle cx="${priority.center.x}%" cy="${priority.center.y}%" r="2.05"></circle>
+          <text x="${priority.center.x}%" y="${priority.center.y + 0.55}%" text-anchor="middle">P${index + 1}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function buildAtlasMilitaryFeatures(shell) {
+
 
 
 
@@ -1358,6 +1432,7 @@ function renderAtlasMilitaryLayer(shell) {
   const commitmentConflicts = buildAtlasMilitaryCommitmentFrontConflicts(stagedCommitment, shell, features);
   const commitmentCoverage = buildAtlasMilitaryCommitmentCoverageSummary(stagedCommitment, commitmentConflicts, shell, features);
   const commitmentDebt = buildAtlasMilitaryCommitmentDebtSummary(commitmentCoverage, stagedCommitment, shell);
+  const commitmentPriority = buildAtlasMilitaryCommitmentDebtPriorities(commitmentDebt, commitmentCoverage, stagedCommitment);
 
   if (!features.routes.length && !features.riskZones.length) {
     return `
@@ -1386,6 +1461,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryStagedCommitment(stagedCommitment)}
       ${renderAtlasMilitaryCommitmentCoverageSummary(commitmentCoverage)}
       ${renderAtlasMilitaryCommitmentDebtSummary(commitmentDebt)}
+      ${renderAtlasMilitaryCommitmentDebtPriorities(commitmentPriority)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `
         <g class="atlas-military-risk atlas-military-risk--${zone.tone}" data-atlas-risk-province="${zone.provinceId}" aria-label="Zone militaire ${zone.label}: pression ${zone.pressure}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -10507,6 +10507,7 @@ button { font: inherit; }
 .atlas-military-staged-commitment,
 .atlas-military-commitment-coverage,
 .atlas-military-commitment-debt,
+.atlas-military-commitment-priority,
 .atlas-military-commitment-conflicts {
   pointer-events: auto;
 }
@@ -10761,6 +10762,51 @@ button { font: inherit; }
   font-weight: 900;
   paint-order: stroke;
   stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.34;
+}
+.atlas-military-commitment-priority__panel {
+  fill: rgba(30, 41, 59, 0.8);
+  stroke: rgba(244, 114, 182, 0.38);
+  stroke-width: 0.35;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-commitment-priority__title,
+.atlas-military-priority-row text,
+.atlas-military-commitment-priority__empty {
+  fill: #fce7f3;
+  font-size: 1.2px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.86);
+  stroke-width: 0.32;
+}
+.atlas-military-priority-row rect {
+  fill: rgba(251, 191, 36, 0.52);
+  stroke: rgba(254, 243, 199, 0.72);
+  stroke-width: 0.22;
+}
+.atlas-military-priority-row--critical rect,
+.atlas-military-priority-marker--critical circle { fill: rgba(248, 113, 113, 0.86); }
+.atlas-military-priority-row--high rect,
+.atlas-military-priority-marker--high circle { fill: rgba(244, 114, 182, 0.78); }
+.atlas-military-priority-row--watch rect,
+.atlas-military-priority-marker--watch circle { fill: rgba(251, 191, 36, 0.78); }
+.atlas-military-priority-row__reason,
+.atlas-military-commitment-priority__empty {
+  fill: #fbcfe8;
+  font-size: 0.9px;
+}
+.atlas-military-priority-marker circle {
+  stroke: rgba(252, 231, 243, 0.86);
+  stroke-width: 0.4;
+  filter: drop-shadow(0 0 4px rgba(244, 114, 182, 0.62));
+}
+.atlas-military-priority-marker text {
+  fill: #fff7ed;
+  font-size: 1.08px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.92);
   stroke-width: 0.34;
 }
 .atlas-military-commitment-conflicts__panel {


### PR DESCRIPTION
Alpha: Implements #819.

Summary:
- ranks visible atlas commitment debts by front pressure, coverage gap, and selected operation delay window
- adds a compact 2-3 item priority panel and small P1/P2/P3 map markers
- keeps existing A9 coverage and A10 debt panels intact with quiet empty state when no priority exists

Validation:
- `node --check web/app.js`
- `npm test -- test/ui/war/webAtlasMilitaryCommitmentDebtPriorities.test.js test/ui/war/webAtlasMilitaryCommitmentDebt.test.js`
- `npm test` (551 passing)
- `git diff --check`