### PR TITLE
Alpha: show fallback orders for blocked hints

### DIFF
--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military fallback order hint builds on top warning best order and relief data', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryFallbackOrderHint\(priorityStack, orderHint, reliefPreview, commitment\)/);
+  assert.match(webAppSource, /getAtlasMilitaryBestOrderBlocker\(topWarning, orderHint, reliefPreview, commitment\)/);
+  assert.match(webAppSource, /buildAtlasMilitaryFallbackOrderHint\(priorityStack, bestOrderHint, topReliefPreview, commitment\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryFallbackOrderHint\(fallbackOrderHint\)/);
+});
+
+test('atlas military fallback order hint handles resource route and overcommitment blocks', () => {
+  assert.match(webAppSource, /return 'resource-blocked'/);
+  assert.match(webAppSource, /return 'route-blocked'/);
+  assert.match(webAppSource, /return 'overcommitment-blocked'/);
+  assert.match(webAppSource, /order: 'Fixer réserve'/);
+  assert.match(webAppSource, /order: 'Sécuriser détour'/);
+  assert.match(webAppSource, /order: 'Geler engagement'/);
+});
+
+test('atlas military fallback order hint stays secondary and hides no-safe fallback state', () => {
+  assert.match(webAppSource, /Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée/);
+  assert.match(webAppSource, /return 'no-safe-fallback'/);
+  assert.match(webAppSource, /if \(!fallbackHint \|\| fallbackHint\.empty \|\| !fallbackHint\.fallback\) return ''/);
+  assert.match(webAppSource, /data-atlas-fallback-order/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order--route-blocked/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order--overcommitment-blocked/);
+});

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -19,6 +19,7 @@ test('atlas military fallback order hint handles resource route and overcommitme
   assert.match(webAppSource, /order: 'Fixer réserve'/);
   assert.match(webAppSource, /order: 'Sécuriser détour'/);
   assert.match(webAppSource, /order: 'Geler engagement'/);
+  assert.match(webAppSource, /detail: `réduire la charge sur \$\{commitment\?\.selectedOption\?\.target \?\? topWarning\?\.label\}`/);
 });
 
 test('atlas military fallback order hint stays secondary and hides no-safe fallback state', () => {

--- a/web/app.js
+++ b/web/app.js
@@ -1618,11 +1618,80 @@ function renderAtlasMilitaryBestNextOrderHint(orderHint) {
   `;
 }
 
+
+function getAtlasMilitaryBestOrderBlocker(topWarning, orderHint, reliefPreview, commitment) {
+  const hint = orderHint?.hint ?? null;
+  const preview = reliefPreview?.preview ?? null;
+  if (!topWarning || !hint || !preview) return 'no-safe-fallback';
+  if (hint.type === 'reinforce-front' && topWarning.frontRisk >= 112) return 'resource-blocked';
+  if (hint.type === 'clear-route-exposure' && topWarning.routeExposure >= 14) return 'route-blocked';
+  if (hint.type === 'reduce-overcommitment' && (commitment?.selectedOption?.delay === 'long' || preview.reliefScore < 30)) return 'overcommitment-blocked';
+  return 'no-safe-fallback';
+}
+
+function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPreview, commitment) {
+  const topWarning = priorityStack?.stack?.[0] ?? null;
+  const blocker = getAtlasMilitaryBestOrderBlocker(topWarning, orderHint, reliefPreview, commitment);
+  const fallback = blocker === 'resource-blocked'
+    ? {
+      type: 'resource-blocked',
+      order: 'Fixer réserve',
+      detail: `tenir ${topWarning.label} avec réserve légère`,
+      why: 'ressources insuffisantes pour l’ordre principal',
+    }
+    : blocker === 'route-blocked'
+      ? {
+        type: 'route-blocked',
+        order: 'Sécuriser détour',
+        detail: `ouvrir un détour avant ${topWarning.label}`,
+        why: 'axe principal trop exposé ce tour',
+      }
+      : blocker === 'overcommitment-blocked'
+        ? {
+          type: 'overcommitment-blocked',
+          order: 'Geler engagement',
+          detail: `réduire la charge sur ${commitment?.selectedOption?.target ?? topWarning?.label}`,
+          why: 'surengagement encore dangereux',
+        }
+        : null;
+
+  if (!fallback) {
+    return {
+      fallback: null,
+      summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
+      empty: true,
+    };
+  }
+
+  return {
+    fallback: {
+      fallbackId: `fallback:${topWarning.warningId}:${fallback.type}`,
+      ...fallback,
+      label: topWarning.label,
+    },
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}).`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
+  if (!fallbackHint || fallbackHint.empty || !fallbackHint.fallback) return '';
+  const fallback = fallbackHint.fallback;
+  return `
+    <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="4.2" rx="1.2"></rect>
+      <text class="atlas-military-fallback-order__label" x="23.2" y="59.5">repli: ${fallback.order}</text>
+      <text class="atlas-military-fallback-order__detail" x="23.2" y="61.1">${fallback.detail}</text>
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryWarningPriorityStack(priorityStack, commitment) {
   if (!priorityStack || priorityStack.empty) return '';
   const [topPriority, ...lowerPriorities] = priorityStack.stack;
   const topReliefPreview = buildAtlasMilitaryTopWarningReliefPreview(priorityStack);
   const bestOrderHint = buildAtlasMilitaryBestNextOrderHint(priorityStack, topReliefPreview, commitment);
+  const fallbackOrderHint = buildAtlasMilitaryFallbackOrderHint(priorityStack, bestOrderHint, topReliefPreview, commitment);
   const height = 8.8 + (lowerPriorities.length * 2.7);
   return `
     <g class="atlas-military-warning-stack" aria-label="Pile de priorités des alertes militaires: ${priorityStack.summary}">
@@ -1635,6 +1704,7 @@ function renderAtlasMilitaryWarningPriorityStack(priorityStack, commitment) {
       </g>
       ${renderAtlasMilitaryTopWarningReliefPreview(topReliefPreview)}
       ${renderAtlasMilitaryBestNextOrderHint(bestOrderHint)}
+      ${renderAtlasMilitaryFallbackOrderHint(fallbackOrderHint)}
       ${lowerPriorities.map((warning, index) => `
         <g class="atlas-military-warning-stack-item atlas-military-warning-stack-item--${warning.tone}" data-atlas-warning-stack-item="${warning.stackId}" aria-label="Priorité ${index + 2} ${warning.frontRoute}: score ${warning.stackScore}; ${warning.action}">
           <text x="5" y="${54.4 + index * 2.7}">${index + 2}. ${warning.label}</text>

--- a/web/styles.css
+++ b/web/styles.css
@@ -10669,6 +10669,7 @@ button { font: inherit; }
 .atlas-military-warning-stack,
 .atlas-military-warning-relief,
 .atlas-military-best-order,
+.atlas-military-fallback-order,
 .atlas-military-commitment-conflicts {
   pointer-events: auto;
 }
@@ -11091,6 +11092,27 @@ button { font: inherit; }
   stroke-width: 0.24;
 }
 .atlas-military-best-order__detail { fill: #bfdbfe; font-size: 0.7px; }
+
+.atlas-military-fallback-order__panel {
+  fill: rgba(71, 85, 105, 0.76);
+  stroke: rgba(203, 213, 225, 0.48);
+  stroke-width: 0.28;
+}
+.atlas-military-fallback-order--route-blocked .atlas-military-fallback-order__panel {
+  fill: rgba(14, 116, 144, 0.72);
+}
+.atlas-military-fallback-order--overcommitment-blocked .atlas-military-fallback-order__panel {
+  fill: rgba(107, 33, 168, 0.72);
+}
+.atlas-military-fallback-order text {
+  fill: #e2e8f0;
+  font-size: 0.76px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.88);
+  stroke-width: 0.24;
+}
+.atlas-military-fallback-order__detail { fill: #cbd5e1; font-size: 0.68px; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #869.

## Summary
- Adds a compact fallback-order hint below the best-next-order hint when the top military order is blocked.
- Reuses the warning priority stack, best order, relief preview, front risk, route exposure, and staged commitment data.
- Handles resource-blocked, route-blocked, overcommitment-blocked, and no-safe-fallback states deterministically.

## Validation
- node --check web/app.js
- git diff --check
- node --test test/ui/war/webAtlasMilitaryBestNextOrderHint.test.js test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
- npm test (576 passing)

Closes #869