### PR TITLE
Delta: suggest residual gap follow-up sweeps

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -435,6 +435,39 @@ test('atlas counterintelligence warns only the best safe resweep about residual 
   assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning--high-priority-blind-spot/);
 });
 
+test('atlas counterintelligence suggests follow-up sweeps from residual gap warnings', () => {
+  const buildFollowUp = (warning, assignments) => {
+    if (!['high-priority-blind-spot', 'stale-critical-signal'].includes(warning.state)) return 'no-follow-up';
+    const followUpAssignment = assignments.find((assignment) => assignment.locationName === warning.locationName);
+    if (!followUpAssignment || followUpAssignment.assignmentStatus !== 'safe') return 'wait-for-safe-window';
+    return warning.state === 'high-priority-blind-spot' ? 'close-blind-spot' : 'refresh-stale-signal';
+  };
+
+  assert.equal(buildFollowUp(
+    { state: 'high-priority-blind-spot', locationName: 'Gap' },
+    [{ locationName: 'Gap', assignmentStatus: 'safe' }],
+  ), 'close-blind-spot');
+  assert.equal(buildFollowUp(
+    { state: 'stale-critical-signal', locationName: 'Old' },
+    [{ locationName: 'Old', assignmentStatus: 'safe' }],
+  ), 'refresh-stale-signal');
+  assert.equal(buildFollowUp(
+    { state: 'high-priority-blind-spot', locationName: 'Unsafe' },
+    [{ locationName: 'Unsafe', assignmentStatus: 'no-safe' }],
+  ), 'wait-for-safe-window');
+  assert.equal(buildFollowUp({ state: 'acceptable-residual', locationName: 'Best safe' }, []), 'no-follow-up');
+  assert.match(webAppSource, /bestResweepFollowUpSuggestion/);
+  assert.match(webAppSource, /close-blind-spot/);
+  assert.match(webAppSource, /refresh-stale-signal/);
+  assert.match(webAppSource, /wait-for-safe-window/);
+  assert.match(webAppSource, /no-follow-up/);
+  assert.match(webAppSource, /Follow-up:/);
+  assert.match(webAppSource, /lancer le prochain sweep court pour fermer l’angle mort prioritaire/);
+  assert.match(webAppSource, /planifier un refresh discret du signal ancien/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__follow-up/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__follow-up--wait-for-safe-window/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -11968,6 +11968,38 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
       detail: 'Les risques restants sont couverts, partiels ou low-gain selon les signaux atlas visibles.',
     };
   })();
+  const bestResweepFollowUpSuggestion = (() => {
+    if (!['high-priority-blind-spot', 'stale-critical-signal'].includes(bestResweepResidualGapWarning.state)) {
+      return {
+        state: 'no-follow-up',
+        label: 'aucun follow-up immédiat',
+        copy: 'Pas de suggestion supplémentaire: le résiduel est acceptable ou aucun meilleur resweep sûr n’existe.',
+      };
+    }
+
+    const followUpAssignment = stagedResweepAssignments.find((assignment) => assignment.locationName === bestResweepResidualGapWarning.locationName);
+    if (!followUpAssignment || followUpAssignment.assignmentStatus !== 'safe') {
+      return {
+        state: 'wait-for-safe-window',
+        label: 'attendre fenêtre sûre',
+        copy: `${bestResweepResidualGapWarning.locationName}: pas de follow-up sûr maintenant; attendre un créneau non contesté ou une couverture locale stable.`,
+      };
+    }
+
+    if (bestResweepResidualGapWarning.state === 'high-priority-blind-spot') {
+      return {
+        state: 'close-blind-spot',
+        label: 'fermer angle mort',
+        copy: `${followUpAssignment.locationName}: lancer le prochain sweep court pour fermer l’angle mort prioritaire après le meilleur resweep.`,
+      };
+    }
+
+    return {
+      state: 'refresh-stale-signal',
+      label: 'rafraîchir signal ancien',
+      copy: `${followUpAssignment.locationName}: planifier un refresh discret du signal ancien avant tout engagement nominatif.`,
+    };
+  })();
   const postOrderCoverage = {
     coveredOrderZones,
     fragileAssignments,
@@ -11987,6 +12019,7 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
     excludedUnsafeResweepAssignments,
     bestRankedStagedResweepAssignment,
     bestResweepResidualGapWarning,
+    bestResweepFollowUpSuggestion,
     summary: postOrderCoverageSummary,
   };
   const exposureCooldownSummary = sweepCandidates.length > 0
@@ -12128,6 +12161,7 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
           <b>Gap résiduel du meilleur resweep</b>
           <span>${plan.postOrderCoverage.bestResweepResidualGapWarning.summary}</span>
           <small>${plan.postOrderCoverage.bestResweepResidualGapWarning.detail}</small>
+          <small class="atlas-counterintelligence-best-resweep-gap-warning__follow-up atlas-counterintelligence-best-resweep-gap-warning__follow-up--${plan.postOrderCoverage.bestResweepFollowUpSuggestion.state}"><b>Follow-up:</b> ${plan.postOrderCoverage.bestResweepFollowUpSuggestion.label} · ${plan.postOrderCoverage.bestResweepFollowUpSuggestion.copy}</small>
         </aside>
       </section>
       <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">

--- a/web/styles.css
+++ b/web/styles.css
@@ -3378,6 +3378,14 @@ button { font: inherit; }
 .atlas-counterintelligence-best-resweep-gap-warning--stale-critical-signal { border-color: rgba(251, 191, 36, 0.46); }
 .atlas-counterintelligence-best-resweep-gap-warning--acceptable-residual { border-color: rgba(74, 222, 128, 0.38); background: rgba(20, 83, 45, 0.2); }
 .atlas-counterintelligence-best-resweep-gap-warning--no-safe-assignment { border-color: rgba(148, 163, 184, 0.35); background: rgba(51, 65, 85, 0.18); }
+.atlas-counterintelligence-best-resweep-gap-warning__follow-up {
+  padding-top: 3px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.atlas-counterintelligence-best-resweep-gap-warning__follow-up--close-blind-spot,
+.atlas-counterintelligence-best-resweep-gap-warning__follow-up--refresh-stale-signal { color: #bfdbfe; }
+.atlas-counterintelligence-best-resweep-gap-warning__follow-up--wait-for-safe-window { color: #fde68a; }
+.atlas-counterintelligence-best-resweep-gap-warning__follow-up--no-follow-up { color: #cbd5e1; }
 .atlas-counterintelligence-schedule-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Implements #872.

Summary:
- add a compact follow-up line attached to the residual-gap warning for the best safe resweep
- suggest close-blind-spot and refresh-stale-signal follow-ups when the residual warning has a clear safe next sweep
- handle wait-for-safe-window and no-follow-up states deterministically without creating a second ranking list

Validation:
- node --check web/app.js
- npm test -- test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- npm test
- git diff --check