### PR TITLE
Delta: explain low-exposure sweep gaps

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -91,6 +91,30 @@ function buildSabotageThreatScore(operation) {
   return clampPercent((operation.progress + operation.heat + (100 - operation.detectionRisk)) / 3);
 }
 
+function buildPostSweepGaps({ sleeperCellCount, sabotageRiskScore, unknownsRemaining }) {
+  if (unknownsRemaining <= 0 && sabotageRiskScore < 70) {
+    return [];
+  }
+
+  return [
+    unknownsRemaining > 0 ? {
+      key: 'unconfirmed-presence',
+      label: 'Présence non confirmée',
+      reason: `${unknownsRemaining} signal${unknownsRemaining > 1 ? 'aux' : ''} rester${unknownsRemaining > 1 ? 'ont' : 'a'} à qualifier après le sweep.`,
+    } : null,
+    sleeperCellCount > 0 && unknownsRemaining > 0 ? {
+      key: 'sleeper-uncertainty',
+      label: 'Dormance encore possible',
+      reason: 'Le sweep bas-risque peut confirmer la zone sans lever toute ambiguïté dormante.',
+    } : null,
+    sabotageRiskScore >= 70 ? {
+      key: 'residual-sabotage-pressure',
+      label: 'Pression sabotage résiduelle',
+      reason: 'Le risque visible reste élevé; éviter toute attribution ou cible cachée après la passe.',
+    } : null,
+  ].filter(Boolean);
+}
+
 function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount, sleeperCellCount, sabotageRiskScore }) {
   if (celluleCount <= 0 || sabotageRiskScore <= 0 || exposedCellCount >= celluleCount) {
     return {
@@ -101,6 +125,7 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
       confidenceDelta: 0,
       exposureAdded: 0,
       unknownsRemaining: Math.max(0, celluleCount - exposedCellCount),
+      postSweepGaps: [],
       summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
     };
   }
@@ -112,6 +137,7 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
   const confidenceDelta = Math.max(0, coverageAfter - coverageBefore);
   const exposureAdded = clampPercent(4 + sleeperCellCount * 3 + (sabotageRiskScore >= 70 ? 5 : sabotageRiskScore >= 35 ? 3 : 1));
   const unknownsRemaining = Math.max(0, celluleCount - exposedCellCount - (confidenceDelta >= 30 ? 2 : 1));
+  const postSweepGaps = buildPostSweepGaps({ sleeperCellCount, sabotageRiskScore, unknownsRemaining });
   const state = exposureAdded <= 8
     ? 'low-exposure-positive'
     : exposureAdded < 12
@@ -126,6 +152,7 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
     confidenceDelta,
     exposureAdded,
     unknownsRemaining,
+    postSweepGaps,
     summary: `Confiance +${confidenceDelta} pts pour +${exposureAdded} exposition; ${unknownsRemaining} inconnue${unknownsRemaining > 1 ? 's' : ''} restante${unknownsRemaining > 1 ? 's' : ''}.`,
   };
 }

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -132,6 +132,7 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
         confidenceDelta: 23,
         exposureAdded: 10,
         unknownsRemaining: 0,
+        postSweepGaps: [],
         summary: 'Confiance +23 pts pour +10 exposition; 0 inconnue restante.',
       },
       style: {
@@ -171,6 +172,7 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
         confidenceDelta: 31,
         exposureAdded: 5,
         unknownsRemaining: 0,
+        postSweepGaps: [],
         summary: 'Confiance +31 pts pour +5 exposition; 0 inconnue restante.',
       },
       style: {
@@ -310,6 +312,7 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
     confidenceDelta: 0,
     exposureAdded: 0,
     unknownsRemaining: 0,
+    postSweepGaps: [],
     summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
   });
   assert.equal(hot.lowExposureSweepConfidencePreview.state, 'watch-exposure');
@@ -319,7 +322,64 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
   assert.equal(hot.lowExposureSweepConfidencePreview.confidenceDelta, 26);
   assert.equal(hot.lowExposureSweepConfidencePreview.exposureAdded, 12);
   assert.equal(hot.lowExposureSweepConfidencePreview.unknownsRemaining, 1);
+  assert.deepEqual(hot.lowExposureSweepConfidencePreview.postSweepGaps, [
+    {
+      key: 'unconfirmed-presence',
+      label: 'Présence non confirmée',
+      reason: '1 signal restera à qualifier après le sweep.',
+    },
+    {
+      key: 'sleeper-uncertainty',
+      label: 'Dormance encore possible',
+      reason: 'Le sweep bas-risque peut confirmer la zone sans lever toute ambiguïté dormante.',
+    },
+    {
+      key: 'residual-sabotage-pressure',
+      label: 'Pression sabotage résiduelle',
+      reason: 'Le risque visible reste élevé; éviter toute attribution ou cible cachée après la passe.',
+    },
+  ]);
   assert.match(hot.lowExposureSweepConfidencePreview.summary, /Confiance \+26 pts pour \+12 exposition/);
+});
+
+test('buildIntrigueMapOverlay keeps post-sweep gap explanations stable and neutral when complete', () => {
+  const overlay = buildIntrigueMapOverlay([
+    {
+      id: 'cell-calm-1',
+      factionId: 'shadow-league',
+      codename: 'Calm',
+      locationId: 'calm',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 10,
+    },
+    {
+      id: 'cell-calm-2',
+      factionId: 'shadow-league',
+      codename: 'Clear',
+      locationId: 'calm',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 80,
+    },
+  ], [
+    {
+      id: 'op-calm',
+      celluleId: 'cell-calm-1',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe safe lane',
+      theaterId: 'calm',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 70,
+      progress: 20,
+      heat: 10,
+    },
+  ]);
+
+  assert.deepEqual(overlay[0].lowExposureSweepConfidencePreview.postSweepGaps, []);
+  assert.equal(overlay[0].lowExposureSweepConfidencePreview.unknownsRemaining, 0);
 });
 
 test('buildIntrigueMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
Delta: Implements #922.

Summary:
- adds `postSweepGaps` to the low-exposure sweep confidence preview payload
- each remaining gap has a stable key, readable label, and short fog-safe reason
- keeps complete/neutral cases explicit with an empty gap list, without exposing actors, targets, hidden causes, or hidden probabilities

Validation:
- node --check src/ui/intrigue/buildIntrigueMapOverlay.js
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check