### PR TITLE
Epsilon: rank climate boost relief

### DIFF
--- a/test/ui/climate/webAtlasClimateReadinessBoostReliefRanking.test.js
+++ b/test/ui/climate/webAtlasClimateReadinessBoostReliefRanking.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const reliefRankingFixture = [
+  { outcome: 'executable', reliefScore: 90, reliefBand: 'temps exécutable gagné' },
+  { outcome: 'still-tight', reliefScore: 55, reliefBand: 'soulagement partiel, deadline serrée' },
+  { outcome: 'insufficient', reliefScore: 20, reliefBand: 'soulagement faible, deadline bloque encore' },
+];
+
+test('atlas ranks climate readiness boosts by post-boost deadline pressure relief', () => {
+  assert.match(webAppSource, /function buildAtlasClimateReadinessBoostReliefRanking/);
+  assert.match(webAppSource, /function renderAtlasClimateReadinessBoostReliefRanking/);
+  assert.match(webAppSource, /postBoostView\.state === 'empty'/);
+  assert.match(webAppSource, /Aucun boost readiness urgent à classer par soulagement de deadline/);
+  assert.match(webAppSource, /Meilleur boost/);
+  assert.match(webAppSource, /Score relief/);
+  assert.match(webAppSource, /Pourquoi maintenant/);
+  assert.match(webAppSource, /right\.reliefScore - left\.reliefScore \|\| left\.residualPenalty - right\.residualPenalty \|\| left\.deadline\.localeCompare\(right\.deadline\) \|\| left\.provinceLabel\.localeCompare\(right\.provinceLabel\)/);
+  assert.match(webAppSource, /atlasClimateReadinessBoostReliefRanking = buildAtlasClimateReadinessBoostReliefRanking\(atlasClimatePostBoostDeadlineRiskPreview\)/);
+  assert.match(webAppSource, /renderAtlasClimateReadinessBoostReliefRanking\(atlasClimateReadinessBoostReliefRanking\)/);
+
+  for (const fixture of reliefRankingFixture) {
+    assert.match(webAppSource, new RegExp(fixture.outcome));
+    assert.match(webAppSource, new RegExp(String(fixture.reliefScore)));
+    assert.match(webAppSource, new RegExp(fixture.reliefBand));
+  }
+
+  assert.match(stylesSource, /\.map-world-climate-boost-relief-ranking/);
+  assert.match(stylesSource, /\.map-world-climate-boost-relief-ranking__item--executable/);
+  assert.match(stylesSource, /\.map-world-climate-boost-relief-ranking__item--still-tight/);
+  assert.match(stylesSource, /\.map-world-climate-boost-relief-ranking__item--insufficient/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -7365,6 +7365,90 @@ function renderAtlasClimatePostBoostDeadlineRiskPreview(view) {
   `;
 }
 
+function buildAtlasClimateReadinessBoostReliefRanking(postBoostView) {
+  if (!postBoostView || postBoostView.state === 'empty' || postBoostView.previews.length === 0) {
+    return {
+      state: 'empty',
+      rankedBoosts: [],
+      summary: 'Aucun boost readiness urgent à classer par soulagement de deadline.',
+    };
+  }
+
+  const reliefByOutcome = {
+    executable: 90,
+    'still-tight': 55,
+    insufficient: 20,
+  };
+  const residualPenaltyByOutcome = {
+    executable: 0,
+    'still-tight': 12,
+    insufficient: 28,
+  };
+
+  const rankedBoosts = postBoostView.previews
+    .map((preview) => {
+      const reliefScore = reliefByOutcome[preview.outcome] ?? 0;
+      const residualPenalty = residualPenaltyByOutcome[preview.outcome] ?? 0;
+      const reliefBand = preview.outcome === 'executable'
+        ? 'temps exécutable gagné'
+        : preview.outcome === 'still-tight'
+          ? 'soulagement partiel, deadline serrée'
+          : 'soulagement faible, deadline bloque encore';
+      return {
+        provinceId: preview.provinceId,
+        provinceLabel: preview.provinceLabel,
+        deadline: preview.deadline,
+        outcome: preview.outcome,
+        reliefScore,
+        residualPenalty,
+        reliefBand,
+        appliedBoost: preview.appliedBoost,
+        explanation: preview.outcome === 'executable'
+          ? `${preview.appliedBoost} achète la fenêtre la plus jouable: ${preview.postBoostSignal}`
+          : preview.outcome === 'still-tight'
+            ? `${preview.appliedBoost} réduit la pression mais laisse peu de marge: ${preview.postBoostSignal}`
+            : `${preview.appliedBoost} soulage trop peu avant la deadline: ${preview.postBoostSignal}`,
+      };
+    })
+    .sort((left, right) => right.reliefScore - left.reliefScore || left.residualPenalty - right.residualPenalty || left.deadline.localeCompare(right.deadline) || left.provinceLabel.localeCompare(right.provinceLabel))
+    .map((boost, index) => ({ ...boost, rank: index + 1 }));
+
+  const best = rankedBoosts[0];
+  return {
+    state: rankedBoosts.length > 0 ? 'ranked' : 'empty',
+    rankedBoosts,
+    summary: best
+      ? `Meilleur boost: ${best.provinceLabel}, car il offre le plus de temps exécutable (${best.reliefBand}).`
+      : 'Aucun boost readiness urgent à classer par soulagement de deadline.',
+  };
+}
+
+function renderAtlasClimateReadinessBoostReliefRanking(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'ranked') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-boost-relief-ranking" aria-label="Classement des boosts readiness climat par soulagement de deadline">
+      <div class="map-world-climate-boost-relief-ranking__header">
+        <strong>Priorité boosts readiness</strong>
+        <span>${view.rankedBoosts.length} classé${view.rankedBoosts.length > 1 ? 's' : ''}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-boost-relief-ranking__list">
+        ${view.rankedBoosts.map((boost) => `
+          <li class="map-world-climate-boost-relief-ranking__item map-world-climate-boost-relief-ranking__item--${boost.outcome}">
+            <b>${boost.rank}. ${boost.provinceLabel}</b>
+            <span>${boost.deadline} · ${boost.reliefBand}</span>
+            <small><b>Score relief</b> · ${boost.reliefScore} (pénalité résiduelle ${boost.residualPenalty})</small>
+            <small><b>Pourquoi maintenant</b> · ${boost.explanation}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -14894,6 +14978,7 @@ function render() {
   const atlasClimateUnderReadyExecutionGaps = buildAtlasClimateUnderReadyExecutionGaps(atlasClimateMitigationReadiness);
   const atlasClimateReadinessBoostRecommendations = buildAtlasClimateReadinessBoostRecommendations(atlasClimateUnderReadyExecutionGaps);
   const atlasClimatePostBoostDeadlineRiskPreview = buildAtlasClimatePostBoostDeadlineRiskPreview(atlasClimateReadinessBoostRecommendations);
+  const atlasClimateReadinessBoostReliefRanking = buildAtlasClimateReadinessBoostReliefRanking(atlasClimatePostBoostDeadlineRiskPreview);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -14935,6 +15020,7 @@ function render() {
           ${renderAtlasClimateUnderReadyExecutionGaps(atlasClimateUnderReadyExecutionGaps)}
           ${renderAtlasClimateReadinessBoostRecommendations(atlasClimateReadinessBoostRecommendations)}
           ${renderAtlasClimatePostBoostDeadlineRiskPreview(atlasClimatePostBoostDeadlineRiskPreview)}
+          ${renderAtlasClimateReadinessBoostReliefRanking(atlasClimateReadinessBoostReliefRanking)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -11808,3 +11808,44 @@ button { font: inherit; }
 .map-world-climate-post-boost-risk__item--executable { border-color: rgba(110, 231, 183, 0.38); }
 .map-world-climate-post-boost-risk__item--still-tight { border-color: rgba(251, 191, 36, 0.44); }
 .map-world-climate-post-boost-risk__item--insufficient { border-color: rgba(248, 113, 113, 0.52); }
+.map-world-climate-boost-relief-ranking {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(88, 28, 135, 0.22));
+  border: 1px solid rgba(192, 132, 252, 0.34);
+}
+.map-world-climate-boost-relief-ranking__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-boost-relief-ranking p,
+.map-world-climate-boost-relief-ranking span,
+.map-world-climate-boost-relief-ranking small {
+  color: #f3e8ff;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-boost-relief-ranking__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-boost-relief-ranking__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.56);
+  border: 1px solid rgba(192, 132, 252, 0.26);
+}
+.map-world-climate-boost-relief-ranking__item--executable { border-color: rgba(110, 231, 183, 0.4); }
+.map-world-climate-boost-relief-ranking__item--still-tight { border-color: rgba(251, 191, 36, 0.44); }
+.map-world-climate-boost-relief-ranking__item--insufficient { border-color: rgba(248, 113, 113, 0.52); }


### PR DESCRIPTION
Epsilon: Couvre #853.

Résumé:
- ajoute un classement compact des boosts readiness climat par soulagement post-boost de la pression deadline;
- réutilise les previews E13 (`executable`, `still-tight`, `insufficient`) avec score de relief, pénalité résiduelle et tri déterministe en cas d’égalité;
- met le meilleur boost en premier avec une explication courte du temps exécutable acheté, tout en gardant l’état vide quand aucun boost urgent n’est éligible.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateReadinessBoostReliefRanking.test.js test/ui/climate/webAtlasClimatePostBoostDeadlineRiskPreview.test.js
- git diff --check
- npm test (568 tests OK)

Merci de valider avant tout merge.