### PR TITLE
Beta: show corridor preparation break-even timing

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -312,7 +312,53 @@ function buildOpportunityCostComparison(bestOption, alternativeOption, estimated
   };
 }
 
-function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLevel) {
+function buildPreparationBreakEven(opportunityCostComparison, capacityMobilized) {
+  if (opportunityCostComparison === null) {
+    return null;
+  }
+
+  const capacityCost = Math.max(1, capacityMobilized);
+  const protectedValue = opportunityCostComparison.gained.protectedValue;
+  const marginValue = opportunityCostComparison.gained.margin * capacityCost;
+  const deferredCost = opportunityCostComparison.deferred.effort;
+  const riskPenalty = opportunityCostComparison.aggravated.risk === 'higher-sequence-risk' ? capacityCost : 0;
+  const netValue = protectedValue + marginValue - deferredCost - riskPenalty;
+
+  if (netValue <= 0) {
+    return {
+      id: `break-even:${opportunityCostComparison.recommendedOptionId}`,
+      status: 'not-profitable-current-data',
+      window: 'not-now',
+      turnLimit: null,
+      netValue,
+      reason: 'La valeur protégée ne couvre pas le coût différé et le risque estimé.',
+    };
+  }
+
+  if (riskPenalty === 0 && netValue >= capacityCost) {
+    return {
+      id: `break-even:${opportunityCostComparison.recommendedOptionId}`,
+      status: 'profitable-now',
+      window: 'now',
+      turnLimit: 0,
+      netValue,
+      reason: `Rentable maintenant: ${protectedValue} valeur protégée et ${marginValue} marge couvrent ${deferredCost} effort différé.`,
+    };
+  }
+
+  const turnLimit = Math.max(1, Math.ceil(netValue / capacityCost));
+
+  return {
+    id: `break-even:${opportunityCostComparison.recommendedOptionId}`,
+    status: 'profitable-before-window-closes',
+    window: `before-${turnLimit}-turns`,
+    turnLimit,
+    netValue,
+    reason: `Rentable si exécuté avant ${turnLimit} tour(s), avant que le risque différé absorbe la valeur protégée.`,
+  };
+}
+
+function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLevel, capacityMobilized) {
   if (preparationOptions.length < 2) {
     return null;
   }
@@ -344,6 +390,14 @@ function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLeve
         : 'acceptable seulement si le coût immédiat prime sur la valeur protégée',
     };
 
+  const opportunityCostComparison = buildOpportunityCostComparison(
+    best.option,
+    alternativeOption,
+    best.estimatedValueProtected,
+    alternativeValueProtected,
+    routeRiskLevel,
+  );
+
   return {
     id: `best-value:${best.option.id}`,
     optionId: best.option.id,
@@ -354,13 +408,8 @@ function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLeve
     reason: `Protège ${best.estimatedValueProtected} valeur corridor avec +${best.option.expectedEffect.marginGain} marge pour ${best.option.effort.amount} ${best.option.effort.unit}.`,
     cheaperAcceptable,
     sequence: buildPreparationSequence(best.option, cheaperAcceptable, best.estimatedValueProtected),
-    opportunityCostComparison: buildOpportunityCostComparison(
-      best.option,
-      alternativeOption,
-      best.estimatedValueProtected,
-      alternativeValueProtected,
-      routeRiskLevel,
-    ),
+    opportunityCostComparison,
+    preparationBreakEven: buildPreparationBreakEven(opportunityCostComparison, capacityMobilized),
   };
 }
 
@@ -386,7 +435,7 @@ function buildNextBottleneck(resourceRows, capacityMobilized, limitingResourceId
     marginRemaining: nextResource.capacityRemaining,
     preparationAction: nextResource.capacityRemaining === 0 ? 'free-route-capacity' : 'reserve-capacity-buffer',
     preparationOptions,
-    bestValuePreparation: buildBestValuePreparation(preparationOptions, routeValue, routeRiskLevel),
+    bestValuePreparation: buildBestValuePreparation(preparationOptions, routeValue, routeRiskLevel, capacityMobilized),
   };
 }
 
@@ -432,6 +481,7 @@ function buildCapacitySpendPreview(route, spendPlan) {
     bestValuePreparation,
     preparationSequence: bestValuePreparation?.sequence ?? [],
     opportunityCostComparison: bestValuePreparation?.opportunityCostComparison ?? null,
+    preparationBreakEven: bestValuePreparation?.preparationBreakEven ?? null,
     state: capacityMobilized === 0
       ? 'no-spend'
       : capacityRemaining === 0

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -155,6 +155,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         bestValuePreparation: null,
         preparationSequence: [],
         opportunityCostComparison: null,
+        preparationBreakEven: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'wood', currentCapacity: 3, capacityMobilized: 0, capacityRemaining: 3 },
@@ -195,6 +196,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         bestValuePreparation: null,
         preparationSequence: [],
         opportunityCostComparison: null,
+        preparationBreakEven: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'fish', currentCapacity: 4, capacityMobilized: 0, capacityRemaining: 4 },
@@ -264,6 +266,7 @@ test('buildEconomyMapOverlay supports plain payloads and style overrides', () =>
     bestValuePreparation: null,
     preparationSequence: [],
     opportunityCostComparison: null,
+    preparationBreakEven: null,
     state: 'no-spend',
     resources: [
       { resourceId: 'salt', currentCapacity: 9, capacityMobilized: 0, capacityRemaining: 9 },
@@ -352,6 +355,7 @@ test('buildEconomyMapOverlay previews capacity spent by recommended unlocks', ()
     bestValuePreparation: null,
     preparationSequence: [],
     opportunityCostComparison: null,
+    preparationBreakEven: null,
     state: 'remaining-margin',
     resources: [
       { resourceId: 'grain', currentCapacity: 5, capacityMobilized: 4, capacityRemaining: 1 },
@@ -454,6 +458,14 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       },
       reconsiderWhen: 'Reconsidérer si le risque corridor augmente encore ou si la capacité opérationnelle manque.',
     },
+    preparationBreakEven: {
+      id: 'break-even:grain:shift-to-tools',
+      status: 'profitable-now',
+      window: 'now',
+      turnLimit: 0,
+      netValue: 14,
+      reason: 'Rentable maintenant: 10 valeur protégée et 5 marge couvrent 1 effort différé.',
+    },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
     {
@@ -501,6 +513,14 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       reason: 'Aucune aggravation nette détectée par rapport à l’alternative comparée.',
     },
     reconsiderWhen: 'Reconsidérer si le risque corridor augmente encore ou si la capacité opérationnelle manque.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationBreakEven, {
+    id: 'break-even:grain:shift-to-tools',
+    status: 'profitable-now',
+    window: 'now',
+    turnLimit: 0,
+    netValue: 14,
+    reason: 'Rentable maintenant: 10 valeur protégée et 5 marge couvrent 1 effort différé.',
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,


### PR DESCRIPTION
## Summary

Beta: Adds `preparationBreakEven` for recommended corridor preparation sequences so the economy overlay can explain whether the sequence is profitable now, profitable only before a timing window closes, or not profitable with current data.

## Changes

- Derive break-even timing from `opportunityCostComparison`, mobilized capacity, protected value, margin value, deferred effort, and risk penalty.
- Expose the break-even summary on both `bestValuePreparation.preparationBreakEven` and `capacitySpendPreview.preparationBreakEven`.
- Keep insufficient/comparison-free states neutral with `null`.
- Extend economy overlay tests for neutral break-even states and deterministic profitable-now output.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (603/603 pass)

Fixes loo469/historia#970