### PR TITLE
Delta: preview staged resweep coverage gain

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -341,6 +341,21 @@ test('atlas counterintelligence stages residual blind spot resweep assignments s
   assert.match(stylesSource, /atlas-counterintelligence-staged-resweep-assignments__item--no-safe/);
 });
 
+test('atlas counterintelligence previews first staged resweep coverage gain safely', () => {
+  assert.match(webAppSource, /firstResweepCoveragePreviewItems/);
+  assert.match(webAppSource, /Couverture gagnée avant confirmation/);
+  assert.match(webAppSource, /Aperçu de couverture gagnée avant confirmation du premier resweep/);
+  assert.match(webAppSource, /blind-spot-reduced/);
+  assert.match(webAppSource, /stale-signal-refreshed/);
+  assert.match(webAppSource, /unsafe-gap-remaining/);
+  assert.match(webAppSource, /gain de couverture élevé/);
+  assert.match(webAppSource, /gain de couverture faible/);
+  assert.match(webAppSource, /Aucun aperçu de couverture: les affectations unsafe\/no-safe ne sont pas prévisualisées/);
+  assert.match(webAppSource, /gain attendu faible: un gap unsafe peut rester malgré l’affectation sûre/);
+  assert.match(stylesSource, /atlas-counterintelligence-first-resweep-preview/);
+  assert.match(stylesSource, /atlas-counterintelligence-first-resweep-preview--no-preview/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -11034,6 +11034,43 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
   const stagedResweepAssignmentSummary = stagedResweepAssignments.length > 0
     ? `${stagedResweepAssignments.filter((assignment) => assignment.assignmentStatus === 'safe').length} affectation${stagedResweepAssignments.filter((assignment) => assignment.assignmentStatus === 'safe').length > 1 ? 's' : ''} de resweep sûre${stagedResweepAssignments.filter((assignment) => assignment.assignmentStatus === 'safe').length > 1 ? 's' : ''}; ${stagedResweepAssignments.filter((assignment) => assignment.assignmentStatus === 'no-safe').length} sans affectation sûre. ${stagedResweepAssignments.some((assignment) => assignment.firstAssignment) ? `Premier: ${stagedResweepAssignments.find((assignment) => assignment.firstAssignment).locationName}, ${stagedResweepAssignments.find((assignment) => assignment.firstAssignment).assignmentReason}.` : 'Aucun premier resweep sûr: attendre une couverture ou un créneau moins risqué.'}`
     : 'Aucune affectation staged: pas de priorité de resweep exploitable sans inventer de signal.';
+  const firstSafeStagedAssignment = stagedResweepAssignments.find((assignment) => assignment.firstAssignment) ?? null;
+  const firstResweepCoveragePreviewItems = firstSafeStagedAssignment
+    ? [
+        {
+          type: 'blind-spot-reduced',
+          tone: firstSafeStagedAssignment.failureType === 'non couvert' ? 'high' : 'medium',
+          gainRank: firstSafeStagedAssignment.failureType === 'non couvert' ? 1 : 2,
+          copy: firstSafeStagedAssignment.failureType === 'non couvert'
+            ? 'angle mort réduit: la zone passe de non couverte à vérification active'
+            : 'angle mort réduit partiellement: renfort de couverture plutôt que résolution complète',
+        },
+        {
+          type: 'stale-signal-refreshed',
+          tone: firstSafeStagedAssignment.freshnessScore <= 1 ? 'high' : 'medium',
+          gainRank: firstSafeStagedAssignment.freshnessScore <= 1 ? 1 : 3,
+          copy: firstSafeStagedAssignment.freshnessScore <= 1
+            ? 'signal ancien rafraîchi avant engagement nominatif'
+            : 'signal visible reconfirmé sans exposer source, relais ou cause cachée',
+        },
+        {
+          type: 'unsafe-gap-remaining',
+          tone: firstSafeStagedAssignment.failureType === 'couverture trop faible' || firstSafeStagedAssignment.priorityLevel === 'prudente' ? 'low' : 'medium',
+          gainRank: firstSafeStagedAssignment.failureType === 'couverture trop faible' || firstSafeStagedAssignment.priorityLevel === 'prudente' ? 4 : 3,
+          copy: firstSafeStagedAssignment.failureType === 'couverture trop faible' || firstSafeStagedAssignment.priorityLevel === 'prudente'
+            ? 'gain attendu faible: un gap unsafe peut rester malgré l’affectation sûre'
+            : 'gap unsafe surveillé: vérifier le créneau avant départ',
+        },
+      ].sort((left, right) => left.gainRank - right.gainRank || left.type.localeCompare(right.type))
+    : [];
+  const firstResweepCoverageGainLevel = firstResweepCoveragePreviewItems.some((item) => item.tone === 'high') && firstSafeStagedAssignment?.failureType === 'non couvert'
+    ? 'high-gain'
+    : firstSafeStagedAssignment
+      ? 'low-gain'
+      : 'no-preview';
+  const firstResweepCoveragePreviewSummary = firstSafeStagedAssignment
+    ? `${firstSafeStagedAssignment.locationName}: ${firstResweepCoverageGainLevel === 'high-gain' ? 'gain de couverture élevé' : 'gain de couverture faible'} avant confirmation du premier resweep sûr.`
+    : 'Aucun aperçu de couverture: les affectations unsafe/no-safe ne sont pas prévisualisées.';
   const postOrderCoverage = {
     coveredOrderZones,
     fragileAssignments,
@@ -11044,6 +11081,10 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
     resweepPrioritySummary,
     stagedResweepAssignments,
     stagedResweepAssignmentSummary,
+    firstSafeStagedAssignment,
+    firstResweepCoveragePreviewItems,
+    firstResweepCoverageGainLevel,
+    firstResweepCoveragePreviewSummary,
     summary: postOrderCoverageSummary,
   };
   const exposureCooldownSummary = sweepCandidates.length > 0
@@ -11167,6 +11208,13 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
         ${plan.postOrderCoverage.stagedResweepAssignments.length > 0
           ? `<ol>${plan.postOrderCoverage.stagedResweepAssignments.map((assignment) => `<li class="atlas-counterintelligence-staged-resweep-assignments__item atlas-counterintelligence-staged-resweep-assignments__item--${assignment.assignmentStatus}"><b>#${assignment.assignmentRank} ${assignment.locationName}</b> · ${assignment.assignmentStage}${assignment.firstAssignment ? ' · première affectation' : ''}<small>${assignment.assignmentReason} · ${assignment.safetyGuardrail}</small></li>`).join('')}</ol>`
           : '<small>Aucune affectation sûre: attendre une couverture supplémentaire ou un créneau non contesté.</small>'}
+      </section>
+      <section class="atlas-counterintelligence-first-resweep-preview atlas-counterintelligence-first-resweep-preview--${plan.postOrderCoverage.firstResweepCoverageGainLevel}" aria-label="Aperçu de couverture gagnée avant confirmation du premier resweep">
+        <strong>Couverture gagnée avant confirmation</strong>
+        <p>${plan.postOrderCoverage.firstResweepCoveragePreviewSummary}</p>
+        ${plan.postOrderCoverage.firstResweepCoveragePreviewItems.length > 0
+          ? `<ol>${plan.postOrderCoverage.firstResweepCoveragePreviewItems.map((item) => `<li class="atlas-counterintelligence-first-resweep-preview__item atlas-counterintelligence-first-resweep-preview__item--${item.tone}"><b>${item.type}</b><small>${item.copy}</small></li>`).join('')}</ol>`
+          : '<small>Aucun preview: l’affectation proposée reste unsafe ou sans couverture récupérable sûre.</small>'}
       </section>
       <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">
         <strong>Conflits de planning</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3309,6 +3309,38 @@ button { font: inherit; }
   display: block;
   margin-top: 2px;
 }
+.atlas-counterintelligence-first-resweep-preview {
+  display: grid;
+  gap: 7px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(52, 211, 153, 0.26);
+  background: rgba(6, 78, 59, 0.18);
+}
+.atlas-counterintelligence-first-resweep-preview--low-gain {
+  border-color: rgba(251, 191, 36, 0.28);
+  background: rgba(113, 63, 18, 0.18);
+}
+.atlas-counterintelligence-first-resweep-preview--no-preview {
+  border-color: rgba(148, 163, 184, 0.24);
+  background: rgba(30, 41, 59, 0.18);
+}
+.atlas-counterintelligence-first-resweep-preview p,
+.atlas-counterintelligence-first-resweep-preview small { margin: 0; color: #d1fae5; }
+.atlas-counterintelligence-first-resweep-preview ol {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding-left: 20px;
+  color: #f8fafc;
+}
+.atlas-counterintelligence-first-resweep-preview__item--high { color: #bbf7d0; }
+.atlas-counterintelligence-first-resweep-preview__item--medium { color: #bae6fd; }
+.atlas-counterintelligence-first-resweep-preview__item--low { color: #fde68a; }
+.atlas-counterintelligence-first-resweep-preview li small {
+  display: block;
+  margin-top: 2px;
+}
 .atlas-counterintelligence-schedule-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Covers #842.

This previews the coverage gained before confirming the first safe staged resweep assignment:
- reuses D9-D12 sweep coverage, residual blind spot priorities, safety, and stale-signal scoring
- shows deterministic high/medium/low preview items for blind spot reduction, stale signal refresh, and remaining unsafe gaps
- avoids previews for unsafe/no-safe assignments
- flags low expected coverage gain even when the staged assignment is safe

Validation:
- node --check web/app.js
- npm test -- test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- git diff --check
- npm test (559 OK)