### PR TITLE
Epsilon: rank climate recovery relief

### DIFF
--- a/test/ui/climate/webAtlasClimateRecoveryCollateralReliefRanking.test.js
+++ b/test/ui/climate/webAtlasClimateRecoveryCollateralReliefRanking.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const deterministicReliefRanking = [
+  ['shift-execution-earlier', 'améliore deadline', 78, 3, 'add-secondary-boost'],
+  ['add-secondary-boost', 'libère capacité', 74, 2, 'reduce-exposure-first'],
+  ['reduce-exposure-first', 'réduit exposition régionale', 70, 1, 'accept-missed-deadline-risk'],
+  ['accept-missed-deadline-risk', 'aucun relief sûr', 24, 0, 'add-secondary-boost'],
+];
+
+test('atlas ranks climate recovery actions by deterministic collateral relief', () => {
+  assert.match(webAppSource, /function buildAtlasClimateRecoveryCollateralReliefRanking/);
+  assert.match(webAppSource, /function renderAtlasClimateRecoveryCollateralReliefRanking/);
+  assert.match(webAppSource, /state !== 'recoverable'/);
+  assert.match(webAppSource, /Aucun ranking relief collatéral/);
+  assert.match(webAppSource, /atlasClimateRecoveryCollateralReliefRanking = buildAtlasClimateRecoveryCollateralReliefRanking\(atlasClimateDeadlineRecoveryAction\)/);
+  assert.match(webAppSource, /renderAtlasClimateRecoveryCollateralReliefRanking\(atlasClimateRecoveryCollateralReliefRanking\)/);
+
+  for (const [action, relief, score, tiebreaker, rejected] of deterministicReliefRanking) {
+    assert.match(webAppSource, new RegExp(action));
+    assert.match(webAppSource, new RegExp(relief));
+    assert.match(webAppSource, new RegExp(`reliefScore: ${score}`));
+    assert.match(webAppSource, new RegExp(`tiebreaker: ${tiebreaker}`));
+    assert.match(webAppSource, new RegExp(`rejectedType: '${rejected}'`));
+  }
+
+  assert.match(webAppSource, /Alternative rejetée/);
+  assert.match(webAppSource, /Top action/);
+  assert.match(webAppSource, /no-safe-relief/);
+  assert.match(stylesSource, /\.map-world-climate-recovery-relief-ranking/);
+  assert.match(stylesSource, /\.map-world-climate-recovery-relief-ranking--no-safe-relief/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -8338,6 +8338,97 @@ function renderAtlasClimateDeadlineRecoveryAction(view) {
   `;
 }
 
+function buildAtlasClimateRecoveryCollateralReliefRanking(recoveryActionView) {
+  if (!recoveryActionView || recoveryActionView.state !== 'recoverable' || !recoveryActionView.action) {
+    return {
+      state: 'empty',
+      rankedActions: [],
+      rejectedAlternative: null,
+      summary: 'Aucun ranking relief collatéral: aucune action recovery réelle proposée.',
+    };
+  }
+
+  const action = recoveryActionView.action;
+  const reliefProfiles = {
+    'shift-execution-earlier': {
+      collateralRelief: 'améliore deadline',
+      reliefScore: 78,
+      tiebreaker: 3,
+      rationale: 'Récupère le tour manquant sans consommer une capacité secondaire incertaine.',
+      rejectedType: 'add-secondary-boost',
+      rejectedReason: 'Rejeté: libère moins vite la deadline que le déplacement immédiat du jalon.',
+    },
+    'add-secondary-boost': {
+      collateralRelief: 'libère capacité',
+      reliefScore: 74,
+      tiebreaker: 2,
+      rationale: 'Ajoute seulement la capacité ciblée déjà signalée et réduit le risque de cascade readiness.',
+      rejectedType: 'reduce-exposure-first',
+      rejectedReason: 'Rejeté: réduit l’exposition mais laisse la capacité courte avant exécution.',
+    },
+    'reduce-exposure-first': {
+      collateralRelief: 'réduit exposition régionale',
+      reliefScore: 70,
+      tiebreaker: 1,
+      rationale: 'Soulage l’exposition régionale avant de réengager le paquet de boost minimal.',
+      rejectedType: 'accept-missed-deadline-risk',
+      rejectedReason: 'Rejeté: accepter le risque ne retire aucune pression régionale sûre.',
+    },
+    'accept-missed-deadline-risk': {
+      collateralRelief: 'aucun relief sûr',
+      reliefScore: 24,
+      tiebreaker: 0,
+      rationale: 'À garder seulement quand les signaux existants ne justifient pas de ressource supplémentaire.',
+      rejectedType: 'add-secondary-boost',
+      rejectedReason: 'Rejeté: impossible de recommander une ressource non confirmée par les signaux readiness.',
+    },
+  };
+  const selected = reliefProfiles[action.type] ?? reliefProfiles['accept-missed-deadline-risk'];
+  const rankedActions = [{
+    rank: 1,
+    provinceId: action.provinceId,
+    provinceLabel: action.provinceLabel,
+    deadline: action.deadline,
+    type: action.type,
+    label: action.label,
+    collateralRelief: selected.collateralRelief,
+    reliefScore: selected.reliefScore,
+    tiebreaker: selected.tiebreaker,
+    rationale: selected.rationale,
+  }];
+  const rejectedAlternative = {
+    type: selected.rejectedType,
+    reason: selected.rejectedReason,
+  };
+
+  return {
+    state: selected.collateralRelief === 'aucun relief sûr' ? 'no-safe-relief' : 'ranked',
+    rankedActions,
+    rejectedAlternative,
+    summary: `${action.provinceLabel}: ${action.label} classée en tête par relief collatéral (${selected.collateralRelief}, score ${selected.reliefScore}, tie-break ${selected.tiebreaker}).`,
+  };
+}
+
+function renderAtlasClimateRecoveryCollateralReliefRanking(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty' || view.rankedActions.length === 0) {
+    return '';
+  }
+
+  const topAction = view.rankedActions[0];
+  return `
+    <aside class="map-world-climate-recovery-relief-ranking map-world-climate-recovery-relief-ranking--${view.state}" aria-label="Ranking des actions recovery climat par relief collatéral">
+      <div class="map-world-climate-recovery-relief-ranking__header">
+        <strong>Relief collatéral recovery</strong>
+        <span>${topAction.collateralRelief}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Top action</b> · ${topAction.label} (${topAction.type}) · score ${topAction.reliefScore}</small>
+      <small><b>Pourquoi</b> · ${topAction.rationale}</small>
+      ${view.rejectedAlternative ? `<small><b>Alternative rejetée</b> · ${view.rejectedAlternative.type}: ${view.rejectedAlternative.reason}</small>` : ''}
+    </aside>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -16057,6 +16148,7 @@ function render() {
   const atlasClimateMinimumViableBoostHint = buildAtlasClimateMinimumViableBoostHint(atlasClimateReadinessBoostReliefRanking);
   const atlasClimateMinimumBoostDeadlineMissWarning = buildAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumViableBoostHint);
   const atlasClimateDeadlineRecoveryAction = buildAtlasClimateDeadlineRecoveryAction(atlasClimateMinimumBoostDeadlineMissWarning);
+  const atlasClimateRecoveryCollateralReliefRanking = buildAtlasClimateRecoveryCollateralReliefRanking(atlasClimateDeadlineRecoveryAction);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -16102,6 +16194,7 @@ function render() {
           ${renderAtlasClimateMinimumViableBoostHint(atlasClimateMinimumViableBoostHint)}
           ${renderAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumBoostDeadlineMissWarning)}
           ${renderAtlasClimateDeadlineRecoveryAction(atlasClimateDeadlineRecoveryAction)}
+          ${renderAtlasClimateRecoveryCollateralReliefRanking(atlasClimateRecoveryCollateralReliefRanking)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12096,3 +12096,28 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+.map-world-climate-recovery-relief-ranking {
+  display: grid;
+  gap: 6px;
+  max-width: 54ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(8, 47, 73, 0.74), rgba(20, 83, 45, 0.24));
+  border: 1px solid rgba(52, 211, 153, 0.44);
+}
+.map-world-climate-recovery-relief-ranking--no-safe-relief { border-color: rgba(251, 146, 60, 0.5); }
+.map-world-climate-recovery-relief-ranking__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-recovery-relief-ranking p,
+.map-world-climate-recovery-relief-ranking span,
+.map-world-climate-recovery-relief-ranking small {
+  color: #d1fae5;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}


### PR DESCRIPTION
Epsilon: Couvre #893.

Résumé:
- ajoute un mini-ranking du relief collatéral pour l’action recovery E17 réelle, affiché uniquement quand une action recoverable existe;
- classe la top action par relief (`améliore deadline`, `libère capacité`, `réduit exposition régionale`, `aucun relief sûr`) avec scores et tie-breakers déterministes;
- montre une alternative rejetée compacte pour expliquer pourquoi elle soulage moins les pressions régionales sans créer de nouvelle table complète.

Validation:
- `node --check web/app.js`
- `node --test test/ui/climate/webAtlasClimateRecoveryCollateralReliefRanking.test.js test/ui/climate/webAtlasClimateDeadlineRecoveryAction.test.js`
- `git diff --check`
- `npm test` (582 tests OK)

Merci de valider avant tout merge.