### PR TITLE
Alpha: turn follow-up cleanup into mini-plan

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -227,6 +227,71 @@ export function buildTopFollowUpReadiness(followUpCleanupChoices = [], residualR
   };
 }
 
+function summarizeUntreatedRisk(residualRisks, treatedRiskKey) {
+  const untreatedRisk = residualRisks.find((risk) => String(risk.key ?? '').trim() !== treatedRiskKey) ?? null;
+
+  return untreatedRisk
+    ? String(untreatedRisk.label ?? 'risque restant').trim() || 'risque restant'
+    : 'aucun risque visible';
+}
+
+export function buildFollowUpCleanupMiniPlan(followUpCleanupChoices = [], residualRisks = [], topFollowUpReadiness = null) {
+  const normalizedChoices = normalizeCleanupInput(followUpCleanupChoices, 'StrategicMapShell followUpCleanupChoices');
+  const normalizedRisks = normalizeCleanupInput(residualRisks, 'StrategicMapShell residualRisks');
+  const topChoice = normalizedChoices[0] ?? null;
+
+  if (!topChoice || topFollowUpReadiness?.state === 'no-safe-followup') {
+    return {
+      empty: true,
+      reason: 'aucun cleanup suivi sûr',
+      targetId: null,
+      steps: [],
+    };
+  }
+
+  const treatedRiskKey = String(topChoice.residualRiskKey ?? '').trim();
+  const readinessStep = topFollowUpReadiness?.state !== 'ready-now'
+    ? {
+      stepId: `followup-readiness:${treatedRiskKey || 'unknown'}`,
+      order: 1,
+      label: topFollowUpReadiness?.action ?? 'Lever bloqueur visible',
+      prerequisite: topFollowUpReadiness?.blocker ?? 'donnée manquante',
+      riskReduced: 'bloqueur readiness',
+      untreatedRisk: String(topChoice.riskCovered ?? 'risque ciblé').trim() || 'risque ciblé',
+      state: topFollowUpReadiness?.state ?? 'unknown',
+    }
+    : null;
+  const cleanupStepOrder = readinessStep ? 2 : 1;
+  const cleanupStep = {
+    stepId: `followup-cleanup:${treatedRiskKey || 'unknown'}`,
+    order: cleanupStepOrder,
+    label: topChoice.cleanupOrderLabel ?? 'Exécuter cleanup suivi',
+    prerequisite: topChoice.prerequisite ?? topFollowUpReadiness?.blocker ?? 'aucun prérequis visible',
+    riskReduced: topChoice.riskCovered ?? 'risque ciblé',
+    untreatedRisk: summarizeUntreatedRisk(normalizedRisks, treatedRiskKey),
+    state: 'execute-cleanup',
+  };
+  const remainingStep = normalizedChoices[1]
+    ? {
+      stepId: `followup-next:${normalizedChoices[1].residualRiskKey || 'unknown'}`,
+      order: cleanupStepOrder + 1,
+      label: normalizedChoices[1].cleanupOrderLabel ?? 'Préparer suivi restant',
+      prerequisite: normalizedChoices[1].prerequisite ?? 'donnée manquante',
+      riskReduced: normalizedChoices[1].riskCovered ?? 'risque suivant',
+      untreatedRisk: summarizeUntreatedRisk(normalizedRisks, String(normalizedChoices[1].residualRiskKey ?? '').trim()),
+      state: 'next-followup',
+    }
+    : null;
+
+  return {
+    empty: false,
+    reason: topFollowUpReadiness?.label ?? 'suivi prêt',
+    targetId: topChoice.targetId ?? null,
+    steps: [readinessStep, cleanupStep, remainingStep].filter(Boolean).slice(0, 3)
+      .map((step, index) => ({ ...step, order: index + 1 })),
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -285,6 +350,11 @@ export function buildStrategicMapShell(provinces, options = {}) {
     firstCleanupPayoff,
   );
   const topFollowUpReadiness = buildTopFollowUpReadiness(followUpCleanupChoices, normalizedOptions.residualRisks);
+  const followUpCleanupMiniPlan = buildFollowUpCleanupMiniPlan(
+    followUpCleanupChoices,
+    normalizedOptions.residualRisks,
+    topFollowUpReadiness,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -327,6 +397,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     firstCleanupPayoff,
     followUpCleanupChoices,
     topFollowUpReadiness,
+    followUpCleanupMiniPlan,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -5,6 +5,7 @@ import { Province } from '../../../src/domain/war/Province.js';
 import {
   buildFirstCleanupPayoff,
   buildFollowUpCleanupChoices,
+  buildFollowUpCleanupMiniPlan,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
 } from '../../../src/ui/war/StrategicMapShell.js';
@@ -214,6 +215,81 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     action: 'sécuriser le corridor court avant exécution',
     targetId: 'front-b',
     residualRiskKey: 'route-exposure:front-b',
+  });
+  assert.deepEqual(shell.followUpCleanupMiniPlan, {
+    empty: false,
+    reason: 'Logistique à vérifier',
+    targetId: 'front-b',
+    steps: [
+      {
+        stepId: 'followup-readiness:route-exposure:front-b',
+        order: 1,
+        label: 'sécuriser le corridor court avant exécution',
+        prerequisite: 'éclaireurs disponibles',
+        riskReduced: 'bloqueur readiness',
+        untreatedRisk: 'axe encore exposé',
+        state: 'needs-logistics',
+      },
+      {
+        stepId: 'followup-cleanup:route-exposure:front-b',
+        order: 2,
+        label: 'Scanner axe détour',
+        prerequisite: 'éclaireurs disponibles',
+        riskReduced: 'axe encore exposé',
+        untreatedRisk: 'pression ravitaillement',
+        state: 'execute-cleanup',
+      },
+      {
+        stepId: 'followup-next:low-loyalty:front-a',
+        order: 3,
+        label: 'Envoyer liaison locale',
+        prerequisite: 'émissaire disponible',
+        riskReduced: 'loyauté basse',
+        untreatedRisk: 'pression ravitaillement',
+        state: 'next-followup',
+      },
+    ],
+  });
+});
+
+test('StrategicMapShell builds a compact executable follow-up cleanup mini-plan', () => {
+  const readiness = buildTopFollowUpReadiness([
+    {
+      cleanupOrderLabel: 'Surveiller risque restant',
+      residualRiskKey: 'watch:front-a',
+      targetId: 'front-a',
+      riskCovered: 'alerte diffuse',
+    },
+  ]);
+
+  assert.deepEqual(buildFollowUpCleanupMiniPlan([
+    {
+      cleanupOrderLabel: 'Surveiller risque restant',
+      residualRiskKey: 'watch:front-a',
+      targetId: 'front-a',
+      riskCovered: 'alerte diffuse',
+    },
+  ], [{ key: 'watch:front-a', label: 'alerte diffuse' }], readiness), {
+    empty: false,
+    reason: 'Prêt maintenant',
+    targetId: 'front-a',
+    steps: [
+      {
+        stepId: 'followup-cleanup:watch:front-a',
+        order: 1,
+        label: 'Surveiller risque restant',
+        prerequisite: 'aucun bloqueur visible',
+        riskReduced: 'alerte diffuse',
+        untreatedRisk: 'aucun risque visible',
+        state: 'execute-cleanup',
+      },
+    ],
+  });
+  assert.deepEqual(buildFollowUpCleanupMiniPlan([], [], buildTopFollowUpReadiness([], [])), {
+    empty: true,
+    reason: 'aucun cleanup suivi sûr',
+    targetId: null,
+    steps: [],
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -61,6 +61,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildFirstCleanupPayoff\(cleanupOrders, residualRisks\)/);
   assert.match(webAppSource, /buildFollowUpCleanupChoices\(cleanupOrders, residualRisks, firstCleanupPayoff\)/);
   assert.match(webAppSource, /buildTopFollowUpReadiness\(followUpCleanupChoices, residualRisks\)/);
+  assert.match(webAppSource, /buildFollowUpCleanupMiniPlan\(followUpCleanupChoices, residualRisks, topFollowUpReadiness\)/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -88,12 +89,15 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /payoff: aucun nettoyage utile/);
   assert.match(webAppSource, /suivi: aucun cleanup utile/);
   assert.match(webAppSource, /readiness: aucun suivi sûr/);
+  assert.match(webAppSource, /plan: aucun suivi sûr/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
+  assert.match(webAppSource, /atlas-military-fallback-order__mini-plan/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
+  assert.match(webAppSource, /plan: \$\{miniPlan\.steps\.map\(\(step\) => `\$\{step\.order\}\.\$\{step\.label\} › \$\{step\.riskReduced\}; reste \$\{step\.untreatedRisk\}`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -107,4 +111,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-payoff/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-followups/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__followup-readiness/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6,6 +6,7 @@ import { buildEconomySeedFromStrategicMap } from '../src/application/economy/Bui
 import {
   buildFirstCleanupPayoff,
   buildFollowUpCleanupChoices,
+  buildFollowUpCleanupMiniPlan,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
 } from '../src/ui/war/StrategicMapShell.js';
@@ -1949,6 +1950,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       firstCleanupPayoff: null,
       followUpCleanupChoices: [],
       topFollowUpReadiness: buildTopFollowUpReadiness([], []),
+      followUpCleanupMiniPlan: buildFollowUpCleanupMiniPlan([], [], buildTopFollowUpReadiness([], [])),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1962,6 +1964,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const firstCleanupPayoff = buildFirstCleanupPayoff(cleanupOrders, residualRisks);
   const followUpCleanupChoices = buildFollowUpCleanupChoices(cleanupOrders, residualRisks, firstCleanupPayoff);
   const topFollowUpReadiness = buildTopFollowUpReadiness(followUpCleanupChoices, residualRisks);
+  const followUpCleanupMiniPlan = buildFollowUpCleanupMiniPlan(followUpCleanupChoices, residualRisks, topFollowUpReadiness);
 
   return {
     fallback: {
@@ -1976,6 +1979,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       firstCleanupPayoff,
       followUpCleanupChoices,
       topFollowUpReadiness,
+      followUpCleanupMiniPlan,
     },
     safetyReason,
     crossDomainBlocker,
@@ -1985,7 +1989,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     firstCleanupPayoff,
     followUpCleanupChoices,
     topFollowUpReadiness,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}).`,
+    followUpCleanupMiniPlan,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes).`,
     empty: false,
   };
 }
@@ -2008,9 +2013,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const followUpReadinessLabel = fallback.topFollowUpReadiness
     ? `readiness: ${fallback.topFollowUpReadiness.label} · ${fallback.topFollowUpReadiness.blocker}`
     : 'readiness: aucun suivi sûr';
+  const miniPlan = fallback.followUpCleanupMiniPlan;
+  const miniPlanLabel = miniPlan && !miniPlan.empty
+    ? `plan: ${miniPlan.steps.map((step) => `${step.order}.${step.label} › ${step.riskReduced}; reste ${step.untreatedRisk}`).join(' · ')}`
+    : 'plan: aucun suivi sûr';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="11" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="13.2" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2021,6 +2030,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__cleanup-payoff" x="23.2" y="66.8">${firstCleanupPayoffLabel}</text>
       <text class="atlas-military-fallback-order__cleanup-followups" x="23.2" y="67.9">${followUpCleanupLabel}</text>
       <text class="atlas-military-fallback-order__followup-readiness atlas-military-fallback-order__followup-readiness--${fallback.topFollowUpReadiness?.tone ?? 'neutral'}" x="23.2" y="69">${followUpReadinessLabel}</text>
+      <text class="atlas-military-fallback-order__mini-plan" x="23.2" y="70.1">${miniPlanLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11158,6 +11158,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__followup-readiness { fill: #fef3c7; font-size: 0.49px; font-weight: 900; }
 .atlas-military-fallback-order__followup-readiness--danger { fill: #fecaca; }
 .atlas-military-fallback-order__followup-readiness--ready { fill: #bbf7d0; }
+.atlas-military-fallback-order__mini-plan { fill: #e0f2fe; font-size: 0.47px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #959.

Summary:
- adds a deterministic follow-up cleanup mini-plan payload from the top recommended cleanup and readiness blocker
- renders compact plan chips/line in the atlas fallback order panel with prerequisite, risk reduced, and untreated risk per step
- preserves empty/no-safe-followup state and readiness blocker visibility

Tests:
- npm test

Zeta: ready for validation before merge.