### PR TITLE
Gamma: show paired support risk relief

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -43,6 +43,7 @@ test('world map atlas renders culture influence zones from existing culture over
   assert.match(webAppSource, /buildAtlasPairedMediationSupport/);
   assert.match(webAppSource, /buildAtlasSafestPairedSupport/);
   assert.match(webAppSource, /buildAtlasPairedSupportSafetyJustification/);
+  assert.match(webAppSource, /buildAtlasPairedSupportRiskRelief/);
 });
 
 test('world map atlas exposes discovery sites without adding a new culture source of truth', () => {
@@ -128,7 +129,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /!fallback \|\| !pairedMediation/);
   assert.match(webAppSource, /appui sûr:/);
   assert.match(webAppSource, /atlas-cultural-border-zone__safest-support/);
-  assert.match(webAppSource, /safetyJustification: buildAtlasPairedSupportSafetyJustification/);
+  assert.match(webAppSource, /const safetyJustification = buildAtlasPairedSupportSafetyJustification/);
   assert.match(webAppSource, /state: 'mediator-available'/);
   assert.match(webAppSource, /state: 'border-pressure-low'/);
   assert.match(webAppSource, /state: 'window-open'/);
@@ -138,6 +139,15 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /safestSupport\.state === 'assign-mediator' && zone\.mediation\.confidence === 'inconnue'/);
   assert.match(webAppSource, /sûr car:/);
   assert.match(webAppSource, /atlas-cultural-border-zone__support-justification/);
+  assert.match(webAppSource, /const riskRelief = buildAtlasPairedSupportRiskRelief/);
+  assert.match(webAppSource, /riskRelief,/);
+  assert.match(webAppSource, /state: 'mediation-stabilized'/);
+  assert.match(webAppSource, /state: 'border-tension-calmed'/);
+  assert.match(webAppSource, /state: 'window-preserved'/);
+  assert.match(webAppSource, /state: 'local-trust-protected'/);
+  assert.match(webAppSource, /safetyJustification\.state === 'no-safe-justification'/);
+  assert.match(webAppSource, /risque retiré:/);
+  assert.match(webAppSource, /atlas-cultural-border-zone__risk-relief/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -171,6 +181,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-border-zone__support-justification--window-open/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__support-justification--local-trust-sufficient/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__support-justification--no-safe-justification/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__risk-relief--mediation-stabilized/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__risk-relief--window-preserved/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__risk-relief--border-tension-calmed/);
+  assert.match(stylesSource, /\.atlas-cultural-border-zone__risk-relief--local-trust-protected/);
   assert.match(stylesSource, /\.atlas-cultural-border-zones\.is-stable rect/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__confidence/);
   assert.match(stylesSource, /\.atlas-cultural-border-zone__consequences/);
@@ -199,4 +213,5 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__paired-mediation/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__safest-support/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__support-justification/);
+  assert.match(stylesSource, /\.atlas-cultural-consolidation-action__risk-relief/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -2359,6 +2359,58 @@ function buildAtlasPairedSupportSafetyJustification(zone, commitment, fallback, 
   };
 }
 
+function buildAtlasPairedSupportRiskRelief(zone, commitment, fallback, latestSafeTurn, pairedMediation, safestSupport, safetyJustification) {
+  if (!fallback || !pairedMediation || !safestSupport || !safetyJustification) {
+    return null;
+  }
+
+  if (safetyJustification.state === 'no-safe-justification' || latestSafeTurn?.state === 'no-safe-window') {
+    return null;
+  }
+
+  if (safetyJustification.state === 'mediator-available') {
+    return {
+      state: 'mediation-stabilized',
+      label: 'médiation stabilisée',
+      reason: `mediation-stabilized · ${zone.mediation.confidence}`,
+      detail: 'le premier risque retiré est une médiation trop fragile pour porter le fallback',
+      priority: 3,
+    };
+  }
+
+  if (safetyJustification.state === 'border-pressure-low') {
+    return {
+      state: 'border-tension-calmed',
+      label: 'tension frontière calmée',
+      reason: `border-tension-calmed · ${zone.mainDriver}`,
+      detail: 'le premier risque retiré est la pression visible qui dépassait le relais',
+      priority: 3,
+    };
+  }
+
+  if (safetyJustification.state === 'window-open') {
+    return {
+      state: 'window-preserved',
+      label: 'fenêtre préservée',
+      reason: `window-preserved · ${latestSafeTurn.value}`,
+      detail: 'le premier risque retiré est la perte du dernier tour sûr',
+      priority: 2,
+    };
+  }
+
+  if (safetyJustification.state === 'local-trust-sufficient') {
+    return {
+      state: 'local-trust-protected',
+      label: 'confiance protégée',
+      reason: `local-trust-protected · ${commitment.remainingConfidence}`,
+      detail: 'le premier risque retiré est une confiance locale qui retombe avant consolidation',
+      priority: 1,
+    };
+  }
+
+  return null;
+}
+
 function buildAtlasConsolidationFollowUpStatus(zone, commitment, recommendation) {
   if (!recommendation) {
     return null;
@@ -2557,6 +2609,8 @@ function buildAtlasMediationCommitment(zone) {
   const latestSafeTurn = buildAtlasLatestSafeFallbackTurn(zone, commitment, followUp, fallback);
   const pairedMediation = buildAtlasPairedMediationSupport(zone, commitment, followUp, fallback, latestSafeTurn);
   const safestSupport = buildAtlasSafestPairedSupport(zone, commitment, fallback, latestSafeTurn, pairedMediation);
+  const safetyJustification = buildAtlasPairedSupportSafetyJustification(zone, commitment, fallback, latestSafeTurn, pairedMediation, safestSupport);
+  const riskRelief = buildAtlasPairedSupportRiskRelief(zone, commitment, fallback, latestSafeTurn, pairedMediation, safestSupport, safetyJustification);
 
   return {
     ...commitment,
@@ -2576,7 +2630,12 @@ function buildAtlasMediationCommitment(zone) {
                             safestSupport: safestSupport
                               ? {
                                   ...safestSupport,
-                                  safetyJustification: buildAtlasPairedSupportSafetyJustification(zone, commitment, fallback, latestSafeTurn, pairedMediation, safestSupport),
+                                  safetyJustification: safetyJustification
+                                    ? {
+                                        ...safetyJustification,
+                                        riskRelief,
+                                      }
+                                    : null,
                                 }
                               : null,
                           }
@@ -2636,24 +2695,25 @@ function renderAtlasCultureLayer(cultureView) {
       `}
       ${features.borderZones.length > 0 ? `
         <g class="atlas-cultural-border-zones" aria-label="Synthèse des frontières culturelles instables et médiations">
-          <rect x="3" y="55" width="30" height="${19 + (features.borderZones.length * 22.8)}" rx="1.8"></rect>
+          <rect x="3" y="55" width="30" height="${20 + (features.borderZones.length * 24.2)}" rx="1.8"></rect>
           <text class="atlas-cultural-border-zones__title" x="5" y="58.4">Médiations culturelles</text>
           ${features.borderZones.map((zone, index) => `
             <g class="atlas-cultural-border-zone atlas-cultural-border-zone--${zone.drift.state} atlas-cultural-border-zone--confidence-${zone.mediation.confidence} atlas-cultural-border-zone--commitment-${zone.commitment.status === 'stable' ? 'stable' : 'risk'}" data-atlas-cultural-border="${zone.regionId}" aria-label="Frontière culturelle ${zone.cultureName}: moteur ${zone.mainDriver}, médiation ${zone.mediation.option}, confiance ${zone.mediation.confidence}, engagement ${zone.commitment.status}, confiance restante ${zone.commitment.remainingConfidence}, prochaine conséquence ${zone.commitment.nextConsequence}, échéance ${zone.commitment.phase}">
-              <text x="5" y="${62 + index * 22.8}">${zone.cultureName}</text>
-              <text class="atlas-cultural-border-zone__chips" x="5" y="${64 + index * 22.8}">${zone.chips.join(' · ')}</text>
-              <text class="atlas-cultural-border-zone__mediation" x="5" y="${66 + index * 22.8}">${zone.mediation.option} → ${zone.mediation.benefit}</text>
-              <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 22.8}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
-              <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 22.8}">${zone.commitment.label} · ${zone.commitment.outcomeStatus} · reste ${zone.commitment.remainingConfidence}</text>
-              <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 22.8}">prochain: ${zone.commitment.nextConsequence} · action: ${zone.commitment.nextAction}</text>
-              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 22.8}">${zone.commitment.consolidation.label}: ${zone.commitment.consolidation.action}</text>
-              ${zone.commitment.consolidationRecommendation ? `<text class="atlas-cultural-border-zone__recommendation" x="5" y="${74.6 + index * 22.8}">reco: ${zone.commitment.consolidationRecommendation.label} · ${zone.commitment.consolidationRecommendation.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp ? `<text class="atlas-cultural-border-zone__followup atlas-cultural-border-zone__followup--${zone.commitment.consolidationRecommendation.followUp.state}" x="5" y="${76.1 + index * 22.8}">suivi: ${zone.commitment.consolidationRecommendation.followUp.label} · ${zone.commitment.consolidationRecommendation.followUp.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp?.fallback ? `<text class="atlas-cultural-border-zone__fallback atlas-cultural-border-zone__fallback--${zone.commitment.consolidationRecommendation.followUp.fallback.state}" x="5" y="${77.5 + index * 22.8}">fallback: ${zone.commitment.consolidationRecommendation.followUp.fallback.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.latestSafeTurn ? `<text class="atlas-cultural-border-zone__latest-safe atlas-cultural-border-zone__latest-safe--${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.state}" x="5" y="${78.9 + index * 22.8}">dernier sûr: ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.value} · ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.pairedMediation ? `<text class="atlas-cultural-border-zone__paired-mediation atlas-cultural-border-zone__paired-mediation--${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.state}" x="5" y="${80.3 + index * 22.8}">support: ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.pairedMediation?.safestSupport ? `<text class="atlas-cultural-border-zone__safest-support atlas-cultural-border-zone__safest-support--${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.state}" x="5" y="${81.7 + index * 22.8}">appui sûr: ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.reason}</text>` : ''}
-              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.pairedMediation?.safestSupport?.safetyJustification ? `<text class="atlas-cultural-border-zone__support-justification atlas-cultural-border-zone__support-justification--${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.state}" x="5" y="${83.1 + index * 22.8}">sûr car: ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.reason}</text>` : ''}
+              <text x="5" y="${62 + index * 24.2}">${zone.cultureName}</text>
+              <text class="atlas-cultural-border-zone__chips" x="5" y="${64 + index * 24.2}">${zone.chips.join(' · ')}</text>
+              <text class="atlas-cultural-border-zone__mediation" x="5" y="${66 + index * 24.2}">${zone.mediation.option} → ${zone.mediation.benefit}</text>
+              <text class="atlas-cultural-border-zone__confidence" x="5" y="${67.8 + index * 24.2}">confiance ${zone.mediation.confidence} · ${zone.mediation.confidenceReason}</text>
+              <text class="atlas-cultural-border-zone__commitment" x="5" y="${69.5 + index * 24.2}">${zone.commitment.label} · ${zone.commitment.outcomeStatus} · reste ${zone.commitment.remainingConfidence}</text>
+              <text class="atlas-cultural-border-zone__consequences" x="5" y="${71.2 + index * 24.2}">prochain: ${zone.commitment.nextConsequence} · action: ${zone.commitment.nextAction}</text>
+              <text class="atlas-cultural-border-zone__risk" x="5" y="${72.9 + index * 24.2}">${zone.commitment.consolidation.label}: ${zone.commitment.consolidation.action}</text>
+              ${zone.commitment.consolidationRecommendation ? `<text class="atlas-cultural-border-zone__recommendation" x="5" y="${74.6 + index * 24.2}">reco: ${zone.commitment.consolidationRecommendation.label} · ${zone.commitment.consolidationRecommendation.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp ? `<text class="atlas-cultural-border-zone__followup atlas-cultural-border-zone__followup--${zone.commitment.consolidationRecommendation.followUp.state}" x="5" y="${76.1 + index * 24.2}">suivi: ${zone.commitment.consolidationRecommendation.followUp.label} · ${zone.commitment.consolidationRecommendation.followUp.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback ? `<text class="atlas-cultural-border-zone__fallback atlas-cultural-border-zone__fallback--${zone.commitment.consolidationRecommendation.followUp.fallback.state}" x="5" y="${77.5 + index * 24.2}">fallback: ${zone.commitment.consolidationRecommendation.followUp.fallback.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.latestSafeTurn ? `<text class="atlas-cultural-border-zone__latest-safe atlas-cultural-border-zone__latest-safe--${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.state}" x="5" y="${78.9 + index * 24.2}">dernier sûr: ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.value} · ${zone.commitment.consolidationRecommendation.followUp.fallback.latestSafeTurn.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.pairedMediation ? `<text class="atlas-cultural-border-zone__paired-mediation atlas-cultural-border-zone__paired-mediation--${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.state}" x="5" y="${80.3 + index * 24.2}">support: ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.pairedMediation?.safestSupport ? `<text class="atlas-cultural-border-zone__safest-support atlas-cultural-border-zone__safest-support--${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.state}" x="5" y="${81.7 + index * 24.2}">appui sûr: ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.pairedMediation?.safestSupport?.safetyJustification ? `<text class="atlas-cultural-border-zone__support-justification atlas-cultural-border-zone__support-justification--${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.state}" x="5" y="${83.1 + index * 24.2}">sûr car: ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.reason}</text>` : ''}
+              ${zone.commitment.consolidationRecommendation?.followUp?.fallback?.pairedMediation?.safestSupport?.safetyJustification?.riskRelief ? `<text class="atlas-cultural-border-zone__risk-relief atlas-cultural-border-zone__risk-relief--${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.riskRelief.state}" x="5" y="${84.5 + index * 24.2}">risque retiré: ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.riskRelief.label} · ${zone.commitment.consolidationRecommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.riskRelief.reason}</text>` : ''}
             </g>
           `).join('')}
         </g>
@@ -2666,18 +2726,19 @@ function renderAtlasCultureLayer(cultureView) {
       `}
       ${features.consolidationRecommendations.length > 0 ? `
         <g class="atlas-cultural-consolidation-actions" aria-label="Actions de consolidation des rebonds culturels fragiles">
-          <rect x="65" y="56" width="31" height="${11.2 + (features.consolidationRecommendations.length * 12.9)}" rx="1.8"></rect>
+          <rect x="65" y="56" width="31" height="${12 + (features.consolidationRecommendations.length * 14.3)}" rx="1.8"></rect>
           <text class="atlas-cultural-consolidation-actions__title" x="67" y="59.2">Actions consolidation</text>
           ${features.consolidationRecommendations.map((item, index) => `
             <g class="atlas-cultural-consolidation-action atlas-cultural-consolidation-action--${item.consolidation.state} atlas-cultural-consolidation-action--followup-${item.recommendation.followUp.state}" data-atlas-consolidation-action="${item.regionId}" aria-label="Action consolidation ${item.cultureName}: ${item.recommendation.label}, suivi ${item.recommendation.followUp.label}, raison ${item.recommendation.followUp.reason}, détail ${item.recommendation.followUp.detail}">
-              <text x="67" y="${62.3 + index * 12.9}">${item.cultureName} · ${item.recommendation.label}</text>
-              <text class="atlas-cultural-consolidation-action__reason" x="67" y="${64.1 + index * 12.9}">${item.recommendation.reason}</text>
-              <text class="atlas-cultural-consolidation-action__followup" x="67" y="${65.8 + index * 12.9}">${item.recommendation.followUp.label} · ${item.recommendation.followUp.reason}</text>
-              ${item.recommendation.followUp.fallback ? `<text class="atlas-cultural-consolidation-action__fallback" x="67" y="${67.5 + index * 12.9}">fallback: ${item.recommendation.followUp.fallback.label} · ${item.recommendation.followUp.fallback.reason}</text>` : ''}
-              ${item.recommendation.followUp.fallback?.latestSafeTurn ? `<text class="atlas-cultural-consolidation-action__latest-safe atlas-cultural-consolidation-action__latest-safe--${item.recommendation.followUp.fallback.latestSafeTurn.state}" x="67" y="${69.1 + index * 12.9}">dernier sûr: ${item.recommendation.followUp.fallback.latestSafeTurn.value}</text>` : ''}
-              ${item.recommendation.followUp.fallback?.pairedMediation ? `<text class="atlas-cultural-consolidation-action__paired-mediation atlas-cultural-consolidation-action__paired-mediation--${item.recommendation.followUp.fallback.pairedMediation.state}" x="67" y="${70.7 + index * 12.9}">support: ${item.recommendation.followUp.fallback.pairedMediation.label}</text>` : ''}
-              ${item.recommendation.followUp.fallback?.pairedMediation?.safestSupport ? `<text class="atlas-cultural-consolidation-action__safest-support atlas-cultural-consolidation-action__safest-support--${item.recommendation.followUp.fallback.pairedMediation.safestSupport.state}" x="67" y="${72.3 + index * 12.9}">appui sûr: ${item.recommendation.followUp.fallback.pairedMediation.safestSupport.label}</text>` : ''}
-              ${item.recommendation.followUp.fallback?.pairedMediation?.safestSupport?.safetyJustification ? `<text class="atlas-cultural-consolidation-action__support-justification atlas-cultural-consolidation-action__support-justification--${item.recommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.state}" x="67" y="${73.9 + index * 12.9}">sûr car: ${item.recommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.label}</text>` : ''}
+              <text x="67" y="${62.3 + index * 14.3}">${item.cultureName} · ${item.recommendation.label}</text>
+              <text class="atlas-cultural-consolidation-action__reason" x="67" y="${64.1 + index * 14.3}">${item.recommendation.reason}</text>
+              <text class="atlas-cultural-consolidation-action__followup" x="67" y="${65.8 + index * 14.3}">${item.recommendation.followUp.label} · ${item.recommendation.followUp.reason}</text>
+              ${item.recommendation.followUp.fallback ? `<text class="atlas-cultural-consolidation-action__fallback" x="67" y="${67.5 + index * 14.3}">fallback: ${item.recommendation.followUp.fallback.label} · ${item.recommendation.followUp.fallback.reason}</text>` : ''}
+              ${item.recommendation.followUp.fallback?.latestSafeTurn ? `<text class="atlas-cultural-consolidation-action__latest-safe atlas-cultural-consolidation-action__latest-safe--${item.recommendation.followUp.fallback.latestSafeTurn.state}" x="67" y="${69.1 + index * 14.3}">dernier sûr: ${item.recommendation.followUp.fallback.latestSafeTurn.value}</text>` : ''}
+              ${item.recommendation.followUp.fallback?.pairedMediation ? `<text class="atlas-cultural-consolidation-action__paired-mediation atlas-cultural-consolidation-action__paired-mediation--${item.recommendation.followUp.fallback.pairedMediation.state}" x="67" y="${70.7 + index * 14.3}">support: ${item.recommendation.followUp.fallback.pairedMediation.label}</text>` : ''}
+              ${item.recommendation.followUp.fallback?.pairedMediation?.safestSupport ? `<text class="atlas-cultural-consolidation-action__safest-support atlas-cultural-consolidation-action__safest-support--${item.recommendation.followUp.fallback.pairedMediation.safestSupport.state}" x="67" y="${72.3 + index * 14.3}">appui sûr: ${item.recommendation.followUp.fallback.pairedMediation.safestSupport.label}</text>` : ''}
+              ${item.recommendation.followUp.fallback?.pairedMediation?.safestSupport?.safetyJustification ? `<text class="atlas-cultural-consolidation-action__support-justification atlas-cultural-consolidation-action__support-justification--${item.recommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.state}" x="67" y="${73.9 + index * 14.3}">sûr car: ${item.recommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.label}</text>` : ''}
+              ${item.recommendation.followUp.fallback?.pairedMediation?.safestSupport?.safetyJustification?.riskRelief ? `<text class="atlas-cultural-consolidation-action__risk-relief atlas-cultural-consolidation-action__risk-relief--${item.recommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.riskRelief.state}" x="67" y="${75.5 + index * 14.3}">risque retiré: ${item.recommendation.followUp.fallback.pairedMediation.safestSupport.safetyJustification.riskRelief.label}</text>` : ''}
             </g>
           `).join('')}
         </g>

--- a/web/styles.css
+++ b/web/styles.css
@@ -11863,6 +11863,15 @@ button { font: inherit; }
 .atlas-cultural-border-zone__support-justification--window-open { fill: #bfdbfe; }
 .atlas-cultural-border-zone__support-justification--local-trust-sufficient { fill: #bbf7d0; }
 .atlas-cultural-border-zone__support-justification--no-safe-justification { fill: #fca5a5; }
+.atlas-cultural-border-zone__risk-relief {
+  fill: #a7f3d0;
+  font-size: 0.72px;
+  font-weight: 900;
+}
+.atlas-cultural-border-zone__risk-relief--mediation-stabilized { fill: #c4b5fd; }
+.atlas-cultural-border-zone__risk-relief--window-preserved { fill: #bfdbfe; }
+.atlas-cultural-border-zone__risk-relief--border-tension-calmed { fill: #fed7aa; }
+.atlas-cultural-border-zone__risk-relief--local-trust-protected { fill: #bbf7d0; }
 .atlas-cultural-consolidation-actions rect {
   fill: rgba(49, 46, 129, 0.54);
   stroke: rgba(196, 181, 253, 0.38);
@@ -11933,6 +11942,15 @@ button { font: inherit; }
 .atlas-cultural-consolidation-action__support-justification--window-open { fill: #bfdbfe; }
 .atlas-cultural-consolidation-action__support-justification--local-trust-sufficient { fill: #bbf7d0; }
 .atlas-cultural-consolidation-action__support-justification--no-safe-justification { fill: #fca5a5; }
+.atlas-cultural-consolidation-action__risk-relief {
+  fill: #a7f3d0;
+  font-size: 0.73px;
+  font-weight: 900;
+}
+.atlas-cultural-consolidation-action__risk-relief--mediation-stabilized { fill: #c4b5fd; }
+.atlas-cultural-consolidation-action__risk-relief--window-preserved { fill: #bfdbfe; }
+.atlas-cultural-consolidation-action__risk-relief--border-tension-calmed { fill: #fed7aa; }
+.atlas-cultural-consolidation-action__risk-relief--local-trust-protected { fill: #bbf7d0; }
 .atlas-cultural-consolidation-action--fragile .atlas-cultural-consolidation-action__reason { fill: #fde68a; }
 .atlas-cultural-consolidation-action--expiring .atlas-cultural-consolidation-action__reason { fill: #fecdd3; }
 .map-world-climate-post-boost-risk {


### PR DESCRIPTION
Gamma: Résout #901.\n\n- Ajoute un risk relief attaché à la justification de l’appui pairé sûr.\n- Couvre les reliefs médiation stabilisée, fenêtre préservée, tension frontalière calmée et confiance locale protégée.\n- Garde le silence quand la justification sûre manque ou que la fenêtre sûre est absente.\n\nValidation:\n- node --check web/app.js\n- npm test -- test/ui/culture/webCultureWorldMapAtlas.test.js\n- git diff --check\n- npm test (582 tests)