### PR TITLE
Beta: preview corridor unlock capacity spend

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -92,6 +92,88 @@ function buildCityMarker(city, cityPositionById) {
   };
 }
 
+function normalizeCapacitySpendPlan(plan, routeId) {
+  if (plan === undefined || plan === null) {
+    return {
+      routeId,
+      capacityMobilized: 0,
+      mobilizedByResource: {},
+      limitingResourceId: null,
+    };
+  }
+
+  const normalizedPlan = requireObject(plan, `EconomyMapOverlay capacity spend preview ${routeId}`);
+  const mobilizedByResource = Object.fromEntries(
+    Object.entries(requireObject(normalizedPlan.mobilizedByResource ?? {}, `EconomyMapOverlay mobilizedByResource ${routeId}`))
+      .map(([resourceId, capacity]) => {
+        const normalizedResourceId = String(resourceId).trim();
+
+        if (!normalizedResourceId) {
+          throw new RangeError('EconomyMapOverlay mobilizedByResource cannot contain an empty resource id.');
+        }
+
+        if (!Number.isInteger(capacity) || capacity < 0) {
+          throw new RangeError('EconomyMapOverlay mobilized capacity must be an integer greater than or equal to 0.');
+        }
+
+        return [normalizedResourceId, capacity];
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+  const mobilizedTotal = Object.values(mobilizedByResource).reduce((sum, capacity) => sum + capacity, 0);
+  const fallbackMobilized = normalizedPlan.capacityMobilized ?? mobilizedTotal;
+
+  if (!Number.isInteger(fallbackMobilized) || fallbackMobilized < 0) {
+    throw new RangeError('EconomyMapOverlay capacityMobilized must be an integer greater than or equal to 0.');
+  }
+
+  return {
+    routeId,
+    capacityMobilized: mobilizedTotal > 0 ? mobilizedTotal : fallbackMobilized,
+    mobilizedByResource,
+    limitingResourceId: normalizedPlan.limitingResourceId === undefined || normalizedPlan.limitingResourceId === null
+      ? null
+      : String(normalizedPlan.limitingResourceId).trim() || null,
+  };
+}
+
+function buildCapacitySpendPreview(route, spendPlan) {
+  const currentCapacity = route.totalCapacity;
+  const capacityMobilized = Math.min(spendPlan.capacityMobilized, currentCapacity);
+  const capacityRemaining = Math.max(0, currentCapacity - capacityMobilized);
+  const resourceRows = Object.entries(route.capacityByResource)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([resourceId, capacity]) => {
+      const mobilized = Math.min(spendPlan.mobilizedByResource[resourceId] ?? 0, capacity);
+
+      return {
+        resourceId,
+        currentCapacity: capacity,
+        capacityMobilized: mobilized,
+        capacityRemaining: capacity - mobilized,
+      };
+    });
+  const computedLimitingResourceId = spendPlan.limitingResourceId
+    ?? resourceRows
+      .filter((row) => row.capacityMobilized > 0)
+      .sort((left, right) => left.capacityRemaining - right.capacityRemaining || left.resourceId.localeCompare(right.resourceId))[0]?.resourceId
+    ?? null;
+
+  return {
+    routeId: route.id,
+    currentCapacity,
+    capacityMobilized,
+    capacityRemaining,
+    limitingResourceId: computedLimitingResourceId,
+    state: capacityMobilized === 0
+      ? 'no-spend'
+      : capacityRemaining === 0
+        ? 'fully-spent'
+        : 'remaining-margin',
+    resources: resourceRows,
+  };
+}
+
 function normalizeRouteStyle(route, styleByTransportMode) {
   const style = route.active
     ? (styleByTransportMode[route.transportMode] ?? styleByTransportMode.default ?? DEFAULT_ROUTE_STYLE_BY_MODE.default)
@@ -114,6 +196,10 @@ export function buildEconomyMapOverlay(cities, routes, options = {}) {
     ...DEFAULT_ROUTE_STYLE_BY_MODE,
     ...requireObject(normalizedOptions.styleByTransportMode ?? {}, 'EconomyMapOverlay styleByTransportMode'),
   };
+  const recommendedUnlockByRouteId = requireObject(
+    normalizedOptions.recommendedUnlockByRouteId ?? {},
+    'EconomyMapOverlay recommendedUnlockByRouteId',
+  );
 
   const cityOverlays = normalizedCities
     .slice()
@@ -141,24 +227,29 @@ export function buildEconomyMapOverlay(cities, routes, options = {}) {
   const routeOverlays = normalizedRoutes
     .slice()
     .sort((left, right) => left.id.localeCompare(right.id))
-    .map((route) => ({
-      overlayId: `route:${route.id}`,
-      type: 'route',
-      routeId: route.id,
-      routeName: route.name,
-      cityIds: [...route.stopCityIds],
-      originCityId: route.originCityId,
-      destinationCityId: route.destinationCityId,
-      active: route.active,
-      transportMode: route.transportMode,
-      riskLevel: route.riskLevel,
-      totalCapacity: route.totalCapacity,
-      resources: Object.entries(route.capacityByResource)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([resourceId, capacity]) => ({ resourceId, capacity })),
-      label: `${route.name} (${route.transportMode})`,
-      style: normalizeRouteStyle(route, styleByTransportMode),
-    }));
+    .map((route) => {
+      const capacitySpendPlan = normalizeCapacitySpendPlan(recommendedUnlockByRouteId[route.id], route.id);
+
+      return {
+        overlayId: `route:${route.id}`,
+        type: 'route',
+        routeId: route.id,
+        routeName: route.name,
+        cityIds: [...route.stopCityIds],
+        originCityId: route.originCityId,
+        destinationCityId: route.destinationCityId,
+        active: route.active,
+        transportMode: route.transportMode,
+        riskLevel: route.riskLevel,
+        totalCapacity: route.totalCapacity,
+        resources: Object.entries(route.capacityByResource)
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([resourceId, capacity]) => ({ resourceId, capacity })),
+        capacitySpendPreview: buildCapacitySpendPreview(route, capacitySpendPlan),
+        label: `${route.name} (${route.transportMode})`,
+        style: normalizeRouteStyle(route, styleByTransportMode),
+      };
+    });
 
   return {
     title: 'Carte économie et logistique',

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -144,6 +144,17 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
       resources: [
         { resourceId: 'wood', capacity: 3 },
       ],
+      capacitySpendPreview: {
+        routeId: 'route-coast',
+        currentCapacity: 3,
+        capacityMobilized: 0,
+        capacityRemaining: 3,
+        limitingResourceId: null,
+        state: 'no-spend',
+        resources: [
+          { resourceId: 'wood', currentCapacity: 3, capacityMobilized: 0, capacityRemaining: 3 },
+        ],
+      },
       label: 'Coast Caravan (land)',
       style: {
         stroke: 'slate',
@@ -168,6 +179,18 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         { resourceId: 'fish', capacity: 4 },
         { resourceId: 'grain', capacity: 7 },
       ],
+      capacitySpendPreview: {
+        routeId: 'route-river',
+        currentCapacity: 11,
+        capacityMobilized: 0,
+        capacityRemaining: 11,
+        limitingResourceId: null,
+        state: 'no-spend',
+        resources: [
+          { resourceId: 'fish', currentCapacity: 4, capacityMobilized: 0, capacityRemaining: 4 },
+          { resourceId: 'grain', currentCapacity: 7, capacityMobilized: 0, capacityRemaining: 7 },
+        ],
+      },
       label: 'River Run (river)',
       style: {
         stroke: 'blue',
@@ -220,6 +243,62 @@ test('buildEconomyMapOverlay supports plain payloads and style overrides', () =>
     opacity: 0.7,
   });
   assert.equal(overlay.cities[0].resources.primaryResourceId, 'salt');
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview, {
+    routeId: 'route-sea',
+    currentCapacity: 9,
+    capacityMobilized: 0,
+    capacityRemaining: 9,
+    limitingResourceId: null,
+    state: 'no-spend',
+    resources: [
+      { resourceId: 'salt', currentCapacity: 9, capacityMobilized: 0, capacityRemaining: 9 },
+    ],
+  });
+});
+
+test('buildEconomyMapOverlay previews capacity spent by recommended unlocks', () => {
+  const overlay = buildEconomyMapOverlay([], [
+    {
+      id: 'route-bread',
+      name: 'Bread Road',
+      stopCityIds: ['city-a', 'city-b'],
+      distance: 3,
+      capacityByResource: { grain: 5, tools: 2 },
+      transportMode: 'land',
+      riskLevel: 20,
+    },
+    {
+      id: 'route-clear',
+      name: 'Clear Road',
+      stopCityIds: ['city-b', 'city-c'],
+      distance: 4,
+      capacityByResource: { wood: 4 },
+      transportMode: 'land',
+      riskLevel: 10,
+    },
+  ], {
+    recommendedUnlockByRouteId: {
+      'route-bread': {
+        mobilizedByResource: { grain: 4, tools: 1 },
+      },
+    },
+  });
+
+  assert.deepEqual(overlay.routes.map((route) => route.routeId), ['route-bread', 'route-clear']);
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview, {
+    routeId: 'route-bread',
+    currentCapacity: 7,
+    capacityMobilized: 5,
+    capacityRemaining: 2,
+    limitingResourceId: 'grain',
+    state: 'remaining-margin',
+    resources: [
+      { resourceId: 'grain', currentCapacity: 5, capacityMobilized: 4, capacityRemaining: 1 },
+      { resourceId: 'tools', currentCapacity: 2, capacityMobilized: 1, capacityRemaining: 1 },
+    ],
+  });
+  assert.equal(overlay.routes[1].capacitySpendPreview.limitingResourceId, null);
+  assert.equal(overlay.routes[1].capacitySpendPreview.state, 'no-spend');
 });
 
 test('buildEconomyMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
Beta: Implements #910.

## Summary
- Adds structured `capacitySpendPreview` data to economy map route overlays.
- Shows current route capacity, capacity mobilized by the recommended unlock, remaining margin, and limiting resource.
- Keeps routes sorted stably and returns a readable unconstrained state with `limitingResourceId: null` / `state: no-spend`.
- Derives the preview from existing route capacity data plus explicit recommended unlock inputs.

## Validation
- node --check src/ui/economy/buildEconomyMapOverlay.js
- git diff --check origin/main...HEAD
- npm test -- test/ui/economy/buildEconomyMapOverlay.test.js (4 OK)
- npm test (587 OK)
