### PR TITLE
Delta: compare second sweep candidates

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -115,13 +115,10 @@ function buildPostSweepGaps({ sleeperCellCount, sabotageRiskScore, unknownsRemai
   ].filter(Boolean);
 }
 
-function buildNextSafeSweep({ postSweepGaps, unknownsRemaining, sleeperCellCount, sabotageRiskScore, exposureAdded }) {
-  if (postSweepGaps.length === 0) {
-    return null;
-  }
-
+function buildSecondSweepCandidateInputs({ postSweepGaps, unknownsRemaining, sleeperCellCount, sabotageRiskScore, exposureAdded }) {
   const gapByKey = new Map(postSweepGaps.map((gap) => [gap.key, gap]));
-  const candidates = [
+
+  return [
     gapByKey.has('unconfirmed-presence') ? {
       gapKey: 'unconfirmed-presence',
       coverageValue: Math.max(1, unknownsRemaining),
@@ -141,8 +138,21 @@ function buildNextSafeSweep({ postSweepGaps, unknownsRemaining, sleeperCellCount
       reason: 'Vérifie la pression sabotage visible sans attribuer de cible cachée.',
     } : null,
   ].filter(Boolean);
+}
 
-  const safest = candidates
+function buildNextSafeSweep({ postSweepGaps, unknownsRemaining, sleeperCellCount, sabotageRiskScore, exposureAdded }) {
+  if (postSweepGaps.length === 0) {
+    return null;
+  }
+
+  const gapByKey = new Map(postSweepGaps.map((gap) => [gap.key, gap]));
+  const safest = buildSecondSweepCandidateInputs({
+    postSweepGaps,
+    unknownsRemaining,
+    sleeperCellCount,
+    sabotageRiskScore,
+    exposureAdded,
+  })
     .sort((left, right) => (
       left.estimatedExposureAdded - right.estimatedExposureAdded
       || right.coverageValue - left.coverageValue
@@ -160,6 +170,46 @@ function buildNextSafeSweep({ postSweepGaps, unknownsRemaining, sleeperCellCount
   };
 }
 
+function buildSecondSweepCandidates({ postSweepGaps, unknownsRemaining, sleeperCellCount, sabotageRiskScore, exposureAdded, nextSafeSweep }) {
+  if (postSweepGaps.length < 2 || nextSafeSweep === null) {
+    return [];
+  }
+
+  const gapByKey = new Map(postSweepGaps.map((gap) => [gap.key, gap]));
+
+  return buildSecondSweepCandidateInputs({
+    postSweepGaps,
+    unknownsRemaining,
+    sleeperCellCount,
+    sabotageRiskScore,
+    exposureAdded,
+  })
+    .map((candidate) => {
+      const gap = gapByKey.get(candidate.gapKey);
+      const estimatedExposureAdded = clampPercent(candidate.estimatedExposureAdded);
+      const estimatedHeat = clampPercent(Math.ceil(candidate.estimatedExposureAdded * 1.5));
+      const exposureCost = Math.max(1, estimatedExposureAdded + estimatedHeat);
+      const coveragePerExposureScore = Number(((candidate.coverageValue * 100) / exposureCost).toFixed(1));
+
+      return {
+        targetGapKey: gap.key,
+        targetGapLabel: gap.label,
+        coverageValue: candidate.coverageValue,
+        estimatedExposureAdded,
+        estimatedHeat,
+        coveragePerExposureScore,
+        recommended: gap.key === nextSafeSweep.targetGapKey,
+        reason: candidate.reason,
+      };
+    })
+    .sort((left, right) => (
+      right.coveragePerExposureScore - left.coveragePerExposureScore
+      || left.estimatedExposureAdded - right.estimatedExposureAdded
+      || left.targetGapKey.localeCompare(right.targetGapKey)
+    ))
+    .slice(0, 3);
+}
+
 function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount, sleeperCellCount, sabotageRiskScore }) {
   if (celluleCount <= 0 || sabotageRiskScore <= 0 || exposedCellCount >= celluleCount) {
     return {
@@ -172,6 +222,7 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
       unknownsRemaining: Math.max(0, celluleCount - exposedCellCount),
       postSweepGaps: [],
       nextSafeSweep: null,
+      secondSweepCandidates: [],
       summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
     };
   }
@@ -191,6 +242,14 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
     sabotageRiskScore,
     exposureAdded,
   });
+  const secondSweepCandidates = buildSecondSweepCandidates({
+    postSweepGaps,
+    unknownsRemaining,
+    sleeperCellCount,
+    sabotageRiskScore,
+    exposureAdded,
+    nextSafeSweep,
+  });
   const state = exposureAdded <= 8
     ? 'low-exposure-positive'
     : exposureAdded < 12
@@ -207,6 +266,7 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
     unknownsRemaining,
     postSweepGaps,
     nextSafeSweep,
+    secondSweepCandidates,
     summary: `Confiance +${confidenceDelta} pts pour +${exposureAdded} exposition; ${unknownsRemaining} inconnue${unknownsRemaining > 1 ? 's' : ''} restante${unknownsRemaining > 1 ? 's' : ''}.`,
   };
 }

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -134,6 +134,7 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
         unknownsRemaining: 0,
         postSweepGaps: [],
         nextSafeSweep: null,
+        secondSweepCandidates: [],
         summary: 'Confiance +23 pts pour +10 exposition; 0 inconnue restante.',
       },
       style: {
@@ -175,6 +176,7 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
         unknownsRemaining: 0,
         postSweepGaps: [],
         nextSafeSweep: null,
+        secondSweepCandidates: [],
         summary: 'Confiance +31 pts pour +5 exposition; 0 inconnue restante.',
       },
       style: {
@@ -316,6 +318,7 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
     unknownsRemaining: 0,
     postSweepGaps: [],
     nextSafeSweep: null,
+    secondSweepCandidates: [],
     summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
   });
   assert.equal(hot.lowExposureSweepConfidencePreview.state, 'watch-exposure');
@@ -350,6 +353,38 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
     estimatedHeat: 12,
     safetyReason: 'Passe courte centrée sur la dormance: couverture limitée mais exposition minimale.',
   });
+  assert.deepEqual(hot.lowExposureSweepConfidencePreview.secondSweepCandidates, [
+    {
+      targetGapKey: 'residual-sabotage-pressure',
+      targetGapLabel: 'Pression sabotage résiduelle',
+      coverageValue: 2,
+      estimatedExposureAdded: 12,
+      estimatedHeat: 18,
+      coveragePerExposureScore: 6.7,
+      recommended: false,
+      reason: 'Vérifie la pression sabotage visible sans attribuer de cible cachée.',
+    },
+    {
+      targetGapKey: 'sleeper-uncertainty',
+      targetGapLabel: 'Dormance encore possible',
+      coverageValue: 1,
+      estimatedExposureAdded: 8,
+      estimatedHeat: 12,
+      coveragePerExposureScore: 5,
+      recommended: true,
+      reason: 'Passe courte centrée sur la dormance: couverture limitée mais exposition minimale.',
+    },
+    {
+      targetGapKey: 'unconfirmed-presence',
+      targetGapLabel: 'Présence non confirmée',
+      coverageValue: 1,
+      estimatedExposureAdded: 10,
+      estimatedHeat: 15,
+      coveragePerExposureScore: 4,
+      recommended: false,
+      reason: "Qualifie 1 signal restant sans élargir la fenêtre d'exposition.",
+    },
+  ]);
   assert.match(hot.lowExposureSweepConfidencePreview.summary, /Confiance \+26 pts pour \+12 exposition/);
 });
 
@@ -391,6 +426,7 @@ test('buildIntrigueMapOverlay keeps post-sweep gap explanations stable and neutr
 
   assert.deepEqual(overlay[0].lowExposureSweepConfidencePreview.postSweepGaps, []);
   assert.equal(overlay[0].lowExposureSweepConfidencePreview.nextSafeSweep, null);
+  assert.deepEqual(overlay[0].lowExposureSweepConfidencePreview.secondSweepCandidates, []);
   assert.equal(overlay[0].lowExposureSweepConfidencePreview.unknownsRemaining, 0);
 });
 


### PR DESCRIPTION
Delta: Implements #942.

Summary:
- Adds `secondSweepCandidates` to low-exposure intrigue sweep previews when multiple post-sweep actions are plausible.
- Scores and sorts candidates by useful coverage per exposure/heat while keeping the safest recommended sweep identifiable.
- Returns an explicit empty candidates list for neutral/no-alternative states.

Tests:
- `npm test`

Zeta: PR ready for validation. Please review before any merge.