### PR TITLE
Delta: mark next safe follow-up sweep

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -468,6 +468,56 @@ test('atlas counterintelligence suggests follow-up sweeps from residual gap warn
   assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__follow-up--wait-for-safe-window/);
 });
 
+test('atlas counterintelligence marks the next safe follow-up sweep priority', () => {
+  const buildNextSafeMarker = (followUpState, bestName, assignments) => {
+    if (followUpState === 'wait-for-safe-window') return { state: 'wait-for-safe-window', shouldRender: true };
+    const candidates = assignments
+      .filter((assignment) => assignment.assignmentStatus === 'safe' && assignment.locationName !== bestName)
+      .map((assignment) => {
+        const priorityState = assignment.failureType === 'non couvert' && ['critique', 'haute'].includes(assignment.priorityLevel)
+          ? 'closes-critical-blind-spot'
+          : assignment.freshnessScore <= 1 && ['critique', 'haute'].includes(assignment.priorityLevel)
+            ? 'refreshes-stale-critical-signal'
+            : 'lowest-exposure-sweep';
+        const priorityWeight = priorityState === 'closes-critical-blind-spot' ? 3 : priorityState === 'refreshes-stale-critical-signal' ? 2 : 1;
+        const exposureRank = assignment.failureType === 'couverture trop faible' || assignment.priorityLevel === 'prudente' ? 1 : 2;
+        return { ...assignment, priorityState, priorityWeight, exposureRank };
+      })
+      .sort((left, right) => right.priorityWeight - left.priorityWeight
+        || right.priorityScore - left.priorityScore
+        || left.exposureRank - right.exposureRank
+        || left.locationName.localeCompare(right.locationName));
+    if (candidates.length === 0) return { state: 'no-safe-follow-up', shouldRender: followUpState !== 'no-follow-up' };
+    return {
+      state: candidates[0].priorityState,
+      shouldRender: candidates.length > 1 || !['close-blind-spot', 'refresh-stale-signal'].includes(followUpState),
+    };
+  };
+
+  assert.deepEqual(buildNextSafeMarker('close-blind-spot', 'Best', [
+    { locationName: 'Best', assignmentStatus: 'safe', failureType: 'non couvert', priorityLevel: 'critique', freshnessScore: 1, priorityScore: 9 },
+    { locationName: 'Critical gap', assignmentStatus: 'safe', failureType: 'non couvert', priorityLevel: 'haute', freshnessScore: 2, priorityScore: 7 },
+    { locationName: 'Old gap', assignmentStatus: 'safe', failureType: 'couverture trop faible', priorityLevel: 'haute', freshnessScore: 1, priorityScore: 8 },
+  ]), { state: 'closes-critical-blind-spot', shouldRender: true });
+  assert.equal(buildNextSafeMarker('refresh-stale-signal', 'Best', [
+    { locationName: 'Old gap', assignmentStatus: 'safe', failureType: 'couverture trop faible', priorityLevel: 'haute', freshnessScore: 1, priorityScore: 8 },
+  ]).shouldRender, false);
+  assert.equal(buildNextSafeMarker('no-follow-up', 'Best', [
+    { locationName: 'Low exposure', assignmentStatus: 'safe', failureType: 'couverture trop faible', priorityLevel: 'prudente', freshnessScore: 3, priorityScore: 3 },
+  ]).state, 'lowest-exposure-sweep');
+  assert.equal(buildNextSafeMarker('wait-for-safe-window', 'Best', []).state, 'wait-for-safe-window');
+  assert.equal(buildNextSafeMarker('close-blind-spot', 'Best', []).state, 'no-safe-follow-up');
+  assert.match(webAppSource, /nextSafeFollowUpPriorityMarker/);
+  assert.match(webAppSource, /Next safe sweep:/);
+  assert.match(webAppSource, /closes-critical-blind-spot/);
+  assert.match(webAppSource, /refreshes-stale-critical-signal/);
+  assert.match(webAppSource, /lowest-exposure-sweep/);
+  assert.match(webAppSource, /no-safe-follow-up/);
+  assert.match(webAppSource, /Priorité suivante/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__next-safe/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__next-safe--lowest-exposure-sweep/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -12276,6 +12276,54 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
       copy: `${followUpAssignment.locationName}: planifier un refresh discret du signal ancien avant tout engagement nominatif.`,
     };
   })();
+  const nextSafeFollowUpPriorityMarker = (() => {
+    if (bestResweepFollowUpSuggestion.state === 'wait-for-safe-window') {
+      return {
+        state: 'wait-for-safe-window',
+        shouldRender: true,
+        label: 'Priorité suivante: attendre une fenêtre sûre avant un second sweep.',
+      };
+    }
+
+    const followUpCandidates = stagedResweepAssignments
+      .filter((assignment) => assignment.assignmentStatus === 'safe' && assignment.locationName !== bestRankedStagedResweepAssignment?.locationName)
+      .map((assignment) => {
+        const priorityState = assignment.failureType === 'non couvert' && ['critique', 'haute'].includes(assignment.priorityLevel)
+          ? 'closes-critical-blind-spot'
+          : assignment.freshnessScore <= 1 && ['critique', 'haute'].includes(assignment.priorityLevel)
+            ? 'refreshes-stale-critical-signal'
+            : 'lowest-exposure-sweep';
+        const priorityWeight = priorityState === 'closes-critical-blind-spot' ? 3 : priorityState === 'refreshes-stale-critical-signal' ? 2 : 1;
+        const exposureRank = assignment.failureType === 'couverture trop faible' || assignment.priorityLevel === 'prudente' ? 1 : 2;
+
+        return { ...assignment, priorityState, priorityWeight, exposureRank };
+      })
+      .sort((left, right) => right.priorityWeight - left.priorityWeight
+        || right.priorityScore - left.priorityScore
+        || left.exposureRank - right.exposureRank
+        || left.locationName.localeCompare(right.locationName));
+
+    if (followUpCandidates.length === 0) {
+      return {
+        state: 'no-safe-follow-up',
+        shouldRender: bestResweepFollowUpSuggestion.state !== 'no-follow-up',
+        label: 'Priorité suivante: aucun follow-up sûr disponible après le meilleur resweep.',
+      };
+    }
+
+    const nextCandidate = followUpCandidates[0];
+    const stateLabel = nextCandidate.priorityState === 'closes-critical-blind-spot'
+      ? 'fermer le blind spot critique'
+      : nextCandidate.priorityState === 'refreshes-stale-critical-signal'
+        ? 'rafraîchir le signal ancien critique'
+        : 'prendre le sweep à exposition minimale';
+
+    return {
+      state: nextCandidate.priorityState,
+      shouldRender: followUpCandidates.length > 1 || !['close-blind-spot', 'refresh-stale-signal'].includes(bestResweepFollowUpSuggestion.state),
+      label: `Priorité suivante: ${nextCandidate.locationName} · ${stateLabel}.`,
+    };
+  })();
   const postOrderCoverage = {
     coveredOrderZones,
     fragileAssignments,
@@ -12296,6 +12344,7 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
     bestRankedStagedResweepAssignment,
     bestResweepResidualGapWarning,
     bestResweepFollowUpSuggestion,
+    nextSafeFollowUpPriorityMarker,
     summary: postOrderCoverageSummary,
   };
   const exposureCooldownSummary = sweepCandidates.length > 0
@@ -12438,6 +12487,7 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
           <span>${plan.postOrderCoverage.bestResweepResidualGapWarning.summary}</span>
           <small>${plan.postOrderCoverage.bestResweepResidualGapWarning.detail}</small>
           <small class="atlas-counterintelligence-best-resweep-gap-warning__follow-up atlas-counterintelligence-best-resweep-gap-warning__follow-up--${plan.postOrderCoverage.bestResweepFollowUpSuggestion.state}"><b>Follow-up:</b> ${plan.postOrderCoverage.bestResweepFollowUpSuggestion.label} · ${plan.postOrderCoverage.bestResweepFollowUpSuggestion.copy}</small>
+          ${plan.postOrderCoverage.nextSafeFollowUpPriorityMarker.shouldRender ? `<small class="atlas-counterintelligence-best-resweep-gap-warning__next-safe atlas-counterintelligence-best-resweep-gap-warning__next-safe--${plan.postOrderCoverage.nextSafeFollowUpPriorityMarker.state}"><b>Next safe sweep:</b> ${plan.postOrderCoverage.nextSafeFollowUpPriorityMarker.label}</small>` : ''}
         </aside>
       </section>
       <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">

--- a/web/styles.css
+++ b/web/styles.css
@@ -3386,6 +3386,15 @@ button { font: inherit; }
 .atlas-counterintelligence-best-resweep-gap-warning__follow-up--refresh-stale-signal { color: #bfdbfe; }
 .atlas-counterintelligence-best-resweep-gap-warning__follow-up--wait-for-safe-window { color: #fde68a; }
 .atlas-counterintelligence-best-resweep-gap-warning__follow-up--no-follow-up { color: #cbd5e1; }
+.atlas-counterintelligence-best-resweep-gap-warning__next-safe {
+  padding-top: 2px;
+  color: #dbeafe;
+}
+.atlas-counterintelligence-best-resweep-gap-warning__next-safe--closes-critical-blind-spot { color: #fecaca; }
+.atlas-counterintelligence-best-resweep-gap-warning__next-safe--refreshes-stale-critical-signal { color: #fde68a; }
+.atlas-counterintelligence-best-resweep-gap-warning__next-safe--lowest-exposure-sweep { color: #bbf7d0; }
+.atlas-counterintelligence-best-resweep-gap-warning__next-safe--wait-for-safe-window,
+.atlas-counterintelligence-best-resweep-gap-warning__next-safe--no-safe-follow-up { color: #cbd5e1; }
 .atlas-counterintelligence-schedule-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Implements #882.

Summary:
- adds a concise next-safe-sweep marker attached to the residual-gap follow-up line
- prioritizes follow-ups deterministically across closes-critical-blind-spot, refreshes-stale-critical-signal, lowest-exposure-sweep, wait-for-safe-window, and no-safe-follow-up states
- suppresses redundant output when a single obvious safe follow-up already has enough context

Validation:
- node --check web/app.js
- npm test -- test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- npm test
- git diff --check