### PR TITLE
Beta: identify best value preparation option

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -224,7 +224,61 @@ function buildPreparationOptions(nextResource, resourceRows, routeRiskLevel) {
     .slice(0, 3);
 }
 
-function buildNextBottleneck(resourceRows, capacityMobilized, limitingResourceId, routeRiskLevel) {
+function scorePreparationOption(option, routeValue, routeRiskLevel) {
+  const safetyWeight = { safe: 2, conditional: 1, risky: 0 };
+  const riskAvoided = option.safety === 'risky'
+    ? Math.ceil(routeRiskLevel / 25)
+    : option.safety === 'conditional'
+      ? Math.ceil(routeRiskLevel / 35)
+      : 1;
+
+  return (option.expectedEffect.marginGain * routeValue)
+    + riskAvoided
+    + (safetyWeight[option.safety] ?? 0)
+    - option.effort.amount;
+}
+
+function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLevel) {
+  if (preparationOptions.length < 2) {
+    return null;
+  }
+
+  const scoredOptions = preparationOptions
+    .map((option) => ({
+      option,
+      score: scorePreparationOption(option, routeValue, routeRiskLevel),
+      estimatedValueProtected: option.expectedEffect.marginGain * routeValue,
+    }))
+    .sort((left, right) => right.score - left.score
+      || right.estimatedValueProtected - left.estimatedValueProtected
+      || left.option.effort.amount - right.option.effort.amount
+      || left.option.id.localeCompare(right.option.id));
+  const best = scoredOptions[0];
+  const cheapest = preparationOptions
+    .slice()
+    .sort((left, right) => left.effort.amount - right.effort.amount || left.id.localeCompare(right.id))[0];
+  const cheaperAcceptable = cheapest.id === best.option.id
+    ? null
+    : {
+      optionId: cheapest.id,
+      condition: cheapest.expectedEffect.marginGain >= best.option.expectedEffect.marginGain
+        ? 'acceptable si le risque corridor reste stable'
+        : 'acceptable seulement si le coût immédiat prime sur la valeur protégée',
+    };
+
+  return {
+    id: `best-value:${best.option.id}`,
+    optionId: best.option.id,
+    action: best.option.action,
+    estimatedValueProtected: best.estimatedValueProtected,
+    marginGain: best.option.expectedEffect.marginGain,
+    effort: { ...best.option.effort },
+    reason: `Protège ${best.estimatedValueProtected} valeur corridor avec +${best.option.expectedEffect.marginGain} marge pour ${best.option.effort.amount} ${best.option.effort.unit}.`,
+    cheaperAcceptable,
+  };
+}
+
+function buildNextBottleneck(resourceRows, capacityMobilized, limitingResourceId, routeRiskLevel, routeValue) {
   if (capacityMobilized === 0) {
     return null;
   }
@@ -238,12 +292,15 @@ function buildNextBottleneck(resourceRows, capacityMobilized, limitingResourceId
     return null;
   }
 
+  const preparationOptions = buildPreparationOptions(nextResource, resourceRows, routeRiskLevel);
+
   return {
     type: nextResource.capacityRemaining === 0 ? 'capacity-exhausted' : 'low-margin',
     resourceId: limitingResourceId ?? nextResource.resourceId,
     marginRemaining: nextResource.capacityRemaining,
     preparationAction: nextResource.capacityRemaining === 0 ? 'free-route-capacity' : 'reserve-capacity-buffer',
-    preparationOptions: buildPreparationOptions(nextResource, resourceRows, routeRiskLevel),
+    preparationOptions,
+    bestValuePreparation: buildBestValuePreparation(preparationOptions, routeValue, routeRiskLevel),
   };
 }
 
@@ -269,7 +326,13 @@ function buildCapacitySpendPreview(route, spendPlan) {
       .sort((left, right) => left.capacityRemaining - right.capacityRemaining || left.resourceId.localeCompare(right.resourceId))[0]?.resourceId
     ?? null;
 
-  const nextBottleneck = buildNextBottleneck(resourceRows, capacityMobilized, computedLimitingResourceId, route.riskLevel);
+  const nextBottleneck = buildNextBottleneck(
+    resourceRows,
+    capacityMobilized,
+    computedLimitingResourceId,
+    route.riskLevel,
+    currentCapacity,
+  );
 
   return {
     routeId: route.id,
@@ -279,6 +342,7 @@ function buildCapacitySpendPreview(route, spendPlan) {
     limitingResourceId: computedLimitingResourceId,
     nextBottleneck,
     preparationOptions: nextBottleneck?.preparationOptions ?? [],
+    bestValuePreparation: nextBottleneck?.bestValuePreparation ?? null,
     state: capacityMobilized === 0
       ? 'no-spend'
       : capacityRemaining === 0

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -152,6 +152,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         limitingResourceId: null,
         nextBottleneck: null,
         preparationOptions: [],
+        bestValuePreparation: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'wood', currentCapacity: 3, capacityMobilized: 0, capacityRemaining: 3 },
@@ -189,6 +190,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         limitingResourceId: null,
         nextBottleneck: null,
         preparationOptions: [],
+        bestValuePreparation: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'fish', currentCapacity: 4, capacityMobilized: 0, capacityRemaining: 4 },
@@ -255,6 +257,7 @@ test('buildEconomyMapOverlay supports plain payloads and style overrides', () =>
     limitingResourceId: null,
     nextBottleneck: null,
     preparationOptions: [],
+    bestValuePreparation: null,
     state: 'no-spend',
     resources: [
       { resourceId: 'salt', currentCapacity: 9, capacityMobilized: 0, capacityRemaining: 9 },
@@ -320,6 +323,7 @@ test('buildEconomyMapOverlay previews capacity spent by recommended unlocks', ()
           safety: 'safe',
         },
       ],
+      bestValuePreparation: null,
     },
     preparationOptions: [
       {
@@ -339,6 +343,7 @@ test('buildEconomyMapOverlay previews capacity spent by recommended unlocks', ()
         safety: 'safe',
       },
     ],
+    bestValuePreparation: null,
     state: 'remaining-margin',
     resources: [
       { resourceId: 'grain', currentCapacity: 5, capacityMobilized: 4, capacityRemaining: 1 },
@@ -378,6 +383,27 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationOptions.map((option) => option.effort.amount), [1, 2, 3]);
   assert.equal(overlay.routes[0].capacitySpendPreview.preparationOptions[0].expectedEffect.marginGain, 1);
   assert.equal(overlay.routes[0].capacitySpendPreview.preparationOptions[2].safety, 'risky');
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.bestValuePreparation, {
+    id: 'best-value:grain:shift-to-tools',
+    optionId: 'grain:shift-to-tools',
+    action: 'shift-load-to-spare-resource',
+    estimatedValueProtected: 20,
+    marginGain: 2,
+    effort: {
+      type: 'coordination',
+      amount: 2,
+      unit: 'turns',
+    },
+    reason: 'Protège 20 valeur corridor avec +2 marge pour 2 turns.',
+    cheaperAcceptable: {
+      optionId: 'grain:reserve-buffer',
+      condition: 'acceptable seulement si le coût immédiat prime sur la valeur protégée',
+    },
+  });
+  assert.deepEqual(
+    overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
+    overlay.routes[0].capacitySpendPreview.bestValuePreparation,
+  );
 });
 
 test('buildEconomyMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
## Summary

Beta: Adds `bestValuePreparation` to corridor capacity spend previews so the economy overlay can call out which preparation option protects the most operational corridor value, not only the cheapest option.

## Changes

- Score comparable preparation options by estimated protected route value, margin gain, effort, and risk/safety.
- Expose a stable best-value summary on both `nextBottleneck.bestValuePreparation` and `capacitySpendPreview.bestValuePreparation`.
- Keep neutral states explicit with `null` when no comparable options exist.
- Cover deterministic best-value selection and cheaper-option guidance in unit tests.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (594/594 pass)

Fixes loo469/historia#940