### PR TITLE
Gamma: flag paired mediation fallback support

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -40,6 +40,7 @@ test('world map atlas renders culture influence zones from existing culture over
   assert.match(webAppSource, /buildAtlasConsolidationFollowUpStatus/);
   assert.match(webAppSource, /buildAtlasStaleRiskFallbackMove/);
   assert.match(webAppSource, /buildAtlasLatestSafeFallbackTurn/);
+  assert.match(webAppSource, /buildAtlasPairedMediationSupport/);
 });
 
 test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
@@ -101,7 +102,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /const fallback = buildAtlasStaleRiskFallbackMove/);
   assert.match(webAppSource, /followUp\?\.state !== 'stale-risk'/);
   assert.match(webAppSource, /atlas-cultural-border-zone__fallback/);
-  assert.match(webAppSource, /latestSafeTurn: buildAtlasLatestSafeFallbackTurn/);
+  assert.match(webAppSource, /const latestSafeTurn = buildAtlasLatestSafeFallbackTurn/);
   assert.match(webAppSource, /followUp\?\.state !== 'stale-risk' \|\| !fallback/);
   assert.match(webAppSource, /state: 'immediate'/);
   assert.match(webAppSource, /state: 'one-turn-left'/);
@@ -109,6 +110,13 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /state: 'no-safe-window'/);
   assert.match(webAppSource, /dernier sûr:/);
   assert.match(webAppSource, /atlas-cultural-border-zone__latest-safe/);
+  assert.match(webAppSource, /pairedMediation: buildAtlasPairedMediationSupport/);
+  assert.match(webAppSource, /state: 'needs-mediation'/);
+  assert.match(webAppSource, /state: 'needs-border-pressure-relief'/);
+  assert.match(webAppSource, /latestSafeTurn\?\.state === 'no-safe-window'/);
+  assert.match(webAppSource, /fallback\.state === 'border-pressure' && commitment\.remainingConfidence === 'faible'/);
+  assert.match(webAppSource, /atlas-cultural-border-zone__paired-mediation/);
+  assert.match(webAppSource, /support:/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -130,6 +138,8 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-border-zone__latest-safe--one-turn-left/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__latest-safe--multi-turn/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__latest-safe--no-safe-window/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__paired-mediation--needs-mediation/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__paired-mediation--needs-border-pressure-relief/);
   assert.match(stylesSource, /\.atlas-cultural-border-zones\.is-stable rect/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__confidence/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__consequences/);
@@ -155,4 +165,5 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action--followup-stale-risk/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__fallback/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__latest-safe/);
+  assert.match(stylesSource, /\.atlas-cultural-consolidation-action__paired-mediation/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -2018,6 +2018,34 @@ function buildAtlasLatestSafeFallbackTurn(zone, commitment, followUp, fallback) 
   };
 }
 
+function buildAtlasPairedMediationSupport(zone, commitment, followUp, fallback, latestSafeTurn) {
+  if (followUp?.state !== 'stale-risk' || !fallback) {
+    return null;
+  }
+
+  if (fallback.state === 'border-pressure' && commitment.remainingConfidence === 'faible') {
+    return {
+      state: 'needs-border-pressure-relief',
+      label: 'relief frontière',
+      reason: `needs-border-pressure-relief · ${zone.mainDriver}`,
+      detail: 'réduire la pression de frontière en parallèle du fallback pour éviter une rechute',
+      priority: 2,
+    };
+  }
+
+  if (latestSafeTurn?.state === 'no-safe-window' || fallback.state === 'mediation-drift' || zone.mediation.confidence === 'inconnue') {
+    return {
+      state: 'needs-mediation',
+      label: 'médiation requise',
+      reason: `needs-mediation · ${zone.mediation.confidenceReason}`,
+      detail: `${zone.mediation.option} doit accompagner le fallback pour rendre le rebond lisible`,
+      priority: 2,
+    };
+  }
+
+  return null;
+}
+
 function buildAtlasConsolidationFollowUpStatus(zone, commitment, recommendation) {
   if (!recommendation) {
     return null;
@@ -2213,6 +2241,7 @@ function buildAtlasMediationCommitment(zone) {
   const consolidationRecommendation = buildAtlasFragileReboundRecommendation(zone, commitment);
   const followUp = buildAtlasConsolidationFollowUpStatus(zone, commitment, consolidationRecommendation);
   const fallback = buildAtlasStaleRiskFallbackMove(zone, commitment, followUp);
+  const latestSafeTurn = buildAtlasLatestSafeFallbackTurn(zone, commitment, followUp, fallback);
 
   return {
     ...commitment,
@@ -2225,7 +2254,8 @@ function buildAtlasMediationCommitment(zone) {
                 fallback: fallback
                   ? {
                       ...fallback,
-                      latestSafeTurn: buildAtlasLatestSafeFallbackTurn(zone, commitment, followUp, fallback),
+                      latestSafeTurn,
+                      pairedMediation: buildAtlasPairedMediationSupport(zone, commitment, followUp, fallback, latestSafeTurn),
                     }
                   : null,
               }
@@ -2281,21 +2311,22 @@ function renderAtlasCultureLayer(cultureView) {
       `}
       ${features.borderZones.length > 0 ? `
         <g class="atlas-cultural-border-zones" aria-label="Synthèse des frontières culturelles instables et médiations">
-          <rect x="3" y="55" width="30" height="${16 + (features.borderZones.length * 18.6)}" rx="1.8"></rect>
+          <rect x="3" y="55" width="30" height="${17 + (features.borderZones.length * 20)}" rx="1.8"></rect>
           <text class="atlas-cultural-border-zones__title" x="5" y="58.4">Médiations culturelles</text>
           ${features.borderZones.map((zone, index) => `
             <g class="atlas-cultural-border-zone atlas-cultural-border-zone--${zone.drift.state} atlas-cultural-border-zone--confidence-${zone.mediation.confidence} atlas-cultural-border-zone--commitment-${zone.commitment.status === 'stable' ? 'stable' : 'risk'}" data-atlas-cultural-border="${zone.regionId}" aria-label="Frontière culturelle ${zone.cultureName}: moteur ${zone.mainDriver}, médiation ${zone.mediation.option}, confiance ${zone.mediation.confidence}, engagement ${zone.commitment.status}, confiance restante ${zone.commitment.remainingConfidence}, prochaine conséquence ${zone.commitment.nextConsequence}, échéance ${zone.commitment.phase}">
-              <text x="5" y="${62 + index * 18.6}">${zone.cultureName}</text>
-              <text class="atlas-cultural-border-zone__chips" x="5" y="${64 + index * 18.6}">${zone.chips.join(' · ')}</text>
-              <text class="atlas-cultural-border-zone__mediation" x="5" y="${66 + index * 18.6}">${zone.mediation.option} → ${zone.mediation.benefit}</text>
-              <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 18.6}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
-              <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 18.6}">${zone.commitment.label} · ${zone.commitment.outcomeStatus} · reste ${zone.commitment.remainingConfidence}</text>
-              <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 18.6}">prochain: ${zone.commitment.nextConsequence} · action: ${zone.commitment.nextAction}</text>
-              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 18.6}">${zone.commitment.consolidation.label}: ${zone.commitment.consolidation.action}</text>
-              ${zone.commitment.consolidationRecommendation ? `<text class="atlas-cultural-border-zone__recommendation" x="5" y="${74.6 + index * 18.6}">reco: ${zone.commitment.consolidationRecommendation.label} · ${zone.commitment.consolidationRecommendation.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp ? `<text class="atlas-cultural-border-zone__followup atlas-cultural-border-zone__followup--${zone.commitment.consolidationRecommendation.followUp.state}" x="5" y="${76.1 + index * 18.6}">suivi: ${zone.commitment.consolidationRecommendation.followUp.label} · ${zone.commitment.consolidationRecommendation.followUp.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp?.fallback ? `<text class="atlas-cultural-border-zone__fallback atlas-cultural-border-zone__fallback--${zone.commitment.consolidationRecommendation.followUp.fallback.state}" x="5" y="${77.5 + index * 18.6}">fallback: ${zone.commitment.consolidationRecommendation.followUp.fallback.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.latestSafeTurn ? `<text class="atlas-cultural-border-zone__latest-safe atlas-cultural-border-zone__latest-safe--${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.state}" x="5" y="${78.9 + index * 18.6}">dernier sûr: ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.value} · ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.reason}</text>` : ''}
+              <text x="5" y="${62 + index * 20}">${zone.cultureName}</text>
+              <text class="atlas-cultural-border-zone__chips" x="5" y="${64 + index * 20}">${zone.chips.join(' · ')}</text>
+              <text class="atlas-cultural-border-zone__mediation" x="5" y="${66 + index * 20}">${zone.mediation.option} → ${zone.mediation.benefit}</text>
+              <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 20}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
+              <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 20}">${zone.commitment.label} · ${zone.commitment.outcomeStatus} · reste ${zone.commitment.remainingConfidence}</text>
+              <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 20}">prochain: ${zone.commitment.nextConsequence} · action: ${zone.commitment.nextAction}</text>
+              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 20}">${zone.commitment.consolidation.label}: ${zone.commitment.consolidation.action}</text>
+              ${zone.commitment.consolidationRecommendation ? `<text class="atlas-cultural-border-zone__recommendation" x="5" y="${74.6 + index * 20}">reco: ${zone.commitment.consolidationRecommendation.label} · ${zone.commitment.consolidationRecommendation.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp ? `<text class="atlas-cultural-border-zone__followup atlas-cultural-border-zone__followup--${zone.commitment.consolidationRecommendation.followUp.state}" x="5" y="${76.1 + index * 20}">suivi: ${zone.commitment.consolidationRecommendation.followUp.label} · ${zone.commitment.consolidationRecommendation.followUp.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback ? `<text class="atlas-cultural-border-zone__fallback atlas-cultural-border-zone__fallback--${zone.commitment.consolidationRecommendation.followUp.fallback.state}" x="5" y="${77.5 + index * 20}">fallback: ${zone.commitment.consolidationRecommendation.followUp.fallback.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.latestSafeTurn ? `<text class="atlas-cultural-border-zone__latest-safe atlas-cultural-border-zone__latest-safe--${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.state}" x="5" y="${78.9 + index * 20}">dernier sûr: ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.value} · ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.pairedMediation ? `<text class="atlas-cultural-border-zone__paired-mediation atlas-cultural-border-zone__paired-mediation--${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.state}" x="5" y="${80.3 + index * 20}">support: ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.reason}</text>` : ''}
             </g>
           `).join('')}
         </g>
@@ -2308,15 +2339,16 @@ function renderAtlasCultureLayer(cultureView) {
       `}
       ${features.consolidationRecommendations.length > 0 ? `
         <g class="atlas-cultural-consolidation-actions" aria-label="Actions de consolidation des rebonds culturels fragiles">
-          <rect x="65" y="56" width="31" height="${9.2 + (features.consolidationRecommendations.length * 8.8)}" rx="1.8"></rect>
+          <rect x="65" y="56" width="31" height="${9.8 + (features.consolidationRecommendations.length * 10.1)}" rx="1.8"></rect>
           <text class="atlas-cultural-consolidation-actions__title" x="67" y="59.2">Actions consolidation</text>
           ${features.consolidationRecommendations.map((item, index) => `
             <g class="atlas-cultural-consolidation-action atlas-cultural-consolidation-action--${item.consolidation.state} atlas-cultural-consolidation-action--followup-${item.recommendation.followUp.state}" data-atlas-consolidation-action="${item.regionId}" aria-label="Action consolidation ${item.cultureName}: ${item.recommendation.label}, suivi ${item.recommendation.followUp.label}, raison ${item.recommendation.followUp.reason}, détail ${item.recommendation.followUp.detail}">
-              <text x="67" y="${62.3 + index * 8.8}">${item.cultureName} · ${item.recommendation.label}</text>
-              <text class="atlas-cultural-consolidation-action__reason" x="67" y="${64.1 + index * 8.8}">${item.recommendation.reason}</text>
-              <text class="atlas-cultural-consolidation-action__followup" x="67" y="${65.8 + index * 8.8}">${item.recommendation.followUp.label} · ${item.recommendation.followUp.reason}</text>
-              ${item.recommendation.followUp.fallback ? `<text class="atlas-cultural-consolidation-action__fallback" x="67" y="${67.5 + index * 8.8}">fallback: ${item.recommendation.followUp.fallback.label} · ${item.recommendation.followUp.fallback.reason}</text>` : ''}
-              ${item.recommendation.followUp.fallback?.latestSafeTurn ? `<text class="atlas-cultural-consolidation-action__latest-safe atlas-cultural-consolidation-action__latest-safe--${item.recommendation.followUp.fallback.latestSafeTurn.state}" x="67" y="${69.1 + index * 8.8}">dernier sûr: ${item.recommendation.followUp.fallback.latestSafeTurn.value}</text>` : ''}
+              <text x="67" y="${62.3 + index * 10.1}">${item.cultureName} · ${item.recommendation.label}</text>
+              <text class="atlas-cultural-consolidation-action__reason" x="67" y="${64.1 + index * 10.1}">${item.recommendation.reason}</text>
+              <text class="atlas-cultural-consolidation-action__followup" x="67" y="${65.8 + index * 10.1}">${item.recommendation.followUp.label} · ${item.recommendation.followUp.reason}</text>
+              ${item.recommendation.followUp.fallback ? `<text class="atlas-cultural-consolidation-action__fallback" x="67" y="${67.5 + index * 10.1}">fallback: ${item.recommendation.followUp.fallback.label} · ${item.recommendation.followUp.fallback.reason}</text>` : ''}
+              ${item.recommendation.followUp.fallback?.latestSafeTurn ? `<text class="atlas-cultural-consolidation-action__latest-safe atlas-cultural-consolidation-action__latest-safe--${item.recommendation.followUp.fallback.latestSafeTurn.state}" x="67" y="${69.1 + index * 10.1}">dernier sûr: ${item.recommendation.followUp.fallback.latestSafeTurn.value}</text>` : ''}
+              ${item.recommendation.followUp.fallback?.pairedMediation ? `<text class="atlas-cultural-consolidation-action__paired-mediation atlas-cultural-consolidation-action__paired-mediation--${item.recommendation.followUp.fallback.pairedMediation.state}" x="67" y="${70.7 + index * 10.1}">support: ${item.recommendation.followUp.fallback.pairedMediation.label}</text>` : ''}
             </g>
           `).join('')}
         </g>

--- a/web/styles.css
+++ b/web/styles.css
@@ -11786,6 +11786,13 @@ button { font: inherit; }
 .atlas-cultural-border-zone__latest-safe--one-turn-left { fill: #fde68a; }
 .atlas-cultural-border-zone__latest-safe--multi-turn { fill: #bfdbfe; }
 .atlas-cultural-border-zone__latest-safe--no-safe-window { fill: #fca5a5; }
+.atlas-cultural-border-zone__paired-mediation {
+  fill: #fef3c7;
+  font-size: 0.75px;
+  font-weight: 860;
+}
+.atlas-cultural-border-zone__paired-mediation--needs-mediation { fill: #c4b5fd; }
+.atlas-cultural-border-zone__paired-mediation--needs-border-pressure-relief { fill: #fed7aa; }
 .atlas-cultural-consolidation-actions rect {
   fill: rgba(49, 46, 129, 0.54);
   stroke: rgba(196, 181, 253, 0.38);
@@ -11829,6 +11836,13 @@ button { font: inherit; }
 .atlas-cultural-consolidation-action__latest-safe--no-safe-window { fill: #fecdd3; }
 .atlas-cultural-consolidation-action__latest-safe--one-turn-left { fill: #fde68a; }
 .atlas-cultural-consolidation-action__latest-safe--multi-turn { fill: #bfdbfe; }
+.atlas-cultural-consolidation-action__paired-mediation {
+  fill: #fef3c7;
+  font-size: 0.76px;
+  font-weight: 860;
+}
+.atlas-cultural-consolidation-action__paired-mediation--needs-mediation { fill: #c4b5fd; }
+.atlas-cultural-consolidation-action__paired-mediation--needs-border-pressure-relief { fill: #fed7aa; }
 .atlas-cultural-consolidation-action--fragile .atlas-cultural-consolidation-action__reason { fill: #fde68a; }
 .atlas-cultural-consolidation-action--expiring .atlas-cultural-consolidation-action__reason { fill: #fecdd3; }
 .map-world-climate-post-boost-risk {


### PR DESCRIPTION
Gamma: Implements #871.

## Summary
- add deterministic paired-mediation support flags for stale-risk fallback moves
- attach support flags to the selected fallback only, alongside latest-safe-turn data
- render compact support lines in atlas border-zone and consolidation-action panels
- cover needs-mediation, needs-border-pressure-relief, and no-flag guard paths in focused source tests

## Validation
- node --check web/app.js
- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js
- git diff --check
- npm test

Zeta: ready for validation before merge.
