### PR TITLE
Epsilon: preview post-boost climate deadline risk

### DIFF
--- a/test/ui/climate/webAtlasClimatePostBoostDeadlineRiskPreview.test.js
+++ b/test/ui/climate/webAtlasClimatePostBoostDeadlineRiskPreview.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const postBoostOutcomeFixture = [
+  {
+    status: 'just-in-time',
+    missingDimension: 'regional coordination',
+    expectedOutcome: 'executable',
+    expectedLabel: 'risque abaissé: exécutable',
+  },
+  {
+    status: 'insufficient',
+    missingDimension: 'timing buffer',
+    expectedOutcome: 'still-tight',
+    expectedLabel: 'risque réduit mais serré',
+  },
+  {
+    status: 'too-late',
+    missingDimension: 'resource coverage',
+    expectedOutcome: 'insufficient',
+    expectedLabel: 'boost insuffisant avant deadline',
+  },
+];
+
+test('atlas previews post-boost deadline risk for urgent under-ready climate plans', () => {
+  assert.match(webAppSource, /function buildAtlasClimatePostBoostDeadlineRiskPreview/);
+  assert.match(webAppSource, /function renderAtlasClimatePostBoostDeadlineRiskPreview/);
+  assert.match(webAppSource, /boostView\.state !== 'actionable'/);
+  assert.match(webAppSource, /Aucun aperçu post-boost/);
+  assert.match(webAppSource, /deadline, readiness corrigée et pression résiduelle/);
+  assert.match(webAppSource, /Boost appliqué/);
+  assert.match(webAppSource, /Pression résiduelle/);
+  assert.match(webAppSource, /atlasClimatePostBoostDeadlineRiskPreview = buildAtlasClimatePostBoostDeadlineRiskPreview\(atlasClimateReadinessBoostRecommendations\)/);
+  assert.match(webAppSource, /renderAtlasClimatePostBoostDeadlineRiskPreview\(atlasClimatePostBoostDeadlineRiskPreview\)/);
+
+  for (const fixture of postBoostOutcomeFixture) {
+    assert.match(webAppSource, new RegExp(fixture.status));
+    assert.match(webAppSource, new RegExp(fixture.missingDimension));
+    assert.match(webAppSource, new RegExp(fixture.expectedOutcome));
+    assert.match(webAppSource, new RegExp(fixture.expectedLabel));
+  }
+
+  assert.match(stylesSource, /\.map-world-climate-post-boost-risk/);
+  assert.match(stylesSource, /\.map-world-climate-post-boost-risk__item--executable/);
+  assert.match(stylesSource, /\.map-world-climate-post-boost-risk__item--still-tight/);
+  assert.match(stylesSource, /\.map-world-climate-post-boost-risk__item--insufficient/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -7153,6 +7153,84 @@ function renderAtlasClimateReadinessBoostRecommendations(view) {
   `;
 }
 
+function buildAtlasClimatePostBoostDeadlineRiskPreview(boostView) {
+  if (!boostView || boostView.state !== 'actionable' || boostView.boosts.length === 0) {
+    return {
+      state: 'empty',
+      previews: [],
+      summary: 'Aucun aperçu post-boost: aucun plan urgent sous-prêt avec boost recommandé.',
+    };
+  }
+
+  const previews = boostView.boosts.slice(0, 3).map((boost) => {
+    const deadlinePressure = /fenêtre courte|deadline|Timing serré|maintenant/i.test(`${boost.smallestBoost} ${boost.consequence}`);
+    const outcome = boost.status === 'too-late'
+      ? 'insufficient'
+      : boost.missingDimension === 'regional coordination' && boost.status === 'just-in-time'
+        ? 'executable'
+        : deadlinePressure
+          ? 'still-tight'
+          : 'executable';
+    const label = outcome === 'executable'
+      ? 'risque abaissé: exécutable'
+      : outcome === 'still-tight'
+        ? 'risque réduit mais serré'
+        : 'boost insuffisant avant deadline';
+    const postBoostSignal = outcome === 'executable'
+      ? 'Le boost couvre la dimension manquante et replace le plan dans une fenêtre jouable.'
+      : outcome === 'still-tight'
+        ? 'Le boost réduit la pression, mais la deadline impose encore une exécution immédiate.'
+        : 'Même après boost, la fenêtre reste probablement dépassée avant exécution fiable.';
+
+    return {
+      provinceId: boost.provinceId,
+      provinceLabel: boost.provinceLabel,
+      deadline: boost.deadline,
+      outcome,
+      label,
+      missingDimension: boost.missingDimension,
+      appliedBoost: boost.smallestBoost,
+      postBoostSignal,
+    };
+  });
+
+  return {
+    state: previews.some((preview) => preview.outcome === 'insufficient')
+      ? 'blocked'
+      : previews.some((preview) => preview.outcome === 'still-tight')
+        ? 'tight'
+        : 'executable',
+    previews,
+    summary: `${previews.length} aperçu${previews.length > 1 ? 's' : ''} post-boost compare${previews.length > 1 ? 'nt' : ''} deadline, readiness corrigée et pression résiduelle.`,
+  };
+}
+
+function renderAtlasClimatePostBoostDeadlineRiskPreview(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-post-boost-risk map-world-climate-post-boost-risk--${view.state}" aria-label="Aperçu du risque de deadline après boost readiness climat">
+      <div class="map-world-climate-post-boost-risk__header">
+        <strong>Risque post-boost</strong>
+        <span>${view.state === 'executable' ? 'exécutable' : view.state === 'tight' ? 'encore serré' : 'insuffisant'}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-post-boost-risk__list">
+        ${view.previews.map((preview) => `
+          <li class="map-world-climate-post-boost-risk__item map-world-climate-post-boost-risk__item--${preview.outcome}">
+            <b>${preview.provinceLabel}</b>
+            <span>${preview.deadline} · ${preview.label}</span>
+            <small><b>Boost appliqué</b> · ${preview.appliedBoost}</small>
+            <small><b>Pression résiduelle</b> · ${preview.postBoostSignal}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -14628,6 +14706,7 @@ function render() {
   const atlasClimateMitigationReadiness = buildAtlasClimateMitigationReadinessComparison(atlasClimateActionUrgencyTimeline);
   const atlasClimateUnderReadyExecutionGaps = buildAtlasClimateUnderReadyExecutionGaps(atlasClimateMitigationReadiness);
   const atlasClimateReadinessBoostRecommendations = buildAtlasClimateReadinessBoostRecommendations(atlasClimateUnderReadyExecutionGaps);
+  const atlasClimatePostBoostDeadlineRiskPreview = buildAtlasClimatePostBoostDeadlineRiskPreview(atlasClimateReadinessBoostRecommendations);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -14668,6 +14747,7 @@ function render() {
           ${renderAtlasClimateMitigationReadinessComparison(atlasClimateMitigationReadiness)}
           ${renderAtlasClimateUnderReadyExecutionGaps(atlasClimateUnderReadyExecutionGaps)}
           ${renderAtlasClimateReadinessBoostRecommendations(atlasClimateReadinessBoostRecommendations)}
+          ${renderAtlasClimatePostBoostDeadlineRiskPreview(atlasClimatePostBoostDeadlineRiskPreview)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -11703,3 +11703,46 @@ button { font: inherit; }
 }
 .atlas-cultural-consolidation-action--fragile .atlas-cultural-consolidation-action__reason { fill: #fde68a; }
 .atlas-cultural-consolidation-action--expiring .atlas-cultural-consolidation-action__reason { fill: #fecdd3; }
+.map-world-climate-post-boost-risk {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(8, 47, 73, 0.24));
+  border: 1px solid rgba(56, 189, 248, 0.34);
+}
+.map-world-climate-post-boost-risk--tight { border-color: rgba(251, 191, 36, 0.4); }
+.map-world-climate-post-boost-risk--blocked { border-color: rgba(248, 113, 113, 0.48); }
+.map-world-climate-post-boost-risk__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-post-boost-risk p,
+.map-world-climate-post-boost-risk span,
+.map-world-climate-post-boost-risk small {
+  color: #e0f2fe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-post-boost-risk__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-post-boost-risk__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.56);
+  border: 1px solid rgba(56, 189, 248, 0.28);
+}
+.map-world-climate-post-boost-risk__item--executable { border-color: rgba(110, 231, 183, 0.38); }
+.map-world-climate-post-boost-risk__item--still-tight { border-color: rgba(251, 191, 36, 0.44); }
+.map-world-climate-post-boost-risk__item--insufficient { border-color: rgba(248, 113, 113, 0.52); }


### PR DESCRIPTION
Epsilon: Couvre #843.

Résumé:
- ajoute un aperçu compact du risque de deadline après application des boosts readiness climat E12;
- distingue les sorties post-boost `exécutable`, `encore serré` et `boost insuffisant avant deadline`;
- réutilise les signaux existants de gaps/readiness/timing sans nouveau modèle de plan climat et limite l’affichage à 3 previews.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimatePostBoostDeadlineRiskPreview.test.js test/ui/climate/webAtlasClimateReadinessBoostRecommendations.test.js
- git diff --check
- npm test (563 tests OK)

Merci de valider avant tout merge.