### PR TITLE
Gamma: flag fragile cultural rebounds

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -34,6 +34,7 @@ test('world map atlas renders culture influence zones from existing culture over
   assert.match(webAppSource, /atlas-mediation-outcome/);
   assert.match(webAppSource, /reboundWindow/);
   assert.match(webAppSource, /atlas-cultural-rebound-window/);
+  assert.match(webAppSource, /consolidation/);
 });
 
 test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
@@ -71,6 +72,12 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /rechute probable/);
   assert.match(webAppSource, /fenêtre manquée/);
   assert.match(webAppSource, /aucune fenêtre active/);
+  assert.match(webAppSource, /rebond stable/);
+  assert.match(webAppSource, /rebond fragile/);
+  assert.match(webAppSource, /rebond expire/);
+  assert.match(webAppSource, /engagement incomplet/);
+  assert.match(webAppSource, /influence adverse/);
+  assert.match(webAppSource, /délai restant faible/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -99,4 +106,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-rebound-window--favorable/);
   assert.match(stylesSource, /\.atlas-cultural-rebound-window--risky/);
   assert.match(stylesSource, /\.atlas-cultural-rebound-window--missed/);
+  assert.match(stylesSource, /\.atlas-cultural-rebound-window--consolidation-stable/);
+  assert.match(stylesSource, /\.atlas-cultural-rebound-window--consolidation-fragile/);
+  assert.match(stylesSource, /\.atlas-cultural-rebound-window--consolidation-expiring/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1715,6 +1715,13 @@ function buildAtlasMediationCommitment(zone) {
           reason: `${remainingConfidence} · ${zone.drift.label}`,
           action: 'renforcer relais',
         };
+  const consolidation = reboundWindow.state === 'favorable' && remainingConfidence === 'forte'
+    ? { state: 'stable', label: 'rebond stable', reason: 'confiance forte', action: 'maintenir veille' }
+    : reboundWindow.state === 'favorable'
+      ? { state: 'fragile', label: 'rebond fragile', reason: 'engagement incomplet', action: 'consolider relais' }
+      : reboundWindow.state === 'risky'
+        ? { state: 'fragile', label: 'rebond fragile', reason: 'influence adverse', action: 'appui culturel' }
+        : { state: 'expiring', label: 'rebond expire', reason: 'délai restant faible', action: 'agir ce tour' };
 
   return {
     status,
@@ -1725,6 +1732,7 @@ function buildAtlasMediationCommitment(zone) {
     nextAction,
     residualRisk,
     reboundWindow,
+    consolidation,
     label: status === 'stable' ? 'engagement stable' : 'engagement à risque',
   };
 }
@@ -1762,10 +1770,10 @@ function renderAtlasCultureLayer(cultureView) {
         </g>
       `).join('')}
       ${features.borderZones.length > 0 ? features.borderZones.map((zone) => `
-        <g class="atlas-cultural-rebound-window atlas-cultural-rebound-window--${zone.commitment.reboundWindow.state}" data-atlas-cultural-rebound-window="${zone.regionId}" aria-label="Fenêtre culturelle ${zone.cultureName}: ${zone.commitment.reboundWindow.label}, pourquoi ${zone.commitment.reboundWindow.reason}, action ${zone.commitment.reboundWindow.action}">
-          <rect x="${Math.min(82, zone.center.x + 3)}" y="${Math.min(88, zone.center.y + 8)}" width="15.8" height="4.8" rx="1.5"></rect>
-          <text x="${Math.min(83, zone.center.x + 4)}%" y="${Math.min(90, zone.center.y + 10.1)}%">${zone.commitment.reboundWindow.label}</text>
-          <text class="atlas-cultural-rebound-window__action" x="${Math.min(83, zone.center.x + 4)}%" y="${Math.min(92, zone.center.y + 12)}%">${zone.commitment.reboundWindow.action}</text>
+        <g class="atlas-cultural-rebound-window atlas-cultural-rebound-window--${zone.commitment.reboundWindow.state} atlas-cultural-rebound-window--consolidation-${zone.commitment.consolidation.state}" data-atlas-cultural-rebound-window="${zone.regionId}" aria-label="Fenêtre culturelle ${zone.cultureName}: ${zone.commitment.reboundWindow.label}, consolidation ${zone.commitment.consolidation.label}, raison ${zone.commitment.consolidation.reason}, action ${zone.commitment.consolidation.action}">
+          <rect x="${Math.min(82, zone.center.x + 3)}" y="${Math.min(88, zone.center.y + 8)}" width="17.8" height="6.3" rx="1.5"></rect>
+          <text x="${Math.min(83, zone.center.x + 4)}%" y="${Math.min(90, zone.center.y + 10.1)}%">${zone.commitment.consolidation.label}</text>
+          <text class="atlas-cultural-rebound-window__action" x="${Math.min(83, zone.center.x + 4)}%" y="${Math.min(92, zone.center.y + 12)}%">${zone.commitment.consolidation.reason} · ${zone.commitment.consolidation.action}</text>
         </g>
       `).join('') : `
         <g class="atlas-cultural-rebound-window is-empty" aria-label="Aucune fenêtre de rebond culturel active">
@@ -1785,7 +1793,7 @@ function renderAtlasCultureLayer(cultureView) {
               <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 12.2}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
               <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 12.2}">${zone.commitment.label} · ${zone.commitment.outcomeStatus} · reste ${zone.commitment.remainingConfidence}</text>
               <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 12.2}">prochain: ${zone.commitment.nextConsequence} · action: ${zone.commitment.nextAction}</text>
-              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 12.2}">${zone.commitment.reboundWindow.label}: ${zone.commitment.reboundWindow.action}</text>
+              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 12.2}">${zone.commitment.consolidation.label}: ${zone.commitment.consolidation.action}</text>
             </g>
           `).join('')}
         </g>

--- a/web/styles.css
+++ b/web/styles.css
@@ -11452,3 +11452,6 @@ button { font: inherit; }
 .atlas-cultural-rebound-window--missed rect { stroke: rgba(251, 113, 133, 0.72); fill: rgba(127, 29, 29, 0.38); }
 .atlas-cultural-rebound-window--missed text { fill: #fecdd3; }
 .atlas-cultural-rebound-window.is-empty rect { stroke: rgba(148, 163, 184, 0.28); fill: rgba(15, 23, 42, 0.52); }
+.atlas-cultural-rebound-window--consolidation-stable rect { stroke-width: 0.34; }
+.atlas-cultural-rebound-window--consolidation-fragile rect { stroke-dasharray: 1.2 0.8; }
+.atlas-cultural-rebound-window--consolidation-expiring rect { stroke-width: 0.48; filter: drop-shadow(0 0 4px rgba(251, 113, 133, 0.36)); }


### PR DESCRIPTION
Gamma: Implements #821.

## Summary
- add consolidation state to cultural rebound windows after mediation
- distinguish stable, fragile, and expiring rebound states with short reasons
- surface compact follow-up actions without duplicating existing mediation conflict alerts

## Validation
- node --check web/app.js
- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js test/ui/culture/webCultureUrgencyReasons.test.js test/ui/war/webAtlasWorldMapCanvas.test.js
- git diff --check
- npm test (552 OK)