### PR TITLE
Alpha: suggest best order for top warning

### DIFF
--- a/test/ui/war/webAtlasMilitaryBestNextOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryBestNextOrderHint.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military best next order hint builds on stack relief and staged commitment data', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryBestNextOrderHint\(priorityStack, reliefPreview, commitment\)/);
+  assert.match(webAppSource, /priorityStack\?\.stack\?\.\[0\]/);
+  assert.match(webAppSource, /reliefPreview\?\.preview/);
+  assert.match(webAppSource, /commitment\?\.selectedOption\?\.target/);
+  assert.match(webAppSource, /renderAtlasMilitaryWarningPriorityStack\(commitmentWarningStack, stagedCommitment\)/);
+});
+
+test('atlas military best next order hint handles reinforce route and overcommitment candidates', () => {
+  assert.match(webAppSource, /type: 'reinforce-front'/);
+  assert.match(webAppSource, /order: 'Renforcer front'/);
+  assert.match(webAppSource, /type: 'clear-route-exposure'/);
+  assert.match(webAppSource, /order: 'Ouvrir route'/);
+  assert.match(webAppSource, /type: 'reduce-overcommitment'/);
+  assert.match(webAppSource, /order: 'Réduire surengagement'/);
+});
+
+test('atlas military best next order hint stays hidden when there is no clear order', () => {
+  assert.match(webAppSource, /Aucun ordre recommandé: pas de priorité actionnable avec gain clair/);
+  assert.match(webAppSource, /if \(!candidate \|\| candidate\.score < 12\)/);
+  assert.match(webAppSource, /if \(!orderHint \|\| orderHint\.empty \|\| !orderHint\.hint\) return ''/);
+  assert.match(webAppSource, /data-atlas-best-next-order/);
+  assert.match(stylesSource, /\.atlas-military-best-order__panel/);
+  assert.match(stylesSource, /\.atlas-military-best-order--clear-route-exposure/);
+  assert.match(stylesSource, /\.atlas-military-best-order--reduce-overcommitment/);
+});

--- a/test/ui/war/webAtlasMilitaryWarningPriorityStack.test.js
+++ b/test/ui/war/webAtlasMilitaryWarningPriorityStack.test.js
@@ -9,7 +9,7 @@ test('atlas military warning priority stack reuses next-turn warning and route d
   assert.match(webAppSource, /function buildAtlasMilitaryWarningPriorityStack\(warningSummary, features\)/);
   assert.match(webAppSource, /warningSummary\.warnings/);
   assert.match(webAppSource, /getAtlasMilitaryWarningRouteExposure\(warning, features\)/);
-  assert.match(webAppSource, /renderAtlasMilitaryWarningPriorityStack\(commitmentWarningStack\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryWarningPriorityStack\(commitmentWarningStack, stagedCommitment\)/);
   assert.doesNotMatch(webAppSource, /new WarModel|simulateWar|hiddenStack/);
 });
 

--- a/web/app.js
+++ b/web/app.js
@@ -1551,10 +1551,78 @@ function renderAtlasMilitaryTopWarningReliefPreview(reliefPreview) {
   `;
 }
 
-function renderAtlasMilitaryWarningPriorityStack(priorityStack) {
+
+function buildAtlasMilitaryBestNextOrderHint(priorityStack, reliefPreview, commitment) {
+  const topWarning = priorityStack?.stack?.[0] ?? null;
+  const preview = reliefPreview?.preview ?? null;
+  if (!topWarning || !preview) {
+    return {
+      hint: null,
+      summary: 'Aucun ordre recommandé: pas de priorité actionnable avec gain clair.',
+      empty: true,
+    };
+  }
+
+  const candidate = topWarning.debtTone === 'absent'
+    ? {
+      type: 'reinforce-front',
+      order: 'Renforcer front',
+      detail: `basculer l’engagement vers ${topWarning.label}`,
+      score: preview.frontRiskReduction + 18,
+    }
+    : topWarning.routeExposure >= 10 && preview.routeExposureReduced > 0
+      ? {
+        type: 'clear-route-exposure',
+        order: 'Ouvrir route',
+        detail: `sécuriser l’axe exposé de ${topWarning.label}`,
+        score: preview.routeExposureReduced + 14,
+      }
+      : topWarning.debtTone === 'partial'
+        ? {
+          type: 'reduce-overcommitment',
+          order: 'Réduire surengagement',
+          detail: `recentrer ${commitment?.selectedOption?.target ?? topWarning.label}`,
+          score: Math.max(12, preview.reliefScore - 8),
+        }
+        : null;
+
+  if (!candidate || candidate.score < 12) {
+    return {
+      hint: null,
+      summary: `Aucun ordre clair pour ${topWarning.label}: gain trop incertain.`,
+      empty: true,
+    };
+  }
+
+  return {
+    hint: {
+      hintId: `order:${topWarning.warningId}`,
+      ...candidate,
+      label: topWarning.label,
+      reliefTone: preview.tone,
+    },
+    summary: `${candidate.order}: ${candidate.detail} pour débloquer ${preview.reliefScore} de relief.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryBestNextOrderHint(orderHint) {
+  if (!orderHint || orderHint.empty || !orderHint.hint) return '';
+  const hint = orderHint.hint;
+  return `
+    <g class="atlas-military-best-order atlas-military-best-order--${hint.type}" data-atlas-best-next-order="${hint.hintId}" aria-label="Meilleur prochain ordre: ${orderHint.summary}">
+      <rect class="atlas-military-best-order__panel" x="22" y="53.2" width="16" height="4.4" rx="1.2"></rect>
+      <text class="atlas-military-best-order__label" x="23.2" y="54.8">ordre: ${hint.order}</text>
+      <text class="atlas-military-best-order__detail" x="23.2" y="56.4">${hint.detail}</text>
+    </g>
+  `;
+}
+
+function renderAtlasMilitaryWarningPriorityStack(priorityStack, commitment) {
   if (!priorityStack || priorityStack.empty) return '';
   const [topPriority, ...lowerPriorities] = priorityStack.stack;
   const topReliefPreview = buildAtlasMilitaryTopWarningReliefPreview(priorityStack);
+  const bestOrderHint = buildAtlasMilitaryBestNextOrderHint(priorityStack, topReliefPreview, commitment);
   const height = 8.8 + (lowerPriorities.length * 2.7);
   return `
     <g class="atlas-military-warning-stack" aria-label="Pile de priorités des alertes militaires: ${priorityStack.summary}">
@@ -1566,6 +1634,7 @@ function renderAtlasMilitaryWarningPriorityStack(priorityStack) {
         <text class="atlas-military-warning-stack-top__why" x="10" y="51.4">why first: ${topPriority.whyFirst}</text>
       </g>
       ${renderAtlasMilitaryTopWarningReliefPreview(topReliefPreview)}
+      ${renderAtlasMilitaryBestNextOrderHint(bestOrderHint)}
       ${lowerPriorities.map((warning, index) => `
         <g class="atlas-military-warning-stack-item atlas-military-warning-stack-item--${warning.tone}" data-atlas-warning-stack-item="${warning.stackId}" aria-label="Priorité ${index + 2} ${warning.frontRoute}: score ${warning.stackScore}; ${warning.action}">
           <text x="5" y="${54.4 + index * 2.7}">${index + 2}. ${warning.label}</text>
@@ -1685,7 +1754,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryCommitmentDebtSummary(commitmentDebt)}
       ${renderAtlasMilitaryCommitmentDebtPriorities(commitmentPriority)}
       ${renderAtlasMilitaryCommitmentNextTurnWarnings(commitmentWarnings)}
-      ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack)}
+      ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `
         <g class="atlas-military-risk atlas-military-risk--${zone.tone}" data-atlas-risk-province="${zone.provinceId}" aria-label="Zone militaire ${zone.label}: pression ${zone.pressure}">

--- a/web/styles.css
+++ b/web/styles.css
@@ -10655,6 +10655,7 @@ button { font: inherit; }
 .atlas-military-commitment-warning,
 .atlas-military-warning-stack,
 .atlas-military-warning-relief,
+.atlas-military-best-order,
 .atlas-military-commitment-conflicts {
   pointer-events: auto;
 }
@@ -11056,6 +11057,27 @@ button { font: inherit; }
 }
 .atlas-military-warning-relief--relief-partial text { fill: #fef3c7; }
 .atlas-military-warning-relief__detail { font-size: 0.74px; }
+
+.atlas-military-best-order__panel {
+  fill: rgba(30, 64, 175, 0.74);
+  stroke: rgba(191, 219, 254, 0.5);
+  stroke-width: 0.28;
+}
+.atlas-military-best-order--clear-route-exposure .atlas-military-best-order__panel {
+  fill: rgba(8, 145, 178, 0.72);
+}
+.atlas-military-best-order--reduce-overcommitment .atlas-military-best-order__panel {
+  fill: rgba(126, 34, 206, 0.7);
+}
+.atlas-military-best-order text {
+  fill: #dbeafe;
+  font-size: 0.78px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.88);
+  stroke-width: 0.24;
+}
+.atlas-military-best-order__detail { fill: #bfdbfe; font-size: 0.7px; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #859.

## Summary
- Adds a compact best-next-order hint beside the top military warning relief preview.
- Reuses the warning priority stack, relief preview, front risk, debt tone, route exposure, and staged commitment target.
- Handles reinforce-front, clear-route-exposure, reduce-overcommitment, and no-clear-order states deterministically.

## Validation
- node --check web/app.js
- git diff --check
- node --test test/ui/war/webAtlasMilitaryWarningPriorityStack.test.js test/ui/war/webAtlasMilitaryTopWarningReliefPreview.test.js test/ui/war/webAtlasMilitaryBestNextOrderHint.test.js
- npm test (571 passing)

Closes #859