### PR TITLE
Epsilon: show minimum viable climate boost

### DIFF
--- a/test/ui/climate/webAtlasClimateMinimumViableBoostHint.test.js
+++ b/test/ui/climate/webAtlasClimateMinimumViableBoostHint.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const minimumViableBoostFixture = [
+  {
+    outcome: 'executable',
+    state: 'minimal-sufficient',
+    level: 'minimum suffisant',
+    package: '1 équipe + réserve ciblée',
+  },
+  {
+    outcome: 'still-tight',
+    state: 'partial-worthwhile',
+    level: 'minimum utile',
+    package: '1 équipe + jalon avancé',
+  },
+  {
+    outcome: 'insufficient',
+    state: 'insufficient-minimum',
+    level: 'minimum insuffisant',
+    package: 'paquet minimal + arbitrage requis',
+  },
+];
+
+test('atlas shows a minimum viable boost hint only for the top ranked climate readiness boost', () => {
+  assert.match(webAppSource, /function buildAtlasClimateMinimumViableBoostHint/);
+  assert.match(webAppSource, /function renderAtlasClimateMinimumViableBoostHint/);
+  assert.match(webAppSource, /reliefRankingView\.state !== 'ranked'/);
+  assert.match(webAppSource, /Aucun boost climat prioritaire éligible à réduire au minimum viable/);
+  assert.match(webAppSource, /const topBoost = reliefRankingView\.rankedBoosts\[0\]/);
+  assert.match(webAppSource, /Minimum viable boost/);
+  assert.match(webAppSource, /Relief attendu/);
+  assert.match(webAppSource, /atlasClimateMinimumViableBoostHint = buildAtlasClimateMinimumViableBoostHint\(atlasClimateReadinessBoostReliefRanking\)/);
+  assert.match(webAppSource, /renderAtlasClimateMinimumViableBoostHint\(atlasClimateMinimumViableBoostHint\)/);
+
+  for (const fixture of minimumViableBoostFixture) {
+    assert.match(webAppSource, new RegExp(fixture.outcome));
+    assert.match(webAppSource, new RegExp(fixture.state));
+    assert.match(webAppSource, new RegExp(fixture.level));
+    assert.match(webAppSource, new RegExp(fixture.package.replace('+', '\\+')));
+  }
+
+  assert.match(stylesSource, /\.map-world-climate-minimum-boost/);
+  assert.match(stylesSource, /\.map-world-climate-minimum-boost--partial-worthwhile/);
+  assert.match(stylesSource, /\.map-world-climate-minimum-boost--insufficient-minimum/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -7615,6 +7615,74 @@ function renderAtlasClimateReadinessBoostReliefRanking(view) {
   `;
 }
 
+function buildAtlasClimateMinimumViableBoostHint(reliefRankingView) {
+  if (!reliefRankingView || reliefRankingView.state !== 'ranked' || reliefRankingView.rankedBoosts.length === 0) {
+    return {
+      state: 'empty',
+      hint: null,
+      summary: 'Aucun boost climat prioritaire éligible à réduire au minimum viable.',
+    };
+  }
+
+  const topBoost = reliefRankingView.rankedBoosts[0];
+  const packageByOutcome = {
+    executable: {
+      state: 'minimal-sufficient',
+      level: 'minimum suffisant',
+      resourcePackage: '1 équipe + réserve ciblée',
+      action: 'Appliquer le boost tel quel; ne pas sur-allouer au-delà du paquet minimal.',
+    },
+    'still-tight': {
+      state: 'partial-worthwhile',
+      level: 'minimum utile',
+      resourcePackage: '1 équipe + jalon avancé',
+      action: 'Lancer le paquet minimal maintenant, puis garder une option de renfort si la deadline reste serrée.',
+    },
+    insufficient: {
+      state: 'insufficient-minimum',
+      level: 'minimum insuffisant',
+      resourcePackage: 'paquet minimal + arbitrage requis',
+      action: 'Ne pas compter sur le minimum seul; escalader ressource ou réduire le périmètre avant exécution.',
+    },
+  };
+  const selectedPackage = packageByOutcome[topBoost.outcome] ?? packageByOutcome.insufficient;
+
+  return {
+    state: selectedPackage.state,
+    hint: {
+      provinceId: topBoost.provinceId,
+      provinceLabel: topBoost.provinceLabel,
+      deadline: topBoost.deadline,
+      outcome: topBoost.outcome,
+      level: selectedPackage.level,
+      resourcePackage: selectedPackage.resourcePackage,
+      action: selectedPackage.action,
+      reliefBand: topBoost.reliefBand,
+      reliefScore: topBoost.reliefScore,
+    },
+    summary: `${topBoost.provinceLabel}: paquet ${selectedPackage.level} pour maximiser le relief deadline sans dupliquer le ranking.`,
+  };
+}
+
+function renderAtlasClimateMinimumViableBoostHint(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty' || !view.hint) {
+    return '';
+  }
+
+  return `
+    <aside class="map-world-climate-minimum-boost map-world-climate-minimum-boost--${view.state}" aria-label="Indice de boost readiness climat minimum viable">
+      <div class="map-world-climate-minimum-boost__header">
+        <strong>Minimum viable boost</strong>
+        <span>${view.hint.level}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>${view.hint.provinceLabel}</b> · ${view.hint.deadline} · ${view.hint.resourcePackage}</small>
+      <small><b>Action</b> · ${view.hint.action}</small>
+      <small><b>Relief attendu</b> · ${view.hint.reliefBand} (${view.hint.reliefScore})</small>
+    </aside>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -15198,6 +15266,7 @@ function render() {
   const atlasClimateReadinessBoostRecommendations = buildAtlasClimateReadinessBoostRecommendations(atlasClimateUnderReadyExecutionGaps);
   const atlasClimatePostBoostDeadlineRiskPreview = buildAtlasClimatePostBoostDeadlineRiskPreview(atlasClimateReadinessBoostRecommendations);
   const atlasClimateReadinessBoostReliefRanking = buildAtlasClimateReadinessBoostReliefRanking(atlasClimatePostBoostDeadlineRiskPreview);
+  const atlasClimateMinimumViableBoostHint = buildAtlasClimateMinimumViableBoostHint(atlasClimateReadinessBoostReliefRanking);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -15240,6 +15309,7 @@ function render() {
           ${renderAtlasClimateReadinessBoostRecommendations(atlasClimateReadinessBoostRecommendations)}
           ${renderAtlasClimatePostBoostDeadlineRiskPreview(atlasClimatePostBoostDeadlineRiskPreview)}
           ${renderAtlasClimateReadinessBoostReliefRanking(atlasClimateReadinessBoostReliefRanking)}
+          ${renderAtlasClimateMinimumViableBoostHint(atlasClimateMinimumViableBoostHint)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -11897,3 +11897,29 @@ button { font: inherit; }
 .map-world-climate-boost-relief-ranking__item--executable { border-color: rgba(110, 231, 183, 0.4); }
 .map-world-climate-boost-relief-ranking__item--still-tight { border-color: rgba(251, 191, 36, 0.44); }
 .map-world-climate-boost-relief-ranking__item--insufficient { border-color: rgba(248, 113, 113, 0.52); }
+.map-world-climate-minimum-boost {
+  display: grid;
+  gap: 6px;
+  max-width: 54ch;
+  margin-top: 8px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.76), rgba(21, 94, 117, 0.22));
+  border: 1px solid rgba(34, 211, 238, 0.34);
+}
+.map-world-climate-minimum-boost--partial-worthwhile { border-color: rgba(251, 191, 36, 0.44); }
+.map-world-climate-minimum-boost--insufficient-minimum { border-color: rgba(248, 113, 113, 0.52); }
+.map-world-climate-minimum-boost__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-minimum-boost p,
+.map-world-climate-minimum-boost span,
+.map-world-climate-minimum-boost small {
+  color: #cffafe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}


### PR DESCRIPTION
Epsilon: Couvre #863.

Résumé:
- ajoute un hint compact “minimum viable boost” uniquement pour le boost readiness climat le mieux classé;
- réutilise le ranking E14 et ses signaux post-boost pour dériver minimum suffisant, minimum utile, ou minimum insuffisant;
- affiche le paquet ressource minimal, l’action courte et le relief attendu sans dupliquer toute l’explication du ranking.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateMinimumViableBoostHint.test.js test/ui/climate/webAtlasClimateReadinessBoostReliefRanking.test.js
- git diff --check
- npm test (573 tests OK)

Merci de valider avant tout merge.