### PR TITLE
Delta: preview low-exposure sweep follow-up

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -548,6 +548,36 @@ test('atlas counterintelligence explains exposure tradeoffs for next safe sweeps
   assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__tradeoff--minimal-exposure-tradeoff/);
 });
 
+test('atlas counterintelligence previews safest follow-up after low-exposure sweeps', () => {
+  const previewFor = (marker, tradeoff) => {
+    if (!marker.shouldRender || !tradeoff.shouldRender) return { state: 'silent-guard', shouldRender: false };
+    if (marker.state === 'wait-for-safe-window') return { state: 'wait-safe-window', shouldRender: true };
+    if (marker.state === 'no-safe-follow-up') return { state: 'no-safe-follow-up', shouldRender: true };
+    if (marker.state === 'refreshes-stale-critical-signal') return { state: 'refresh-critical-signal', shouldRender: true };
+    if (marker.state === 'closes-critical-blind-spot') return { state: 'reduce-residual-gap', shouldRender: true };
+    return { state: 'switch-domain', shouldRender: true };
+  };
+
+  assert.deepEqual(previewFor({ state: 'refreshes-stale-critical-signal', shouldRender: true }, { shouldRender: true }), { state: 'refresh-critical-signal', shouldRender: true });
+  assert.deepEqual(previewFor({ state: 'closes-critical-blind-spot', shouldRender: true }, { shouldRender: true }), { state: 'reduce-residual-gap', shouldRender: true });
+  assert.deepEqual(previewFor({ state: 'wait-for-safe-window', shouldRender: true }, { shouldRender: true }), { state: 'wait-safe-window', shouldRender: true });
+  assert.deepEqual(previewFor({ state: 'lowest-exposure-sweep', shouldRender: true }, { shouldRender: true }), { state: 'switch-domain', shouldRender: true });
+  assert.deepEqual(previewFor({ state: 'no-safe-follow-up', shouldRender: true }, { shouldRender: true }), { state: 'no-safe-follow-up', shouldRender: true });
+  assert.deepEqual(previewFor({ state: 'lowest-exposure-sweep', shouldRender: false }, { shouldRender: true }), { state: 'silent-guard', shouldRender: false });
+  assert.deepEqual(previewFor({ state: 'lowest-exposure-sweep', shouldRender: true }, { shouldRender: false }), { state: 'silent-guard', shouldRender: false });
+  assert.match(webAppSource, /nextSafeSweepFollowUpPreview/);
+  assert.match(webAppSource, /Après sweep bas-risque:/);
+  assert.match(webAppSource, /refresh-critical-signal/);
+  assert.match(webAppSource, /reduce-residual-gap/);
+  assert.match(webAppSource, /wait-safe-window/);
+  assert.match(webAppSource, /switch-domain/);
+  assert.match(webAppSource, /aucun follow-up sûr sans nouveau signal visible/);
+  assert.match(webAppSource, /sans nommer source ni cible/);
+  assert.match(webAppSource, /basculer vers un autre domaine si le gain visible reste marginal/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up/);
+  assert.match(stylesSource, /atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up--switch-domain/);
+});
+
 test('atlas intrigue filters prioritize stale uncertain recent and probable signals safely', () => {
   assert.match(webAppSource, /atlasIntrigueSignalFilters/);
   assert.match(webAppSource, /function getActiveAtlasIntrigueSignalFilters/);

--- a/web/app.js
+++ b/web/app.js
@@ -12723,6 +12723,53 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
       label: 'Tradeoff: choisir l’exposition minimale plutôt qu’un gain de couverture plus spéculatif.',
     };
   })();
+  const nextSafeSweepFollowUpPreview = (() => {
+    if (!nextSafeFollowUpPriorityMarker.shouldRender || !nextSafeSweepExposureTradeoff.shouldRender) {
+      return {
+        state: 'silent-guard',
+        shouldRender: false,
+        label: 'aucun follow-up preview affiché',
+      };
+    }
+
+    if (nextSafeFollowUpPriorityMarker.state === 'wait-for-safe-window') {
+      return {
+        state: 'wait-safe-window',
+        shouldRender: true,
+        label: 'Après sweep bas-risque: attendre la prochaine fenêtre sûre avant tout relais.',
+      };
+    }
+
+    if (nextSafeFollowUpPriorityMarker.state === 'no-safe-follow-up') {
+      return {
+        state: 'no-safe-follow-up',
+        shouldRender: true,
+        label: 'Après sweep bas-risque: aucun follow-up sûr sans nouveau signal visible.',
+      };
+    }
+
+    if (nextSafeFollowUpPriorityMarker.state === 'refreshes-stale-critical-signal') {
+      return {
+        state: 'refresh-critical-signal',
+        shouldRender: true,
+        label: 'Après sweep bas-risque: rafraîchir le signal critique restant, sans nommer source ni cible.',
+      };
+    }
+
+    if (nextSafeFollowUpPriorityMarker.state === 'closes-critical-blind-spot') {
+      return {
+        state: 'reduce-residual-gap',
+        shouldRender: true,
+        label: 'Après sweep bas-risque: réduire le gap résiduel prioritaire avec une passe courte.',
+      };
+    }
+
+    return {
+      state: 'switch-domain',
+      shouldRender: true,
+      label: 'Après sweep bas-risque: basculer vers un autre domaine si le gain visible reste marginal.',
+    };
+  })();
   const postOrderCoverage = {
     coveredOrderZones,
     fragileAssignments,
@@ -12745,6 +12792,7 @@ function buildAtlasCounterintelligenceSweepPlan(signals) {
     bestResweepFollowUpSuggestion,
     nextSafeFollowUpPriorityMarker,
     nextSafeSweepExposureTradeoff,
+    nextSafeSweepFollowUpPreview,
     summary: postOrderCoverageSummary,
   };
   const exposureCooldownSummary = sweepCandidates.length > 0
@@ -12889,6 +12937,7 @@ function renderAtlasCounterintelligenceSweepPlan(plan) {
           <small class="atlas-counterintelligence-best-resweep-gap-warning__follow-up atlas-counterintelligence-best-resweep-gap-warning__follow-up--${plan.postOrderCoverage.bestResweepFollowUpSuggestion.state}"><b>Follow-up:</b> ${plan.postOrderCoverage.bestResweepFollowUpSuggestion.label} · ${plan.postOrderCoverage.bestResweepFollowUpSuggestion.copy}</small>
           ${plan.postOrderCoverage.nextSafeFollowUpPriorityMarker.shouldRender ? `<small class="atlas-counterintelligence-best-resweep-gap-warning__next-safe atlas-counterintelligence-best-resweep-gap-warning__next-safe--${plan.postOrderCoverage.nextSafeFollowUpPriorityMarker.state}"><b>Next safe sweep:</b> ${plan.postOrderCoverage.nextSafeFollowUpPriorityMarker.label}</small>` : ''}
           ${plan.postOrderCoverage.nextSafeSweepExposureTradeoff.shouldRender ? `<small class="atlas-counterintelligence-best-resweep-gap-warning__tradeoff atlas-counterintelligence-best-resweep-gap-warning__tradeoff--${plan.postOrderCoverage.nextSafeSweepExposureTradeoff.state}"><b>Tradeoff exposition:</b> ${plan.postOrderCoverage.nextSafeSweepExposureTradeoff.label}</small>` : ''}
+          ${plan.postOrderCoverage.nextSafeSweepFollowUpPreview.shouldRender ? `<small class="atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up--${plan.postOrderCoverage.nextSafeSweepFollowUpPreview.state}"><b>Après sweep bas-risque:</b> ${plan.postOrderCoverage.nextSafeSweepFollowUpPreview.label}</small>` : ''}
         </aside>
       </section>
       <section class="atlas-counterintelligence-schedule-conflicts" aria-label="Conflits de calendrier contre-espionnage fog-safe">

--- a/web/styles.css
+++ b/web/styles.css
@@ -3404,6 +3404,15 @@ button { font: inherit; }
 .atlas-counterintelligence-best-resweep-gap-warning__tradeoff--minimal-exposure-tradeoff { color: #bbf7d0; }
 .atlas-counterintelligence-best-resweep-gap-warning__tradeoff--wait-required,
 .atlas-counterintelligence-best-resweep-gap-warning__tradeoff--no-safe-tradeoff { color: #cbd5e1; }
+.atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up {
+  padding-top: 2px;
+  color: #ccfbf1;
+}
+.atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up--refresh-critical-signal { color: #fde68a; }
+.atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up--reduce-residual-gap { color: #fecaca; }
+.atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up--switch-domain { color: #bfdbfe; }
+.atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up--wait-safe-window,
+.atlas-counterintelligence-best-resweep-gap-warning__low-exposure-follow-up--no-safe-follow-up { color: #cbd5e1; }
 .atlas-counterintelligence-schedule-conflicts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Delta: Implements #902.

Summary:
- adds a compact low-exposure follow-up preview after the D17/D18 next-safe-sweep/tradeoff lines
- covers refresh-critical-signal, reduce-residual-gap, wait-safe-window, switch-domain, no-safe-follow-up, and silent guard states
- keeps the preview deterministic and fog-safe without exposing actors, relays, targets, hidden causes, or hidden probabilities

Validation:
- node --check web/app.js
- npm test -- test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- npm test
- git diff --check