### PR TITLE
Beta: preview post-spend corridor bottleneck

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -137,6 +137,28 @@ function normalizeCapacitySpendPlan(plan, routeId) {
   };
 }
 
+function buildNextBottleneck(resourceRows, capacityMobilized, limitingResourceId) {
+  if (capacityMobilized === 0) {
+    return null;
+  }
+
+  const spentResources = resourceRows
+    .filter((row) => row.capacityMobilized > 0)
+    .sort((left, right) => left.capacityRemaining - right.capacityRemaining || left.resourceId.localeCompare(right.resourceId));
+  const nextResource = spentResources[0] ?? null;
+
+  if (nextResource === null || nextResource.capacityRemaining > 1) {
+    return null;
+  }
+
+  return {
+    type: nextResource.capacityRemaining === 0 ? 'capacity-exhausted' : 'low-margin',
+    resourceId: limitingResourceId ?? nextResource.resourceId,
+    marginRemaining: nextResource.capacityRemaining,
+    preparationAction: nextResource.capacityRemaining === 0 ? 'free-route-capacity' : 'reserve-capacity-buffer',
+  };
+}
+
 function buildCapacitySpendPreview(route, spendPlan) {
   const currentCapacity = route.totalCapacity;
   const capacityMobilized = Math.min(spendPlan.capacityMobilized, currentCapacity);
@@ -165,6 +187,7 @@ function buildCapacitySpendPreview(route, spendPlan) {
     capacityMobilized,
     capacityRemaining,
     limitingResourceId: computedLimitingResourceId,
+    nextBottleneck: buildNextBottleneck(resourceRows, capacityMobilized, computedLimitingResourceId),
     state: capacityMobilized === 0
       ? 'no-spend'
       : capacityRemaining === 0

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -150,6 +150,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         capacityMobilized: 0,
         capacityRemaining: 3,
         limitingResourceId: null,
+        nextBottleneck: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'wood', currentCapacity: 3, capacityMobilized: 0, capacityRemaining: 3 },
@@ -185,6 +186,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         capacityMobilized: 0,
         capacityRemaining: 11,
         limitingResourceId: null,
+        nextBottleneck: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'fish', currentCapacity: 4, capacityMobilized: 0, capacityRemaining: 4 },
@@ -249,6 +251,7 @@ test('buildEconomyMapOverlay supports plain payloads and style overrides', () =>
     capacityMobilized: 0,
     capacityRemaining: 9,
     limitingResourceId: null,
+    nextBottleneck: null,
     state: 'no-spend',
     resources: [
       { resourceId: 'salt', currentCapacity: 9, capacityMobilized: 0, capacityRemaining: 9 },
@@ -291,6 +294,12 @@ test('buildEconomyMapOverlay previews capacity spent by recommended unlocks', ()
     capacityMobilized: 5,
     capacityRemaining: 2,
     limitingResourceId: 'grain',
+    nextBottleneck: {
+      type: 'low-margin',
+      resourceId: 'grain',
+      marginRemaining: 1,
+      preparationAction: 'reserve-capacity-buffer',
+    },
     state: 'remaining-margin',
     resources: [
       { resourceId: 'grain', currentCapacity: 5, capacityMobilized: 4, capacityRemaining: 1 },
@@ -298,6 +307,7 @@ test('buildEconomyMapOverlay previews capacity spent by recommended unlocks', ()
     ],
   });
   assert.equal(overlay.routes[1].capacitySpendPreview.limitingResourceId, null);
+  assert.equal(overlay.routes[1].capacitySpendPreview.nextBottleneck, null);
   assert.equal(overlay.routes[1].capacitySpendPreview.state, 'no-spend');
 });
 


### PR DESCRIPTION
Beta: Implements #920.

## Summary
- Adds structured `nextBottleneck` data inside each route `capacitySpendPreview`.
- Derives the next bottleneck deterministically from post-spend resource margins, choosing the tightest spent resource with stable resource-id tie-breaking.
- Returns `nextBottleneck: null` for routes without spend or without a tight post-spend margin.
- Includes margin remaining, likely limiting resource, bottleneck type, and a preparation action.

## Validation
- node --check src/ui/economy/buildEconomyMapOverlay.js
- git diff --check
- npm test -- test/ui/economy/buildEconomyMapOverlay.test.js (4 OK)
- npm test (588 OK)
