### PR TITLE
Epsilon: project climate recovery plan

### DIFF
--- a/test/ui/climate/webAtlasClimateRecoveryPlanProjection.test.js
+++ b/test/ui/climate/webAtlasClimateRecoveryPlanProjection.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const projectionSignals = [
+  ['deadline moins serrée', 'deadline à surveiller'],
+  ['capacité régionale libérée', 'cascade évitée à confirmer'],
+  ['exposition réduite', 'exposition résiduelle'],
+  ['aucun relief sûr', 'risque accepté sans relief sûr'],
+];
+
+test('atlas projects the climate recovery plan before and after with stable remaining risks', () => {
+  assert.match(webAppSource, /function buildAtlasClimateRecoveryPlanProjection/);
+  assert.match(webAppSource, /function renderAtlasClimateRecoveryPlanProjection/);
+  assert.match(webAppSource, /state: 'neutral'/);
+  assert.match(webAppSource, /Aucune projection recovery climat: aucune anomalie, catastrophe ou action recovery active/);
+  assert.match(webAppSource, /currentState/);
+  assert.match(webAppSource, /proposedActions/);
+  assert.match(webAppSource, /projectedState/);
+  assert.match(webAppSource, /firstPressureRelieved/);
+  assert.match(webAppSource, /remainingRiskCandidates/);
+  assert.match(webAppSource, /sort\(\(left, right\) => left\.priority - right\.priority \|\| left\.label\.localeCompare\(right\.label\)\)/);
+  assert.match(webAppSource, /atlasClimateRecoveryPlanProjection = buildAtlasClimateRecoveryPlanProjection\(atlasClimateFirstRecoveryPressureReliefExplanation, atlasClimateRecoveryCollateralReliefRanking\)/);
+  assert.match(webAppSource, /renderAtlasClimateRecoveryPlanProjection\(atlasClimateRecoveryPlanProjection\)/);
+
+  for (const [relief, remainingRisk] of projectionSignals) {
+    assert.match(webAppSource, new RegExp(relief));
+    assert.match(webAppSource, new RegExp(remainingRisk));
+  }
+
+  assert.match(webAppSource, /Projection recovery/);
+  assert.match(webAppSource, /Risques restants/);
+  assert.match(stylesSource, /\.map-world-climate-recovery-projection/);
+  assert.match(stylesSource, /\.map-world-climate-recovery-projection--projected-with-risk/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -8732,6 +8732,66 @@ function renderAtlasClimateFirstRecoveryPressureReliefExplanation(view) {
   `;
 }
 
+function buildAtlasClimateRecoveryPlanProjection(firstReliefView, recoveryRankingView) {
+  if (!firstReliefView || firstReliefView.state === 'empty' || !firstReliefView.explanation) {
+    return {
+      state: 'neutral',
+      projection: null,
+      remainingRisks: [],
+      summary: 'Aucune projection recovery climat: aucune anomalie, catastrophe ou action recovery active à projeter.',
+    };
+  }
+
+  const relief = firstReliefView.explanation;
+  const topAction = recoveryRankingView?.rankedActions?.[0] ?? { label: relief.actionLabel, type: relief.actionType, rationale: 'Action recovery issue du relief principal.' };
+  const remainingRiskCandidates = [
+    { key: 'deadline-monitoring', label: 'deadline à surveiller', priority: relief.indicator === 'deadline moins serrée' ? 3 : 1 },
+    { key: 'cascade-watch', label: 'cascade évitée à confirmer', priority: relief.indicator === 'capacité régionale libérée' ? 1 : 2 },
+    { key: 'exposure-tail', label: 'exposition résiduelle', priority: relief.indicator === 'exposition réduite' ? 3 : 2 },
+    { key: 'accepted-risk', label: 'risque accepté sans relief sûr', priority: relief.indicator === 'aucun relief sûr' ? 0 : 4 },
+  ]
+    .filter((risk) => risk.priority < 4)
+    .sort((left, right) => left.priority - right.priority || left.label.localeCompare(right.label));
+
+  return {
+    state: firstReliefView.state === 'no-safe-relief' ? 'projected-with-risk' : 'projected',
+    projection: {
+      provinceId: relief.provinceId,
+      provinceLabel: relief.provinceLabel,
+      deadline: relief.deadline,
+      currentState: `Avant: ${relief.deadline}, pression recovery encore active.`,
+      proposedActions: [`${topAction.label} (${topAction.type})`],
+      projectedState: `Après: ${relief.indicator}; ${relief.firstVisibleRelief}`,
+      firstPressureRelieved: relief.indicator,
+      sourceScore: relief.reliefScore,
+      tiebreaker: relief.tiebreaker,
+    },
+    remainingRisks: remainingRiskCandidates,
+    summary: `${relief.provinceLabel}: projection avant/après courte avec ${relief.indicator} en premier relief et ${remainingRiskCandidates.length} risque${remainingRiskCandidates.length > 1 ? 's' : ''} restant${remainingRiskCandidates.length > 1 ? 's' : ''} trié${remainingRiskCandidates.length > 1 ? 's' : ''}.`,
+  };
+}
+
+function renderAtlasClimateRecoveryPlanProjection(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'neutral' || !view.projection) {
+    return '';
+  }
+
+  return `
+    <aside class="map-world-climate-recovery-projection map-world-climate-recovery-projection--${view.state}" aria-label="Projection avant après du plan recovery climat">
+      <div class="map-world-climate-recovery-projection__header">
+        <strong>Projection recovery</strong>
+        <span>${view.projection.firstPressureRelieved}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Avant</b> · ${view.projection.currentState}</small>
+      <small><b>Action proposée</b> · ${view.projection.proposedActions.join(' · ')}</small>
+      <small><b>Après</b> · ${view.projection.projectedState}</small>
+      <small><b>Risques restants</b> · ${view.remainingRisks.map((risk) => risk.label).join(' → ')}</small>
+      <small><b>Score source</b> · ${view.projection.sourceScore}, tie-break ${view.projection.tiebreaker}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -16502,6 +16562,7 @@ function render() {
   const atlasClimateDeadlineRecoveryAction = buildAtlasClimateDeadlineRecoveryAction(atlasClimateMinimumBoostDeadlineMissWarning);
   const atlasClimateRecoveryCollateralReliefRanking = buildAtlasClimateRecoveryCollateralReliefRanking(atlasClimateDeadlineRecoveryAction);
   const atlasClimateFirstRecoveryPressureReliefExplanation = buildAtlasClimateFirstRecoveryPressureReliefExplanation(atlasClimateRecoveryCollateralReliefRanking);
+  const atlasClimateRecoveryPlanProjection = buildAtlasClimateRecoveryPlanProjection(atlasClimateFirstRecoveryPressureReliefExplanation, atlasClimateRecoveryCollateralReliefRanking);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -16549,6 +16610,7 @@ function render() {
           ${renderAtlasClimateDeadlineRecoveryAction(atlasClimateDeadlineRecoveryAction)}
           ${renderAtlasClimateRecoveryCollateralReliefRanking(atlasClimateRecoveryCollateralReliefRanking)}
           ${renderAtlasClimateFirstRecoveryPressureReliefExplanation(atlasClimateFirstRecoveryPressureReliefExplanation)}
+          ${renderAtlasClimateRecoveryPlanProjection(atlasClimateRecoveryPlanProjection)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12177,3 +12177,28 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+.map-world-climate-recovery-projection {
+  display: grid;
+  gap: 6px;
+  max-width: 56ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.78), rgba(21, 94, 117, 0.26));
+  border: 1px solid rgba(56, 189, 248, 0.44);
+}
+.map-world-climate-recovery-projection--projected-with-risk { border-color: rgba(251, 146, 60, 0.52); }
+.map-world-climate-recovery-projection__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-recovery-projection p,
+.map-world-climate-recovery-projection span,
+.map-world-climate-recovery-projection small {
+  color: #e0f2fe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}


### PR DESCRIPTION
Epsilon: Couvre #913.

Résumé:
- ajoute une projection avant/après courte du plan recovery climat dérivée du premier relief visible E19;
- expose une structure testable avec `currentState`, `proposedActions`, `projectedState`, `firstPressureRelieved` et risques restants;
- garde un état neutre clair sans action/anomalie/catastrophe recovery active et trie les risques restants de façon stable.

Validation:
- `node --check web/app.js`
- `node --test test/ui/climate/webAtlasClimateRecoveryPlanProjection.test.js test/ui/climate/webAtlasClimateFirstRecoveryPressureReliefExplanation.test.js`
- `git diff --check`
- `npm test` (585 tests OK)

Merci de valider avant tout merge.