### PR TITLE
Epsilon: warn missed climate boost deadlines

### DIFF
--- a/test/ui/climate/webAtlasClimateMinimumBoostDeadlineMissWarning.test.js
+++ b/test/ui/climate/webAtlasClimateMinimumBoostDeadlineMissWarning.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const deadlineMissWarningFixture = [
+  {
+    state: 'misses-by-one-turn',
+    reason: 'un tour de marge manquant',
+    nextStep: 'Avancer l’ordre au tour courant',
+  },
+  {
+    state: 'misses-by-capacity-gap',
+    reason: 'capacité de readiness sous le seuil exécutable',
+    nextStep: 'Ajouter une capacité ciblée',
+  },
+  {
+    state: 'recovered-in-time',
+    reason: 'récupère la fenêtre deadline à temps',
+    nextStep: 'warning: null',
+  },
+  {
+    state: 'empty',
+    reason: 'aucun minimum viable boost éligible',
+    nextStep: 'warning: null',
+  },
+];
+
+test('atlas warns when the top minimum viable climate boost still misses deadline risk', () => {
+  assert.match(webAppSource, /function buildAtlasClimateMinimumBoostDeadlineMissWarning/);
+  assert.match(webAppSource, /function renderAtlasClimateMinimumBoostDeadlineMissWarning/);
+  assert.match(webAppSource, /minimumBoostView\.state === 'empty'/);
+  assert.match(webAppSource, /minimumBoostView\.state === 'minimal-sufficient'/);
+  assert.match(webAppSource, /minimumBoostView\.state === 'insufficient-minimum'/);
+  assert.match(webAppSource, /Deadline encore risquée/);
+  assert.match(webAppSource, /À sécuriser/);
+  assert.match(webAppSource, /atlasClimateMinimumBoostDeadlineMissWarning = buildAtlasClimateMinimumBoostDeadlineMissWarning\(atlasClimateMinimumViableBoostHint\)/);
+  assert.match(webAppSource, /renderAtlasClimateMinimumBoostDeadlineMissWarning\(atlasClimateMinimumBoostDeadlineMissWarning\)/);
+
+  for (const fixture of deadlineMissWarningFixture) {
+    assert.match(webAppSource, new RegExp(fixture.state));
+    assert.match(webAppSource, new RegExp(fixture.reason));
+    assert.match(webAppSource, new RegExp(fixture.nextStep));
+  }
+
+  assert.match(stylesSource, /\.map-world-climate-minimum-boost-miss/);
+  assert.match(stylesSource, /\.map-world-climate-minimum-boost-miss--misses-by-capacity-gap/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -7735,6 +7735,73 @@ function renderAtlasClimateMinimumViableBoostHint(view) {
   `;
 }
 
+function buildAtlasClimateMinimumBoostDeadlineMissWarning(minimumBoostView) {
+  if (!minimumBoostView || minimumBoostView.state === 'empty' || !minimumBoostView.hint) {
+    return {
+      state: 'empty',
+      warning: null,
+      summary: 'Aucun warning deadline: aucun minimum viable boost éligible.',
+    };
+  }
+
+  if (minimumBoostView.state === 'minimal-sufficient') {
+    return {
+      state: 'recovered-in-time',
+      warning: null,
+      summary: 'Le minimum viable boost récupère la fenêtre deadline à temps.',
+    };
+  }
+
+  if (minimumBoostView.state === 'insufficient-minimum') {
+    return {
+      state: 'insufficient-even-at-minimum',
+      warning: null,
+      summary: 'Le minimum est déjà insuffisant: l’alerte dédiée reste portée par le hint minimum viable.',
+    };
+  }
+
+  const missType = /jalon avancé|serrée|still-tight|minimum utile/i.test(`${minimumBoostView.hint.resourcePackage} ${minimumBoostView.hint.action} ${minimumBoostView.hint.outcome} ${minimumBoostView.hint.level}`)
+    ? 'misses-by-one-turn'
+    : 'misses-by-capacity-gap';
+  const reason = missType === 'misses-by-one-turn'
+    ? 'Le boost améliore le timing mais laisse un tour de marge manquant avant la fenêtre critique.'
+    : 'Le boost améliore la pression mais laisse une capacité de readiness sous le seuil exécutable.';
+
+  return {
+    state: missType,
+    warning: {
+      provinceId: minimumBoostView.hint.provinceId,
+      provinceLabel: minimumBoostView.hint.provinceLabel,
+      deadline: minimumBoostView.hint.deadline,
+      resourcePackage: minimumBoostView.hint.resourcePackage,
+      reason,
+      nextStep: missType === 'misses-by-one-turn'
+        ? 'Avancer l’ordre au tour courant ou ajouter un tampon de calendrier.'
+        : 'Ajouter une capacité ciblée ou réduire le périmètre avant validation.',
+    },
+    summary: `${minimumBoostView.hint.provinceLabel}: minimum viable utile, mais deadline encore à risque après boost.`,
+  };
+}
+
+function renderAtlasClimateMinimumBoostDeadlineMissWarning(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || !view.warning || !/^misses-by-/.test(view.state)) {
+    return '';
+  }
+
+  return `
+    <aside class="map-world-climate-minimum-boost-miss map-world-climate-minimum-boost-miss--${view.state}" aria-label="Alerte deadline encore manquée après minimum viable boost climat">
+      <div class="map-world-climate-minimum-boost-miss__header">
+        <strong>Deadline encore risquée</strong>
+        <span>${view.state === 'misses-by-one-turn' ? 'manque 1 tour' : 'capacité courte'}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>${view.warning.provinceLabel}</b> · ${view.warning.deadline} · ${view.warning.resourcePackage}</small>
+      <small><b>Pourquoi</b> · ${view.warning.reason}</small>
+      <small><b>À sécuriser</b> · ${view.warning.nextStep}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -15319,6 +15386,7 @@ function render() {
   const atlasClimatePostBoostDeadlineRiskPreview = buildAtlasClimatePostBoostDeadlineRiskPreview(atlasClimateReadinessBoostRecommendations);
   const atlasClimateReadinessBoostReliefRanking = buildAtlasClimateReadinessBoostReliefRanking(atlasClimatePostBoostDeadlineRiskPreview);
   const atlasClimateMinimumViableBoostHint = buildAtlasClimateMinimumViableBoostHint(atlasClimateReadinessBoostReliefRanking);
+  const atlasClimateMinimumBoostDeadlineMissWarning = buildAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumViableBoostHint);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -15362,6 +15430,7 @@ function render() {
           ${renderAtlasClimatePostBoostDeadlineRiskPreview(atlasClimatePostBoostDeadlineRiskPreview)}
           ${renderAtlasClimateReadinessBoostReliefRanking(atlasClimateReadinessBoostReliefRanking)}
           ${renderAtlasClimateMinimumViableBoostHint(atlasClimateMinimumViableBoostHint)}
+          ${renderAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumBoostDeadlineMissWarning)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -11941,3 +11941,28 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+.map-world-climate-minimum-boost-miss {
+  display: grid;
+  gap: 6px;
+  max-width: 54ch;
+  margin-top: 8px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.78), rgba(120, 53, 15, 0.24));
+  border: 1px solid rgba(251, 191, 36, 0.48);
+}
+.map-world-climate-minimum-boost-miss--misses-by-capacity-gap { border-color: rgba(248, 113, 113, 0.52); }
+.map-world-climate-minimum-boost-miss__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-minimum-boost-miss p,
+.map-world-climate-minimum-boost-miss span,
+.map-world-climate-minimum-boost-miss small {
+  color: #fef3c7;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}


### PR DESCRIPTION
Epsilon: Couvre #873.

Résumé:
- ajoute un warning compact quand le minimum viable boost du plan climat prioritaire améliore la pression mais laisse encore la deadline risquée;
- distingue les cas `misses-by-one-turn`, `misses-by-capacity-gap`, `recovered-in-time` et aucun boost éligible, sans dupliquer l’alerte `insufficient-minimum`;
- réutilise le hint minimum viable E15 et reste limité au plan urgent le mieux classé.

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateMinimumBoostDeadlineMissWarning.test.js test/ui/climate/webAtlasClimateMinimumViableBoostHint.test.js
- git diff --check
- npm test (574 tests OK)

Merci de valider avant tout merge.