### PR TITLE
Beta: sequence best value corridor preparation

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -238,6 +238,40 @@ function scorePreparationOption(option, routeValue, routeRiskLevel) {
     - option.effort.amount;
 }
 
+function buildPreparationSequence(bestOption, cheaperAcceptable, estimatedValueProtected) {
+  const sequence = [
+    {
+      id: `${bestOption.id}:now`,
+      timing: 'now',
+      optionId: bestOption.id,
+      action: bestOption.action,
+      label: bestOption.label,
+      reason: `Sécurise ${estimatedValueProtected} valeur corridor avant dépense.`,
+    },
+    {
+      id: `${bestOption.id}:next`,
+      timing: 'next',
+      optionId: bestOption.id,
+      action: 'spend-capacity-after-preparation',
+      label: 'Dépenser la capacité après marge confirmée',
+      reason: `Engage la dépense seulement après +${bestOption.expectedEffect.marginGain} marge préparée.`,
+    },
+  ];
+
+  if (cheaperAcceptable !== null) {
+    sequence.push({
+      id: `${cheaperAcceptable.optionId}:defer`,
+      timing: 'defer',
+      optionId: cheaperAcceptable.optionId,
+      action: 'keep-cheaper-fallback',
+      label: 'Garder l’option moins chère en repli',
+      reason: cheaperAcceptable.condition,
+    });
+  }
+
+  return sequence;
+}
+
 function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLevel) {
   if (preparationOptions.length < 2) {
     return null;
@@ -275,6 +309,7 @@ function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLeve
     effort: { ...best.option.effort },
     reason: `Protège ${best.estimatedValueProtected} valeur corridor avec +${best.option.expectedEffect.marginGain} marge pour ${best.option.effort.amount} ${best.option.effort.unit}.`,
     cheaperAcceptable,
+    sequence: buildPreparationSequence(best.option, cheaperAcceptable, best.estimatedValueProtected),
   };
 }
 
@@ -333,6 +368,7 @@ function buildCapacitySpendPreview(route, spendPlan) {
     route.riskLevel,
     currentCapacity,
   );
+  const bestValuePreparation = nextBottleneck?.bestValuePreparation ?? null;
 
   return {
     routeId: route.id,
@@ -342,7 +378,8 @@ function buildCapacitySpendPreview(route, spendPlan) {
     limitingResourceId: computedLimitingResourceId,
     nextBottleneck,
     preparationOptions: nextBottleneck?.preparationOptions ?? [],
-    bestValuePreparation: nextBottleneck?.bestValuePreparation ?? null,
+    bestValuePreparation,
+    preparationSequence: bestValuePreparation?.sequence ?? [],
     state: capacityMobilized === 0
       ? 'no-spend'
       : capacityRemaining === 0

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -153,6 +153,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         nextBottleneck: null,
         preparationOptions: [],
         bestValuePreparation: null,
+        preparationSequence: [],
         state: 'no-spend',
         resources: [
           { resourceId: 'wood', currentCapacity: 3, capacityMobilized: 0, capacityRemaining: 3 },
@@ -191,6 +192,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         nextBottleneck: null,
         preparationOptions: [],
         bestValuePreparation: null,
+        preparationSequence: [],
         state: 'no-spend',
         resources: [
           { resourceId: 'fish', currentCapacity: 4, capacityMobilized: 0, capacityRemaining: 4 },
@@ -258,6 +260,7 @@ test('buildEconomyMapOverlay supports plain payloads and style overrides', () =>
     nextBottleneck: null,
     preparationOptions: [],
     bestValuePreparation: null,
+    preparationSequence: [],
     state: 'no-spend',
     resources: [
       { resourceId: 'salt', currentCapacity: 9, capacityMobilized: 0, capacityRemaining: 9 },
@@ -344,6 +347,7 @@ test('buildEconomyMapOverlay previews capacity spent by recommended unlocks', ()
       },
     ],
     bestValuePreparation: null,
+    preparationSequence: [],
     state: 'remaining-margin',
     resources: [
       { resourceId: 'grain', currentCapacity: 5, capacityMobilized: 4, capacityRemaining: 1 },
@@ -399,7 +403,59 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       optionId: 'grain:reserve-buffer',
       condition: 'acceptable seulement si le coût immédiat prime sur la valeur protégée',
     },
+    sequence: [
+      {
+        id: 'grain:shift-to-tools:now',
+        timing: 'now',
+        optionId: 'grain:shift-to-tools',
+        action: 'shift-load-to-spare-resource',
+        label: 'Reporter une partie du flux vers tools',
+        reason: 'Sécurise 20 valeur corridor avant dépense.',
+      },
+      {
+        id: 'grain:shift-to-tools:next',
+        timing: 'next',
+        optionId: 'grain:shift-to-tools',
+        action: 'spend-capacity-after-preparation',
+        label: 'Dépenser la capacité après marge confirmée',
+        reason: 'Engage la dépense seulement après +2 marge préparée.',
+      },
+      {
+        id: 'grain:reserve-buffer:defer',
+        timing: 'defer',
+        optionId: 'grain:reserve-buffer',
+        action: 'keep-cheaper-fallback',
+        label: 'Garder l’option moins chère en repli',
+        reason: 'acceptable seulement si le coût immédiat prime sur la valeur protégée',
+      },
+    ],
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
+    {
+      id: 'grain:shift-to-tools:now',
+      timing: 'now',
+      optionId: 'grain:shift-to-tools',
+      action: 'shift-load-to-spare-resource',
+      label: 'Reporter une partie du flux vers tools',
+      reason: 'Sécurise 20 valeur corridor avant dépense.',
+    },
+    {
+      id: 'grain:shift-to-tools:next',
+      timing: 'next',
+      optionId: 'grain:shift-to-tools',
+      action: 'spend-capacity-after-preparation',
+      label: 'Dépenser la capacité après marge confirmée',
+      reason: 'Engage la dépense seulement après +2 marge préparée.',
+    },
+    {
+      id: 'grain:reserve-buffer:defer',
+      timing: 'defer',
+      optionId: 'grain:reserve-buffer',
+      action: 'keep-cheaper-fallback',
+      label: 'Garder l’option moins chère en repli',
+      reason: 'acceptable seulement si le coût immédiat prime sur la valeur protégée',
+    },
+  ]);
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
     overlay.routes[0].capacitySpendPreview.bestValuePreparation,


### PR DESCRIPTION
## Summary

Beta: Adds a compact preparation sequence for the best-value corridor preparation so the economy overlay can show what to do now, what to do next, and what to defer before spending capacity.

## Changes

- Derive `bestValuePreparation.sequence` with stable `now` / `next` / optional `defer` steps.
- Expose `capacitySpendPreview.preparationSequence` as a stable empty array when no comparable best-value preparation exists.
- Include short step reasons covering protected value, improved margin, and cheaper fallback conditions.
- Extend economy overlay tests for neutral empty sequences and deterministic best-value sequencing.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (597/597 pass)

Fixes loo469/historia#950