### PR TITLE
Delta: add second sweep stop conditions

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -210,6 +210,69 @@ function buildSecondSweepCandidates({ postSweepGaps, unknownsRemaining, sleeperC
     .slice(0, 3);
 }
 
+function buildSecondSweepStopCondition({ nextSafeSweep, unknownsRemaining, sabotageRiskScore }) {
+  if (nextSafeSweep === null) {
+    return {
+      state: 'no-safe-sweep',
+      action: 'stop',
+      continueNow: false,
+      stopSignal: 'Aucun second sweep sûr n’est disponible dans la fenêtre actuelle.',
+      explanation: 'Ne pas enchaîner: attendre un signal lisible avant de rouvrir la zone.',
+    };
+  }
+
+  const exposure = nextSafeSweep.estimatedExposureAdded;
+  const heat = nextSafeSweep.estimatedHeat;
+
+  if (exposure >= 14 || heat >= 21) {
+    return {
+      state: 'exposure-too-high',
+      action: 'stop',
+      continueNow: false,
+      stopSignal: `Stop si le second sweep ajoute ${exposure} exposition ou ${heat} heat.`,
+      explanation: 'La limite de sécurité serait dépassée; garder la zone froide avant toute nouvelle passe.',
+    };
+  }
+
+  if (unknownsRemaining <= 0 && nextSafeSweep.targetGapKey === 'residual-sabotage-pressure') {
+    return {
+      state: 'needs-fresh-signal',
+      action: 'wait-for-signal',
+      continueNow: false,
+      stopSignal: 'Stop tant qu’aucun nouveau signal bas-risque ne justifie de rouvrir la pression sabotage.',
+      explanation: 'La couverture utile est déjà lisible; attendre un signal frais évite une exposition gratuite.',
+    };
+  }
+
+  if (sabotageRiskScore >= 90 && heat >= 18) {
+    return {
+      state: 'wait-cooler-window',
+      action: 'wait',
+      continueNow: false,
+      stopSignal: `Attendre si le heat estimé reste à ${heat} dans une zone déjà chaude.`,
+      explanation: 'La prochaine passe reste plausible, mais une fenêtre plus froide protège mieux le réseau.',
+    };
+  }
+
+  if (exposure <= 8 && heat <= 12) {
+    return {
+      state: 'continue-now',
+      action: 'continue',
+      continueNow: true,
+      stopSignal: `Continuer tant que l’exposition ajoutée reste ≤ 8 et le heat ≤ 12.`,
+      explanation: 'Le second sweep recommandé couvre le gap prioritaire avec une exposition contenue.',
+    };
+  }
+
+  return {
+    state: 'wait-cooler-window',
+    action: 'wait',
+    continueNow: false,
+    stopSignal: `Attendre une fenêtre plus froide si l’exposition reste à ${exposure} ou le heat à ${heat}.`,
+    explanation: 'La recommandation reste valable, mais le coût d’exposition mérite une pause avant enchaînement.',
+  };
+}
+
 function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount, sleeperCellCount, sabotageRiskScore }) {
   if (celluleCount <= 0 || sabotageRiskScore <= 0 || exposedCellCount >= celluleCount) {
     return {
@@ -223,6 +286,11 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
       postSweepGaps: [],
       nextSafeSweep: null,
       secondSweepCandidates: [],
+      secondSweepStopCondition: buildSecondSweepStopCondition({
+        nextSafeSweep: null,
+        unknownsRemaining: Math.max(0, celluleCount - exposedCellCount),
+        sabotageRiskScore,
+      }),
       summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
     };
   }
@@ -250,6 +318,11 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
     exposureAdded,
     nextSafeSweep,
   });
+  const secondSweepStopCondition = buildSecondSweepStopCondition({
+    nextSafeSweep,
+    unknownsRemaining,
+    sabotageRiskScore,
+  });
   const state = exposureAdded <= 8
     ? 'low-exposure-positive'
     : exposureAdded < 12
@@ -267,6 +340,7 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
     postSweepGaps,
     nextSafeSweep,
     secondSweepCandidates,
+    secondSweepStopCondition,
     summary: `Confiance +${confidenceDelta} pts pour +${exposureAdded} exposition; ${unknownsRemaining} inconnue${unknownsRemaining > 1 ? 's' : ''} restante${unknownsRemaining > 1 ? 's' : ''}.`,
   };
 }

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -135,6 +135,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
         postSweepGaps: [],
         nextSafeSweep: null,
         secondSweepCandidates: [],
+        secondSweepStopCondition: {
+          state: 'no-safe-sweep',
+          action: 'stop',
+          continueNow: false,
+          stopSignal: 'Aucun second sweep sûr n’est disponible dans la fenêtre actuelle.',
+          explanation: 'Ne pas enchaîner: attendre un signal lisible avant de rouvrir la zone.',
+        },
         summary: 'Confiance +23 pts pour +10 exposition; 0 inconnue restante.',
       },
       style: {
@@ -177,6 +184,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
         postSweepGaps: [],
         nextSafeSweep: null,
         secondSweepCandidates: [],
+        secondSweepStopCondition: {
+          state: 'no-safe-sweep',
+          action: 'stop',
+          continueNow: false,
+          stopSignal: 'Aucun second sweep sûr n’est disponible dans la fenêtre actuelle.',
+          explanation: 'Ne pas enchaîner: attendre un signal lisible avant de rouvrir la zone.',
+        },
         summary: 'Confiance +31 pts pour +5 exposition; 0 inconnue restante.',
       },
       style: {
@@ -319,6 +333,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
     postSweepGaps: [],
     nextSafeSweep: null,
     secondSweepCandidates: [],
+    secondSweepStopCondition: {
+      state: 'no-safe-sweep',
+      action: 'stop',
+      continueNow: false,
+      stopSignal: 'Aucun second sweep sûr n’est disponible dans la fenêtre actuelle.',
+      explanation: 'Ne pas enchaîner: attendre un signal lisible avant de rouvrir la zone.',
+    },
     summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
   });
   assert.equal(hot.lowExposureSweepConfidencePreview.state, 'watch-exposure');
@@ -352,6 +373,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
     estimatedExposureAdded: 8,
     estimatedHeat: 12,
     safetyReason: 'Passe courte centrée sur la dormance: couverture limitée mais exposition minimale.',
+  });
+  assert.deepEqual(hot.lowExposureSweepConfidencePreview.secondSweepStopCondition, {
+    state: 'continue-now',
+    action: 'continue',
+    continueNow: true,
+    stopSignal: 'Continuer tant que l’exposition ajoutée reste ≤ 8 et le heat ≤ 12.',
+    explanation: 'Le second sweep recommandé couvre le gap prioritaire avec une exposition contenue.',
   });
   assert.deepEqual(hot.lowExposureSweepConfidencePreview.secondSweepCandidates, [
     {
@@ -427,7 +455,76 @@ test('buildIntrigueMapOverlay keeps post-sweep gap explanations stable and neutr
   assert.deepEqual(overlay[0].lowExposureSweepConfidencePreview.postSweepGaps, []);
   assert.equal(overlay[0].lowExposureSweepConfidencePreview.nextSafeSweep, null);
   assert.deepEqual(overlay[0].lowExposureSweepConfidencePreview.secondSweepCandidates, []);
+  assert.equal(overlay[0].lowExposureSweepConfidencePreview.secondSweepStopCondition.state, 'no-safe-sweep');
   assert.equal(overlay[0].lowExposureSweepConfidencePreview.unknownsRemaining, 0);
+});
+
+test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and exposure limits', () => {
+  const needsSignal = buildIntrigueMapOverlay([
+    {
+      id: 'cell-pressure-1',
+      factionId: 'shadow-league',
+      codename: 'Pressure',
+      locationId: 'pressure',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 10,
+    },
+  ], [
+    {
+      id: 'op-pressure',
+      celluleId: 'cell-pressure-1',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe pressure',
+      theaterId: 'pressure',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 5,
+      progress: 100,
+      heat: 100,
+    },
+  ])[0].lowExposureSweepConfidencePreview;
+
+  assert.equal(needsSignal.nextSafeSweep.targetGapKey, 'residual-sabotage-pressure');
+  assert.deepEqual(needsSignal.secondSweepStopCondition, {
+    state: 'needs-fresh-signal',
+    action: 'wait-for-signal',
+    continueNow: false,
+    stopSignal: 'Stop tant qu’aucun nouveau signal bas-risque ne justifie de rouvrir la pression sabotage.',
+    explanation: 'La couverture utile est déjà lisible; attendre un signal frais évite une exposition gratuite.',
+  });
+
+  const tooExposed = buildIntrigueMapOverlay([
+    ...Array.from({ length: 6 }, (_, index) => ({
+      id: `cell-burn-${index}`,
+      factionId: 'shadow-league',
+      codename: `Burn ${index}`,
+      locationId: 'burn',
+      memberIds: [`ag-${index}`],
+      assetIds: [`asset-${index}`],
+      sleeper: index < 4,
+      exposure: 10,
+    })),
+  ], [
+    {
+      id: 'op-burn',
+      celluleId: 'cell-burn-0',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe burn limit',
+      theaterId: 'burn',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 5,
+      progress: 100,
+      heat: 100,
+    },
+  ])[0].lowExposureSweepConfidencePreview;
+
+  assert.equal(tooExposed.secondSweepStopCondition.state, 'exposure-too-high');
+  assert.equal(tooExposed.secondSweepStopCondition.continueNow, false);
+  assert.match(tooExposed.secondSweepStopCondition.stopSignal, /Stop si le second sweep ajoute/);
 });
 
 test('buildIntrigueMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
Delta: Implements #952.

Summary:
- Adds `secondSweepStopCondition` to low-exposure intrigue sweep previews.
- Covers continue, wait, fresh-signal, too-exposed, and no-safe-sweep stop states with fog-safe explanations.
- Keeps second sweep candidate comparison and nextSafeSweep recommendation intact.

Tests:
- `node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js`
- `npm test` (598/598)

Zeta: PR ready for validation. Please review before any merge.