### PR TITLE
Beta: compare corridor sequence opportunity cost

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -272,6 +272,46 @@ function buildPreparationSequence(bestOption, cheaperAcceptable, estimatedValueP
   return sequence;
 }
 
+function buildOpportunityCostComparison(bestOption, alternativeOption, estimatedValueProtected, alternativeValueProtected, routeRiskLevel) {
+  if (alternativeOption === null) {
+    return null;
+  }
+
+  const marginDelta = bestOption.expectedEffect.marginGain - alternativeOption.expectedEffect.marginGain;
+  const effortDelta = bestOption.effort.amount - alternativeOption.effort.amount;
+  const valueDelta = estimatedValueProtected - alternativeValueProtected;
+
+  return {
+    id: `opportunity-cost:${bestOption.id}:vs:${alternativeOption.id}`,
+    recommendedOptionId: bestOption.id,
+    alternativeOptionId: alternativeOption.id,
+    summary: valueDelta >= 0
+      ? `Meilleure maintenant: +${valueDelta} valeur protégée contre ${alternativeOption.label}.`
+      : `Option prudente: protège moins de valeur mais réduit le coût immédiat face à ${alternativeOption.label}.`,
+    gained: {
+      protectedValue: Math.max(0, valueDelta),
+      margin: Math.max(0, marginDelta),
+      reason: `${bestOption.label} protège davantage le corridor avant la dépense.`,
+    },
+    deferred: {
+      effort: Math.max(0, effortDelta),
+      unit: bestOption.effort.unit,
+      reason: effortDelta > 0
+        ? `${alternativeOption.label} reste moins coûteuse si le coût immédiat devient prioritaire.`
+        : 'Aucun effort additionnel net par rapport à l’alternative.',
+    },
+    aggravated: {
+      risk: bestOption.safety === 'risky' && alternativeOption.safety !== 'risky' ? 'higher-sequence-risk' : 'none',
+      reason: bestOption.safety === 'risky' && alternativeOption.safety !== 'risky'
+        ? 'La séquence recommandée protège plus de valeur mais expose davantage le corridor.'
+        : 'Aucune aggravation nette détectée par rapport à l’alternative comparée.',
+    },
+    reconsiderWhen: routeRiskLevel >= 50
+      ? 'Reconsidérer si le risque corridor augmente encore ou si la capacité opérationnelle manque.'
+      : 'Reconsidérer si la marge disponible, le risque corridor ou le coût immédiat change.',
+  };
+}
+
 function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLevel) {
   if (preparationOptions.length < 2) {
     return null;
@@ -291,6 +331,10 @@ function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLeve
   const cheapest = preparationOptions
     .slice()
     .sort((left, right) => left.effort.amount - right.effort.amount || left.id.localeCompare(right.id))[0];
+  const alternativeOption = cheapest.id === best.option.id
+    ? (scoredOptions.find((entry) => entry.option.id !== best.option.id)?.option ?? null)
+    : cheapest;
+  const alternativeValueProtected = alternativeOption === null ? 0 : alternativeOption.expectedEffect.marginGain * routeValue;
   const cheaperAcceptable = cheapest.id === best.option.id
     ? null
     : {
@@ -310,6 +354,13 @@ function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLeve
     reason: `Protège ${best.estimatedValueProtected} valeur corridor avec +${best.option.expectedEffect.marginGain} marge pour ${best.option.effort.amount} ${best.option.effort.unit}.`,
     cheaperAcceptable,
     sequence: buildPreparationSequence(best.option, cheaperAcceptable, best.estimatedValueProtected),
+    opportunityCostComparison: buildOpportunityCostComparison(
+      best.option,
+      alternativeOption,
+      best.estimatedValueProtected,
+      alternativeValueProtected,
+      routeRiskLevel,
+    ),
   };
 }
 
@@ -380,6 +431,7 @@ function buildCapacitySpendPreview(route, spendPlan) {
     preparationOptions: nextBottleneck?.preparationOptions ?? [],
     bestValuePreparation,
     preparationSequence: bestValuePreparation?.sequence ?? [],
+    opportunityCostComparison: bestValuePreparation?.opportunityCostComparison ?? null,
     state: capacityMobilized === 0
       ? 'no-spend'
       : capacityRemaining === 0

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -154,6 +154,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         preparationOptions: [],
         bestValuePreparation: null,
         preparationSequence: [],
+        opportunityCostComparison: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'wood', currentCapacity: 3, capacityMobilized: 0, capacityRemaining: 3 },
@@ -193,6 +194,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         preparationOptions: [],
         bestValuePreparation: null,
         preparationSequence: [],
+        opportunityCostComparison: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'fish', currentCapacity: 4, capacityMobilized: 0, capacityRemaining: 4 },
@@ -261,6 +263,7 @@ test('buildEconomyMapOverlay supports plain payloads and style overrides', () =>
     preparationOptions: [],
     bestValuePreparation: null,
     preparationSequence: [],
+    opportunityCostComparison: null,
     state: 'no-spend',
     resources: [
       { resourceId: 'salt', currentCapacity: 9, capacityMobilized: 0, capacityRemaining: 9 },
@@ -348,6 +351,7 @@ test('buildEconomyMapOverlay previews capacity spent by recommended unlocks', ()
     ],
     bestValuePreparation: null,
     preparationSequence: [],
+    opportunityCostComparison: null,
     state: 'remaining-margin',
     resources: [
       { resourceId: 'grain', currentCapacity: 5, capacityMobilized: 4, capacityRemaining: 1 },
@@ -429,6 +433,27 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         reason: 'acceptable seulement si le coût immédiat prime sur la valeur protégée',
       },
     ],
+    opportunityCostComparison: {
+      id: 'opportunity-cost:grain:shift-to-tools:vs:grain:reserve-buffer',
+      recommendedOptionId: 'grain:shift-to-tools',
+      alternativeOptionId: 'grain:reserve-buffer',
+      summary: 'Meilleure maintenant: +10 valeur protégée contre Libérer 1 capacité grain.',
+      gained: {
+        protectedValue: 10,
+        margin: 1,
+        reason: 'Reporter une partie du flux vers tools protège davantage le corridor avant la dépense.',
+      },
+      deferred: {
+        effort: 1,
+        unit: 'turns',
+        reason: 'Libérer 1 capacité grain reste moins coûteuse si le coût immédiat devient prioritaire.',
+      },
+      aggravated: {
+        risk: 'none',
+        reason: 'Aucune aggravation nette détectée par rapport à l’alternative comparée.',
+      },
+      reconsiderWhen: 'Reconsidérer si le risque corridor augmente encore ou si la capacité opérationnelle manque.',
+    },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
     {
@@ -456,6 +481,27 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       reason: 'acceptable seulement si le coût immédiat prime sur la valeur protégée',
     },
   ]);
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.opportunityCostComparison, {
+    id: 'opportunity-cost:grain:shift-to-tools:vs:grain:reserve-buffer',
+    recommendedOptionId: 'grain:shift-to-tools',
+    alternativeOptionId: 'grain:reserve-buffer',
+    summary: 'Meilleure maintenant: +10 valeur protégée contre Libérer 1 capacité grain.',
+    gained: {
+      protectedValue: 10,
+      margin: 1,
+      reason: 'Reporter une partie du flux vers tools protège davantage le corridor avant la dépense.',
+    },
+    deferred: {
+      effort: 1,
+      unit: 'turns',
+      reason: 'Libérer 1 capacité grain reste moins coûteuse si le coût immédiat devient prioritaire.',
+    },
+    aggravated: {
+      risk: 'none',
+      reason: 'Aucune aggravation nette détectée par rapport à l’alternative comparée.',
+    },
+    reconsiderWhen: 'Reconsidérer si le risque corridor augmente encore ou si la capacité opérationnelle manque.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
     overlay.routes[0].capacitySpendPreview.bestValuePreparation,


### PR DESCRIPTION
## Summary

Beta: Adds an actionable opportunity-cost comparison for the recommended corridor preparation sequence so the economy overlay can explain what the sequence gains, defers, may aggravate, and when to reconsider it.

## Changes

- Compare the best-value preparation against a plausible alternative (prefer the cheaper fallback when available).
- Expose `opportunityCostComparison` on `bestValuePreparation` and `capacitySpendPreview` with stable ids, gained/deferred/aggravated impacts, and a reconsideration trigger.
- Keep insufficient-data states neutral with `null` rather than implying the recommendation is mandatory.
- Extend economy overlay tests for empty states and deterministic opportunity-cost output.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (600/600 pass)

Fixes loo469/historia#960