### PR TITLE
Delta: prioritize residual blind spot resweeps

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -311,6 +311,21 @@ test('atlas counterintelligence marks residual blind spots after sweep summaries
   assert.match(stylesSource, /atlas-counterintelligence-blind-spots__item--haute/);
 });
 
+test('atlas counterintelligence prioritizes residual blind spots for safe resweeps', () => {
+  assert.match(webAppSource, /resweepPriorities/);
+  assert.match(webAppSource, /Priorités de resweep/);
+  assert.match(webAppSource, /Priorités de resweep fog-safe pour angles morts/);
+  assert.match(webAppSource, /operationalRiskScore/);
+  assert.match(webAppSource, /freshnessScore/);
+  assert.match(webAppSource, /sensitiveObjectiveScore/);
+  assert.match(webAppSource, /proche d’un objectif sensible visible/);
+  assert.match(webAppSource, /proximité non confirmée/);
+  assert.match(webAppSource, /Resweep sûr immédiat avant nouvel engagement/);
+  assert.match(webAppSource, /Zones sans données suffisantes: priorité prudente plutôt qu’une précision inventée/);
+  assert.match(stylesSource, /atlas-counterintelligence-resweep-priorities/);
+  assert.match(stylesSource, /atlas-counterintelligence-resweep-priorities__item--critique/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -10560,12 +10560,53 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
   const residualBlindSpotSummary = residualBlindSpots.length > 0
     ? `${residualBlindSpots.length} angle${residualBlindSpots.length > 1 ? 's' : ''} mort${residualBlindSpots.length > 1 ? 's' : ''} résiduel${residualBlindSpots.length > 1 ? 's' : ''}: ${residualBlindSpots.filter((spot) => spot.failureType === 'non couvert').length} non couvert${residualBlindSpots.filter((spot) => spot.failureType === 'non couvert').length > 1 ? 's' : ''}, ${residualBlindSpots.filter((spot) => spot.failureType === 'couverture trop faible').length} couverture${residualBlindSpots.filter((spot) => spot.failureType === 'couverture trop faible').length > 1 ? 's' : ''} trop faible${residualBlindSpots.filter((spot) => spot.failureType === 'couverture trop faible').length > 1 ? 's' : ''}, ${residualBlindSpots.filter((spot) => spot.failureType === 'couverture expirante/contestée').length} contesté${residualBlindSpots.filter((spot) => spot.failureType === 'couverture expirante/contestée').length > 1 ? 's' : ''}.`
     : 'Aucun angle mort résiduel visible: la couverture actuelle suffit selon les signaux atlas.';
+  const resweepPriorities = residualBlindSpots.map((spot) => {
+    const operationalRiskScore = spot.severity === 'haute' ? 3 : 2;
+    const freshnessScore = spot.detail.includes('récent')
+      ? 3
+      : spot.detail.includes('incertain') || spot.failureType === 'couverture expirante/contestée'
+        ? 2
+        : 1;
+    const sensitiveObjectiveScore = spot.failureType === 'non couvert'
+      ? 3
+      : spot.failureType === 'couverture expirante/contestée'
+        ? 2
+        : 1;
+    const priorityScore = operationalRiskScore + freshnessScore + sensitiveObjectiveScore;
+    const priorityLevel = priorityScore >= 8 ? 'critique' : priorityScore >= 6 ? 'haute' : 'prudente';
+    const objectiveProximity = sensitiveObjectiveScore >= 3
+      ? 'proche d’un objectif sensible visible'
+      : sensitiveObjectiveScore === 2
+        ? 'objectif sensible possible à reconfirmer'
+        : 'proximité non confirmée';
+
+    return {
+      ...spot,
+      operationalRiskScore,
+      freshnessScore,
+      sensitiveObjectiveScore,
+      priorityScore,
+      priorityLevel,
+      objectiveProximity,
+      priorityReason: `risque ${spot.severity}; fraîcheur ${freshnessScore >= 3 ? 'récente' : freshnessScore === 2 ? 'incertaine' : 'ancienne'}; ${objectiveProximity}`,
+      resweepAction: priorityLevel === 'critique'
+        ? 'Resweep sûr immédiat avant nouvel engagement.'
+        : priorityLevel === 'haute'
+          ? 'Planifier le resweep au prochain créneau libre.'
+          : 'Garder une vérification prudente si les données restent faibles.',
+    };
+  }).sort((left, right) => right.priorityScore - left.priorityScore || left.locationName.localeCompare(right.locationName));
+  const resweepPrioritySummary = resweepPriorities.length > 0
+    ? `${resweepPriorities.length} priorité${resweepPriorities.length > 1 ? 's' : ''} de resweep: ${resweepPriorities.filter((spot) => spot.priorityLevel === 'critique').length} critique${resweepPriorities.filter((spot) => spot.priorityLevel === 'critique').length > 1 ? 's' : ''}, ${resweepPriorities.filter((spot) => spot.priorityLevel === 'haute').length} haute${resweepPriorities.filter((spot) => spot.priorityLevel === 'haute').length > 1 ? 's' : ''}, ${resweepPriorities.filter((spot) => spot.priorityLevel === 'prudente').length} prudente${resweepPriorities.filter((spot) => spot.priorityLevel === 'prudente').length > 1 ? 's' : ''}.`
+    : 'Aucune priorité de resweep: données suffisantes ou trop faibles pour hiérarchiser sans spéculer.';
   const postOrderCoverage = {
     coveredOrderZones,
     fragileAssignments,
     uncoveredRiskZones,
     residualBlindSpots,
     residualBlindSpotSummary,
+    resweepPriorities,
+    resweepPrioritySummary,
     summary: postOrderCoverageSummary,
   };
   const exposureCooldownSummary = sweepCandidates.length > 0
@@ -10675,6 +10716,13 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
         ${plan.postOrderCoverage.residualBlindSpots.length > 0
           ? `<ul>${plan.postOrderCoverage.residualBlindSpots.map((spot) => `<li class="atlas-counterintelligence-blind-spots__item atlas-counterintelligence-blind-spots__item--${spot.severity}"><b>${spot.locationName}</b> · ${spot.failureType} · sévérité ${spot.severity}<small>${spot.detail} · ${spot.nextAction}</small></li>`).join('')}</ul>`
           : '<small>État vide: aucune province ne reste aveugle ou fragile après ces ordres.</small>'}
+      </section>
+      <section class="atlas-counterintelligence-resweep-priorities" aria-label="Priorités de resweep fog-safe pour angles morts">
+        <strong>Priorités de resweep</strong>
+        <p>${plan.postOrderCoverage.resweepPrioritySummary}</p>
+        ${plan.postOrderCoverage.resweepPriorities.length > 0
+          ? `<ol>${plan.postOrderCoverage.resweepPriorities.map((spot) => `<li class="atlas-counterintelligence-resweep-priorities__item atlas-counterintelligence-resweep-priorities__item--${spot.priorityLevel}"><b>${spot.locationName}</b> · priorité ${spot.priorityLevel}<small>${spot.priorityReason} · ${spot.resweepAction}</small></li>`).join('')}</ol>`
+          : '<small>Zones sans données suffisantes: priorité prudente plutôt qu’une précision inventée.</small>'}
       </section>
       <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">
         <strong>Conflits de planning</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3262,6 +3262,30 @@ button { font: inherit; }
   display: block;
   margin-top: 2px;
 }
+.atlas-counterintelligence-resweep-priorities {
+  display: grid;
+  gap: 7px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(45, 212, 191, 0.28);
+  background: rgba(20, 83, 45, 0.18);
+}
+.atlas-counterintelligence-resweep-priorities p,
+.atlas-counterintelligence-resweep-priorities small { margin: 0; color: #ccfbf1; }
+.atlas-counterintelligence-resweep-priorities ol {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding-left: 20px;
+  color: #f8fafc;
+}
+.atlas-counterintelligence-resweep-priorities__item--critique { color: #fecaca; }
+.atlas-counterintelligence-resweep-priorities__item--haute { color: #fde68a; }
+.atlas-counterintelligence-resweep-priorities__item--prudente { color: #bfdbfe; }
+.atlas-counterintelligence-resweep-priorities li small {
+  display: block;
+  margin-top: 2px;
+}
 .atlas-counterintelligence-schedule-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Implements #822.

Summary:
- derives safe resweep priorities from existing residual blind spots
- combines operational risk, intelligence freshness, and visible sensitive-objective proximity into compact priority levels
- keeps insufficient data cautious and preserves fog-safe wording without revealing hidden actors, cells, relays, causes, targets, or exact threat details

Validation:
- node --test test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- node --check web/app.js
- git diff --check
- git diff --check HEAD~1..HEAD
- npm test

Delta: Zeta, this PR is ready for validation before merge.