### PR TITLE
Gamma: summarize second bundle stabilization

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -623,6 +623,78 @@ function buildNextSafeSupportBundle(supportBundles, recommendedFirstBundle, post
   };
 }
 
+function buildCultureStabilizationSummary(regionId, recommendedFirstBundle, nextSafeSupportBundle, postBundleCumulativeRisk) {
+  if (postBundleCumulativeRisk.status === 'neutral') {
+    return {
+      status: 'complete',
+      beforeSecondBundle: { score: 0, level: 'low' },
+      afterSecondBundle: { score: 0, level: 'low' },
+      stableRegionIds: [regionId],
+      fragileRegionIds: [],
+      mediationRegionIds: [],
+      dependencies: [],
+      incompatibilities: [],
+      summary: 'stabilisation complète: aucun second soutien requis',
+    };
+  }
+
+  if (!nextSafeSupportBundle) {
+    return {
+      status: 'future-debt',
+      beforeSecondBundle: postBundleCumulativeRisk.after,
+      afterSecondBundle: postBundleCumulativeRisk.after,
+      stableRegionIds: [],
+      fragileRegionIds: [regionId],
+      mediationRegionIds: [],
+      dependencies: recommendedFirstBundle ? [{
+        fromBundleId: recommendedFirstBundle.bundleId,
+        toBundleId: null,
+        reason: 'aucun second soutien sûr disponible après le premier bundle',
+      }] : [],
+      incompatibilities: [],
+      summary: `dette future: ${postBundleCumulativeRisk.remainingPriority} reste prioritaire`,
+    };
+  }
+
+  const afterSecondScore = clampScore(postBundleCumulativeRisk.after.score - (nextSafeSupportBundle.residualReliefScore * 2));
+  const afterSecondBundle = {
+    score: afterSecondScore,
+    level: buildCumulativeRiskLevel(afterSecondScore),
+  };
+  const status = afterSecondScore < 30
+    ? 'complete'
+    : afterSecondScore < postBundleCumulativeRisk.after.score
+      ? 'partial'
+      : 'future-debt';
+  const tradeoffNeedsMediation = nextSafeSupportBundle.tradeoffToWatch.includes('sous surveillance')
+    || nextSafeSupportBundle.tradeoffToWatch.includes('ouverture -')
+    || nextSafeSupportBundle.tradeoffToWatch.includes('recherche ralentie');
+
+  return {
+    status,
+    beforeSecondBundle: postBundleCumulativeRisk.after,
+    afterSecondBundle,
+    stableRegionIds: status === 'complete' ? [regionId] : [],
+    fragileRegionIds: afterSecondScore >= 55 ? [regionId] : [],
+    mediationRegionIds: afterSecondScore >= 30 && afterSecondScore < 55 ? [regionId] : [],
+    dependencies: [{
+      fromBundleId: recommendedFirstBundle.bundleId,
+      toBundleId: nextSafeSupportBundle.bundleId,
+      reason: 'appliquer le second soutien seulement après stabilisation du premier bundle',
+    }],
+    incompatibilities: tradeoffNeedsMediation ? [{
+      bundleId: nextSafeSupportBundle.bundleId,
+      tradeoff: nextSafeSupportBundle.tradeoffToWatch,
+      mitigation: 'médiation ultérieure recommandée avant d’empiler un troisième soutien',
+    }] : [],
+    summary: status === 'complete'
+      ? 'stabilisation complète après le second soutien'
+      : status === 'partial'
+        ? `amélioration partielle: ${nextSafeSupportBundle.monitoredRisk} baisse, médiation à prévoir`
+        : `dette future: ${postBundleCumulativeRisk.remainingPriority} reste prioritaire`,
+  };
+}
+
 function buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById) {
   const cultureIds = regionPresence.map((entry) => entry.cultureId).sort();
   const cultureNames = regionPresence.map((entry) => entry.cultureName).sort();
@@ -737,6 +809,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
         const postBundleCumulativeRisk = buildCultureSupportCumulativeRisk(culture, regionId, riskChangePreview, regionPresence, cultureState);
         const recommendedFirstBundle = buildRecommendedFirstCultureSupportBundle(supportBundles, riskChangePreview, postBundleCumulativeRisk);
         const nextSafeSupportBundle = buildNextSafeSupportBundle(supportBundles, recommendedFirstBundle, postBundleCumulativeRisk);
+        const cultureStabilizationSummary = buildCultureStabilizationSummary(regionId, recommendedFirstBundle, nextSafeSupportBundle, postBundleCumulativeRisk);
 
         const regionalDiscoveryLinks = cultureState.signals.highlightedDiscoveries.map((discoveryId) => {
           const linkedEvents = cultureState.signals.orderedHistoricalEvents.filter((historicalEvent) => historicalEvent.discoveryIds.includes(discoveryId));
@@ -805,6 +878,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           riskChangePreview,
           postBundleCumulativeRisk,
           nextSafeSupportBundle,
+          cultureStabilizationSummary,
           ...(supportBundles.length > 0 ? { supportBundles, recommendedFirstBundle } : {}),
           ...(clusterSummary ? { clusterSummary } : {}),
           zoneContour: buildZoneContour(cultureState.influenceTier, overlapCount, zoneRank),

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -17,7 +17,7 @@ function withoutSupportRiskPreviews(value) {
 
   return Object.fromEntries(
     Object.entries(value)
-      .filter(([key]) => !['riskChangePreview', 'postBundleCumulativeRisk', 'nextSafeSupportBundle'].includes(key))
+      .filter(([key]) => !['riskChangePreview', 'postBundleCumulativeRisk', 'nextSafeSupportBundle', 'cultureStabilizationSummary'].includes(key))
       .map(([key, nestedValue]) => [key, withoutSupportRiskPreviews(nestedValue)]),
   );
 }
@@ -777,6 +777,35 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
     tradeoffToWatch: 'ouverture + / cohésion sous surveillance',
     followsBundleId: 'shared-marsh:culture-marsh:bundle:cohesion-anchor',
   });
+  assert.deepEqual(marsh.cultureStabilizationSummary, {
+    status: 'partial',
+    beforeSecondBundle: {
+      score: 67,
+      level: 'elevated',
+    },
+    afterSecondBundle: {
+      score: 43,
+      level: 'guarded',
+    },
+    stableRegionIds: [],
+    fragileRegionIds: [],
+    mediationRegionIds: ['shared-marsh'],
+    dependencies: [
+      {
+        fromBundleId: 'shared-marsh:culture-marsh:bundle:cohesion-anchor',
+        toBundleId: 'shared-marsh:culture-marsh:bundle:guided-opening',
+        reason: 'appliquer le second soutien seulement après stabilisation du premier bundle',
+      },
+    ],
+    incompatibilities: [
+      {
+        bundleId: 'shared-marsh:culture-marsh:bundle:guided-opening',
+        tradeoff: 'ouverture + / cohésion sous surveillance',
+        mitigation: 'médiation ultérieure recommandée avant d’empiler un troisième soutien',
+      },
+    ],
+    summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
+  });
   assert.deepEqual(stable.supportBundles, undefined);
   assert.deepEqual(stable.recommendedFirstBundle, undefined);
   assert.deepEqual(stable.riskChangePreview, {
@@ -805,6 +834,23 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
     nextAttention: 'aucune attention supplémentaire recommandée',
   });
   assert.equal(stable.nextSafeSupportBundle, null);
+  assert.deepEqual(stable.cultureStabilizationSummary, {
+    status: 'complete',
+    beforeSecondBundle: {
+      score: 0,
+      level: 'low',
+    },
+    afterSecondBundle: {
+      score: 0,
+      level: 'low',
+    },
+    stableRegionIds: ['stable-market'],
+    fragileRegionIds: [],
+    mediationRegionIds: [],
+    dependencies: [],
+    incompatibilities: [],
+    summary: 'stabilisation complète: aucun second soutien requis',
+  });
 });
 
 test('buildCultureMapOverlay can summarize overlapping culture clusters with discovery and event pins', () => {


### PR DESCRIPTION
Gamma: ## Summary

Adds a compact stabilization summary after the second cultural support bundle so province cards can distinguish complete stabilization, partial improvement, and future cultural debt.

## Changes

- Adds `cultureStabilizationSummary` to culture overlay entries.
- Reports before/after second-bundle risk levels, stable/fragile/mediation region buckets, dependencies, and incompatibility/tradeoff notes.
- Keeps neutral regions readable as complete/no-second-support-required.
- Preserves existing trust/dissent support cues and first/second bundle recommendations.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#961