### PR TITLE
Gamma: bundle cultural support tradeoffs

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -292,6 +292,76 @@ function buildZoneContour(influenceTier, overlapCount, zoneRank) {
   };
 }
 
+function buildCultureSupportBundles(culture, regionId, regionPresence, cultureState) {
+  const underBorderPressure = regionPresence.some((entry) => entry.cultureId !== culture.id && entry.influenceScore >= cultureState.influenceScore);
+  const needsSupport = culture.cohesion < 50
+    || (culture.openness < 45 && cultureState.signals.activeResearchCount > 0)
+    || (underBorderPressure && culture.cohesion < 50);
+
+  if (!needsSupport) {
+    return [];
+  }
+
+  const bundles = [];
+  const hasDiscovery = cultureState.signals.highlightedDiscoveries.length > 0;
+  const hasActiveResearch = cultureState.signals.activeResearchCount > 0;
+  const hasEvents = cultureState.signals.eventCount > 0;
+  const identityTag = cultureState.signals.identityTags[0] ?? 'identity-anchor';
+  const discoveryId = cultureState.signals.highlightedDiscoveries[0] ?? 'known-discovery';
+  const researchId = cultureState.signals.unlockedResearchIds[0] ?? 'research-track';
+  const rivalCultureIds = regionPresence
+    .filter((entry) => entry.cultureId !== culture.id)
+    .map((entry) => entry.cultureId)
+    .sort();
+
+  if (culture.cohesion < 50) {
+    bundles.push({
+      id: `${regionId}:${culture.id}:bundle:cohesion-anchor`,
+      label: 'ancrer cohésion locale',
+      actionIds: [`identity:${identityTag}`, hasEvents ? 'event:mediate-public-memory' : 'ritual:local-assembly'],
+      actionKeys: ['protect-identity', hasEvents ? 'mediate-event-memory' : 'local-assembly'],
+      expectedBenefit: 'réduit la fragmentation visible avant soutien externe',
+      tradeoff: 'cohésion + / ouverture -',
+      riskReduced: 'fragmentation culturelle',
+      reason: `cohésion ${culture.cohesion} · ${identityTag}`,
+      priority: 4,
+    });
+  }
+
+  if (culture.openness < 45 && (hasDiscovery || hasActiveResearch)) {
+    bundles.push({
+      id: `${regionId}:${culture.id}:bundle:guided-opening`,
+      label: 'ouvrir par relais savant',
+      actionIds: [`discovery:${discoveryId}`, `research:${researchId}`],
+      actionKeys: ['share-discovery', 'pace-research'],
+      expectedBenefit: 'garde l’ouverture lisible sans casser les repères locaux',
+      tradeoff: 'ouverture + / cohésion sous surveillance',
+      riskReduced: 'isolement du support',
+      reason: `ouverture ${culture.openness} · ${discoveryId}`,
+      priority: 3,
+    });
+  }
+
+  if (rivalCultureIds.length > 0) {
+    bundles.push({
+      id: `${regionId}:${culture.id}:bundle:border-compromise`,
+      label: 'composer avec influence voisine',
+      actionIds: ['border:shared-mediation', `culture:${rivalCultureIds[0]}`],
+      actionKeys: ['shared-mediation', 'limit-border-pressure'],
+      expectedBenefit: 'absorbe la pression voisine sans promettre une dominance immédiate',
+      tradeoff: 'ouverture + / recherche ralentie',
+      riskReduced: 'pression frontalière',
+      reason: `voisin ${rivalCultureIds[0]}`,
+      priority: 2,
+    });
+  }
+
+  return bundles
+    .sort((left, right) => right.priority - left.priority || left.id.localeCompare(right.id))
+    .slice(0, 2)
+    .map(({ priority, ...bundle }) => bundle);
+}
+
 function buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById) {
   const cultureIds = regionPresence.map((entry) => entry.cultureId).sort();
   const cultureNames = regionPresence.map((entry) => entry.cultureName).sort();
@@ -401,6 +471,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
         const clusterSummary = includeClusterSummaries && overlapCount > 1
           ? buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById)
           : null;
+        const supportBundles = buildCultureSupportBundles(culture, regionId, regionPresence, cultureState);
 
         const regionalDiscoveryLinks = cultureState.signals.highlightedDiscoveries.map((discoveryId) => {
           const linkedEvents = cultureState.signals.orderedHistoricalEvents.filter((historicalEvent) => historicalEvent.discoveryIds.includes(discoveryId));
@@ -466,6 +537,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           zoneBand,
           dominantInRegion: dominantCulture?.cultureId === culture.id,
           competingCultureIds: regionPresence.filter((entry) => entry.cultureId !== culture.id).map((entry) => entry.cultureId),
+          ...(supportBundles.length > 0 ? { supportBundles } : {}),
           ...(clusterSummary ? { clusterSummary } : {}),
           zoneContour: buildZoneContour(cultureState.influenceTier, overlapCount, zoneRank),
           style,

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -614,6 +614,105 @@ test('buildCultureMapOverlay supports plain payloads and style overrides', () =>
   assert.equal(overlay[0].zoneStyle.glow, 'sparking');
 });
 
+test('buildCultureMapOverlay bundles compatible supports for fragile cultural regions', () => {
+  const overlay = buildCultureMapOverlay(
+    {
+      cultures: [
+        {
+          id: 'culture-marsh',
+          name: 'Marsh Houses',
+          archetype: 'riverine',
+          primaryLanguage: 'marsh-cant',
+          valueIds: ['oaths'],
+          traditionIds: ['reed-courts'],
+          openness: 38,
+          cohesion: 34,
+          researchDrive: 64,
+        },
+        {
+          id: 'culture-hill',
+          name: 'Hill Compact',
+          archetype: 'highland',
+          primaryLanguage: 'hill-speech',
+          valueIds: ['trade'],
+          traditionIds: ['beacons'],
+          openness: 61,
+          cohesion: 66,
+          researchDrive: 58,
+        },
+        {
+          id: 'culture-stable',
+          name: 'Stable Guilds',
+          archetype: 'urban',
+          primaryLanguage: 'guild-tongue',
+          valueIds: ['craft'],
+          traditionIds: ['charters'],
+          openness: 58,
+          cohesion: 72,
+          researchDrive: 62,
+        },
+      ],
+      researchStates: [
+        {
+          id: 'research-marsh-couriers',
+          cultureId: 'culture-marsh',
+          topicId: 'reed-couriers',
+          status: 'active',
+          progress: 44,
+          discoveredConceptIds: ['reed-routes'],
+        },
+      ],
+      historicalEvents: [
+        {
+          id: 'event-marsh-accord',
+          title: 'Marsh Accord',
+          category: 'diplomacy',
+          summary: 'Border delegates reopen a contested ferry.',
+          era: 'map-play',
+          importance: 3,
+          triggeredAt: '2026-05-13T00:00:00.000Z',
+          affectedCultureIds: ['culture-marsh'],
+          discoveryIds: ['ferry-charter'],
+        },
+      ],
+    },
+    {
+      regionIdsByCulture: {
+        'culture-marsh': ['shared-marsh'],
+        'culture-hill': ['shared-marsh'],
+        'culture-stable': ['stable-market'],
+      },
+    },
+  );
+
+  const marsh = overlay.find((entry) => entry.cultureId === 'culture-marsh');
+  const stable = overlay.find((entry) => entry.cultureId === 'culture-stable');
+
+  assert.deepEqual(marsh.supportBundles, [
+    {
+      id: 'shared-marsh:culture-marsh:bundle:cohesion-anchor',
+      label: 'ancrer cohésion locale',
+      actionIds: ['identity:oaths', 'event:mediate-public-memory'],
+      actionKeys: ['protect-identity', 'mediate-event-memory'],
+      expectedBenefit: 'réduit la fragmentation visible avant soutien externe',
+      tradeoff: 'cohésion + / ouverture -',
+      riskReduced: 'fragmentation culturelle',
+      reason: 'cohésion 34 · oaths',
+    },
+    {
+      id: 'shared-marsh:culture-marsh:bundle:guided-opening',
+      label: 'ouvrir par relais savant',
+      actionIds: ['discovery:ferry-charter', 'research:reed-couriers'],
+      actionKeys: ['share-discovery', 'pace-research'],
+      expectedBenefit: 'garde l’ouverture lisible sans casser les repères locaux',
+      tradeoff: 'ouverture + / cohésion sous surveillance',
+      riskReduced: 'isolement du support',
+      reason: 'ouverture 38 · ferry-charter',
+    },
+  ]);
+  assert.deepEqual(stable.supportBundles, undefined);
+});
+
 test('buildCultureMapOverlay can summarize overlapping culture clusters with discovery and event pins', () => {
   const overlay = buildCultureMapOverlay(
     {


### PR DESCRIPTION
Gamma: Résout #911.\n\n- Ajoute des supportBundles déterministes pour les régions culturelles fragiles.\n- Chaque paquet expose id, label, actionIds/actionKeys, bénéfice attendu, tradeoff, risque réduit et raison.\n- Les cultures sans besoin de support restent silencieuses.\n\nValidation:\n- node --check src/ui/culture/buildCultureMapOverlay.js\n- npm test -- test/ui/culture/buildCultureMapOverlay.test.js\n- git diff --check\n- npm test (585 tests)