### PR TITLE
Epsilon: surface cheapest climate recovery commitment

### DIFF
--- a/test/ui/climate/webAtlasClimateCheapestSafeRecoveryCommitment.test.js
+++ b/test/ui/climate/webAtlasClimateCheapestSafeRecoveryCommitment.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+const deterministicCommitments = [
+  ['deadline moins serrée', 'faible', 1, 'déplace seulement le jalon déjà recommandé'],
+  ['capacité régionale libérée', 'modéré', 2, 'engage une capacité ciblée déjà signalée'],
+  ['exposition réduite', 'modéré', 2, 'réduit d’abord le périmètre exposé'],
+  ['aucun relief sûr', 'minimal', 0, 'ne promet aucun relief non confirmé'],
+];
+
+test('atlas surfaces the cheapest safe climate recovery commitment from the projection', () => {
+  assert.match(webAppSource, /function buildAtlasClimateCheapestSafeRecoveryCommitment/);
+  assert.match(webAppSource, /function renderAtlasClimateCheapestSafeRecoveryCommitment/);
+  assert.match(webAppSource, /cheapestSafeCommitment: null/);
+  assert.match(webAppSource, /Aucun engagement climat minimal sûr/);
+  assert.match(webAppSource, /atlasClimateCheapestSafeRecoveryCommitment = buildAtlasClimateCheapestSafeRecoveryCommitment\(atlasClimateRecoveryPlanProjection\)/);
+  assert.match(webAppSource, /renderAtlasClimateCheapestSafeRecoveryCommitment\(atlasClimateCheapestSafeRecoveryCommitment\)/);
+
+  for (const [pressure, cost, effort, safeBecause] of deterministicCommitments) {
+    assert.match(webAppSource, new RegExp(pressure));
+    assert.match(webAppSource, new RegExp(`cost: '${cost}'`));
+    assert.match(webAppSource, new RegExp(`effortScore: ${effort}`));
+    assert.match(webAppSource, new RegExp(safeBecause));
+  }
+
+  assert.match(webAppSource, /deadlineCovered/);
+  assert.match(webAppSource, /pressureReduced/);
+  assert.match(webAppSource, /stillActiveRisk/);
+  assert.match(webAppSource, /doesNotSolve/);
+  assert.match(webAppSource, /Pourquoi sûr/);
+  assert.match(webAppSource, /Reste actif/);
+  assert.match(stylesSource, /\.map-world-climate-cheapest-commitment/);
+  assert.match(stylesSource, /\.map-world-climate-cheapest-commitment--safe-but-risky/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -8857,6 +8857,65 @@ function renderAtlasClimateRecoveryPlanProjection(view) {
   `;
 }
 
+function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView) {
+  if (!recoveryProjectionView || recoveryProjectionView.state === 'neutral' || !recoveryProjectionView.projection) {
+    return {
+      state: 'neutral',
+      cheapestSafeCommitment: null,
+      summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
+    };
+  }
+
+  const projection = recoveryProjectionView.projection;
+  const effortByRelief = {
+    'deadline moins serrée': { cost: 'faible', effortScore: 1, safeBecause: 'déplace seulement le jalon déjà recommandé sans engager de capacité secondaire.' },
+    'capacité régionale libérée': { cost: 'modéré', effortScore: 2, safeBecause: 'engage une capacité ciblée déjà signalée par la projection recovery.' },
+    'exposition réduite': { cost: 'modéré', effortScore: 2, safeBecause: 'réduit d’abord le périmètre exposé sans inventer de nouvelle ressource.' },
+    'aucun relief sûr': { cost: 'minimal', effortScore: 0, safeBecause: 'ne promet aucun relief non confirmé et limite l’engagement à l’acceptation explicite du risque.' },
+  };
+  const selected = effortByRelief[projection.firstPressureRelieved] ?? effortByRelief['aucun relief sûr'];
+  const unresolvedRisk = recoveryProjectionView.remainingRisks?.[0]?.label ?? 'risque résiduel à surveiller';
+
+  return {
+    state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
+    cheapestSafeCommitment: {
+      provinceId: projection.provinceId,
+      provinceLabel: projection.provinceLabel,
+      action: projection.proposedActions[0] ?? 'Démarrer le plan recovery minimal.',
+      cost: selected.cost,
+      effortScore: selected.effortScore,
+      deadlineCovered: projection.deadline,
+      pressureReduced: projection.firstPressureRelieved,
+      stillActiveRisk: unresolvedRisk,
+      safeBecause: selected.safeBecause,
+      doesNotSolve: `Ne résout pas encore: ${unresolvedRisk}.`,
+    },
+    summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
+  };
+}
+
+function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'neutral' || !view.cheapestSafeCommitment) {
+    return '';
+  }
+
+  const commitment = view.cheapestSafeCommitment;
+  return `
+    <aside class="map-world-climate-cheapest-commitment map-world-climate-cheapest-commitment--${view.state}" aria-label="Engagement recovery climat minimal sûr">
+      <div class="map-world-climate-cheapest-commitment__header">
+        <strong>Engagement sûr minimal</strong>
+        <span>${commitment.cost} · effort ${commitment.effortScore}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Action</b> · ${commitment.action}</small>
+      <small><b>Deadline couverte</b> · ${commitment.deadlineCovered}</small>
+      <small><b>Pression réduite</b> · ${commitment.pressureReduced}</small>
+      <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
+      <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasClimateUnderReadyExecutionGaps(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
     return '';
@@ -16628,6 +16687,7 @@ function render() {
   const atlasClimateRecoveryCollateralReliefRanking = buildAtlasClimateRecoveryCollateralReliefRanking(atlasClimateDeadlineRecoveryAction);
   const atlasClimateFirstRecoveryPressureReliefExplanation = buildAtlasClimateFirstRecoveryPressureReliefExplanation(atlasClimateRecoveryCollateralReliefRanking);
   const atlasClimateRecoveryPlanProjection = buildAtlasClimateRecoveryPlanProjection(atlasClimateFirstRecoveryPressureReliefExplanation, atlasClimateRecoveryCollateralReliefRanking);
+  const atlasClimateCheapestSafeRecoveryCommitment = buildAtlasClimateCheapestSafeRecoveryCommitment(atlasClimateRecoveryPlanProjection);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -16676,6 +16736,7 @@ function render() {
           ${renderAtlasClimateRecoveryCollateralReliefRanking(atlasClimateRecoveryCollateralReliefRanking)}
           ${renderAtlasClimateFirstRecoveryPressureReliefExplanation(atlasClimateFirstRecoveryPressureReliefExplanation)}
           ${renderAtlasClimateRecoveryPlanProjection(atlasClimateRecoveryPlanProjection)}
+          ${renderAtlasClimateCheapestSafeRecoveryCommitment(atlasClimateCheapestSafeRecoveryCommitment)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12203,3 +12203,28 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+.map-world-climate-cheapest-commitment {
+  display: grid;
+  gap: 6px;
+  max-width: 56ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.8), rgba(6, 95, 70, 0.24));
+  border: 1px solid rgba(110, 231, 183, 0.46);
+}
+.map-world-climate-cheapest-commitment--safe-but-risky { border-color: rgba(251, 146, 60, 0.52); }
+.map-world-climate-cheapest-commitment__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-cheapest-commitment p,
+.map-world-climate-cheapest-commitment span,
+.map-world-climate-cheapest-commitment small {
+  color: #d1fae5;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}


### PR DESCRIPTION
Epsilon: Couvre #923.

Résumé:
- ajoute une recommandation `cheapestSafeCommitment` dérivée de la projection recovery climat existante;
- expose action, coût/effort, deadline couverte, pression réduite, risque encore actif, raison de sûreté et ce que l’engagement ne résout pas encore;
- garde un état neutre clair sans plan recovery actif et reste déterministe sans nouveau modèle économique.

Validation:
- `node --check web/app.js`
- `node --test test/ui/climate/webAtlasClimateCheapestSafeRecoveryCommitment.test.js test/ui/climate/webAtlasClimateRecoveryPlanProjection.test.js`
- `git diff --check`
- `npm test` (589 tests OK)

Merci de valider avant tout merge.