### PR TITLE
Epsilon: explain first climate recovery relief

### DIFF
--- a/test/ui/climate/webAtlasClimateFirstRecoveryPressureReliefExplanation.test.js
+++ b/test/ui/climate/webAtlasClimateFirstRecoveryPressureReliefExplanation.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const deterministicFirstReliefs = [
+  ['améliore deadline', 'deadline-less-tight', 'deadline moins serrée', 3],
+  ['libère capacité', 'capacity-freed', 'capacité régionale libérée', 2],
+  ['réduit exposition régionale', 'exposure-reduced', 'exposition réduite', 1],
+  ['aucun relief sûr', 'no-safe-relief', 'aucun relief sûr', 0],
+];
+
+test('atlas explains the first pressure relieved after the ranked climate recovery action', () => {
+  assert.match(webAppSource, /function buildAtlasClimateFirstRecoveryPressureReliefExplanation/);
+  assert.match(webAppSource, /function renderAtlasClimateFirstRecoveryPressureReliefExplanation/);
+  assert.match(webAppSource, /Aucune micro-explication pressure relief/);
+  assert.match(webAppSource, /rankedActions\?\.length/);
+  assert.match(webAppSource, /atlasClimateFirstRecoveryPressureReliefExplanation = buildAtlasClimateFirstRecoveryPressureReliefExplanation\(atlasClimateRecoveryCollateralReliefRanking\)/);
+  assert.match(webAppSource, /renderAtlasClimateFirstRecoveryPressureReliefExplanation\(atlasClimateFirstRecoveryPressureReliefExplanation\)/);
+
+  for (const [collateralRelief, state, indicator, tiebreaker] of deterministicFirstReliefs) {
+    assert.match(webAppSource, new RegExp(collateralRelief));
+    assert.match(webAppSource, new RegExp(state));
+    assert.match(webAppSource, new RegExp(indicator));
+    assert.match(webAppSource, new RegExp(`tiebreaker: ${tiebreaker}`));
+  }
+
+  assert.match(webAppSource, /Premier relief visible/);
+  assert.match(webAppSource, /Signal attendu/);
+  assert.match(webAppSource, /Score source/);
+  assert.match(stylesSource, /\.map-world-climate-first-recovery-relief/);
+  assert.match(stylesSource, /\.map-world-climate-first-recovery-relief--capacity-freed/);
+  assert.match(stylesSource, /\.map-world-climate-first-recovery-relief--exposure-reduced/);
+  assert.match(stylesSource, /\.map-world-climate-first-recovery-relief--no-safe-relief/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -8491,6 +8491,80 @@ function renderAtlasClimateRecoveryCollateralReliefRanking(view) {
   `;
 }
 
+function buildAtlasClimateFirstRecoveryPressureReliefExplanation(recoveryReliefRankingView) {
+  if (!recoveryReliefRankingView || recoveryReliefRankingView.state === 'empty' || !recoveryReliefRankingView.rankedActions?.length) {
+    return {
+      state: 'empty',
+      explanation: null,
+      summary: 'Aucune micro-explication pressure relief: aucune top recovery action réelle.',
+    };
+  }
+
+  const topAction = recoveryReliefRankingView.rankedActions[0];
+  const reliefSignals = {
+    'améliore deadline': {
+      state: 'deadline-less-tight',
+      indicator: 'deadline moins serrée',
+      firstVisibleRelief: 'La fenêtre critique devrait perdre un tour de pression avant les autres jauges.',
+      tiebreaker: 3,
+    },
+    'libère capacité': {
+      state: 'capacity-freed',
+      indicator: 'capacité régionale libérée',
+      firstVisibleRelief: 'La jauge readiness devrait repasser au-dessus du seuil d’exécution ciblé.',
+      tiebreaker: 2,
+    },
+    'réduit exposition régionale': {
+      state: 'exposure-reduced',
+      indicator: 'exposition réduite',
+      firstVisibleRelief: 'Le premier signal visible devrait être une exposition régionale moins prioritaire.',
+      tiebreaker: 1,
+    },
+    'aucun relief sûr': {
+      state: 'no-safe-relief',
+      indicator: 'aucun relief sûr',
+      firstVisibleRelief: 'Aucun indicateur ne devrait être promis; le risque reste explicitement accepté.',
+      tiebreaker: 0,
+    },
+  };
+  const selected = reliefSignals[topAction.collateralRelief] ?? reliefSignals['aucun relief sûr'];
+
+  return {
+    state: selected.state,
+    explanation: {
+      provinceId: topAction.provinceId,
+      provinceLabel: topAction.provinceLabel,
+      deadline: topAction.deadline,
+      actionType: topAction.type,
+      actionLabel: topAction.label,
+      indicator: selected.indicator,
+      firstVisibleRelief: selected.firstVisibleRelief,
+      reliefScore: topAction.reliefScore,
+      tiebreaker: selected.tiebreaker,
+    },
+    summary: `${topAction.provinceLabel}: premier relief attendu après ${topAction.label} — ${selected.indicator}.`,
+  };
+}
+
+function renderAtlasClimateFirstRecoveryPressureReliefExplanation(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty' || !view.explanation) {
+    return '';
+  }
+
+  return `
+    <aside class="map-world-climate-first-recovery-relief map-world-climate-first-recovery-relief--${view.state}" aria-label="Première pression soulagée après recovery climat">
+      <div class="map-world-climate-first-recovery-relief__header">
+        <strong>Premier relief visible</strong>
+        <span>${view.explanation.indicator}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>${view.explanation.provinceLabel}</b> · ${view.explanation.deadline} · ${view.explanation.actionType}</small>
+      <small><b>Signal attendu</b> · ${view.explanation.firstVisibleRelief}</small>
+      <small><b>Score source</b> · ${view.explanation.reliefScore}, tie-break ${view.explanation.tiebreaker}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -16211,6 +16285,7 @@ function render() {
   const atlasClimateMinimumBoostDeadlineMissWarning = buildAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumViableBoostHint);
   const atlasClimateDeadlineRecoveryAction = buildAtlasClimateDeadlineRecoveryAction(atlasClimateMinimumBoostDeadlineMissWarning);
   const atlasClimateRecoveryCollateralReliefRanking = buildAtlasClimateRecoveryCollateralReliefRanking(atlasClimateDeadlineRecoveryAction);
+  const atlasClimateFirstRecoveryPressureReliefExplanation = buildAtlasClimateFirstRecoveryPressureReliefExplanation(atlasClimateRecoveryCollateralReliefRanking);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -16257,6 +16332,7 @@ function render() {
           ${renderAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumBoostDeadlineMissWarning)}
           ${renderAtlasClimateDeadlineRecoveryAction(atlasClimateDeadlineRecoveryAction)}
           ${renderAtlasClimateRecoveryCollateralReliefRanking(atlasClimateRecoveryCollateralReliefRanking)}
+          ${renderAtlasClimateFirstRecoveryPressureReliefExplanation(atlasClimateFirstRecoveryPressureReliefExplanation)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12122,3 +12122,30 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+.map-world-climate-first-recovery-relief {
+  display: grid;
+  gap: 6px;
+  max-width: 54ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(12, 74, 110, 0.72), rgba(5, 46, 22, 0.24));
+  border: 1px solid rgba(125, 211, 252, 0.44);
+}
+.map-world-climate-first-recovery-relief--capacity-freed { border-color: rgba(167, 139, 250, 0.46); }
+.map-world-climate-first-recovery-relief--exposure-reduced { border-color: rgba(74, 222, 128, 0.46); }
+.map-world-climate-first-recovery-relief--no-safe-relief { border-color: rgba(251, 146, 60, 0.52); }
+.map-world-climate-first-recovery-relief__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-first-recovery-relief p,
+.map-world-climate-first-recovery-relief span,
+.map-world-climate-first-recovery-relief small {
+  color: #e0f2fe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}


### PR DESCRIPTION
Epsilon: Couvre #903.

Résumé:
- ajoute une micro-explication du premier indicateur de pression qui devrait se détendre après la top recovery action E18;
- couvre les reliefs déterministes `deadline moins serrée`, `capacité régionale libérée`, `exposition réduite` et `aucun relief sûr`;
- reste limité à une seule explication courte, dérivée du ranking recovery existant, avec score source et tie-breaker visibles.

Validation:
- `node --check web/app.js`
- `node --test test/ui/climate/webAtlasClimateFirstRecoveryPressureReliefExplanation.test.js test/ui/climate/webAtlasClimateRecoveryCollateralReliefRanking.test.js`
- `git diff --check`
- `npm test` (583 tests OK)

Merci de valider avant tout merge.