### PR TITLE
Alpha: preview top warning relief

### DIFF
--- a/test/ui/war/webAtlasMilitaryTopWarningReliefPreview.test.js
+++ b/test/ui/war/webAtlasMilitaryTopWarningReliefPreview.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military top warning relief preview builds on priority stack signals', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryTopWarningReliefPreview\(priorityStack\)/);
+  assert.match(webAppSource, /const topWarning = priorityStack\?\.stack\?\.\[0\]/);
+  assert.match(webAppSource, /frontRiskReduction = Math\.min\(36, Math\.max\(0, Math\.round\(topWarning\.frontRisk \* 0\.28\)\)\)/);
+  assert.match(webAppSource, /routeExposureReduced = Math\.min\(12, Math\.max\(0, topWarning\.routeExposure\)\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryTopWarningReliefPreview\(topReliefPreview\)/);
+});
+
+test('atlas military top warning relief preview has deterministic high partial and no-relief cases', () => {
+  assert.match(webAppSource, /if \(reliefScore >= 38\) return 'relief-high'/);
+  assert.match(webAppSource, /if \(reliefScore >= 22\) return 'relief-partial'/);
+  assert.match(webAppSource, /return 'no-meaningful-relief'/);
+  assert.match(webAppSource, /if \(tone === 'no-meaningful-relief'\)/);
+  assert.match(webAppSource, /Aucun gain significatif prévu/);
+});
+
+test('atlas military top warning relief preview renders only beside the top actionable stack item', () => {
+  assert.match(webAppSource, /if \(!reliefPreview \|\| reliefPreview\.empty \|\| !reliefPreview\.preview\) return ''/);
+  assert.match(webAppSource, /data-atlas-warning-relief/);
+  assert.match(webAppSource, /gain \$\{preview\.tone === 'relief-high' \? 'fort' : 'partiel'\}/);
+  assert.doesNotMatch(webAppSource, /lowerPriorities\.map[\s\S]*renderAtlasMilitaryTopWarningReliefPreview/);
+  assert.match(stylesSource, /\.atlas-military-warning-relief__panel/);
+  assert.match(stylesSource, /\.atlas-military-warning-relief--relief-partial/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1492,9 +1492,69 @@ function buildAtlasMilitaryWarningPriorityStack(warningSummary, features) {
   };
 }
 
+
+function getAtlasMilitaryTopWarningReliefTone(reliefScore) {
+  if (reliefScore >= 38) return 'relief-high';
+  if (reliefScore >= 22) return 'relief-partial';
+  return 'no-meaningful-relief';
+}
+
+function buildAtlasMilitaryTopWarningReliefPreview(priorityStack) {
+  const topWarning = priorityStack?.stack?.[0] ?? null;
+  if (!topWarning) {
+    return {
+      preview: null,
+      summary: 'Aucun gain prévisible: aucune alerte militaire prioritaire actionnable.',
+      empty: true,
+    };
+  }
+
+  const frontRiskReduction = Math.min(36, Math.max(0, Math.round(topWarning.frontRisk * 0.28)));
+  const commitmentDebtCleared = topWarning.debtTone === 'absent' ? 18 : topWarning.debtTone === 'partial' ? 10 : 7;
+  const routeExposureReduced = Math.min(12, Math.max(0, topWarning.routeExposure));
+  const reliefScore = frontRiskReduction + commitmentDebtCleared + routeExposureReduced;
+  const tone = getAtlasMilitaryTopWarningReliefTone(reliefScore);
+
+  if (tone === 'no-meaningful-relief') {
+    return {
+      preview: null,
+      summary: `Aucun gain significatif prévu pour ${topWarning.label}: surveiller avant d’engager.`,
+      empty: true,
+    };
+  }
+
+  return {
+    preview: {
+      reliefId: `relief:${topWarning.warningId}`,
+      label: topWarning.label,
+      tone,
+      reliefScore,
+      frontRiskReduction,
+      commitmentDebtCleared: topWarning.debtTone === 'absent' ? 'dette directe levée' : topWarning.debtTone === 'partial' ? 'dette partielle clarifiée' : 'menace contenue',
+      routeExposureReduced,
+      action: topWarning.action,
+    },
+    summary: `${topWarning.label}: risque -${frontRiskReduction}, dette ${topWarning.debtTone}, route -${routeExposureReduced}.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryTopWarningReliefPreview(reliefPreview) {
+  if (!reliefPreview || reliefPreview.empty || !reliefPreview.preview) return '';
+  const preview = reliefPreview.preview;
+  return `
+    <g class="atlas-military-warning-relief atlas-military-warning-relief--${preview.tone}" data-atlas-warning-relief="${preview.reliefId}" aria-label="Gain attendu si priorité traitée: ${reliefPreview.summary} Action: ${preview.action}">
+      <rect class="atlas-military-warning-relief__panel" x="22" y="48.2" width="16" height="4.6" rx="1.2"></rect>
+      <text class="atlas-military-warning-relief__label" x="23.2" y="49.8">gain ${preview.tone === 'relief-high' ? 'fort' : 'partiel'} · ${preview.reliefScore}</text>
+      <text class="atlas-military-warning-relief__detail" x="23.2" y="51.5">risque -${preview.frontRiskReduction} · route -${preview.routeExposureReduced}</text>
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryWarningPriorityStack(priorityStack) {
   if (!priorityStack || priorityStack.empty) return '';
   const [topPriority, ...lowerPriorities] = priorityStack.stack;
+  const topReliefPreview = buildAtlasMilitaryTopWarningReliefPreview(priorityStack);
   const height = 8.8 + (lowerPriorities.length * 2.7);
   return `
     <g class="atlas-military-warning-stack" aria-label="Pile de priorités des alertes militaires: ${priorityStack.summary}">
@@ -1505,6 +1565,7 @@ function renderAtlasMilitaryWarningPriorityStack(priorityStack) {
         <text class="atlas-military-warning-stack-top__label" x="10" y="49.8">1. ${topPriority.label} · ${topPriority.stackScore}</text>
         <text class="atlas-military-warning-stack-top__why" x="10" y="51.4">why first: ${topPriority.whyFirst}</text>
       </g>
+      ${renderAtlasMilitaryTopWarningReliefPreview(topReliefPreview)}
       ${lowerPriorities.map((warning, index) => `
         <g class="atlas-military-warning-stack-item atlas-military-warning-stack-item--${warning.tone}" data-atlas-warning-stack-item="${warning.stackId}" aria-label="Priorité ${index + 2} ${warning.frontRoute}: score ${warning.stackScore}; ${warning.action}">
           <text x="5" y="${54.4 + index * 2.7}">${index + 2}. ${warning.label}</text>

--- a/web/styles.css
+++ b/web/styles.css
@@ -10630,6 +10630,7 @@ button { font: inherit; }
 .atlas-military-commitment-priority,
 .atlas-military-commitment-warning,
 .atlas-military-warning-stack,
+.atlas-military-warning-relief,
 .atlas-military-commitment-conflicts {
   pointer-events: auto;
 }
@@ -11011,6 +11012,26 @@ button { font: inherit; }
   fill: #fde68a;
   font-size: 0.8px;
 }
+
+.atlas-military-warning-relief__panel {
+  fill: rgba(20, 83, 45, 0.76);
+  stroke: rgba(134, 239, 172, 0.46);
+  stroke-width: 0.28;
+}
+.atlas-military-warning-relief--relief-partial .atlas-military-warning-relief__panel {
+  fill: rgba(113, 63, 18, 0.76);
+  stroke: rgba(253, 230, 138, 0.46);
+}
+.atlas-military-warning-relief text {
+  fill: #dcfce7;
+  font-size: 0.82px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.88);
+  stroke-width: 0.24;
+}
+.atlas-military-warning-relief--relief-partial text { fill: #fef3c7; }
+.atlas-military-warning-relief__detail { font-size: 0.74px; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #849.

## Summary
- Adds a compact relief preview for the top actionable military warning in the atlas priority stack.
- Reuses the stack's front risk, commitment debt tone, and route exposure signals.
- Handles relief-high, relief-partial, and no-meaningful-relief states while only rendering beside the top stack item.

## Validation
- node --check web/app.js
- git diff --check
- node --test test/ui/war/webAtlasMilitaryWarningPriorityStack.test.js test/ui/war/webAtlasMilitaryTopWarningReliefPreview.test.js
- npm test (566 passing)

Closes #849