### PR TITLE
Gamma: rank safest cultural support bundles

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -356,10 +356,77 @@ function buildCultureSupportBundles(culture, regionId, regionPresence, cultureSt
     });
   }
 
+  return rankCultureSupportBundles(bundles).slice(0, 2);
+}
+
+function scoreCultureSupportBundle(bundle) {
+  const actionScores = {
+    'protect-identity': 5,
+    'mediate-event-memory': 4,
+    'local-assembly': 3,
+    'limit-border-pressure': 3,
+    'shared-mediation': 2,
+    'share-discovery': 2,
+    'pace-research': 1,
+  };
+  const tradeoffPenalty = bundle.tradeoff.includes('recherche ralentie')
+    ? 2
+    : bundle.tradeoff.includes('sous surveillance') || bundle.tradeoff.includes('ouverture -')
+      ? 1
+      : 0;
+
+  return Math.max(0, bundle.actionKeys.reduce((total, actionKey) => total + (actionScores[actionKey] ?? 0), 0) + bundle.priority - tradeoffPenalty);
+}
+
+function buildCultureSupportBundleSafetyReason(bundle, safetyScore) {
+  if (bundle.actionKeys.includes('protect-identity')) {
+    return `engagement sûr: ancre identitaire d’abord · score ${safetyScore}`;
+  }
+
+  if (bundle.actionKeys.includes('limit-border-pressure')) {
+    return `engagement sûr: pression frontalière bornée · score ${safetyScore}`;
+  }
+
+  if (bundle.actionKeys.includes('pace-research')) {
+    return `engagement sûr: recherche cadencée avant ouverture · score ${safetyScore}`;
+  }
+
+  return `engagement sûr: actions compatibles · score ${safetyScore}`;
+}
+
+function rankCultureSupportBundles(bundles) {
   return bundles
-    .sort((left, right) => right.priority - left.priority || left.id.localeCompare(right.id))
-    .slice(0, 2)
-    .map(({ priority, ...bundle }) => bundle);
+    .map((bundle) => {
+      const safetyScore = scoreCultureSupportBundle(bundle);
+
+      return {
+        ...bundle,
+        safetyScore,
+        safetyReason: buildCultureSupportBundleSafetyReason(bundle, safetyScore),
+        monitoredRisk: bundle.riskReduced,
+      };
+    })
+    .sort((left, right) => right.safetyScore - left.safetyScore || right.priority - left.priority || left.id.localeCompare(right.id))
+    .map(({ priority, ...bundle }, index) => ({
+      ...bundle,
+      rank: index + 1,
+    }));
+}
+
+function buildRecommendedFirstCultureSupportBundle(supportBundles) {
+  const firstBundle = supportBundles[0] ?? null;
+
+  if (!firstBundle) {
+    return null;
+  }
+
+  return {
+    bundleId: firstBundle.id,
+    label: firstBundle.label,
+    safetyScore: firstBundle.safetyScore,
+    reason: firstBundle.safetyReason,
+    monitoredRisk: firstBundle.monitoredRisk,
+  };
 }
 
 function buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById) {
@@ -472,6 +539,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           ? buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById)
           : null;
         const supportBundles = buildCultureSupportBundles(culture, regionId, regionPresence, cultureState);
+        const recommendedFirstBundle = buildRecommendedFirstCultureSupportBundle(supportBundles);
 
         const regionalDiscoveryLinks = cultureState.signals.highlightedDiscoveries.map((discoveryId) => {
           const linkedEvents = cultureState.signals.orderedHistoricalEvents.filter((historicalEvent) => historicalEvent.discoveryIds.includes(discoveryId));
@@ -537,7 +605,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           zoneBand,
           dominantInRegion: dominantCulture?.cultureId === culture.id,
           competingCultureIds: regionPresence.filter((entry) => entry.cultureId !== culture.id).map((entry) => entry.cultureId),
-          ...(supportBundles.length > 0 ? { supportBundles } : {}),
+          ...(supportBundles.length > 0 ? { supportBundles, recommendedFirstBundle } : {}),
           ...(clusterSummary ? { clusterSummary } : {}),
           zoneContour: buildZoneContour(cultureState.influenceTier, overlapCount, zoneRank),
           style,

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -698,6 +698,10 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
       tradeoff: 'cohésion + / ouverture -',
       riskReduced: 'fragmentation culturelle',
       reason: 'cohésion 34 · oaths',
+      safetyScore: 12,
+      safetyReason: 'engagement sûr: ancre identitaire d’abord · score 12',
+      monitoredRisk: 'fragmentation culturelle',
+      rank: 1,
     },
     {
       id: 'shared-marsh:culture-marsh:bundle:guided-opening',
@@ -708,9 +712,21 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
       tradeoff: 'ouverture + / cohésion sous surveillance',
       riskReduced: 'isolement du support',
       reason: 'ouverture 38 · ferry-charter',
+      safetyScore: 5,
+      safetyReason: 'engagement sûr: recherche cadencée avant ouverture · score 5',
+      monitoredRisk: 'isolement du support',
+      rank: 2,
     },
   ]);
+  assert.deepEqual(marsh.recommendedFirstBundle, {
+    bundleId: 'shared-marsh:culture-marsh:bundle:cohesion-anchor',
+    label: 'ancrer cohésion locale',
+    safetyScore: 12,
+    reason: 'engagement sûr: ancre identitaire d’abord · score 12',
+    monitoredRisk: 'fragmentation culturelle',
+  });
   assert.deepEqual(stable.supportBundles, undefined);
+  assert.deepEqual(stable.recommendedFirstBundle, undefined);
 });
 
 test('buildCultureMapOverlay can summarize overlapping culture clusters with discovery and event pins', () => {


### PR DESCRIPTION
Gamma: Résout #921.\n\n- Ajoute un score/rang stable aux supportBundles culturels.\n- Expose recommendedFirstBundle avec raison de sûreté et risque surveillé.\n- Conserve les régions sans bundle en état neutre sans recommandation.\n\nValidation:\n- node --check src/ui/culture/buildCultureMapOverlay.js\n- npm test -- test/ui/culture/buildCultureMapOverlay.test.js\n- git diff --check\n- npm test (589 tests)