### PR TITLE
Gamma: show post-bundle cumulative risk

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -457,6 +457,89 @@ function buildCultureSupportRiskChangePreview(culture, bundle, regionPresence, c
   };
 }
 
+function buildCumulativeRiskLevel(score) {
+  if (score >= 75) {
+    return 'critical';
+  }
+
+  if (score >= 55) {
+    return 'elevated';
+  }
+
+  if (score >= 30) {
+    return 'guarded';
+  }
+
+  return 'low';
+}
+
+function buildCultureSupportCumulativeRisk(culture, regionId, riskChangePreview, regionPresence, cultureState) {
+  if (riskChangePreview.status === 'neutral') {
+    return {
+      status: 'neutral',
+      before: { score: 0, level: 'low' },
+      after: { score: 0, level: 'low' },
+      reducedRisk: 'aucun support recommandé',
+      remainingPriority: 'aucun',
+      fragileRegionId: null,
+      fragileCultureId: null,
+      nextAttention: 'aucune attention supplémentaire recommandée',
+    };
+  }
+
+  const rivalPressure = Math.max(
+    0,
+    ...regionPresence
+      .filter((entry) => entry.cultureId !== culture.id)
+      .map((entry) => entry.influenceScore - cultureState.influenceScore),
+  );
+  const riskComponents = [
+    {
+      risk: 'fragmentation culturelle',
+      score: clampScore((100 - culture.cohesion) + (rivalPressure > 0 ? 8 : 0)),
+      nextAttention: 'consolider les repères locaux après le premier soutien',
+    },
+    {
+      risk: 'isolement du support',
+      score: clampScore((100 - culture.openness) + (cultureState.signals.activeResearchCount * 5)),
+      nextAttention: 'surveiller les relais savants et le rythme d’ouverture',
+    },
+    {
+      risk: 'pression frontalière',
+      score: clampScore(45 + rivalPressure + (regionPresence.length > 1 ? regionPresence.length * 3 : 0)),
+      nextAttention: 'suivre les compromis avec les influences voisines',
+    },
+  ];
+  const beforeScore = Math.max(...riskComponents.map((component) => component.score));
+  const afterComponents = riskComponents.map((component) => ({
+    ...component,
+    score: component.risk === riskChangePreview.monitoredRisk
+      ? riskChangePreview.expectedRisk
+      : component.score,
+  }));
+  const afterScore = Math.max(...afterComponents.map((component) => component.score));
+  const remainingPriority = afterComponents
+    .slice()
+    .sort((left, right) => right.score - left.score || left.risk.localeCompare(right.risk))[0];
+
+  return {
+    status: afterScore < beforeScore ? 'improves' : 'redirects-attention',
+    before: {
+      score: beforeScore,
+      level: buildCumulativeRiskLevel(beforeScore),
+    },
+    after: {
+      score: afterScore,
+      level: buildCumulativeRiskLevel(afterScore),
+    },
+    reducedRisk: riskChangePreview.monitoredRisk,
+    remainingPriority: remainingPriority.risk,
+    fragileRegionId: regionId,
+    fragileCultureId: culture.id,
+    nextAttention: remainingPriority.nextAttention,
+  };
+}
+
 function rankCultureSupportBundles(bundles) {
   return bundles
     .map((bundle) => {
@@ -476,7 +559,7 @@ function rankCultureSupportBundles(bundles) {
     }));
 }
 
-function buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePreview) {
+function buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePreview, postBundleCumulativeRisk) {
   const firstBundle = supportBundles[0] ?? null;
 
   if (!firstBundle) {
@@ -490,6 +573,7 @@ function buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePre
     reason: firstBundle.safetyReason,
     monitoredRisk: firstBundle.monitoredRisk,
     riskChangePreview,
+    postBundleCumulativeRisk,
   };
 }
 
@@ -604,7 +688,8 @@ export function buildCultureMapOverlay(payload, options = {}) {
           : null;
         const supportBundles = buildCultureSupportBundles(culture, regionId, regionPresence, cultureState);
         const riskChangePreview = buildCultureSupportRiskChangePreview(culture, supportBundles[0] ?? null, regionPresence, cultureState);
-        const recommendedFirstBundle = buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePreview);
+        const postBundleCumulativeRisk = buildCultureSupportCumulativeRisk(culture, regionId, riskChangePreview, regionPresence, cultureState);
+        const recommendedFirstBundle = buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePreview, postBundleCumulativeRisk);
 
         const regionalDiscoveryLinks = cultureState.signals.highlightedDiscoveries.map((discoveryId) => {
           const linkedEvents = cultureState.signals.orderedHistoricalEvents.filter((historicalEvent) => historicalEvent.discoveryIds.includes(discoveryId));
@@ -671,6 +756,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           dominantInRegion: dominantCulture?.cultureId === culture.id,
           competingCultureIds: regionPresence.filter((entry) => entry.cultureId !== culture.id).map((entry) => entry.cultureId),
           riskChangePreview,
+          postBundleCumulativeRisk,
           ...(supportBundles.length > 0 ? { supportBundles, recommendedFirstBundle } : {}),
           ...(clusterSummary ? { clusterSummary } : {}),
           zoneContour: buildZoneContour(cultureState.influenceTier, overlapCount, zoneRank),

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -6,9 +6,9 @@ import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js'
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
 import { buildCultureMapOverlay } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
-function withoutRiskChangePreview(value) {
+function withoutSupportRiskPreviews(value) {
   if (Array.isArray(value)) {
-    return value.map(withoutRiskChangePreview);
+    return value.map(withoutSupportRiskPreviews);
   }
 
   if (value === null || typeof value !== 'object') {
@@ -17,8 +17,8 @@ function withoutRiskChangePreview(value) {
 
   return Object.fromEntries(
     Object.entries(value)
-      .filter(([key]) => key !== 'riskChangePreview')
-      .map(([key, nestedValue]) => [key, withoutRiskChangePreview(nestedValue)]),
+      .filter(([key]) => !['riskChangePreview', 'postBundleCumulativeRisk'].includes(key))
+      .map(([key, nestedValue]) => [key, withoutSupportRiskPreviews(nestedValue)]),
   );
 }
 
@@ -90,7 +90,7 @@ test('buildCultureMapOverlay expands cultures into stable regional markers with 
     },
   );
 
-  assert.deepEqual(withoutRiskChangePreview(overlay), [
+  assert.deepEqual(withoutSupportRiskPreviews(overlay), [
     {
       overlayId: 'archipelago:culture-north',
       regionId: 'archipelago',
@@ -432,7 +432,7 @@ test('buildCultureMapOverlay distinguishes overlapping cultural influences in th
     },
   );
 
-  assert.deepEqual(withoutRiskChangePreview(overlay), [
+  assert.deepEqual(withoutSupportRiskPreviews(overlay), [
     {
       overlayId: 'shared-bay:culture-delta',
       regionId: 'shared-bay',
@@ -749,8 +749,25 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
       tradeoffToWatch: 'cohésion + / ouverture -',
       reason: 'réduit la fragmentation visible avant soutien externe',
     },
+    postBundleCumulativeRisk: {
+      status: 'redirects-attention',
+      before: {
+        score: 67,
+        level: 'elevated',
+      },
+      after: {
+        score: 67,
+        level: 'elevated',
+      },
+      reducedRisk: 'fragmentation culturelle',
+      remainingPriority: 'isolement du support',
+      fragileRegionId: 'shared-marsh',
+      fragileCultureId: 'culture-marsh',
+      nextAttention: 'surveiller les relais savants et le rythme d’ouverture',
+    },
   });
   assert.deepEqual(marsh.riskChangePreview, marsh.recommendedFirstBundle.riskChangePreview);
+  assert.deepEqual(marsh.postBundleCumulativeRisk, marsh.recommendedFirstBundle.postBundleCumulativeRisk);
   assert.deepEqual(stable.supportBundles, undefined);
   assert.deepEqual(stable.recommendedFirstBundle, undefined);
   assert.deepEqual(stable.riskChangePreview, {
@@ -761,6 +778,22 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
     monitoredRisk: 'aucun support recommandé',
     tradeoffToWatch: 'aucun',
     reason: 'aucun bundle recommandé: stabilité suffisante',
+  });
+  assert.deepEqual(stable.postBundleCumulativeRisk, {
+    status: 'neutral',
+    before: {
+      score: 0,
+      level: 'low',
+    },
+    after: {
+      score: 0,
+      level: 'low',
+    },
+    reducedRisk: 'aucun support recommandé',
+    remainingPriority: 'aucun',
+    fragileRegionId: null,
+    fragileCultureId: null,
+    nextAttention: 'aucune attention supplémentaire recommandée',
   });
 });
 


### PR DESCRIPTION
Gamma: ## Summary

Adds a deterministic cumulative risk preview after applying the recommended first cultural support bundle.

## Changes

- Exposes `postBundleCumulativeRisk` on culture overlay entries and `recommendedFirstBundle`.
- Separates the reduced risk from the remaining priority risk after the first bundle.
- Includes before/after score + level, fragile region/culture, and next attention copy.
- Keeps no-bundle regions explicit with a neutral cumulative-risk state.
- Updates culture overlay unit tests for active and neutral cases.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#941