### PR TITLE
Alpha: rank cleanup follow-up choices

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -119,6 +119,43 @@ export function buildFirstCleanupPayoff(cleanupOrders = [], residualRisks = []) 
   };
 }
 
+export function buildFollowUpCleanupChoices(cleanupOrders = [], residualRisks = [], firstCleanupPayoff = null) {
+  const normalizedOrders = normalizeCleanupInput(cleanupOrders, 'StrategicMapShell cleanupOrders');
+  const normalizedRisks = normalizeCleanupInput(residualRisks, 'StrategicMapShell residualRisks');
+  const skippedOrderId = String(firstCleanupPayoff?.cleanupOrderId ?? normalizedOrders[0]?.id ?? '').trim();
+  const skippedRiskKey = String(firstCleanupPayoff?.residualRiskKey ?? normalizedOrders[0]?.residualRiskKey ?? '').trim();
+
+  return normalizedOrders
+    .filter((order) => {
+      const orderId = String(order.id ?? '').trim();
+      const residualRiskKey = String(order.residualRiskKey ?? '').trim();
+
+      return orderId !== skippedOrderId && residualRiskKey !== skippedRiskKey;
+    })
+    .map((order) => {
+      const residualRiskKey = String(order.residualRiskKey ?? '').trim();
+      const matchingRisk = normalizedRisks.find((risk) => String(risk.key ?? '').trim() === residualRiskKey) ?? null;
+      const riskCovered = String(order.riskReduced ?? matchingRisk?.label ?? 'risque résiduel').trim() || 'risque résiduel';
+
+      return {
+        rank: 0,
+        cleanupOrderId: String(order.id ?? '').trim() || null,
+        cleanupOrderLabel: String(order.label ?? 'Ordre de suivi').trim() || 'Ordre de suivi',
+        residualRiskKey,
+        targetId: getRiskLocationId(residualRiskKey),
+        riskCovered,
+        expectedBenefit: String(order.expectedBenefit ?? order.expectedEffect ?? `réduit ${riskCovered}`).trim(),
+        rankReason: String(order.reason ?? matchingRisk?.reason ?? 'meilleur suivi restant').trim() || 'meilleur suivi restant',
+        safetyScore: Number.isFinite(order.safetyScore) ? order.safetyScore : 0,
+      };
+    })
+    .sort((left, right) => right.safetyScore - left.safetyScore
+      || left.residualRiskKey.localeCompare(right.residualRiskKey)
+      || String(left.cleanupOrderId ?? '').localeCompare(String(right.cleanupOrderId ?? '')))
+    .slice(0, 3)
+    .map((choice, index) => ({ ...choice, rank: index + 1 }));
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -171,6 +208,11 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const overlaySlots = normalizeOverlaySlots(normalizedOptions.overlaySlots);
   const provinceGeometryById = normalizeGeometryMap(normalizedOptions.provinceGeometryById);
   const firstCleanupPayoff = buildFirstCleanupPayoff(normalizedOptions.cleanupOrders, normalizedOptions.residualRisks);
+  const followUpCleanupChoices = buildFollowUpCleanupChoices(
+    normalizedOptions.cleanupOrders,
+    normalizedOptions.residualRisks,
+    firstCleanupPayoff,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -211,6 +253,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
       })),
     },
     firstCleanupPayoff,
+    followUpCleanupChoices,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { Province } from '../../../src/domain/war/Province.js';
-import { buildFirstCleanupPayoff, buildStrategicMapShell } from '../../../src/ui/war/StrategicMapShell.js';
+import { buildFirstCleanupPayoff, buildFollowUpCleanupChoices, buildStrategicMapShell } from '../../../src/ui/war/StrategicMapShell.js';
 
 function createProvince(overrides = {}) {
   return new Province({
@@ -135,6 +135,77 @@ test('StrategicMapShell exposes the first cleanup payoff from cleanup orders and
       { key: 'low-loyalty:front-a', label: 'loyauté basse', reason: 'loyauté 42' },
     ],
   });
+});
+
+test('StrategicMapShell ranks follow-up cleanup choices after the first payoff', () => {
+  const shell = buildStrategicMapShell([createProvince({ id: 'front-a', name: 'Front A' })], {
+    residualRisks: [
+      { key: 'supply-pressure:front-a', label: 'pression ravitaillement', reason: 'approvisionnement tendu' },
+      { key: 'low-loyalty:front-a', label: 'loyauté basse', reason: 'loyauté 42' },
+      { key: 'route-exposure:front-b', label: 'axe encore exposé', reason: 'exposition route 21' },
+    ],
+    cleanupOrders: [
+      {
+        id: 'cleanup:route-blocked:supply-pressure:front-a',
+        label: 'Prioriser convoi court',
+        residualRiskKey: 'supply-pressure:front-a',
+        riskReduced: 'pression ravitaillement',
+        reason: 'ravitaillement visible à faible détour',
+        safetyScore: 46,
+      },
+      {
+        id: 'cleanup:route-blocked:low-loyalty:front-a',
+        label: 'Envoyer liaison locale',
+        residualRiskKey: 'low-loyalty:front-a',
+        riskReduced: 'loyauté basse',
+        reason: 'faible coût et peu d’effet secondaire',
+        safetyScore: 42,
+      },
+      {
+        id: 'cleanup:route-blocked:route-exposure:front-b',
+        label: 'Scanner axe détour',
+        residualRiskKey: 'route-exposure:front-b',
+        riskReduced: 'axe encore exposé',
+        reason: 'réduit l’exposition sans combat',
+        safetyScore: 45,
+      },
+    ],
+  });
+
+  assert.deepEqual(shell.followUpCleanupChoices, [
+    {
+      rank: 1,
+      cleanupOrderId: 'cleanup:route-blocked:route-exposure:front-b',
+      cleanupOrderLabel: 'Scanner axe détour',
+      residualRiskKey: 'route-exposure:front-b',
+      targetId: 'front-b',
+      riskCovered: 'axe encore exposé',
+      expectedBenefit: 'réduit axe encore exposé',
+      rankReason: 'réduit l’exposition sans combat',
+      safetyScore: 45,
+    },
+    {
+      rank: 2,
+      cleanupOrderId: 'cleanup:route-blocked:low-loyalty:front-a',
+      cleanupOrderLabel: 'Envoyer liaison locale',
+      residualRiskKey: 'low-loyalty:front-a',
+      targetId: 'front-a',
+      riskCovered: 'loyauté basse',
+      expectedBenefit: 'réduit loyauté basse',
+      rankReason: 'faible coût et peu d’effet secondaire',
+      safetyScore: 42,
+    },
+  ]);
+});
+
+test('StrategicMapShell returns empty follow-up cleanup choices when no follow-up is useful', () => {
+  assert.deepEqual(buildFollowUpCleanupChoices([
+    { id: 'cleanup:first', residualRiskKey: 'low-loyalty:front-a', riskReduced: 'loyauté basse' },
+  ], [{ key: 'low-loyalty:front-a', label: 'loyauté basse' }], {
+    cleanupOrderId: 'cleanup:first',
+    residualRiskKey: 'low-loyalty:front-a',
+  }), []);
+  assert.deepEqual(buildStrategicMapShell([], {}).followUpCleanupChoices, []);
 });
 
 test('StrategicMapShell returns a neutral cleanup payoff when no cleanup order is useful', () => {

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -59,7 +59,9 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /prerequisite: cleanup\.prerequisite/);
   assert.match(webAppSource, /safetyScore/);
   assert.match(webAppSource, /buildFirstCleanupPayoff\(cleanupOrders, residualRisks\)/);
+  assert.match(webAppSource, /buildFollowUpCleanupChoices\(cleanupOrders, residualRisks, firstCleanupPayoff\)/);
   assert.match(webAppSource, /firstCleanupPayoff/);
+  assert.match(webAppSource, /followUpCleanupChoices/);
 });
 
 test('atlas military fallback order hint stays secondary and hides no-safe fallback state', () => {
@@ -82,8 +84,11 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /reste: aucun risque visible/);
   assert.match(webAppSource, /nettoyer: aucun ordre requis/);
   assert.match(webAppSource, /payoff: aucun nettoyage utile/);
+  assert.match(webAppSource, /suivi: aucun cleanup utile/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
+  assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
+  assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -95,4 +100,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__residual-risks/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-orders/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-payoff/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-followups/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@ import { Province } from '../src/domain/war/Province.js';
 import { City } from '../src/domain/economy/City.js';
 import { TradeRoute } from '../src/domain/economy/TradeRoute.js';
 import { buildEconomySeedFromStrategicMap } from '../src/application/economy/BuildEconomySeedFromStrategicMap.js';
-import { buildFirstCleanupPayoff, buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
+import { buildFirstCleanupPayoff, buildFollowUpCleanupChoices, buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
 import { buildLauncherMapSelection } from '../src/ui/launcher/buildLauncherMapSelection.js';
 import { buildEconomyMapOverlay } from '../src/ui/economy/buildEconomyMapOverlay.js';
 import { buildCityStockPanel } from '../src/ui/economy/buildCityStockPanel.js';
@@ -1942,6 +1942,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       residualRisks: [],
       cleanupOrders: [],
       firstCleanupPayoff: null,
+      followUpCleanupChoices: [],
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1953,6 +1954,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const residualRisks = buildAtlasMilitaryFallbackResidualRisks(fallback, topWarning, shell, priorityStack);
   const cleanupOrders = buildAtlasMilitaryFallbackCleanupOrders(residualRisks, fallback);
   const firstCleanupPayoff = buildFirstCleanupPayoff(cleanupOrders, residualRisks);
+  const followUpCleanupChoices = buildFollowUpCleanupChoices(cleanupOrders, residualRisks, firstCleanupPayoff);
 
   return {
     fallback: {
@@ -1965,6 +1967,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       residualRisks,
       cleanupOrders,
       firstCleanupPayoff,
+      followUpCleanupChoices,
     },
     safetyReason,
     crossDomainBlocker,
@@ -1972,7 +1975,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     residualRisks,
     cleanupOrders,
     firstCleanupPayoff,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}).`,
+    followUpCleanupChoices,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}).`,
     empty: false,
   };
 }
@@ -1989,6 +1993,9 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const firstCleanupPayoffLabel = fallback.firstCleanupPayoff
     ? `payoff: ${fallback.firstCleanupPayoff.riskReduced} ↓ · reste ${fallback.firstCleanupPayoff.remainingRiskCount}`
     : 'payoff: aucun nettoyage utile';
+  const followUpCleanupLabel = fallback.followUpCleanupChoices?.length
+    ? `suivi: ${fallback.followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel} (${choice.riskCovered})`).join(' · ')}`
+    : 'suivi: aucun cleanup utile';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
       <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="11" rx="1.2"></rect>
@@ -2000,6 +2007,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__residual-risks" x="23.2" y="64.6">${residualRiskLabel}</text>
       <text class="atlas-military-fallback-order__cleanup-orders" x="23.2" y="65.7">${cleanupOrderLabel}</text>
       <text class="atlas-military-fallback-order__cleanup-payoff" x="23.2" y="66.8">${firstCleanupPayoffLabel}</text>
+      <text class="atlas-military-fallback-order__cleanup-followups" x="23.2" y="67.9">${followUpCleanupLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11154,6 +11154,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__residual-risks { fill: #fecaca; font-size: 0.54px; font-weight: 800; }
 .atlas-military-fallback-order__cleanup-orders { fill: #bfdbfe; font-size: 0.53px; font-weight: 800; }
 .atlas-military-fallback-order__cleanup-payoff { fill: #bbf7d0; font-size: 0.52px; font-weight: 900; }
+.atlas-military-fallback-order__cleanup-followups { fill: #ddd6fe; font-size: 0.5px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #939.

Summary:
- Adds deterministic `followUpCleanupChoices` alongside `firstCleanupPayoff`.
- Excludes the cleanup already covered by the first payoff and ranks remaining choices by safety score with stable tie-breaks.
- Renders the follow-up choices in the military fallback cleanup panel.

Tests:
- `npm test`

Closes #939