### PR TITLE
Alpha: preview first cleanup payoff

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -66,6 +66,59 @@ function normalizeOverlaySlots(overlaySlots) {
   return [...new Set(overlaySlots.map((slot) => String(slot).trim()).filter(Boolean))];
 }
 
+function normalizeCleanupInput(value, label) {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array.`);
+  }
+
+  return value.filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry));
+}
+
+function getRiskLocationId(riskKey) {
+  const [, locationId = null] = String(riskKey ?? '').split(':');
+
+  return locationId && locationId.trim() ? locationId.trim() : null;
+}
+
+export function buildFirstCleanupPayoff(cleanupOrders = [], residualRisks = []) {
+  const normalizedOrders = normalizeCleanupInput(cleanupOrders, 'StrategicMapShell cleanupOrders');
+  const normalizedRisks = normalizeCleanupInput(residualRisks, 'StrategicMapShell residualRisks');
+  const firstOrder = normalizedOrders[0] ?? null;
+
+  if (!firstOrder) {
+    return null;
+  }
+
+  const residualRiskKey = String(firstOrder.residualRiskKey ?? '').trim();
+  const targetedRisk = normalizedRisks.find((risk) => String(risk.key ?? '').trim() === residualRiskKey) ?? null;
+  const remainingRisks = normalizedRisks
+    .filter((risk) => String(risk.key ?? '').trim() !== residualRiskKey)
+    .map((risk) => ({
+      key: String(risk.key ?? '').trim(),
+      label: String(risk.label ?? 'risque restant').trim() || 'risque restant',
+      reason: String(risk.reason ?? '').trim() || null,
+    }));
+
+  return {
+    cleanupOrderId: String(firstOrder.id ?? '').trim() || null,
+    cleanupOrderLabel: String(firstOrder.label ?? 'Ordre de nettoyage').trim() || 'Ordre de nettoyage',
+    residualRiskKey,
+    targetId: getRiskLocationId(residualRiskKey),
+    riskReduced: String(firstOrder.riskReduced ?? targetedRisk?.label ?? 'risque résiduel').trim() || 'risque résiduel',
+    priorityReason: String(firstOrder.reason ?? targetedRisk?.reason ?? 'premier ordre recommandé').trim()
+      || 'premier ordre recommandé',
+    currentRiskReason: String(targetedRisk?.reason ?? '').trim() || null,
+    expectedEffect: String(firstOrder.expectedEffect ?? `réduit ${firstOrder.riskReduced ?? targetedRisk?.label ?? 'le risque ciblé'}`).trim(),
+    remainingRiskState: remainingRisks.length === 0 ? 'no-visible-risk' : 'residual-risk-remains',
+    remainingRiskCount: remainingRisks.length,
+    remainingRisks,
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -117,6 +170,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     || 'Vue d’ensemble des provinces et lignes de front';
   const overlaySlots = normalizeOverlaySlots(normalizedOptions.overlaySlots);
   const provinceGeometryById = normalizeGeometryMap(normalizedOptions.provinceGeometryById);
+  const firstCleanupPayoff = buildFirstCleanupPayoff(normalizedOptions.cleanupOrders, normalizedOptions.residualRisks);
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -156,6 +210,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
         enabled: true,
       })),
     },
+    firstCleanupPayoff,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { Province } from '../../../src/domain/war/Province.js';
-import { buildStrategicMapShell } from '../../../src/ui/war/StrategicMapShell.js';
+import { buildFirstCleanupPayoff, buildStrategicMapShell } from '../../../src/ui/war/StrategicMapShell.js';
 
 function createProvince(overrides = {}) {
   return new Province({
@@ -101,6 +101,47 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     'intrigue-overlay',
   ]);
   assert.equal(shell.activeProvince.provinceId, 'prov-a');
+});
+
+test('StrategicMapShell exposes the first cleanup payoff from cleanup orders and residual risks', () => {
+  const shell = buildStrategicMapShell([createProvince({ id: 'front-a', name: 'Front A' })], {
+    residualRisks: [
+      { key: 'supply-pressure:front-a', label: 'pression ravitaillement', reason: 'approvisionnement tendu' },
+      { key: 'low-loyalty:front-a', label: 'loyauté basse', reason: 'loyauté 42' },
+    ],
+    cleanupOrders: [
+      {
+        id: 'cleanup:route-blocked:supply-pressure:front-a',
+        label: 'Prioriser convoi court',
+        residualRiskKey: 'supply-pressure:front-a',
+        riskReduced: 'pression ravitaillement',
+        reason: 'ravitaillement visible à faible détour',
+      },
+    ],
+  });
+
+  assert.deepEqual(shell.firstCleanupPayoff, {
+    cleanupOrderId: 'cleanup:route-blocked:supply-pressure:front-a',
+    cleanupOrderLabel: 'Prioriser convoi court',
+    residualRiskKey: 'supply-pressure:front-a',
+    targetId: 'front-a',
+    riskReduced: 'pression ravitaillement',
+    priorityReason: 'ravitaillement visible à faible détour',
+    currentRiskReason: 'approvisionnement tendu',
+    expectedEffect: 'réduit pression ravitaillement',
+    remainingRiskState: 'residual-risk-remains',
+    remainingRiskCount: 1,
+    remainingRisks: [
+      { key: 'low-loyalty:front-a', label: 'loyauté basse', reason: 'loyauté 42' },
+    ],
+  });
+});
+
+test('StrategicMapShell returns a neutral cleanup payoff when no cleanup order is useful', () => {
+  assert.equal(buildFirstCleanupPayoff([], [{ key: 'low-loyalty:front-a', label: 'loyauté basse' }]), null);
+  assert.equal(buildStrategicMapShell([], {}).firstCleanupPayoff, null);
+  assert.throws(() => buildStrategicMapShell([], { cleanupOrders: {} }), /cleanupOrders must be an array/);
+  assert.throws(() => buildStrategicMapShell([], { residualRisks: {} }), /residualRisks must be an array/);
 });
 
 test('StrategicMapShell falls back to default title and validates inputs', () => {

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -58,6 +58,8 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /riskReduced: risk\.label/);
   assert.match(webAppSource, /prerequisite: cleanup\.prerequisite/);
   assert.match(webAppSource, /safetyScore/);
+  assert.match(webAppSource, /buildFirstCleanupPayoff\(cleanupOrders, residualRisks\)/);
+  assert.match(webAppSource, /firstCleanupPayoff/);
 });
 
 test('atlas military fallback order hint stays secondary and hides no-safe fallback state', () => {
@@ -79,6 +81,9 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-orders/);
   assert.match(webAppSource, /reste: aucun risque visible/);
   assert.match(webAppSource, /nettoyer: aucun ordre requis/);
+  assert.match(webAppSource, /payoff: aucun nettoyage utile/);
+  assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
+  assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -89,4 +94,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__preview/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__residual-risks/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-orders/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-payoff/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@ import { Province } from '../src/domain/war/Province.js';
 import { City } from '../src/domain/economy/City.js';
 import { TradeRoute } from '../src/domain/economy/TradeRoute.js';
 import { buildEconomySeedFromStrategicMap } from '../src/application/economy/BuildEconomySeedFromStrategicMap.js';
-import { buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
+import { buildFirstCleanupPayoff, buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
 import { buildLauncherMapSelection } from '../src/ui/launcher/buildLauncherMapSelection.js';
 import { buildEconomyMapOverlay } from '../src/ui/economy/buildEconomyMapOverlay.js';
 import { buildCityStockPanel } from '../src/ui/economy/buildCityStockPanel.js';
@@ -1941,6 +1941,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       selectionPreview: null,
       residualRisks: [],
       cleanupOrders: [],
+      firstCleanupPayoff: null,
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1951,6 +1952,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const selectionPreview = buildAtlasMilitaryFallbackSelectionPreview(fallback, topWarning, reliefPreview);
   const residualRisks = buildAtlasMilitaryFallbackResidualRisks(fallback, topWarning, shell, priorityStack);
   const cleanupOrders = buildAtlasMilitaryFallbackCleanupOrders(residualRisks, fallback);
+  const firstCleanupPayoff = buildFirstCleanupPayoff(cleanupOrders, residualRisks);
 
   return {
     fallback: {
@@ -1962,13 +1964,15 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       selectionPreview,
       residualRisks,
       cleanupOrders,
+      firstCleanupPayoff,
     },
     safetyReason,
     crossDomainBlocker,
     selectionPreview,
     residualRisks,
     cleanupOrders,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}).`,
+    firstCleanupPayoff,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}).`,
     empty: false,
   };
 }
@@ -1982,6 +1986,9 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const cleanupOrderLabel = fallback.cleanupOrders?.length
     ? `nettoyer: ${fallback.cleanupOrders.map((order) => order.label).join(' · ')}`
     : 'nettoyer: aucun ordre requis';
+  const firstCleanupPayoffLabel = fallback.firstCleanupPayoff
+    ? `payoff: ${fallback.firstCleanupPayoff.riskReduced} ↓ · reste ${fallback.firstCleanupPayoff.remainingRiskCount}`
+    : 'payoff: aucun nettoyage utile';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
       <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="11" rx="1.2"></rect>
@@ -1992,6 +1999,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       ${fallback.selectionPreview ? `<text class="atlas-military-fallback-order__preview atlas-military-fallback-order__preview--${fallback.selectionPreview.type}" x="23.2" y="63.5">${fallback.selectionPreview.label}</text>` : ''}
       <text class="atlas-military-fallback-order__residual-risks" x="23.2" y="64.6">${residualRiskLabel}</text>
       <text class="atlas-military-fallback-order__cleanup-orders" x="23.2" y="65.7">${cleanupOrderLabel}</text>
+      <text class="atlas-military-fallback-order__cleanup-payoff" x="23.2" y="66.8">${firstCleanupPayoffLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11153,6 +11153,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__preview { fill: #bbf7d0; font-size: 0.56px; font-weight: 800; }
 .atlas-military-fallback-order__residual-risks { fill: #fecaca; font-size: 0.54px; font-weight: 800; }
 .atlas-military-fallback-order__cleanup-orders { fill: #bfdbfe; font-size: 0.53px; font-weight: 800; }
+.atlas-military-fallback-order__cleanup-payoff { fill: #bbf7d0; font-size: 0.52px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #929.

Summary:
- Adds a structured `firstCleanupPayoff` payload derived from the first cleanup order and residual risks.
- Surfaces the payoff in the military fallback cleanup panel with remaining-risk count.
- Covers neutral/no-cleanup states and validation with unit tests.

Tests:
- `npm test`

Closes #929