### PR TITLE
Epsilon: recommend climate readiness boosts

### DIFF
--- a/test/ui/climate/webAtlasClimateReadinessBoostRecommendations.test.js
+++ b/test/ui/climate/webAtlasClimateReadinessBoostRecommendations.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const climateReadinessBoostFixture = [
+  {
+    gapType: 'capacité',
+    expectedDimension: 'mitigation capacity',
+    expectedBoost: 'Pré-affecter une équipe mitigation',
+  },
+  {
+    gapType: 'dépendance régionale',
+    expectedDimension: 'regional coordination',
+    expectedBoost: 'Nommer un relais régional',
+  },
+];
+
+test('atlas recommends minimal readiness boosts for urgent under-ready climate plans', () => {
+  assert.match(webAppSource, /function buildAtlasClimateReadinessBoostRecommendations/);
+  assert.match(webAppSource, /function renderAtlasClimateReadinessBoostRecommendations/);
+  assert.match(webAppSource, /gapView\.state !== 'warning'/);
+  assert.match(webAppSource, /les plans urgents restent exécutables/);
+  assert.match(webAppSource, /Boost minimal/);
+  assert.match(webAppSource, /Raison concrète/);
+  assert.match(webAppSource, /Dimension manquante/);
+  assert.match(webAppSource, /resource coverage/);
+  assert.match(webAppSource, /timing buffer/);
+  assert.match(webAppSource, /atlasClimateReadinessBoostRecommendations = buildAtlasClimateReadinessBoostRecommendations\(atlasClimateUnderReadyExecutionGaps\)/);
+  assert.match(webAppSource, /renderAtlasClimateReadinessBoostRecommendations\(atlasClimateReadinessBoostRecommendations\)/);
+
+  for (const fixture of climateReadinessBoostFixture) {
+    assert.match(webAppSource, new RegExp(fixture.gapType));
+    assert.match(webAppSource, new RegExp(fixture.expectedDimension));
+    assert.match(webAppSource, new RegExp(fixture.expectedBoost));
+  }
+
+  assert.match(stylesSource, /\.map-world-climate-readiness-boosts/);
+  assert.match(stylesSource, /\.map-world-climate-readiness-boosts__item--insufficient/);
+  assert.match(stylesSource, /\.map-world-climate-readiness-boosts__item--too-late/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -6897,6 +6897,91 @@ function buildAtlasClimateUnderReadyExecutionGaps(readinessView) {
   };
 }
 
+function buildAtlasClimateReadinessBoostRecommendations(gapView) {
+  if (!gapView || gapView.state !== 'warning' || gapView.gaps.length === 0) {
+    return {
+      state: 'empty',
+      boosts: [],
+      summary: 'Aucun boost readiness climat requis: les plans urgents restent exécutables.',
+    };
+  }
+
+  const boostByGapType = {
+    'capacité': {
+      dimension: 'mitigation capacity',
+      label: 'Capacité mitigation',
+      boost: 'Pré-affecter une équipe mitigation et verrouiller une capacité de réserve avant la deadline.',
+    },
+    'dépendance régionale': {
+      dimension: 'regional coordination',
+      label: 'Coordination régionale',
+      boost: 'Nommer un relais régional et confirmer le corridor partagé avant de lancer le plan.',
+    },
+    'délai': {
+      dimension: 'timing buffer',
+      label: 'Tampon timing',
+      boost: 'Avancer le premier jalon d’un tour ou réduire le périmètre pour regagner une fenêtre courte.',
+    },
+    'ressource': {
+      dimension: 'resource coverage',
+      label: 'Couverture ressources',
+      boost: 'Réserver le stock critique manquant et lier un fallback logistique au plan climat.',
+    },
+  };
+
+  const boosts = gapView.gaps
+    .map((gap) => {
+      const recommendation = boostByGapType[gap.gapType] ?? boostByGapType.ressource;
+      return {
+        provinceId: gap.provinceId,
+        provinceLabel: gap.provinceLabel,
+        status: gap.status,
+        deadline: gap.deadline,
+        missingDimension: recommendation.dimension,
+        label: recommendation.label,
+        concreteReason: gap.shortfall,
+        smallestBoost: recommendation.boost,
+        consequence: gap.consequence,
+      };
+    })
+    .slice(0, 3);
+
+  return {
+    state: boosts.length > 0 ? 'actionable' : 'empty',
+    boosts,
+    summary: boosts.length > 0
+      ? `${boosts.length} boost${boosts.length > 1 ? 's' : ''} readiness minimal${boosts.length > 1 ? 's' : ''} recommandé${boosts.length > 1 ? 's' : ''} avant aggravation des deadlines.`
+      : 'Aucun boost readiness climat requis: les plans urgents restent exécutables.',
+  };
+}
+
+function renderAtlasClimateReadinessBoostRecommendations(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'actionable') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-readiness-boosts" aria-label="Boosts readiness recommandés pour plans climat sous-prêts">
+      <div class="map-world-climate-readiness-boosts__header">
+        <strong>Boosts readiness climat</strong>
+        <span>${view.boosts.length} action${view.boosts.length > 1 ? 's' : ''} minimale${view.boosts.length > 1 ? 's' : ''}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-readiness-boosts__list">
+        ${view.boosts.map((boost) => `
+          <li class="map-world-climate-readiness-boosts__item map-world-climate-readiness-boosts__item--${boost.status}">
+            <b>${boost.provinceLabel}</b>
+            <span>${boost.deadline} · ${boost.label}</span>
+            <small><b>Dimension manquante</b> · ${boost.missingDimension}</small>
+            <small><b>Raison concrète</b> · ${boost.concreteReason}</small>
+            <small><b>Boost minimal</b> · ${boost.smallestBoost}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -14323,6 +14408,7 @@ function render() {
   const atlasClimateActionUrgencyTimeline = buildAtlasClimateActionUrgencyTimeline(atlasClimateActionPlanRanking);
   const atlasClimateMitigationReadiness = buildAtlasClimateMitigationReadinessComparison(atlasClimateActionUrgencyTimeline);
   const atlasClimateUnderReadyExecutionGaps = buildAtlasClimateUnderReadyExecutionGaps(atlasClimateMitigationReadiness);
+  const atlasClimateReadinessBoostRecommendations = buildAtlasClimateReadinessBoostRecommendations(atlasClimateUnderReadyExecutionGaps);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -14362,6 +14448,7 @@ function render() {
           ${renderAtlasClimateActionUrgencyTimeline(atlasClimateActionUrgencyTimeline)}
           ${renderAtlasClimateMitigationReadinessComparison(atlasClimateMitigationReadiness)}
           ${renderAtlasClimateUnderReadyExecutionGaps(atlasClimateUnderReadyExecutionGaps)}
+          ${renderAtlasClimateReadinessBoostRecommendations(atlasClimateReadinessBoostRecommendations)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -11568,3 +11568,44 @@ button { font: inherit; }
 .atlas-cultural-rebound-window--consolidation-stable rect { stroke-width: 0.34; }
 .atlas-cultural-rebound-window--consolidation-fragile rect { stroke-dasharray: 1.2 0.8; }
 .atlas-cultural-rebound-window--consolidation-expiring rect { stroke-width: 0.48; filter: drop-shadow(0 0 4px rgba(251, 113, 133, 0.36)); }
+.map-world-climate-readiness-boosts {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(67, 56, 202, 0.22));
+  border: 1px solid rgba(129, 140, 248, 0.36);
+}
+.map-world-climate-readiness-boosts__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-readiness-boosts p,
+.map-world-climate-readiness-boosts span,
+.map-world-climate-readiness-boosts small {
+  color: #e0e7ff;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-readiness-boosts__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-readiness-boosts__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.56);
+  border: 1px solid rgba(129, 140, 248, 0.28);
+}
+.map-world-climate-readiness-boosts__item--just-in-time { border-color: rgba(251, 191, 36, 0.42); }
+.map-world-climate-readiness-boosts__item--insufficient,
+.map-world-climate-readiness-boosts__item--too-late { border-color: rgba(248, 113, 113, 0.5); }


### PR DESCRIPTION
Epsilon: Couvre #833.

Résumé:
- ajoute des recommandations de boosts readiness pour les plans climat urgents sous-prêts, dérivées des gaps E11 existants;
- mappe les dimensions manquantes capacité mitigation, coordination régionale, tampon timing et couverture ressources vers un boost minimal concret;
- garde la couche concise en affichant jusqu’à 3 actions et reste silencieuse quand aucun gap urgent n’existe.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateReadinessBoostRecommendations.test.js test/ui/climate/webAtlasClimateUnderReadyExecutionGaps.test.js test/ui/climate/webAtlasClimateMitigationReadinessComparison.test.js
- git diff --check
- npm test (558 tests OK)

Merci de valider avant tout merge.