### PR TITLE
Delta: rank staged resweep coverage value

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -356,6 +356,48 @@ test('atlas counterintelligence previews first staged resweep coverage gain safe
   assert.match(stylesSource, /atlas-counterintelligence-first-resweep-preview--no-preview/);
 });
 
+test('atlas counterintelligence ranks safe staged resweeps by coverage value', () => {
+  const fixtureAssignments = [
+    { locationName: 'Highland', assignmentStatus: 'safe', failureType: 'non couvert', freshnessScore: 1, priorityLevel: 'haute', priorityScore: 5 },
+    { locationName: 'Lowland', assignmentStatus: 'safe', failureType: 'surveillance fragile', freshnessScore: 3, priorityLevel: 'prudente', priorityScore: 2 },
+    { locationName: 'A-tie', assignmentStatus: 'safe', failureType: 'couverture trop faible', freshnessScore: 2, priorityLevel: 'moyenne', priorityScore: 4 },
+    { locationName: 'B-tie', assignmentStatus: 'safe', failureType: 'couverture trop faible', freshnessScore: 2, priorityLevel: 'moyenne', priorityScore: 4 },
+    { locationName: 'Unsafe', assignmentStatus: 'no-safe', failureType: 'non couvert', freshnessScore: 1, priorityLevel: 'haute', priorityScore: 9 },
+  ];
+  const rankedFixture = fixtureAssignments
+    .filter((assignment) => assignment.assignmentStatus === 'safe')
+    .map((assignment) => {
+      const blindSpotValue = assignment.failureType === 'non couvert' ? 4 : assignment.failureType === 'couverture trop faible' ? 2 : 1;
+      const staleRefreshValue = assignment.freshnessScore <= 1 ? 3 : assignment.freshnessScore === 2 ? 2 : 1;
+      const unsafeGapPenalty = assignment.failureType === 'couverture trop faible' || assignment.priorityLevel === 'prudente' ? 2 : 0;
+      const previewValue = assignment.failureType === 'non couvert' ? 3 : assignment.failureType === 'couverture trop faible' ? 1 : 0;
+      return {
+        ...assignment,
+        coverageValueScore: assignment.priorityScore + blindSpotValue + staleRefreshValue + previewValue - unsafeGapPenalty,
+      };
+    })
+    .sort((left, right) => right.coverageValueScore - left.coverageValueScore
+      || right.priorityScore - left.priorityScore
+      || left.failureType.localeCompare(right.failureType)
+      || left.locationName.localeCompare(right.locationName));
+
+  assert.deepEqual(rankedFixture.map((assignment) => assignment.locationName), ['Highland', 'A-tie', 'B-tie', 'Lowland']);
+  assert.equal(rankedFixture[0].coverageValueScore > rankedFixture.at(-1).coverageValueScore, true);
+  assert.equal(rankedFixture.some((assignment) => assignment.locationName === 'Unsafe'), false);
+  assert.match(webAppSource, /rankedStagedResweepAssignments/);
+  assert.match(webAppSource, /Classement des resweeps staged sûrs par valeur de couverture/);
+  assert.match(webAppSource, /Valeur de couverture des resweeps/);
+  assert.match(webAppSource, /coverageValueScore/);
+  assert.match(webAppSource, /bestCoverageValue/);
+  assert.match(webAppSource, /high-value/);
+  assert.match(webAppSource, /low-value/);
+  assert.match(webAppSource, /faible gain: garder en réserve après les resweeps plus rentables/);
+  assert.match(webAppSource, /unsafe exclu/);
+  assert.match(webAppSource, /left\.locationName\.localeCompare\(right\.locationName\)/);
+  assert.match(stylesSource, /atlas-counterintelligence-resweep-value-ranking/);
+  assert.match(stylesSource, /atlas-counterintelligence-resweep-value-ranking__item--low-value/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -11300,6 +11300,49 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
   const firstResweepCoveragePreviewSummary = firstSafeStagedAssignment
     ? `${firstSafeStagedAssignment.locationName}: ${firstResweepCoverageGainLevel === 'high-gain' ? 'gain de couverture élevé' : 'gain de couverture faible'} avant confirmation du premier resweep sûr.`
     : 'Aucun aperçu de couverture: les affectations unsafe/no-safe ne sont pas prévisualisées.';
+  const rankedStagedResweepAssignments = stagedResweepAssignments
+    .filter((assignment) => assignment.assignmentStatus === 'safe')
+    .map((assignment) => {
+      const blindSpotValue = assignment.failureType === 'non couvert' ? 4 : assignment.failureType === 'couverture trop faible' ? 2 : 1;
+      const staleRefreshValue = assignment.freshnessScore <= 1 ? 3 : assignment.freshnessScore === 2 ? 2 : 1;
+      const unsafeGapPenalty = assignment.failureType === 'couverture trop faible' || assignment.priorityLevel === 'prudente' ? 2 : 0;
+      const previewValue = assignment.failureType === 'non couvert'
+        ? 3
+        : assignment.failureType === 'couverture trop faible'
+          ? 1
+          : 0;
+      const coverageValueScore = assignment.priorityScore + blindSpotValue + staleRefreshValue + previewValue - unsafeGapPenalty;
+      const coverageValueLevel = coverageValueScore >= 12 ? 'high-value' : coverageValueScore >= 9 ? 'medium-value' : 'low-value';
+      const lessUrgentReason = coverageValueLevel === 'high-value'
+        ? 'meilleur gain: priorité haute, récupération de couverture et rafraîchissement utiles'
+        : coverageValueLevel === 'medium-value'
+          ? 'moins urgent: gain utile mais couverture déjà partielle ou fraîcheur moins critique'
+          : 'faible gain: garder en réserve après les resweeps plus rentables';
+
+      return {
+        ...assignment,
+        blindSpotValue,
+        staleRefreshValue,
+        unsafeGapPenalty,
+        previewValue,
+        coverageValueScore,
+        coverageValueLevel,
+        lessUrgentReason,
+      };
+    })
+    .sort((left, right) => right.coverageValueScore - left.coverageValueScore
+      || right.priorityScore - left.priorityScore
+      || left.failureType.localeCompare(right.failureType)
+      || left.locationName.localeCompare(right.locationName))
+    .map((assignment, index) => ({
+      ...assignment,
+      coverageValueRank: index + 1,
+      bestCoverageValue: index === 0,
+    }));
+  const excludedUnsafeResweepAssignments = stagedResweepAssignments.filter((assignment) => assignment.assignmentStatus !== 'safe');
+  const rankedStagedResweepAssignmentSummary = rankedStagedResweepAssignments.length > 0
+    ? `${rankedStagedResweepAssignments.length} resweep${rankedStagedResweepAssignments.length > 1 ? 's' : ''} sûr${rankedStagedResweepAssignments.length > 1 ? 's' : ''} classé${rankedStagedResweepAssignments.length > 1 ? 's' : ''} par valeur de couverture; meilleur: ${rankedStagedResweepAssignments[0].locationName}. ${rankedStagedResweepAssignments.filter((assignment) => assignment.coverageValueLevel === 'low-value').length} low-gain à garder en réserve; ${excludedUnsafeResweepAssignments.length} unsafe exclu${excludedUnsafeResweepAssignments.length > 1 ? 's' : ''}.`
+    : 'Aucun classement de valeur: toutes les affectations staged sont unsafe/no-safe ou sans gain exploitable.';
   const postOrderCoverage = {
     coveredOrderZones,
     fragileAssignments,
@@ -11314,6 +11357,9 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
     firstResweepCoveragePreviewItems,
     firstResweepCoverageGainLevel,
     firstResweepCoveragePreviewSummary,
+    rankedStagedResweepAssignments,
+    rankedStagedResweepAssignmentSummary,
+    excludedUnsafeResweepAssignments,
     summary: postOrderCoverageSummary,
   };
   const exposureCooldownSummary = sweepCandidates.length > 0
@@ -11444,6 +11490,13 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
         ${plan.postOrderCoverage.firstResweepCoveragePreviewItems.length > 0
           ? `<ol>${plan.postOrderCoverage.firstResweepCoveragePreviewItems.map((item) => `<li class="atlas-counterintelligence-first-resweep-preview__item atlas-counterintelligence-first-resweep-preview__item--${item.tone}"><b>${item.type}</b><small>${item.copy}</small></li>`).join('')}</ol>`
           : '<small>Aucun preview: l’affectation proposée reste unsafe ou sans couverture récupérable sûre.</small>'}
+      </section>
+      <section class="atlas-counterintelligence-resweep-value-ranking" aria-label="Classement des resweeps staged sûrs par valeur de couverture">
+        <strong>Valeur de couverture des resweeps</strong>
+        <p>${plan.postOrderCoverage.rankedStagedResweepAssignmentSummary}</p>
+        ${plan.postOrderCoverage.rankedStagedResweepAssignments.length > 0
+          ? `<ol>${plan.postOrderCoverage.rankedStagedResweepAssignments.map((assignment) => `<li class="atlas-counterintelligence-resweep-value-ranking__item atlas-counterintelligence-resweep-value-ranking__item--${assignment.coverageValueLevel}"><b>#${assignment.coverageValueRank} ${assignment.locationName}</b> · ${assignment.coverageValueScore} valeur${assignment.bestCoverageValue ? ' · meilleur choix' : ''}<small>${assignment.lessUrgentReason} · priorité ${assignment.priorityScore}, refresh ${assignment.staleRefreshValue}, preview ${assignment.previewValue}, gap unsafe -${assignment.unsafeGapPenalty}</small></li>`).join('')}</ol>`
+          : '<small>Aucun resweep sûr à classer: les affectations rejetées par sécurité restent exclues.</small>'}
       </section>
       <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">
         <strong>Conflits de planning</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3341,6 +3341,30 @@ button { font: inherit; }
   display: block;
   margin-top: 2px;
 }
+.atlas-counterintelligence-resweep-value-ranking {
+  display: grid;
+  gap: 7px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(129, 140, 248, 0.28);
+  background: rgba(49, 46, 129, 0.18);
+}
+.atlas-counterintelligence-resweep-value-ranking p,
+.atlas-counterintelligence-resweep-value-ranking small { margin: 0; color: #ddd6fe; }
+.atlas-counterintelligence-resweep-value-ranking ol {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding-left: 20px;
+  color: #f8fafc;
+}
+.atlas-counterintelligence-resweep-value-ranking__item--high-value { color: #bbf7d0; }
+.atlas-counterintelligence-resweep-value-ranking__item--medium-value { color: #bfdbfe; }
+.atlas-counterintelligence-resweep-value-ranking__item--low-value { color: #fde68a; }
+.atlas-counterintelligence-resweep-value-ranking li small {
+  display: block;
+  margin-top: 2px;
+}
 .atlas-counterintelligence-schedule-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Implements #852.

Summary:
- rank safe staged resweep assignments by coverage value, combining blind spot severity, stale refresh, unsafe-gap penalty, and preview value
- highlight the best coverage-value resweep while explaining why medium/low gain choices are less urgent
- keep unsafe/no-safe assignments excluded from the value ranking and report the exclusion count

Validation:
- node --check web/app.js
- npm test -- test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- npm test
- git diff --check