### PR TITLE
Delta: preview low-exposure sweep confidence

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -91,6 +91,45 @@ function buildSabotageThreatScore(operation) {
   return clampPercent((operation.progress + operation.heat + (100 - operation.detectionRisk)) / 3);
 }
 
+function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount, sleeperCellCount, sabotageRiskScore }) {
+  if (celluleCount <= 0 || sabotageRiskScore <= 0 || exposedCellCount >= celluleCount) {
+    return {
+      state: 'neutral',
+      recommended: false,
+      coverageBefore: 0,
+      coverageAfter: 0,
+      confidenceDelta: 0,
+      exposureAdded: 0,
+      unknownsRemaining: Math.max(0, celluleCount - exposedCellCount),
+      summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
+    };
+  }
+
+  const coverageBefore = clampPercent((exposedCellCount / celluleCount) * 100);
+  const safeGain = sleeperCellCount > 0 ? 18 : 28;
+  const riskAdjustment = sabotageRiskScore >= 70 ? 8 : sabotageRiskScore >= 35 ? 5 : 3;
+  const coverageAfter = clampPercent(Math.min(95, coverageBefore + safeGain + riskAdjustment));
+  const confidenceDelta = Math.max(0, coverageAfter - coverageBefore);
+  const exposureAdded = clampPercent(4 + sleeperCellCount * 3 + (sabotageRiskScore >= 70 ? 5 : sabotageRiskScore >= 35 ? 3 : 1));
+  const unknownsRemaining = Math.max(0, celluleCount - exposedCellCount - (confidenceDelta >= 30 ? 2 : 1));
+  const state = exposureAdded <= 8
+    ? 'low-exposure-positive'
+    : exposureAdded < 12
+      ? 'guarded-positive'
+      : 'watch-exposure';
+
+  return {
+    state,
+    recommended: true,
+    coverageBefore,
+    coverageAfter,
+    confidenceDelta,
+    exposureAdded,
+    unknownsRemaining,
+    summary: `Confiance +${confidenceDelta} pts pour +${exposureAdded} exposition; ${unknownsRemaining} inconnue${unknownsRemaining > 1 ? 's' : ''} restante${unknownsRemaining > 1 ? 's' : ''}.`,
+  };
+}
+
 function normalizeStyle(styleMap, key, defaults) {
   const style = styleMap[key] ?? styleMap.default ?? defaults[key] ?? defaults.none;
   const fallback = defaults[key] ?? defaults.none;
@@ -155,6 +194,13 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
       const sleeperCellCount = locationCellules.filter((cellule) => cellule.sleeper).length;
       const locationName = String(locationNames[locationId] ?? locationId).trim() || locationId;
 
+      const lowExposureSweepConfidencePreview = buildLowExposureSweepConfidencePreview({
+        celluleCount: locationCellules.length,
+        exposedCellCount,
+        sleeperCellCount,
+        sabotageRiskScore,
+      });
+
       return {
         overlayId: `intrigue:${locationId}`,
         locationId,
@@ -171,6 +217,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           sleeperCellCount,
           sabotageOperationCount: locationOperations.length,
         },
+        lowExposureSweepConfidencePreview,
         style: {
           presence: normalizeStyle(styleByPresence, presenceLevel, DEFAULT_STYLE_BY_PRESENCE),
           risk: normalizeStyle(styleByRisk, riskLevel, DEFAULT_STYLE_BY_RISK),

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -124,6 +124,16 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
         sleeperCellCount: 1,
         sabotageOperationCount: 1,
       },
+      lowExposureSweepConfidencePreview: {
+        state: 'guarded-positive',
+        recommended: true,
+        coverageBefore: 50,
+        coverageAfter: 73,
+        confidenceDelta: 23,
+        exposureAdded: 10,
+        unknownsRemaining: 0,
+        summary: 'Confiance +23 pts pour +10 exposition; 0 inconnue restante.',
+      },
       style: {
         presence: {
           marker: '◑',
@@ -152,6 +162,16 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
         exposedCellCount: 0,
         sleeperCellCount: 0,
         sabotageOperationCount: 1,
+      },
+      lowExposureSweepConfidencePreview: {
+        state: 'low-exposure-positive',
+        recommended: true,
+        coverageBefore: 0,
+        coverageAfter: 31,
+        confidenceDelta: 31,
+        exposureAdded: 5,
+        unknownsRemaining: 0,
+        summary: 'Confiance +31 pts pour +5 exposition; 0 inconnue restante.',
       },
       style: {
         presence: {
@@ -218,6 +238,88 @@ test('buildIntrigueMapOverlay supports plain payloads and style overrides', () =
       emphasis: 'critical',
     },
   });
+});
+
+test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and neutral states', () => {
+  const overlay = buildIntrigueMapOverlay([
+    {
+      id: 'cell-covered',
+      factionId: 'shadow-league',
+      codename: 'Covered',
+      locationId: 'covered',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 80,
+    },
+    {
+      id: 'cell-hot-1',
+      factionId: 'shadow-league',
+      codename: 'Hot one',
+      locationId: 'hot',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      sleeper: true,
+      exposure: 20,
+    },
+    {
+      id: 'cell-hot-2',
+      factionId: 'shadow-league',
+      codename: 'Hot two',
+      locationId: 'hot',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      exposure: 20,
+    },
+  ], [
+    {
+      id: 'op-covered',
+      celluleId: 'cell-covered',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe visible route',
+      theaterId: 'covered',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 80,
+      progress: 0,
+      heat: 0,
+    },
+    {
+      id: 'op-hot',
+      celluleId: 'cell-hot-1',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Mask hot cache',
+      theaterId: 'hot',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 5,
+      progress: 100,
+      heat: 100,
+    },
+  ]);
+
+  const covered = overlay.find((entry) => entry.locationId === 'covered');
+  const hot = overlay.find((entry) => entry.locationId === 'hot');
+
+  assert.deepEqual(covered.lowExposureSweepConfidencePreview, {
+    state: 'neutral',
+    recommended: false,
+    coverageBefore: 0,
+    coverageAfter: 0,
+    confidenceDelta: 0,
+    exposureAdded: 0,
+    unknownsRemaining: 0,
+    summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
+  });
+  assert.equal(hot.lowExposureSweepConfidencePreview.state, 'watch-exposure');
+  assert.equal(hot.lowExposureSweepConfidencePreview.recommended, true);
+  assert.equal(hot.lowExposureSweepConfidencePreview.coverageBefore, 0);
+  assert.equal(hot.lowExposureSweepConfidencePreview.coverageAfter, 26);
+  assert.equal(hot.lowExposureSweepConfidencePreview.confidenceDelta, 26);
+  assert.equal(hot.lowExposureSweepConfidencePreview.exposureAdded, 12);
+  assert.equal(hot.lowExposureSweepConfidencePreview.unknownsRemaining, 1);
+  assert.match(hot.lowExposureSweepConfidencePreview.summary, /Confiance \+26 pts pour \+12 exposition/);
 });
 
 test('buildIntrigueMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
Delta: Implements #912.

Summary:
- adds a bounded `lowExposureSweepConfidencePreview` payload to intrigue map overlay entries
- exposes deterministic before/after coverage, confidence delta, added exposure, remaining unknowns, recommendation state, and neutral states
- reuses existing cellule/exposed/sleeper/sabotage-risk metrics without adding a heavy model or exposing hidden actor/target details

Validation:
- node --check src/ui/intrigue/buildIntrigueMapOverlay.js
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check