### PR TITLE
Gamma: show latest safe fallback turns

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -39,6 +39,7 @@ test('world map atlas renders culture influence zones from existing culture over
   assert.match(webAppSource, /consolidationRecommendations/);
   assert.match(webAppSource, /buildAtlasConsolidationFollowUpStatus/);
   assert.match(webAppSource, /buildAtlasStaleRiskFallbackMove/);
+  assert.match(webAppSource, /buildAtlasLatestSafeFallbackTurn/);
 });
 
 test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
@@ -97,9 +98,17 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /atlas-cultural-border-zone__followup/);
   assert.match(webAppSource, /closing-window/);
   assert.match(webAppSource, /border-pressure/);
-  assert.match(webAppSource, /fallback: buildAtlasStaleRiskFallbackMove/);
+  assert.match(webAppSource, /const fallback = buildAtlasStaleRiskFallbackMove/);
   assert.match(webAppSource, /followUp\?\.state !== 'stale-risk'/);
   assert.match(webAppSource, /atlas-cultural-border-zone__fallback/);
+  assert.match(webAppSource, /latestSafeTurn: buildAtlasLatestSafeFallbackTurn/);
+  assert.match(webAppSource, /followUp\?\.state !== 'stale-risk' \|\| !fallback/);
+  assert.match(webAppSource, /state: 'immediate'/);
+  assert.match(webAppSource, /state: 'one-turn-left'/);
+  assert.match(webAppSource, /state: 'multi-turn'/);
+  assert.match(webAppSource, /state: 'no-safe-window'/);
+  assert.match(webAppSource, /dernier sûr:/);
+  assert.match(webAppSource, /atlas-cultural-border-zone__latest-safe/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -117,6 +126,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-border-zone__followup--stale-risk/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__fallback--closing-window/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__fallback--border-pressure/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__latest-safe--immediate/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__latest-safe--one-turn-left/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__latest-safe--multi-turn/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__latest-safe--no-safe-window/);
   assert.match(stylesSource, /\.atlas-cultural-border-zones\.is-stable rect/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__confidence/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__consequences/);
@@ -141,4 +154,5 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action--followup-covered/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action--followup-stale-risk/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__fallback/);
+  assert.match(stylesSource, /\.atlas-cultural-consolidation-action__latest-safe/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1974,6 +1974,50 @@ function buildAtlasStaleRiskFallbackMove(zone, commitment, followUp) {
   return null;
 }
 
+function buildAtlasLatestSafeFallbackTurn(zone, commitment, followUp, fallback) {
+  if (followUp?.state !== 'stale-risk' || !fallback) {
+    return null;
+  }
+
+  if (commitment.reboundWindow.state === 'missed') {
+    return {
+      state: 'no-safe-window',
+      label: 'fenêtre échue',
+      value: 'aucun tour sûr',
+      reason: `no-safe-window · ${commitment.reboundWindow.label}`,
+      detail: 'la médiation doit être révisée avant que le fallback puisse protéger ce rebond',
+    };
+  }
+
+  if (commitment.consolidation.state === 'expiring' || fallback.state === 'closing-window') {
+    return {
+      state: 'immediate',
+      label: 'dernier sûr',
+      value: 'maintenant',
+      reason: `immediate · ${commitment.consolidation.reason}`,
+      detail: 'jouer le fallback ce tour pour conserver le rebond fragile',
+    };
+  }
+
+  if (fallback.state === 'border-pressure' || commitment.remainingConfidence === 'faible') {
+    return {
+      state: 'one-turn-left',
+      label: 'dernier sûr',
+      value: 'tour +1',
+      reason: `one-turn-left · ${zone.mainDriver}`,
+      detail: 'laisser un seul tour de tampon avant que la pression de frontière ne dépasse le relais',
+    };
+  }
+
+  return {
+    state: 'multi-turn',
+    label: 'dernier sûr',
+    value: 'tour +2',
+    reason: `multi-turn · ${commitment.remainingConfidence}`,
+    detail: 'fenêtre courte mais planifiable tant que le signal de médiation reste lisible',
+  };
+}
+
 function buildAtlasConsolidationFollowUpStatus(zone, commitment, recommendation) {
   if (!recommendation) {
     return null;
@@ -2168,6 +2212,7 @@ function buildAtlasMediationCommitment(zone) {
 
   const consolidationRecommendation = buildAtlasFragileReboundRecommendation(zone, commitment);
   const followUp = buildAtlasConsolidationFollowUpStatus(zone, commitment, consolidationRecommendation);
+  const fallback = buildAtlasStaleRiskFallbackMove(zone, commitment, followUp);
 
   return {
     ...commitment,
@@ -2177,7 +2222,12 @@ function buildAtlasMediationCommitment(zone) {
           followUp: followUp
             ? {
                 ...followUp,
-                fallback: buildAtlasStaleRiskFallbackMove(zone, commitment, followUp),
+                fallback: fallback
+                  ? {
+                      ...fallback,
+                      latestSafeTurn: buildAtlasLatestSafeFallbackTurn(zone, commitment, followUp, fallback),
+                    }
+                  : null,
               }
             : null,
         }
@@ -2231,20 +2281,21 @@ function renderAtlasCultureLayer(cultureView) {
       `}
       ${features.borderZones.length > 0 ? `
         <g class="atlas-cultural-border-zones" aria-label="Synthèse des frontières culturelles instables et médiations">
-          <rect x="3" y="55" width="30" height="${15 + (features.borderZones.length * 17.2)}" rx="1.8"></rect>
+          <rect x="3" y="55" width="30" height="${16 + (features.borderZones.length * 18.6)}" rx="1.8"></rect>
           <text class="atlas-cultural-border-zones__title" x="5" y="58.4">Médiations culturelles</text>
           ${features.borderZones.map((zone, index) => `
             <g class="atlas-cultural-border-zone atlas-cultural-border-zone--${zone.drift.state} atlas-cultural-border-zone--confidence-${zone.mediation.confidence} atlas-cultural-border-zone--commitment-${zone.commitment.status === 'stable' ? 'stable' : 'risk'}" data-atlas-cultural-border="${zone.regionId}" aria-label="Frontière culturelle ${zone.cultureName}: moteur ${zone.mainDriver}, médiation ${zone.mediation.option}, confiance ${zone.mediation.confidence}, engagement ${zone.commitment.status}, confiance restante ${zone.commitment.remainingConfidence}, prochaine conséquence ${zone.commitment.nextConsequence}, échéance ${zone.commitment.phase}">
-              <text x="5" y="${62 + index * 17.2}">${zone.cultureName}</text>
-              <text class="atlas-cultural-border-zone__chips" x="5" y="${64 + index * 17.2}">${zone.chips.join(' · ')}</text>
-              <text class="atlas-cultural-border-zone__mediation" x="5" y="${66 + index * 17.2}">${zone.mediation.option} → ${zone.mediation.benefit}</text>
-              <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 17.2}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
-              <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 17.2}">${zone.commitment.label} · ${zone.commitment.outcomeStatus} · reste ${zone.commitment.remainingConfidence}</text>
-              <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 17.2}">prochain: ${zone.commitment.nextConsequence} · action: ${zone.commitment.nextAction}</text>
-              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 17.2}">${zone.commitment.consolidation.label}: ${zone.commitment.consolidation.action}</text>
-              ${zone.commitment.consolidationRecommendation ? `<text class="atlas-cultural-border-zone__recommendation" x="5" y="${74.6 + index * 17.2}">reco: ${zone.commitment.consolidationRecommendation.label} · ${zone.commitment.consolidationRecommendation.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp ? `<text class="atlas-cultural-border-zone__followup atlas-cultural-border-zone__followup--${zone.commitment.consolidationRecommendation.followUp.state}" x="5" y="${76.1 + index * 17.2}">suivi: ${zone.commitment.consolidationRecommendation.followUp.label} · ${zone.commitment.consolidationRecommendation.followUp.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp?.fallback ? `<text class="atlas-cultural-border-zone__fallback atlas-cultural-border-zone__fallback--${zone.commitment.consolidationRecommendation.followUp.fallback.state}" x="5" y="${77.5 + index * 17.2}">fallback: ${zone.commitment.consolidationRecommendation.followUp.fallback.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.reason}</text>` : ''}
+              <text x="5" y="${62 + index * 18.6}">${zone.cultureName}</text>
+              <text class="atlas-cultural-border-zone__chips" x="5" y="${64 + index * 18.6}">${zone.chips.join(' · ')}</text>
+              <text class="atlas-cultural-border-zone__mediation" x="5" y="${66 + index * 18.6}">${zone.mediation.option} → ${zone.mediation.benefit}</text>
+              <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 18.6}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
+              <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 18.6}">${zone.commitment.label} · ${zone.commitment.outcomeStatus} · reste ${zone.commitment.remainingConfidence}</text>
+              <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 18.6}">prochain: ${zone.commitment.nextConsequence} · action: ${zone.commitment.nextAction}</text>
+              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 18.6}">${zone.commitment.consolidation.label}: ${zone.commitment.consolidation.action}</text>
+              ${zone.commitment.consolidationRecommendation ? `<text class="atlas-cultural-border-zone__recommendation" x="5" y="${74.6 + index * 18.6}">reco: ${zone.commitment.consolidationRecommendation.label} · ${zone.commitment.consolidationRecommendation.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp ? `<text class="atlas-cultural-border-zone__followup atlas-cultural-border-zone__followup--${zone.commitment.consolidationRecommendation.followUp.state}" x="5" y="${76.1 + index * 18.6}">suivi: ${zone.commitment.consolidationRecommendation.followUp.label} · ${zone.commitment.consolidationRecommendation.followUp.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback ? `<text class="atlas-cultural-border-zone__fallback atlas-cultural-border-zone__fallback--${zone.commitment.consolidationRecommendation.followUp.fallback.state}" x="5" y="${77.5 + index * 18.6}">fallback: ${zone.commitment.consolidationRecommendation.followUp.fallback.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.latestSafeTurn ? `<text class="atlas-cultural-border-zone__latest-safe atlas-cultural-border-zone__latest-safe--${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.state}" x="5" y="${78.9 + index * 18.6}">dernier sûr: ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.value} · ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.reason}</text>` : ''}
             </g>
           `).join('')}
         </g>
@@ -2257,14 +2308,15 @@ function renderAtlasCultureLayer(cultureView) {
       `}
       ${features.consolidationRecommendations.length > 0 ? `
         <g class="atlas-cultural-consolidation-actions" aria-label="Actions de consolidation des rebonds culturels fragiles">
-          <rect x="65" y="56" width="31" height="${8.6 + (features.consolidationRecommendations.length * 7.4)}" rx="1.8"></rect>
+          <rect x="65" y="56" width="31" height="${9.2 + (features.consolidationRecommendations.length * 8.8)}" rx="1.8"></rect>
           <text class="atlas-cultural-consolidation-actions__title" x="67" y="59.2">Actions consolidation</text>
           ${features.consolidationRecommendations.map((item, index) => `
             <g class="atlas-cultural-consolidation-action atlas-cultural-consolidation-action--${item.consolidation.state} atlas-cultural-consolidation-action--followup-${item.recommendation.followUp.state}" data-atlas-consolidation-action="${item.regionId}" aria-label="Action consolidation ${item.cultureName}: ${item.recommendation.label}, suivi ${item.recommendation.followUp.label}, raison ${item.recommendation.followUp.reason}, détail ${item.recommendation.followUp.detail}">
-              <text x="67" y="${62.3 + index * 7.4}">${item.cultureName} · ${item.recommendation.label}</text>
-              <text class="atlas-cultural-consolidation-action__reason" x="67" y="${64.1 + index * 7.4}">${item.recommendation.reason}</text>
-              <text class="atlas-cultural-consolidation-action__followup" x="67" y="${65.8 + index * 7.4}">${item.recommendation.followUp.label} · ${item.recommendation.followUp.reason}</text>
-              ${item.recommendation.followUp.fallback ? `<text class="atlas-cultural-consolidation-action__fallback" x="67" y="${67.5 + index * 7.4}">fallback: ${item.recommendation.followUp.fallback.label} · ${item.recommendation.followUp.fallback.reason}</text>` : ''}
+              <text x="67" y="${62.3 + index * 8.8}">${item.cultureName} · ${item.recommendation.label}</text>
+              <text class="atlas-cultural-consolidation-action__reason" x="67" y="${64.1 + index * 8.8}">${item.recommendation.reason}</text>
+              <text class="atlas-cultural-consolidation-action__followup" x="67" y="${65.8 + index * 8.8}">${item.recommendation.followUp.label} · ${item.recommendation.followUp.reason}</text>
+              ${item.recommendation.followUp.fallback ? `<text class="atlas-cultural-consolidation-action__fallback" x="67" y="${67.5 + index * 8.8}">fallback: ${item.recommendation.followUp.fallback.label} · ${item.recommendation.followUp.fallback.reason}</text>` : ''}
+              ${item.recommendation.followUp.fallback?.latestSafeTurn ? `<text class="atlas-cultural-consolidation-action__latest-safe atlas-cultural-consolidation-action__latest-safe--${item.recommendation.followUp.fallback.latestSafeTurn.state}" x="67" y="${69.1 + index * 8.8}">dernier sûr: ${item.recommendation.followUp.fallback.latestSafeTurn.value}</text>` : ''}
             </g>
           `).join('')}
         </g>

--- a/web/styles.css
+++ b/web/styles.css
@@ -11777,6 +11777,15 @@ button { font: inherit; }
 .atlas-cultural-border-zone__fallback--closing-window { fill: #fecdd3; }
 .atlas-cultural-border-zone__fallback--border-pressure { fill: #fed7aa; }
 .atlas-cultural-border-zone__fallback--mediation-drift { fill: #ddd6fe; }
+.atlas-cultural-border-zone__latest-safe {
+  fill: #bfdbfe;
+  font-size: 0.76px;
+  font-weight: 840;
+}
+.atlas-cultural-border-zone__latest-safe--immediate { fill: #fecdd3; }
+.atlas-cultural-border-zone__latest-safe--one-turn-left { fill: #fde68a; }
+.atlas-cultural-border-zone__latest-safe--multi-turn { fill: #bfdbfe; }
+.atlas-cultural-border-zone__latest-safe--no-safe-window { fill: #fca5a5; }
 .atlas-cultural-consolidation-actions rect {
   fill: rgba(49, 46, 129, 0.54);
   stroke: rgba(196, 181, 253, 0.38);
@@ -11811,6 +11820,15 @@ button { font: inherit; }
   font-size: 0.8px;
   font-weight: 840;
 }
+.atlas-cultural-consolidation-action__latest-safe {
+  fill: #bfdbfe;
+  font-size: 0.78px;
+  font-weight: 860;
+}
+.atlas-cultural-consolidation-action__latest-safe--immediate,
+.atlas-cultural-consolidation-action__latest-safe--no-safe-window { fill: #fecdd3; }
+.atlas-cultural-consolidation-action__latest-safe--one-turn-left { fill: #fde68a; }
+.atlas-cultural-consolidation-action__latest-safe--multi-turn { fill: #bfdbfe; }
 .atlas-cultural-consolidation-action--fragile .atlas-cultural-consolidation-action__reason { fill: #fde68a; }
 .atlas-cultural-consolidation-action--expiring .atlas-cultural-consolidation-action__reason { fill: #fecdd3; }
 .map-world-climate-post-boost-risk {


### PR DESCRIPTION
Gamma: Implements #861.

## Summary
- add deterministic latest-safe-turn timing for stale-risk cultural fallback moves
- render compact latest-safe labels in border-zone and consolidation-action atlas panels
- add styling and focused source coverage for immediate, one-turn-left, multi-turn, no-safe-window, and no-indicator states

## Validation
- node --check web/app.js
- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js
- git diff --check
- npm test

Zeta: ready for validation before merge.
