### PR TITLE
Alpha: explain follow-up cleanup readiness

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -146,6 +146,7 @@ export function buildFollowUpCleanupChoices(cleanupOrders = [], residualRisks = 
         riskCovered,
         expectedBenefit: String(order.expectedBenefit ?? order.expectedEffect ?? `réduit ${riskCovered}`).trim(),
         rankReason: String(order.reason ?? matchingRisk?.reason ?? 'meilleur suivi restant').trim() || 'meilleur suivi restant',
+        prerequisite: String(order.prerequisite ?? '').trim() || null,
         safetyScore: Number.isFinite(order.safetyScore) ? order.safetyScore : 0,
       };
     })
@@ -154,6 +155,76 @@ export function buildFollowUpCleanupChoices(cleanupOrders = [], residualRisks = 
       || String(left.cleanupOrderId ?? '').localeCompare(String(right.cleanupOrderId ?? '')))
     .slice(0, 3)
     .map((choice, index) => ({ ...choice, rank: index + 1 }));
+}
+
+export function buildTopFollowUpReadiness(followUpCleanupChoices = [], residualRisks = []) {
+  const normalizedChoices = normalizeCleanupInput(followUpCleanupChoices, 'StrategicMapShell followUpCleanupChoices');
+  const normalizedRisks = normalizeCleanupInput(residualRisks, 'StrategicMapShell residualRisks');
+  const topChoice = normalizedChoices[0] ?? null;
+
+  if (!topChoice) {
+    return {
+      state: 'no-safe-followup',
+      tone: 'neutral',
+      label: 'Aucun suivi sûr',
+      blocker: 'aucun cleanup de suivi exploitable',
+      action: null,
+      targetId: null,
+      residualRiskKey: null,
+    };
+  }
+
+  const riskKey = String(topChoice.residualRiskKey ?? '').trim();
+  const riskType = riskKey.split(':')[0];
+  const matchingRisk = normalizedRisks.find((risk) => String(risk.key ?? '').trim() === riskKey) ?? null;
+  const prerequisite = String(topChoice.prerequisite ?? '').trim();
+  const riskReason = String(matchingRisk?.reason ?? topChoice.rankReason ?? '').trim();
+
+  if (riskType === 'route-exposure' || /éclaireur|détour|route|axe|corridor/i.test(`${prerequisite} ${riskReason}`)) {
+    return {
+      state: 'needs-logistics',
+      tone: 'warning',
+      label: 'Logistique à vérifier',
+      blocker: prerequisite || 'axe ou détour encore exposé',
+      action: 'sécuriser le corridor court avant exécution',
+      targetId: topChoice.targetId,
+      residualRiskKey: riskKey,
+    };
+  }
+
+  if (riskType === 'low-loyalty' || riskType === 'contested-occupation' || /loyauté|occupation|patrouille|émissaire|disputée/i.test(`${prerequisite} ${riskReason}`)) {
+    return {
+      state: 'stabilize-control',
+      tone: 'warning',
+      label: 'Contrôle local à stabiliser',
+      blocker: prerequisite || 'loyauté ou occupation encore fragile',
+      action: 'stabiliser la province avant le suivi',
+      targetId: topChoice.targetId,
+      residualRiskKey: riskKey,
+    };
+  }
+
+  if (riskType === 'supply-pressure' || /ravitaillement|convoi|approvisionnement/i.test(`${prerequisite} ${riskReason}`)) {
+    return {
+      state: 'supply-pressure',
+      tone: 'danger',
+      label: 'Ravitaillement sous pression',
+      blocker: prerequisite || 'pression ravitaillement visible',
+      action: 'ouvrir le convoi court avant de confirmer',
+      targetId: topChoice.targetId,
+      residualRiskKey: riskKey,
+    };
+  }
+
+  return {
+    state: 'ready-now',
+    tone: 'ready',
+    label: 'Prêt maintenant',
+    blocker: prerequisite || 'aucun bloqueur visible',
+    action: topChoice.cleanupOrderLabel,
+    targetId: topChoice.targetId,
+    residualRiskKey: riskKey,
+  };
 }
 
 function buildLegend(renderedProvinces, options) {
@@ -213,6 +284,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     normalizedOptions.residualRisks,
     firstCleanupPayoff,
   );
+  const topFollowUpReadiness = buildTopFollowUpReadiness(followUpCleanupChoices, normalizedOptions.residualRisks);
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -254,6 +326,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     },
     firstCleanupPayoff,
     followUpCleanupChoices,
+    topFollowUpReadiness,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -2,7 +2,12 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { Province } from '../../../src/domain/war/Province.js';
-import { buildFirstCleanupPayoff, buildFollowUpCleanupChoices, buildStrategicMapShell } from '../../../src/ui/war/StrategicMapShell.js';
+import {
+  buildFirstCleanupPayoff,
+  buildFollowUpCleanupChoices,
+  buildStrategicMapShell,
+  buildTopFollowUpReadiness,
+} from '../../../src/ui/war/StrategicMapShell.js';
 
 function createProvince(overrides = {}) {
   return new Province({
@@ -159,6 +164,7 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
         residualRiskKey: 'low-loyalty:front-a',
         riskReduced: 'loyauté basse',
         reason: 'faible coût et peu d’effet secondaire',
+        prerequisite: 'émissaire disponible',
         safetyScore: 42,
       },
       {
@@ -167,6 +173,7 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
         residualRiskKey: 'route-exposure:front-b',
         riskReduced: 'axe encore exposé',
         reason: 'réduit l’exposition sans combat',
+        prerequisite: 'éclaireurs disponibles',
         safetyScore: 45,
       },
     ],
@@ -182,6 +189,7 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
       riskCovered: 'axe encore exposé',
       expectedBenefit: 'réduit axe encore exposé',
       rankReason: 'réduit l’exposition sans combat',
+      prerequisite: 'éclaireurs disponibles',
       safetyScore: 45,
     },
     {
@@ -193,9 +201,41 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
       riskCovered: 'loyauté basse',
       expectedBenefit: 'réduit loyauté basse',
       rankReason: 'faible coût et peu d’effet secondaire',
+      prerequisite: 'émissaire disponible',
       safetyScore: 42,
     },
   ]);
+
+  assert.deepEqual(shell.topFollowUpReadiness, {
+    state: 'needs-logistics',
+    tone: 'warning',
+    label: 'Logistique à vérifier',
+    blocker: 'éclaireurs disponibles',
+    action: 'sécuriser le corridor court avant exécution',
+    targetId: 'front-b',
+    residualRiskKey: 'route-exposure:front-b',
+  });
+});
+
+test('StrategicMapShell explains deterministic readiness blockers for the top follow-up', () => {
+  assert.deepEqual(buildTopFollowUpReadiness([], []), {
+    state: 'no-safe-followup',
+    tone: 'neutral',
+    label: 'Aucun suivi sûr',
+    blocker: 'aucun cleanup de suivi exploitable',
+    action: null,
+    targetId: null,
+    residualRiskKey: null,
+  });
+  assert.deepEqual(buildTopFollowUpReadiness([
+    { residualRiskKey: 'supply-pressure:front-a', targetId: 'front-a', rankReason: 'approvisionnement tendu' },
+  ], [{ key: 'supply-pressure:front-a', reason: 'approvisionnement tendu' }]).state, 'supply-pressure');
+  assert.deepEqual(buildTopFollowUpReadiness([
+    { residualRiskKey: 'low-loyalty:front-a', targetId: 'front-a', prerequisite: 'émissaire disponible' },
+  ]).state, 'stabilize-control');
+  assert.deepEqual(buildTopFollowUpReadiness([
+    { residualRiskKey: 'watch:front-a', targetId: 'front-a', cleanupOrderLabel: 'Surveiller risque restant' },
+  ]).state, 'ready-now');
 });
 
 test('StrategicMapShell returns empty follow-up cleanup choices when no follow-up is useful', () => {

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -60,8 +60,10 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /safetyScore/);
   assert.match(webAppSource, /buildFirstCleanupPayoff\(cleanupOrders, residualRisks\)/);
   assert.match(webAppSource, /buildFollowUpCleanupChoices\(cleanupOrders, residualRisks, firstCleanupPayoff\)/);
+  assert.match(webAppSource, /buildTopFollowUpReadiness\(followUpCleanupChoices, residualRisks\)/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
+  assert.match(webAppSource, /topFollowUpReadiness/);
 });
 
 test('atlas military fallback order hint stays secondary and hides no-safe fallback state', () => {
@@ -85,10 +87,13 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /nettoyer: aucun ordre requis/);
   assert.match(webAppSource, /payoff: aucun nettoyage utile/);
   assert.match(webAppSource, /suivi: aucun cleanup utile/);
+  assert.match(webAppSource, /readiness: aucun suivi sûr/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
+  assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
+  assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -101,4 +106,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-orders/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-payoff/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-followups/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__followup-readiness/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,12 @@ import { Province } from '../src/domain/war/Province.js';
 import { City } from '../src/domain/economy/City.js';
 import { TradeRoute } from '../src/domain/economy/TradeRoute.js';
 import { buildEconomySeedFromStrategicMap } from '../src/application/economy/BuildEconomySeedFromStrategicMap.js';
-import { buildFirstCleanupPayoff, buildFollowUpCleanupChoices, buildStrategicMapShell } from '../src/ui/war/StrategicMapShell.js';
+import {
+  buildFirstCleanupPayoff,
+  buildFollowUpCleanupChoices,
+  buildStrategicMapShell,
+  buildTopFollowUpReadiness,
+} from '../src/ui/war/StrategicMapShell.js';
 import { buildLauncherMapSelection } from '../src/ui/launcher/buildLauncherMapSelection.js';
 import { buildEconomyMapOverlay } from '../src/ui/economy/buildEconomyMapOverlay.js';
 import { buildCityStockPanel } from '../src/ui/economy/buildCityStockPanel.js';
@@ -1943,6 +1948,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       cleanupOrders: [],
       firstCleanupPayoff: null,
       followUpCleanupChoices: [],
+      topFollowUpReadiness: buildTopFollowUpReadiness([], []),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1955,6 +1961,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const cleanupOrders = buildAtlasMilitaryFallbackCleanupOrders(residualRisks, fallback);
   const firstCleanupPayoff = buildFirstCleanupPayoff(cleanupOrders, residualRisks);
   const followUpCleanupChoices = buildFollowUpCleanupChoices(cleanupOrders, residualRisks, firstCleanupPayoff);
+  const topFollowUpReadiness = buildTopFollowUpReadiness(followUpCleanupChoices, residualRisks);
 
   return {
     fallback: {
@@ -1968,6 +1975,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       cleanupOrders,
       firstCleanupPayoff,
       followUpCleanupChoices,
+      topFollowUpReadiness,
     },
     safetyReason,
     crossDomainBlocker,
@@ -1976,7 +1984,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     cleanupOrders,
     firstCleanupPayoff,
     followUpCleanupChoices,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}).`,
+    topFollowUpReadiness,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}).`,
     empty: false,
   };
 }
@@ -1996,6 +2005,9 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const followUpCleanupLabel = fallback.followUpCleanupChoices?.length
     ? `suivi: ${fallback.followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel} (${choice.riskCovered})`).join(' · ')}`
     : 'suivi: aucun cleanup utile';
+  const followUpReadinessLabel = fallback.topFollowUpReadiness
+    ? `readiness: ${fallback.topFollowUpReadiness.label} · ${fallback.topFollowUpReadiness.blocker}`
+    : 'readiness: aucun suivi sûr';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
       <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="11" rx="1.2"></rect>
@@ -2008,6 +2020,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__cleanup-orders" x="23.2" y="65.7">${cleanupOrderLabel}</text>
       <text class="atlas-military-fallback-order__cleanup-payoff" x="23.2" y="66.8">${firstCleanupPayoffLabel}</text>
       <text class="atlas-military-fallback-order__cleanup-followups" x="23.2" y="67.9">${followUpCleanupLabel}</text>
+      <text class="atlas-military-fallback-order__followup-readiness atlas-military-fallback-order__followup-readiness--${fallback.topFollowUpReadiness?.tone ?? 'neutral'}" x="23.2" y="69">${followUpReadinessLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11155,6 +11155,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__cleanup-orders { fill: #bfdbfe; font-size: 0.53px; font-weight: 800; }
 .atlas-military-fallback-order__cleanup-payoff { fill: #bbf7d0; font-size: 0.52px; font-weight: 900; }
 .atlas-military-fallback-order__cleanup-followups { fill: #ddd6fe; font-size: 0.5px; font-weight: 900; }
+.atlas-military-fallback-order__followup-readiness { fill: #fef3c7; font-size: 0.49px; font-weight: 900; }
+.atlas-military-fallback-order__followup-readiness--danger { fill: #fecaca; }
+.atlas-military-fallback-order__followup-readiness--ready { fill: #bbf7d0; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #949.

Summary:
- Adds `topFollowUpReadiness` for the best `followUpCleanupChoices[0]` candidate.
- Covers deterministic states for no safe follow-up, logistics/route needs, local control stabilization, supply pressure, and ready-now.
- Renders a compact readiness line in the military fallback cleanup panel without duplicating the ranked follow-ups.

Tests:
- `npm test` (598/598)

Closes #949