### PR TITLE
Gamma: preview cultural support risk change

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -394,6 +394,69 @@ function buildCultureSupportBundleSafetyReason(bundle, safetyScore) {
   return `engagement sûr: actions compatibles · score ${safetyScore}`;
 }
 
+function buildCultureSupportRiskCurrentScore(culture, bundle, regionPresence, cultureState) {
+  const rivalPressure = Math.max(
+    0,
+    ...regionPresence
+      .filter((entry) => entry.cultureId !== culture.id)
+      .map((entry) => entry.influenceScore - cultureState.influenceScore),
+  );
+
+  if (bundle.riskReduced === 'fragmentation culturelle') {
+    return clampScore((100 - culture.cohesion) + (rivalPressure > 0 ? 8 : 0));
+  }
+
+  if (bundle.riskReduced === 'isolement du support') {
+    return clampScore((100 - culture.openness) + (cultureState.signals.activeResearchCount * 5));
+  }
+
+  if (bundle.riskReduced === 'pression frontalière') {
+    return clampScore(45 + rivalPressure + (regionPresence.length * 3));
+  }
+
+  return clampScore(50 - Math.min(culture.cohesion, culture.openness));
+}
+
+function buildCultureSupportRiskChangePreview(culture, bundle, regionPresence, cultureState) {
+  if (!bundle) {
+    return {
+      status: 'neutral',
+      currentRisk: 0,
+      expectedRisk: 0,
+      delta: 0,
+      monitoredRisk: 'aucun support recommandé',
+      tradeoffToWatch: 'aucun',
+      reason: 'aucun bundle recommandé: stabilité suffisante',
+    };
+  }
+
+  const currentRisk = buildCultureSupportRiskCurrentScore(culture, bundle, regionPresence, cultureState);
+  const actionRelief = bundle.actionKeys.reduce((total, actionKey) => {
+    const reliefByAction = {
+      'protect-identity': 16,
+      'mediate-event-memory': 10,
+      'local-assembly': 8,
+      'limit-border-pressure': 12,
+      'shared-mediation': 8,
+      'share-discovery': 7,
+      'pace-research': 6,
+    };
+
+    return total + (reliefByAction[actionKey] ?? 4);
+  }, 0);
+  const expectedRisk = clampScore(currentRisk - actionRelief);
+
+  return {
+    status: expectedRisk < currentRisk ? 'improves' : 'steady',
+    currentRisk,
+    expectedRisk,
+    delta: expectedRisk - currentRisk,
+    monitoredRisk: bundle.riskReduced,
+    tradeoffToWatch: bundle.tradeoff,
+    reason: bundle.expectedBenefit,
+  };
+}
+
 function rankCultureSupportBundles(bundles) {
   return bundles
     .map((bundle) => {
@@ -413,7 +476,7 @@ function rankCultureSupportBundles(bundles) {
     }));
 }
 
-function buildRecommendedFirstCultureSupportBundle(supportBundles) {
+function buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePreview) {
   const firstBundle = supportBundles[0] ?? null;
 
   if (!firstBundle) {
@@ -426,6 +489,7 @@ function buildRecommendedFirstCultureSupportBundle(supportBundles) {
     safetyScore: firstBundle.safetyScore,
     reason: firstBundle.safetyReason,
     monitoredRisk: firstBundle.monitoredRisk,
+    riskChangePreview,
   };
 }
 
@@ -539,7 +603,8 @@ export function buildCultureMapOverlay(payload, options = {}) {
           ? buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById)
           : null;
         const supportBundles = buildCultureSupportBundles(culture, regionId, regionPresence, cultureState);
-        const recommendedFirstBundle = buildRecommendedFirstCultureSupportBundle(supportBundles);
+        const riskChangePreview = buildCultureSupportRiskChangePreview(culture, supportBundles[0] ?? null, regionPresence, cultureState);
+        const recommendedFirstBundle = buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePreview);
 
         const regionalDiscoveryLinks = cultureState.signals.highlightedDiscoveries.map((discoveryId) => {
           const linkedEvents = cultureState.signals.orderedHistoricalEvents.filter((historicalEvent) => historicalEvent.discoveryIds.includes(discoveryId));
@@ -605,6 +670,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           zoneBand,
           dominantInRegion: dominantCulture?.cultureId === culture.id,
           competingCultureIds: regionPresence.filter((entry) => entry.cultureId !== culture.id).map((entry) => entry.cultureId),
+          riskChangePreview,
           ...(supportBundles.length > 0 ? { supportBundles, recommendedFirstBundle } : {}),
           ...(clusterSummary ? { clusterSummary } : {}),
           zoneContour: buildZoneContour(cultureState.influenceTier, overlapCount, zoneRank),

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -6,6 +6,22 @@ import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js'
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
 import { buildCultureMapOverlay } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
+function withoutRiskChangePreview(value) {
+  if (Array.isArray(value)) {
+    return value.map(withoutRiskChangePreview);
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== 'riskChangePreview')
+      .map(([key, nestedValue]) => [key, withoutRiskChangePreview(nestedValue)]),
+  );
+}
+
 test('buildCultureMapOverlay expands cultures into stable regional markers with discoveries', () => {
   const overlay = buildCultureMapOverlay(
     {
@@ -74,7 +90,7 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
     },
   );
 
-  assert.deepEqual(overlay, [
+  assert.deepEqual(withoutRiskChangePreview(overlay), [
     {
       overlayId: 'archipelago:culture-north',
       regionId: 'archipelago',
@@ -416,7 +432,7 @@ test('buildCultureMapOverlay distinguishes overlapping cultural influences in th
     },
   );
 
-  assert.deepEqual(overlay, [
+  assert.deepEqual(withoutRiskChangePreview(overlay), [
     {
       overlayId: 'shared-bay:culture-delta',
       regionId: 'shared-bay',
@@ -724,9 +740,28 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
     safetyScore: 12,
     reason: 'engagement sûr: ancre identitaire d’abord · score 12',
     monitoredRisk: 'fragmentation culturelle',
+    riskChangePreview: {
+      status: 'improves',
+      currentRisk: 66,
+      expectedRisk: 40,
+      delta: -26,
+      monitoredRisk: 'fragmentation culturelle',
+      tradeoffToWatch: 'cohésion + / ouverture -',
+      reason: 'réduit la fragmentation visible avant soutien externe',
+    },
   });
+  assert.deepEqual(marsh.riskChangePreview, marsh.recommendedFirstBundle.riskChangePreview);
   assert.deepEqual(stable.supportBundles, undefined);
   assert.deepEqual(stable.recommendedFirstBundle, undefined);
+  assert.deepEqual(stable.riskChangePreview, {
+    status: 'neutral',
+    currentRisk: 0,
+    expectedRisk: 0,
+    delta: 0,
+    monitoredRisk: 'aucun support recommandé',
+    tradeoffToWatch: 'aucun',
+    reason: 'aucun bundle recommandé: stabilité suffisante',
+  });
 });
 
 test('buildCultureMapOverlay can summarize overlapping culture clusters with discovery and event pins', () => {


### PR DESCRIPTION
Gamma: ## Summary

Adds a deterministic before/after risk preview for the recommended first cultural support bundle, while keeping a neutral preview for regions without a recommended bundle.

## Changes

- Adds current/expected risk scoring derived from existing culture metrics, support bundle actions, and regional pressure.
- Exposes `riskChangePreview` on the overlay and the `recommendedFirstBundle`.
- Keeps no-bundle cases explicit with a neutral risk preview.
- Updates culture overlay tests for recommended and neutral previews.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#931