### PR TITLE
Delta: recommend third sweep posture

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -273,6 +273,75 @@ function buildSecondSweepStopCondition({ nextSafeSweep, unknownsRemaining, sabot
   };
 }
 
+function buildThirdSweepRecommendation({ secondSweepStopCondition, nextSafeSweep, unknownsRemaining, sabotageRiskScore }) {
+  if (nextSafeSweep === null || secondSweepStopCondition.state === 'no-safe-sweep') {
+    return {
+      state: 'do-nothing',
+      action: 'none',
+      prepareThirdSweep: false,
+      marginalExposureAdded: 0,
+      expectedConfidenceGain: 0,
+      rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
+    };
+  }
+
+  if (secondSweepStopCondition.state === 'exposure-too-high') {
+    return {
+      state: 'stop-after-second',
+      action: 'stop',
+      prepareThirdSweep: false,
+      marginalExposureAdded: clampPercent(nextSafeSweep.estimatedExposureAdded + 3),
+      expectedConfidenceGain: 0,
+      rationale: 'Arrêter: une troisième passe ajouterait trop d’exposition marginale après une seconde déjà chaude.',
+    };
+  }
+
+  if (secondSweepStopCondition.state === 'needs-fresh-signal') {
+    return {
+      state: 'monitor-only',
+      action: 'monitor',
+      prepareThirdSweep: false,
+      marginalExposureAdded: clampPercent(Math.max(3, nextSafeSweep.estimatedExposureAdded - 1)),
+      expectedConfidenceGain: 0,
+      rationale: 'Surveiller seulement: attendre un signal frais avant de préparer une troisième passe.',
+    };
+  }
+
+  if (secondSweepStopCondition.state === 'wait-cooler-window') {
+    return {
+      state: 'monitor-cooldown',
+      action: 'monitor',
+      prepareThirdSweep: false,
+      marginalExposureAdded: clampPercent(nextSafeSweep.estimatedExposureAdded),
+      expectedConfidenceGain: clampPercent(Math.min(8, unknownsRemaining * 3)),
+      rationale: 'Surveiller: le gain attendu ne justifie pas encore le coût tant que la fenêtre ne refroidit pas.',
+    };
+  }
+
+  if (unknownsRemaining >= 2 && nextSafeSweep.estimatedExposureAdded <= 8 && sabotageRiskScore < 90) {
+    const marginalExposureAdded = clampPercent(nextSafeSweep.estimatedExposureAdded + 2);
+    const expectedConfidenceGain = clampPercent(Math.min(18, 6 + unknownsRemaining * 4));
+
+    return {
+      state: 'prepare-third-safe-sweep',
+      action: 'prepare',
+      prepareThirdSweep: true,
+      marginalExposureAdded,
+      expectedConfidenceGain,
+      rationale: `Préparer une troisième passe prudente: ${unknownsRemaining} inconnues resteraient et le gain de confiance attendu dépasse l’exposition marginale.`,
+    };
+  }
+
+  return {
+    state: 'stop-after-second',
+    action: 'stop',
+    prepareThirdSweep: false,
+    marginalExposureAdded: clampPercent(nextSafeSweep.estimatedExposureAdded + 1),
+    expectedConfidenceGain: clampPercent(Math.min(5, unknownsRemaining * 3)),
+    rationale: 'Arrêter après la seconde passe: le gain restant serait trop faible par rapport à l’exposition marginale.',
+  };
+}
+
 function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount, sleeperCellCount, sabotageRiskScore }) {
   if (celluleCount <= 0 || sabotageRiskScore <= 0 || exposedCellCount >= celluleCount) {
     return {
@@ -287,6 +356,16 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
       nextSafeSweep: null,
       secondSweepCandidates: [],
       secondSweepStopCondition: buildSecondSweepStopCondition({
+        nextSafeSweep: null,
+        unknownsRemaining: Math.max(0, celluleCount - exposedCellCount),
+        sabotageRiskScore,
+      }),
+      thirdSweepRecommendation: buildThirdSweepRecommendation({
+        secondSweepStopCondition: buildSecondSweepStopCondition({
+          nextSafeSweep: null,
+          unknownsRemaining: Math.max(0, celluleCount - exposedCellCount),
+          sabotageRiskScore,
+        }),
         nextSafeSweep: null,
         unknownsRemaining: Math.max(0, celluleCount - exposedCellCount),
         sabotageRiskScore,
@@ -323,6 +402,12 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
     unknownsRemaining,
     sabotageRiskScore,
   });
+  const thirdSweepRecommendation = buildThirdSweepRecommendation({
+    secondSweepStopCondition,
+    nextSafeSweep,
+    unknownsRemaining,
+    sabotageRiskScore,
+  });
   const state = exposureAdded <= 8
     ? 'low-exposure-positive'
     : exposureAdded < 12
@@ -341,6 +426,7 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
     nextSafeSweep,
     secondSweepCandidates,
     secondSweepStopCondition,
+    thirdSweepRecommendation,
     summary: `Confiance +${confidenceDelta} pts pour +${exposureAdded} exposition; ${unknownsRemaining} inconnue${unknownsRemaining > 1 ? 's' : ''} restante${unknownsRemaining > 1 ? 's' : ''}.`,
   };
 }

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -142,6 +142,14 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           stopSignal: 'Aucun second sweep sûr n’est disponible dans la fenêtre actuelle.',
           explanation: 'Ne pas enchaîner: attendre un signal lisible avant de rouvrir la zone.',
         },
+        thirdSweepRecommendation: {
+          state: 'do-nothing',
+          action: 'none',
+          prepareThirdSweep: false,
+          marginalExposureAdded: 0,
+          expectedConfidenceGain: 0,
+          rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
+        },
         summary: 'Confiance +23 pts pour +10 exposition; 0 inconnue restante.',
       },
       style: {
@@ -190,6 +198,14 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           continueNow: false,
           stopSignal: 'Aucun second sweep sûr n’est disponible dans la fenêtre actuelle.',
           explanation: 'Ne pas enchaîner: attendre un signal lisible avant de rouvrir la zone.',
+        },
+        thirdSweepRecommendation: {
+          state: 'do-nothing',
+          action: 'none',
+          prepareThirdSweep: false,
+          marginalExposureAdded: 0,
+          expectedConfidenceGain: 0,
+          rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
         },
         summary: 'Confiance +31 pts pour +5 exposition; 0 inconnue restante.',
       },
@@ -340,6 +356,14 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
       stopSignal: 'Aucun second sweep sûr n’est disponible dans la fenêtre actuelle.',
       explanation: 'Ne pas enchaîner: attendre un signal lisible avant de rouvrir la zone.',
     },
+    thirdSweepRecommendation: {
+      state: 'do-nothing',
+      action: 'none',
+      prepareThirdSweep: false,
+      marginalExposureAdded: 0,
+      expectedConfidenceGain: 0,
+      rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
+    },
     summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
   });
   assert.equal(hot.lowExposureSweepConfidencePreview.state, 'watch-exposure');
@@ -380,6 +404,14 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
     continueNow: true,
     stopSignal: 'Continuer tant que l’exposition ajoutée reste ≤ 8 et le heat ≤ 12.',
     explanation: 'Le second sweep recommandé couvre le gap prioritaire avec une exposition contenue.',
+  });
+  assert.deepEqual(hot.lowExposureSweepConfidencePreview.thirdSweepRecommendation, {
+    state: 'stop-after-second',
+    action: 'stop',
+    prepareThirdSweep: false,
+    marginalExposureAdded: 9,
+    expectedConfidenceGain: 3,
+    rationale: 'Arrêter après la seconde passe: le gain restant serait trop faible par rapport à l’exposition marginale.',
   });
   assert.deepEqual(hot.lowExposureSweepConfidencePreview.secondSweepCandidates, [
     {
@@ -456,7 +488,46 @@ test('buildIntrigueMapOverlay keeps post-sweep gap explanations stable and neutr
   assert.equal(overlay[0].lowExposureSweepConfidencePreview.nextSafeSweep, null);
   assert.deepEqual(overlay[0].lowExposureSweepConfidencePreview.secondSweepCandidates, []);
   assert.equal(overlay[0].lowExposureSweepConfidencePreview.secondSweepStopCondition.state, 'no-safe-sweep');
+  assert.equal(overlay[0].lowExposureSweepConfidencePreview.thirdSweepRecommendation.state, 'do-nothing');
   assert.equal(overlay[0].lowExposureSweepConfidencePreview.unknownsRemaining, 0);
+});
+
+test('buildIntrigueMapOverlay recommends preparing a third sweep only when residual value beats marginal exposure', () => {
+  const preview = buildIntrigueMapOverlay([
+    ...Array.from({ length: 4 }, (_, index) => ({
+      id: `cell-wide-${index}`,
+      factionId: 'shadow-league',
+      codename: `Wide ${index}`,
+      locationId: 'wide',
+      memberIds: [`ag-${index}`],
+      assetIds: [`asset-${index}`],
+      exposure: 10,
+    })),
+  ], [
+    {
+      id: 'op-wide',
+      celluleId: 'cell-wide-0',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe wide residuals',
+      theaterId: 'wide',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 20,
+      progress: 80,
+      heat: 80,
+    },
+  ])[0].lowExposureSweepConfidencePreview;
+
+  assert.equal(preview.secondSweepStopCondition.state, 'continue-now');
+  assert.deepEqual(preview.thirdSweepRecommendation, {
+    state: 'prepare-third-safe-sweep',
+    action: 'prepare',
+    prepareThirdSweep: true,
+    marginalExposureAdded: 9,
+    expectedConfidenceGain: 14,
+    rationale: 'Préparer une troisième passe prudente: 2 inconnues resteraient et le gain de confiance attendu dépasse l’exposition marginale.',
+  });
 });
 
 test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and exposure limits', () => {
@@ -494,6 +565,7 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
     stopSignal: 'Stop tant qu’aucun nouveau signal bas-risque ne justifie de rouvrir la pression sabotage.',
     explanation: 'La couverture utile est déjà lisible; attendre un signal frais évite une exposition gratuite.',
   });
+  assert.equal(needsSignal.thirdSweepRecommendation.state, 'monitor-only');
 
   const tooExposed = buildIntrigueMapOverlay([
     ...Array.from({ length: 6 }, (_, index) => ({
@@ -525,6 +597,7 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
   assert.equal(tooExposed.secondSweepStopCondition.state, 'exposure-too-high');
   assert.equal(tooExposed.secondSweepStopCondition.continueNow, false);
   assert.match(tooExposed.secondSweepStopCondition.stopSignal, /Stop si le second sweep ajoute/);
+  assert.equal(tooExposed.thirdSweepRecommendation.state, 'stop-after-second');
 });
 
 test('buildIntrigueMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
Delta: Implements #962.

Summary:
- Adds `thirdSweepRecommendation` after the second sweep stop condition.
- Recommends do nothing, monitor, stop after the second sweep, or prepare a third safe sweep without exposing hidden causes.
- Includes marginal third-sweep exposure and expected confidence gain so the recommendation does not contradict stop conditions.

Tests:
- `node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js`
- `npm test` (601/601)

Zeta: PR ready for validation. Please review before any merge.