### PR TITLE
Epsilon: suggest climate deadline recovery actions

### DIFF
--- a/test/ui/climate/webAtlasClimateDeadlineRecoveryAction.test.js
+++ b/test/ui/climate/webAtlasClimateDeadlineRecoveryAction.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const recoveryActionFixture = [
+  {
+    warningState: 'misses-by-one-turn',
+    action: 'shift-execution-earlier',
+    label: 'Avancer exécution',
+  },
+  {
+    warningState: 'misses-by-capacity-gap',
+    action: 'add-secondary-boost',
+    label: 'Ajouter boost secondaire',
+  },
+  {
+    warningState: 'reduce-exposure-first',
+    action: 'reduce-exposure-first',
+    label: 'Réduire exposition d’abord',
+  },
+  {
+    warningState: 'accept-missed-deadline-risk',
+    action: 'accept-missed-deadline-risk',
+    label: 'Accepter risque deadline',
+  },
+  {
+    warningState: 'empty',
+    action: 'no-recovery-action',
+    label: 'Aucune action recovery climat',
+  },
+];
+
+test('atlas suggests one compact recovery action when minimum climate boost still misses deadline', () => {
+  assert.match(webAppSource, /function buildAtlasClimateDeadlineRecoveryAction/);
+  assert.match(webAppSource, /function renderAtlasClimateDeadlineRecoveryAction/);
+  assert.match(webAppSource, /!deadlineWarningView\.warning/);
+  assert.match(webAppSource, /Action compacte/);
+  assert.match(webAppSource, /Liée au warning/);
+  assert.match(webAppSource, /atlasClimateDeadlineRecoveryAction = buildAtlasClimateDeadlineRecoveryAction\(atlasClimateMinimumBoostDeadlineMissWarning\)/);
+  assert.match(webAppSource, /renderAtlasClimateDeadlineRecoveryAction\(atlasClimateDeadlineRecoveryAction\)/);
+
+  for (const fixture of recoveryActionFixture) {
+    assert.match(webAppSource, new RegExp(fixture.warningState));
+    assert.match(webAppSource, new RegExp(fixture.action));
+    assert.match(webAppSource, new RegExp(fixture.label));
+  }
+
+  assert.match(stylesSource, /\.map-world-climate-deadline-recovery/);
+  assert.match(stylesSource, /\.map-world-climate-deadline-recovery--add-secondary-boost/);
+  assert.match(stylesSource, /\.map-world-climate-deadline-recovery--reduce-exposure-first/);
+  assert.match(stylesSource, /\.map-world-climate-deadline-recovery--accept-missed-deadline-risk/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -7965,6 +7965,72 @@ function renderAtlasClimateMinimumBoostDeadlineMissWarning(view) {
   `;
 }
 
+function buildAtlasClimateDeadlineRecoveryAction(deadlineWarningView) {
+  if (!deadlineWarningView || !deadlineWarningView.warning || !/^misses-by-/.test(deadlineWarningView.state)) {
+    return {
+      state: 'no-recovery-action',
+      action: null,
+      summary: 'Aucune action recovery climat: la deadline est récupérée, insuffisante par design, ou aucun boost n’est éligible.',
+    };
+  }
+
+  const warning = deadlineWarningView.warning;
+  const actionType = deadlineWarningView.state === 'misses-by-one-turn'
+    ? 'shift-execution-earlier'
+    : /capacité ciblée|capacité courte|readiness sous le seuil/i.test(`${warning.nextStep} ${warning.reason}`)
+      ? 'add-secondary-boost'
+      : /réduire le périmètre|exposition/i.test(`${warning.nextStep} ${warning.reason}`)
+        ? 'reduce-exposure-first'
+        : 'accept-missed-deadline-risk';
+  const actionLabel = actionType === 'shift-execution-earlier'
+    ? 'Avancer exécution'
+    : actionType === 'add-secondary-boost'
+      ? 'Ajouter boost secondaire'
+      : actionType === 'reduce-exposure-first'
+        ? 'Réduire exposition d’abord'
+        : 'Accepter risque deadline';
+  const instruction = actionType === 'shift-execution-earlier'
+    ? 'Jouer le paquet minimum au tour courant et déplacer le jalon climat avant la fenêtre critique.'
+    : actionType === 'add-secondary-boost'
+      ? 'Ajouter une capacité readiness ciblée au paquet minimum avant de confirmer l’exécution.'
+      : actionType === 'reduce-exposure-first'
+        ? 'Réduire le périmètre exposé avant d’appliquer le boost pour rendre la deadline atteignable.'
+        : 'Marquer le risque comme accepté et éviter d’investir des ressources impossibles avant la deadline.';
+
+  return {
+    state: 'recoverable',
+    action: {
+      provinceId: warning.provinceId,
+      provinceLabel: warning.provinceLabel,
+      deadline: warning.deadline,
+      type: actionType,
+      label: actionLabel,
+      instruction,
+      tiedWarning: warning.reason,
+    },
+    summary: `${warning.provinceLabel}: action recovery proposée pour transformer l’alerte deadline en choix jouable.`,
+  };
+}
+
+function renderAtlasClimateDeadlineRecoveryAction(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'recoverable' || !view.action) {
+    return '';
+  }
+
+  return `
+    <aside class="map-world-climate-deadline-recovery map-world-climate-deadline-recovery--${view.action.type}" aria-label="Action recovery pour deadline climat encore risquée">
+      <div class="map-world-climate-deadline-recovery__header">
+        <strong>Recovery deadline</strong>
+        <span>${view.action.label}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>${view.action.provinceLabel}</b> · ${view.action.deadline} · ${view.action.type}</small>
+      <small><b>Action compacte</b> · ${view.action.instruction}</small>
+      <small><b>Liée au warning</b> · ${view.action.tiedWarning}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -15584,6 +15650,7 @@ function render() {
   const atlasClimateReadinessBoostReliefRanking = buildAtlasClimateReadinessBoostReliefRanking(atlasClimatePostBoostDeadlineRiskPreview);
   const atlasClimateMinimumViableBoostHint = buildAtlasClimateMinimumViableBoostHint(atlasClimateReadinessBoostReliefRanking);
   const atlasClimateMinimumBoostDeadlineMissWarning = buildAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumViableBoostHint);
+  const atlasClimateDeadlineRecoveryAction = buildAtlasClimateDeadlineRecoveryAction(atlasClimateMinimumBoostDeadlineMissWarning);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -15628,6 +15695,7 @@ function render() {
           ${renderAtlasClimateReadinessBoostReliefRanking(atlasClimateReadinessBoostReliefRanking)}
           ${renderAtlasClimateMinimumViableBoostHint(atlasClimateMinimumViableBoostHint)}
           ${renderAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumBoostDeadlineMissWarning)}
+          ${renderAtlasClimateDeadlineRecoveryAction(atlasClimateDeadlineRecoveryAction)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12010,3 +12010,30 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+.map-world-climate-deadline-recovery {
+  display: grid;
+  gap: 6px;
+  max-width: 54ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.78), rgba(22, 78, 99, 0.26));
+  border: 1px solid rgba(45, 212, 191, 0.42);
+}
+.map-world-climate-deadline-recovery--add-secondary-boost { border-color: rgba(129, 140, 248, 0.46); }
+.map-world-climate-deadline-recovery--reduce-exposure-first { border-color: rgba(251, 191, 36, 0.48); }
+.map-world-climate-deadline-recovery--accept-missed-deadline-risk { border-color: rgba(248, 113, 113, 0.52); }
+.map-world-climate-deadline-recovery__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-deadline-recovery p,
+.map-world-climate-deadline-recovery span,
+.map-world-climate-deadline-recovery small {
+  color: #ccfbf1;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}


### PR DESCRIPTION
Epsilon: Couvre #883.

Résumé:
- ajoute une action compacte de recovery quand l’alerte E16 indique qu’un minimum viable boost améliore le plan climat prioritaire mais laisse encore la deadline risquée;
- dérive une seule action depuis le warning existant: `shift-execution-earlier`, `add-secondary-boost`, `reduce-exposure-first`, `accept-missed-deadline-risk` ou `no-recovery-action`;
- affiche l’action juste après le warning pour rester visuellement liée à la deadline encore manquée, sans nouveau sous-système de planification climat.

Validation:
- `node --check web/app.js`
- `node --test test/ui/climate/webAtlasClimateDeadlineRecoveryAction.test.js test/ui/climate/webAtlasClimateMinimumBoostDeadlineMissWarning.test.js`
- `git diff --check`
- `npm test` (579 tests OK)

Merci de valider avant tout merge.