### PR TITLE
Delta: explain next sweep exposure tradeoffs

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -518,6 +518,36 @@ test('atlas counterintelligence marks the next safe follow-up sweep priority', (
   assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__next-safe--lowest-exposure-sweep/);
 });
 
+test('atlas counterintelligence explains exposure tradeoffs for next safe sweeps', () => {
+  const tradeoffFor = (marker) => {
+    if (!marker.shouldRender) return { state: 'silent-guard', shouldRender: false };
+    if (marker.state === 'wait-for-safe-window') return { state: 'wait-required', shouldRender: true };
+    if (marker.state === 'no-safe-follow-up') return { state: 'no-safe-tradeoff', shouldRender: true };
+    if (marker.state === 'closes-critical-blind-spot') return { state: 'critical-coverage-tradeoff', shouldRender: true };
+    if (marker.state === 'refreshes-stale-critical-signal') return { state: 'stale-refresh-tradeoff', shouldRender: true };
+    return { state: 'minimal-exposure-tradeoff', shouldRender: true };
+  };
+
+  assert.deepEqual(tradeoffFor({ state: 'closes-critical-blind-spot', shouldRender: true }), { state: 'critical-coverage-tradeoff', shouldRender: true });
+  assert.deepEqual(tradeoffFor({ state: 'refreshes-stale-critical-signal', shouldRender: true }), { state: 'stale-refresh-tradeoff', shouldRender: true });
+  assert.deepEqual(tradeoffFor({ state: 'lowest-exposure-sweep', shouldRender: true }), { state: 'minimal-exposure-tradeoff', shouldRender: true });
+  assert.deepEqual(tradeoffFor({ state: 'wait-for-safe-window', shouldRender: true }), { state: 'wait-required', shouldRender: true });
+  assert.deepEqual(tradeoffFor({ state: 'no-safe-follow-up', shouldRender: true }), { state: 'no-safe-tradeoff', shouldRender: true });
+  assert.deepEqual(tradeoffFor({ state: 'closes-critical-blind-spot', shouldRender: false }), { state: 'silent-guard', shouldRender: false });
+  assert.match(webAppSource, /nextSafeSweepExposureTradeoff/);
+  assert.match(webAppSource, /Tradeoff exposition:/);
+  assert.match(webAppSource, /critical-coverage-tradeoff/);
+  assert.match(webAppSource, /stale-refresh-tradeoff/);
+  assert.match(webAppSource, /minimal-exposure-tradeoff/);
+  assert.match(webAppSource, /wait-required/);
+  assert.match(webAppSource, /no-safe-tradeoff/);
+  assert.match(webAppSource, /silent-guard/);
+  assert.match(webAppSource, /meilleure couverture critique malgré une exposition contrôlée/);
+  assert.match(webAppSource, /choisir l’exposition minimale plutôt qu’un gain de couverture plus spéculatif/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__tradeoff/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__tradeoff--minimal-exposure-tradeoff/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -12390,6 +12390,53 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
       label: `Priorité suivante: ${nextCandidate.locationName} · ${stateLabel}.`,
     };
   })();
+  const nextSafeSweepExposureTradeoff = (() => {
+    if (!nextSafeFollowUpPriorityMarker.shouldRender) {
+      return {
+        state: 'silent-guard',
+        shouldRender: false,
+        label: 'aucun tradeoff affiché',
+      };
+    }
+
+    if (nextSafeFollowUpPriorityMarker.state === 'wait-for-safe-window') {
+      return {
+        state: 'wait-required',
+        shouldRender: true,
+        label: 'Tradeoff: attendre réduit l’exposition; partir maintenant risquerait de briser le fog-of-war.',
+      };
+    }
+
+    if (nextSafeFollowUpPriorityMarker.state === 'no-safe-follow-up') {
+      return {
+        state: 'no-safe-tradeoff',
+        shouldRender: true,
+        label: 'Tradeoff: aucun sweep sûr ne bat le risque d’exposition pour l’instant.',
+      };
+    }
+
+    if (nextSafeFollowUpPriorityMarker.state === 'closes-critical-blind-spot') {
+      return {
+        state: 'critical-coverage-tradeoff',
+        shouldRender: true,
+        label: 'Tradeoff: meilleure couverture critique malgré une exposition contrôlée et non nominative.',
+      };
+    }
+
+    if (nextSafeFollowUpPriorityMarker.state === 'refreshes-stale-critical-signal') {
+      return {
+        state: 'stale-refresh-tradeoff',
+        shouldRender: true,
+        label: 'Tradeoff: refresh du signal ancien avant action directe, avec exposition courte et limitée.',
+      };
+    }
+
+    return {
+      state: 'minimal-exposure-tradeoff',
+      shouldRender: true,
+      label: 'Tradeoff: choisir l’exposition minimale plutôt qu’un gain de couverture plus spéculatif.',
+    };
+  })();
   const postOrderCoverage = {
     coveredOrderZones,
     fragileAssignments,
@@ -12411,6 +12458,7 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
     bestResweepResidualGapWarning,
     bestResweepFollowUpSuggestion,
     nextSafeFollowUpPriorityMarker,
+    nextSafeSweepExposureTradeoff,
     summary: postOrderCoverageSummary,
   };
   const exposureCooldownSummary = sweepCandidates.length > 0
@@ -12554,6 +12602,7 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
           <small>${plan.postOrderCoverage.bestResweepResidualGapWarning.detail}</small>
           <small class="atlas-counterintelligence-best-resweep-gap-warning__follow-up atlas-counterintelligence-best-resweep-gap-warning__follow-up--${plan.postOrderCoverage.bestResweepFollowUpSuggestion.state}"><b>Follow-up:</b> ${plan.postOrderCoverage.bestResweepFollowUpSuggestion.label} · ${plan.postOrderCoverage.bestResweepFollowUpSuggestion.copy}</small>
           ${plan.postOrderCoverage.nextSafeFollowUpPriorityMarker.shouldRender ? `<small class="atlas-counterintelligence-best-resweep-gap-warning__next-safe atlas-counterintelligence-best-resweep-gap-warning__next-safe--${plan.postOrderCoverage.nextSafeFollowUpPriorityMarker.state}"><b>Next safe sweep:</b> ${plan.postOrderCoverage.nextSafeFollowUpPriorityMarker.label}</small>` : ''}
+          ${plan.postOrderCoverage.nextSafeSweepExposureTradeoff.shouldRender ? `<small class="atlas-counterintelligence-best-resweep-gap-warning__tradeoff atlas-counterintelligence-best-resweep-gap-warning__tradeoff--${plan.postOrderCoverage.nextSafeSweepExposureTradeoff.state}"><b>Tradeoff exposition:</b> ${plan.postOrderCoverage.nextSafeSweepExposureTradeoff.label}</small>` : ''}
         </aside>
       </section>
       <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">

--- a/web/styles.css
+++ b/web/styles.css
@@ -3395,6 +3395,15 @@ button { font: inherit; }
 .atlas-counterintelligence-best-resweep-gap-warning__next-safe--lowest-exposure-sweep { color: #bbf7d0; }
 .atlas-counterintelligence-best-resweep-gap-warning__next-safe--wait-for-safe-window,
 .atlas-counterintelligence-best-resweep-gap-warning__next-safe--no-safe-follow-up { color: #cbd5e1; }
+.atlas-counterintelligence-best-resweep-gap-warning__tradeoff {
+  padding-top: 2px;
+  color: #ddd6fe;
+}
+.atlas-counterintelligence-best-resweep-gap-warning__tradeoff--critical-coverage-tradeoff { color: #fecaca; }
+.atlas-counterintelligence-best-resweep-gap-warning__tradeoff--stale-refresh-tradeoff { color: #fde68a; }
+.atlas-counterintelligence-best-resweep-gap-warning__tradeoff--minimal-exposure-tradeoff { color: #bbf7d0; }
+.atlas-counterintelligence-best-resweep-gap-warning__tradeoff--wait-required,
+.atlas-counterintelligence-best-resweep-gap-warning__tradeoff--no-safe-tradeoff { color: #cbd5e1; }
 .atlas-counterintelligence-schedule-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Implements #892.

Summary:
- adds a compact exposure tradeoff line attached to the next-safe-sweep marker
- covers critical coverage, stale-signal refresh, minimal-exposure, wait-required, no-safe-tradeoff, and silent guard states
- keeps the explanation fog-safe and non-nominative while preferring safety over exhaustive ranking

Validation:
- node --check web/app.js
- npm test -- test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- npm test
- git diff --check