### PR TITLE
Alpha: explain fallback order safety

### DIFF
--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -20,6 +20,11 @@ test('atlas military fallback order hint handles resource route and overcommitme
   assert.match(webAppSource, /order: 'Sécuriser détour'/);
   assert.match(webAppSource, /order: 'Geler engagement'/);
   assert.match(webAppSource, /detail: `réduire la charge sur \$\{commitment\?\.selectedOption\?\.target \?\? topWarning\?\.label\}`/);
+  assert.match(webAppSource, /type: 'avoids-overcommitment'/);
+  assert.match(webAppSource, /type: 'bypasses-route-exposure'/);
+  assert.match(webAppSource, /type: 'preserves-front-coverage'/);
+  assert.match(webAppSource, /type: 'waits-for-resupply'/);
+  assert.match(webAppSource, /type: 'no-clear-safety-reason'/);
 });
 
 test('atlas military fallback order hint stays secondary and hides no-safe fallback state', () => {
@@ -27,7 +32,10 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /return 'no-safe-fallback'/);
   assert.match(webAppSource, /if \(!fallbackHint \|\| fallbackHint\.empty \|\| !fallbackHint\.fallback\) return ''/);
   assert.match(webAppSource, /data-atlas-fallback-order/);
+  assert.match(webAppSource, /atlas-military-fallback-order__safety/);
+  assert.match(webAppSource, /summary: `\$\{fallback\.order\}: \$\{fallback\.detail\} \(\$\{fallback\.why\}; \$\{safetyReason\.label\}\)\.`/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
   assert.match(stylesSource, /\.atlas-military-fallback-order--route-blocked/);
   assert.match(stylesSource, /\.atlas-military-fallback-order--overcommitment-blocked/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__safety/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -1629,6 +1629,54 @@ function getAtlasMilitaryBestOrderBlocker(topWarning, orderHint, reliefPreview, 
   return 'no-safe-fallback';
 }
 
+function buildAtlasMilitaryFallbackSafetyReason(fallback, topWarning, orderHint, reliefPreview, commitment) {
+  if (!fallback || !topWarning || !orderHint?.hint || !reliefPreview?.preview) {
+    return {
+      type: 'no-clear-safety-reason',
+      label: 'sécurité non confirmée',
+      detail: 'aucun motif sûr visible',
+    };
+  }
+
+  if (fallback.type === 'overcommitment-blocked') {
+    return {
+      type: 'avoids-overcommitment',
+      label: 'plus sûr: évite surengagement',
+      detail: `charge gelée sur ${commitment?.selectedOption?.target ?? topWarning.label}`,
+    };
+  }
+
+  if (fallback.type === 'route-blocked') {
+    return {
+      type: 'bypasses-route-exposure',
+      label: 'plus sûr: contourne route exposée',
+      detail: `exposition route ${topWarning.routeExposure} évitée`,
+    };
+  }
+
+  if (fallback.type === 'resource-blocked' && topWarning.frontRisk >= 120) {
+    return {
+      type: 'waits-for-resupply',
+      label: 'plus sûr: attend ravitaillement',
+      detail: 'réserve légère sans dépense lourde',
+    };
+  }
+
+  if (fallback.type === 'resource-blocked') {
+    return {
+      type: 'preserves-front-coverage',
+      label: 'plus sûr: garde couverture',
+      detail: `front ${topWarning.label} tenu sans percée`,
+    };
+  }
+
+  return {
+    type: 'no-clear-safety-reason',
+    label: 'sécurité non confirmée',
+    detail: 'aucun motif sûr visible',
+  };
+}
+
 function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPreview, commitment) {
   const topWarning = priorityStack?.stack?.[0] ?? null;
   const blocker = getAtlasMilitaryBestOrderBlocker(topWarning, orderHint, reliefPreview, commitment);
@@ -1658,18 +1706,23 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   if (!fallback) {
     return {
       fallback: null,
+      safetyReason: buildAtlasMilitaryFallbackSafetyReason(null, topWarning, orderHint, reliefPreview, commitment),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
   }
+
+  const safetyReason = buildAtlasMilitaryFallbackSafetyReason(fallback, topWarning, orderHint, reliefPreview, commitment);
 
   return {
     fallback: {
       fallbackId: `fallback:${topWarning.warningId}:${fallback.type}`,
       ...fallback,
       label: topWarning.label,
+      safetyReason,
     },
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}).`,
+    safetyReason,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}).`,
     empty: false,
   };
 }
@@ -1679,9 +1732,10 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const fallback = fallbackHint.fallback;
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="4.2" rx="1.2"></rect>
-      <text class="atlas-military-fallback-order__label" x="23.2" y="59.5">repli: ${fallback.order}</text>
-      <text class="atlas-military-fallback-order__detail" x="23.2" y="61.1">${fallback.detail}</text>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="5.6" rx="1.2"></rect>
+      <text class="atlas-military-fallback-order__label" x="23.2" y="59.4">repli: ${fallback.order}</text>
+      <text class="atlas-military-fallback-order__detail" x="23.2" y="60.9">${fallback.detail}</text>
+      <text class="atlas-military-fallback-order__safety" x="23.2" y="62.4">${fallback.safetyReason.label}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11121,6 +11121,7 @@ button { font: inherit; }
   stroke-width: 0.24;
 }
 .atlas-military-fallback-order__detail { fill: #cbd5e1; font-size: 0.68px; }
+.atlas-military-fallback-order__safety { fill: #bae6fd; font-size: 0.6px; font-weight: 800; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #879.

## Summary
- Adds a compact secondary safety-reason line to fallback military orders so they explain why they are safer/available while the best hint is blocked.
- Reuses the existing priority stack, best-order hint, fallback hint, route exposure, front risk, relief preview, and commitment data.
- Covers deterministic safety reasons: avoids-overcommitment, bypasses-route-exposure, preserves-front-coverage, waits-for-resupply, and no-clear-safety-reason without adding a second ranking list.

## Validation
- node --check web/app.js
- git diff --check
- node --test test/ui/war/webAtlasMilitaryBestNextOrderHint.test.js test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
- npm test (578 passing)

Closes #879