### PR TITLE
Delta: warn best resweep residual gaps

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -398,6 +398,43 @@ test('atlas counterintelligence ranks safe staged resweeps by coverage value', (
   assert.match(stylesSource, /atlas-counterintelligence-resweep-value-ranking__item--low-value/);
 });
 
+test('atlas counterintelligence warns only the best safe resweep about residual gaps', () => {
+  const buildBestWarning = (bestAssignment, priorities) => {
+    if (!bestAssignment) return 'no-safe-assignment';
+    const remainingPriorities = priorities
+      .filter((spot) => spot.locationName !== bestAssignment.locationName)
+      .sort((left, right) => right.priorityScore - left.priorityScore || left.locationName.localeCompare(right.locationName));
+    const highPriorityBlindSpot = remainingPriorities.find((spot) => spot.failureType === 'non couvert' && ['critique', 'haute'].includes(spot.priorityLevel));
+    const staleCriticalSignal = remainingPriorities.find((spot) => spot.freshnessScore <= 1 && ['critique', 'haute'].includes(spot.priorityLevel));
+
+    if (highPriorityBlindSpot) return 'high-priority-blind-spot';
+    if (staleCriticalSignal) return 'stale-critical-signal';
+    return 'acceptable-residual';
+  };
+
+  const bestAssignment = { locationName: 'Best safe' };
+  assert.equal(buildBestWarning(bestAssignment, [
+    { locationName: 'Best safe', failureType: 'non couvert', priorityLevel: 'critique', freshnessScore: 1, priorityScore: 9 },
+    { locationName: 'Danger gap', failureType: 'non couvert', priorityLevel: 'haute', freshnessScore: 2, priorityScore: 8 },
+  ]), 'high-priority-blind-spot');
+  assert.equal(buildBestWarning(bestAssignment, [
+    { locationName: 'Old signal', failureType: 'couverture trop faible', priorityLevel: 'haute', freshnessScore: 1, priorityScore: 7 },
+  ]), 'stale-critical-signal');
+  assert.equal(buildBestWarning(bestAssignment, [
+    { locationName: 'Low residue', failureType: 'couverture trop faible', priorityLevel: 'prudente', freshnessScore: 3, priorityScore: 3 },
+  ]), 'acceptable-residual');
+  assert.equal(buildBestWarning(null, []), 'no-safe-assignment');
+  assert.match(webAppSource, /bestResweepResidualGapWarning/);
+  assert.match(webAppSource, /Warning de gap résiduel après le meilleur resweep sûr/);
+  assert.match(webAppSource, /high-priority-blind-spot/);
+  assert.match(webAppSource, /stale-critical-signal/);
+  assert.match(webAppSource, /acceptable-residual/);
+  assert.match(webAppSource, /no-safe-assignment/);
+  assert.match(webAppSource, /Gap résiduel du meilleur resweep/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning--high-priority-blind-spot/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -11554,6 +11554,52 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
   const rankedStagedResweepAssignmentSummary = rankedStagedResweepAssignments.length > 0
     ? `${rankedStagedResweepAssignments.length} resweep${rankedStagedResweepAssignments.length > 1 ? 's' : ''} sûr${rankedStagedResweepAssignments.length > 1 ? 's' : ''} classé${rankedStagedResweepAssignments.length > 1 ? 's' : ''} par valeur de couverture; meilleur: ${rankedStagedResweepAssignments[0].locationName}. ${rankedStagedResweepAssignments.filter((assignment) => assignment.coverageValueLevel === 'low-value').length} low-gain à garder en réserve; ${excludedUnsafeResweepAssignments.length} unsafe exclu${excludedUnsafeResweepAssignments.length > 1 ? 's' : ''}.`
     : 'Aucun classement de valeur: toutes les affectations staged sont unsafe/no-safe ou sans gain exploitable.';
+  const bestRankedStagedResweepAssignment = rankedStagedResweepAssignments.find((assignment) => assignment.bestCoverageValue) ?? null;
+  const bestResweepResidualGapWarning = (() => {
+    if (!bestRankedStagedResweepAssignment) {
+      return {
+        state: 'no-safe-assignment',
+        tone: 'muted',
+        locationName: null,
+        summary: 'Aucun warning résiduel: aucun meilleur resweep sûr n’est disponible à confirmer.',
+        detail: 'Les affectations unsafe/no-safe restent exclues; attendre un créneau ou une couverture plus sûre.',
+      };
+    }
+
+    const remainingPriorities = resweepPriorities
+      .filter((spot) => spot.locationName !== bestRankedStagedResweepAssignment.locationName)
+      .sort((left, right) => right.priorityScore - left.priorityScore || left.locationName.localeCompare(right.locationName));
+    const highPriorityBlindSpot = remainingPriorities.find((spot) => spot.failureType === 'non couvert' && ['critique', 'haute'].includes(spot.priorityLevel));
+    const staleCriticalSignal = remainingPriorities.find((spot) => spot.freshnessScore <= 1 && ['critique', 'haute'].includes(spot.priorityLevel));
+
+    if (highPriorityBlindSpot) {
+      return {
+        state: 'high-priority-blind-spot',
+        tone: 'danger',
+        locationName: highPriorityBlindSpot.locationName,
+        summary: `${bestRankedStagedResweepAssignment.locationName} est le meilleur resweep sûr, mais laisse ${highPriorityBlindSpot.locationName} en angle mort prioritaire.`,
+        detail: `${highPriorityBlindSpot.priorityReason}; garder un second créneau ou remplacer une veille stable.`,
+      };
+    }
+
+    if (staleCriticalSignal) {
+      return {
+        state: 'stale-critical-signal',
+        tone: 'warning',
+        locationName: staleCriticalSignal.locationName,
+        summary: `${bestRankedStagedResweepAssignment.locationName} est le meilleur resweep sûr, mais un signal ancien critique reste non rafraîchi.`,
+        detail: `${staleCriticalSignal.locationName}: ${staleCriticalSignal.priorityReason}; prévoir un refresh court avant engagement nominatif.`,
+      };
+    }
+
+    return {
+      state: 'acceptable-residual',
+      tone: 'safe',
+      locationName: bestRankedStagedResweepAssignment.locationName,
+      summary: `${bestRankedStagedResweepAssignment.locationName} ne laisse aucun gap résiduel critique après le meilleur resweep sûr.`,
+      detail: 'Les risques restants sont couverts, partiels ou low-gain selon les signaux atlas visibles.',
+    };
+  })();
   const postOrderCoverage = {
     coveredOrderZones,
     fragileAssignments,
@@ -11571,6 +11617,8 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
     rankedStagedResweepAssignments,
     rankedStagedResweepAssignmentSummary,
     excludedUnsafeResweepAssignments,
+    bestRankedStagedResweepAssignment,
+    bestResweepResidualGapWarning,
     summary: postOrderCoverageSummary,
   };
   const exposureCooldownSummary = sweepCandidates.length > 0
@@ -11708,6 +11756,11 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
         ${plan.postOrderCoverage.rankedStagedResweepAssignments.length > 0
           ? `<ol>${plan.postOrderCoverage.rankedStagedResweepAssignments.map((assignment) => `<li class="atlas-counterintelligence-resweep-value-ranking__item atlas-counterintelligence-resweep-value-ranking__item--${assignment.coverageValueLevel}"><b>#${assignment.coverageValueRank} ${assignment.locationName}</b> · ${assignment.coverageValueScore} valeur${assignment.bestCoverageValue ? ' · meilleur choix' : ''}<small>${assignment.lessUrgentReason} · priorité ${assignment.priorityScore}, refresh ${assignment.staleRefreshValue}, preview ${assignment.previewValue}, gap unsafe -${assignment.unsafeGapPenalty}</small></li>`).join('')}</ol>`
           : '<small>Aucun resweep sûr à classer: les affectations rejetées par sécurité restent exclues.</small>'}
+        <aside class="atlas-counterintelligence-best-resweep-gap-warning atlas-counterintelligence-best-resweep-gap-warning--${plan.postOrderCoverage.bestResweepResidualGapWarning.state}" aria-label="Warning de gap résiduel après le meilleur resweep sûr">
+          <b>Gap résiduel du meilleur resweep</b>
+          <span>${plan.postOrderCoverage.bestResweepResidualGapWarning.summary}</span>
+          <small>${plan.postOrderCoverage.bestResweepResidualGapWarning.detail}</small>
+        </aside>
       </section>
       <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">
         <strong>Conflits de planning</strong>

--- a/web/styles.css
+++ b/web/styles.css
@@ -3365,6 +3365,19 @@ button { font: inherit; }
   display: block;
   margin-top: 2px;
 }
+.atlas-counterintelligence-best-resweep-gap-warning {
+  display: grid;
+  gap: 3px;
+  padding: 7px;
+  border-radius: 10px;
+  border: 1px solid rgba(251, 191, 36, 0.28);
+  background: rgba(120, 53, 15, 0.2);
+}
+.atlas-counterintelligence-best-resweep-gap-warning span { color: #fef3c7; }
+.atlas-counterintelligence-best-resweep-gap-warning--high-priority-blind-spot { border-color: rgba(248, 113, 113, 0.5); background: rgba(127, 29, 29, 0.26); }
+.atlas-counterintelligence-best-resweep-gap-warning--stale-critical-signal { border-color: rgba(251, 191, 36, 0.46); }
+.atlas-counterintelligence-best-resweep-gap-warning--acceptable-residual { border-color: rgba(74, 222, 128, 0.38); background: rgba(20, 83, 45, 0.2); }
+.atlas-counterintelligence-best-resweep-gap-warning--no-safe-assignment { border-color: rgba(148, 163, 184, 0.35); background: rgba(51, 65, 85, 0.18); }
 .atlas-counterintelligence-schedule-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Implements #862.

Summary:
- add a best-assignment-only residual gap warning after staged resweeps are ranked by coverage value
- detect high-priority blind spots, stale critical signals, acceptable residual risk, and no-safe-assignment states deterministically
- render the warning inside the ranked resweep section without exposing hidden actors, relays, targets, or causes

Validation:
- node --check web/app.js
- npm test -- test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- npm test
- git diff --check