### PR TITLE
Gamma: recommend next safe cultural support

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -577,6 +577,52 @@ function buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePre
   };
 }
 
+function buildNextSafeSupportBundle(supportBundles, recommendedFirstBundle, postBundleCumulativeRisk) {
+  if (!recommendedFirstBundle || postBundleCumulativeRisk.status === 'neutral') {
+    return null;
+  }
+
+  const remainingCandidates = supportBundles
+    .filter((bundle) => bundle.id !== recommendedFirstBundle.bundleId)
+    .map((bundle) => {
+      const residualMatchBonus = bundle.monitoredRisk === postBundleCumulativeRisk.remainingPriority ? 8 : 0;
+      const tradeoffGuardPenalty = bundle.tradeoff.includes('recherche ralentie')
+        ? 3
+        : bundle.tradeoff.includes('sous surveillance') || bundle.tradeoff.includes('ouverture -')
+          ? 1
+          : 0;
+      const residualReliefScore = Math.max(0, bundle.safetyScore + residualMatchBonus - tradeoffGuardPenalty);
+
+      return { ...bundle, residualReliefScore, tradeoffGuardPenalty };
+    })
+    .filter((bundle) => bundle.residualReliefScore >= 4)
+    .sort((left, right) => (
+      right.residualReliefScore - left.residualReliefScore
+      || right.safetyScore - left.safetyScore
+      || left.id.localeCompare(right.id)
+    ));
+
+  const nextBundle = remainingCandidates[0] ?? null;
+
+  if (!nextBundle) {
+    return null;
+  }
+
+  const safetyReason = nextBundle.monitoredRisk === postBundleCumulativeRisk.remainingPriority
+    ? `second soutien sûr: cible le risque résiduel ${nextBundle.monitoredRisk} · score ${nextBundle.residualReliefScore}`
+    : `second soutien sûr: garde-fou compatible après ${recommendedFirstBundle.label} · score ${nextBundle.residualReliefScore}`;
+
+  return {
+    bundleId: nextBundle.id,
+    label: nextBundle.label,
+    residualReliefScore: nextBundle.residualReliefScore,
+    reason: safetyReason,
+    monitoredRisk: nextBundle.monitoredRisk,
+    tradeoffToWatch: nextBundle.tradeoff,
+    followsBundleId: recommendedFirstBundle.bundleId,
+  };
+}
+
 function buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById) {
   const cultureIds = regionPresence.map((entry) => entry.cultureId).sort();
   const cultureNames = regionPresence.map((entry) => entry.cultureName).sort();
@@ -690,6 +736,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
         const riskChangePreview = buildCultureSupportRiskChangePreview(culture, supportBundles[0] ?? null, regionPresence, cultureState);
         const postBundleCumulativeRisk = buildCultureSupportCumulativeRisk(culture, regionId, riskChangePreview, regionPresence, cultureState);
         const recommendedFirstBundle = buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePreview, postBundleCumulativeRisk);
+        const nextSafeSupportBundle = buildNextSafeSupportBundle(supportBundles, recommendedFirstBundle, postBundleCumulativeRisk);
 
         const regionalDiscoveryLinks = cultureState.signals.highlightedDiscoveries.map((discoveryId) => {
           const linkedEvents = cultureState.signals.orderedHistoricalEvents.filter((historicalEvent) => historicalEvent.discoveryIds.includes(discoveryId));
@@ -757,6 +804,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           competingCultureIds: regionPresence.filter((entry) => entry.cultureId !== culture.id).map((entry) => entry.cultureId),
           riskChangePreview,
           postBundleCumulativeRisk,
+          nextSafeSupportBundle,
           ...(supportBundles.length > 0 ? { supportBundles, recommendedFirstBundle } : {}),
           ...(clusterSummary ? { clusterSummary } : {}),
           zoneContour: buildZoneContour(cultureState.influenceTier, overlapCount, zoneRank),

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -17,7 +17,7 @@ function withoutSupportRiskPreviews(value) {
 
   return Object.fromEntries(
     Object.entries(value)
-      .filter(([key]) => !['riskChangePreview', 'postBundleCumulativeRisk'].includes(key))
+      .filter(([key]) => !['riskChangePreview', 'postBundleCumulativeRisk', 'nextSafeSupportBundle'].includes(key))
       .map(([key, nestedValue]) => [key, withoutSupportRiskPreviews(nestedValue)]),
   );
 }
@@ -768,6 +768,15 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
   });
   assert.deepEqual(marsh.riskChangePreview, marsh.recommendedFirstBundle.riskChangePreview);
   assert.deepEqual(marsh.postBundleCumulativeRisk, marsh.recommendedFirstBundle.postBundleCumulativeRisk);
+  assert.deepEqual(marsh.nextSafeSupportBundle, {
+    bundleId: 'shared-marsh:culture-marsh:bundle:guided-opening',
+    label: 'ouvrir par relais savant',
+    residualReliefScore: 12,
+    reason: 'second soutien sûr: cible le risque résiduel isolement du support · score 12',
+    monitoredRisk: 'isolement du support',
+    tradeoffToWatch: 'ouverture + / cohésion sous surveillance',
+    followsBundleId: 'shared-marsh:culture-marsh:bundle:cohesion-anchor',
+  });
   assert.deepEqual(stable.supportBundles, undefined);
   assert.deepEqual(stable.recommendedFirstBundle, undefined);
   assert.deepEqual(stable.riskChangePreview, {
@@ -795,6 +804,7 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
     fragileCultureId: null,
     nextAttention: 'aucune attention supplémentaire recommandée',
   });
+  assert.equal(stable.nextSafeSupportBundle, null);
 });
 
 test('buildCultureMapOverlay can summarize overlapping culture clusters with discovery and event pins', () => {


### PR DESCRIPTION
Gamma: ## Summary

Adds a safe second cultural support recommendation when residual post-bundle risk remains actionable.

## Changes

- Derives `nextSafeSupportBundle` from existing support bundles, the first recommendation, and `postBundleCumulativeRisk`.
- Excludes the already recommended first bundle from second-step candidates.
- Scores remaining candidates by residual risk match with tradeoff guardrails.
- Returns `null` clearly when there is no safe second bundle.
- Adds test coverage for a residual-risk second bundle and neutral no-bundle state.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#951