### PR TITLE
Delta: justify monitoring over third sweep

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -281,6 +281,13 @@ function buildThirdSweepRecommendation({ secondSweepStopCondition, nextSafeSweep
       prepareThirdSweep: false,
       marginalExposureAdded: 0,
       expectedConfidenceGain: 0,
+      monitoringRationale: {
+        state: 'surveillance-active-sufficient',
+        monitoringPreferred: true,
+        signalFreshness: 'insufficient',
+        heatState: 'stable',
+        tradeoff: 'Aucun gain de confiance attendu ne compense une nouvelle exposition.',
+      },
       rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
     };
   }
@@ -292,6 +299,13 @@ function buildThirdSweepRecommendation({ secondSweepStopCondition, nextSafeSweep
       prepareThirdSweep: false,
       marginalExposureAdded: clampPercent(nextSafeSweep.estimatedExposureAdded + 3),
       expectedConfidenceGain: 0,
+      monitoringRationale: {
+        state: 'heat-too-high',
+        monitoringPreferred: true,
+        signalFreshness: 'stale',
+        heatState: 'too-hot',
+        tradeoff: 'Le heat/exposition marginal dépasse le gain de confiance attendu.',
+      },
       rationale: 'Arrêter: une troisième passe ajouterait trop d’exposition marginale après une seconde déjà chaude.',
     };
   }
@@ -303,6 +317,13 @@ function buildThirdSweepRecommendation({ secondSweepStopCondition, nextSafeSweep
       prepareThirdSweep: false,
       marginalExposureAdded: clampPercent(Math.max(3, nextSafeSweep.estimatedExposureAdded - 1)),
       expectedConfidenceGain: 0,
+      monitoringRationale: {
+        state: 'await-fresh-signal',
+        monitoringPreferred: true,
+        signalFreshness: 'needs-refresh',
+        heatState: 'contained',
+        tradeoff: 'Sans signal frais, une nouvelle sweep ajouterait de l’exposition sans gain fiable.',
+      },
       rationale: 'Surveiller seulement: attendre un signal frais avant de préparer une troisième passe.',
     };
   }
@@ -314,6 +335,13 @@ function buildThirdSweepRecommendation({ secondSweepStopCondition, nextSafeSweep
       prepareThirdSweep: false,
       marginalExposureAdded: clampPercent(nextSafeSweep.estimatedExposureAdded),
       expectedConfidenceGain: clampPercent(Math.min(8, unknownsRemaining * 3)),
+      monitoringRationale: {
+        state: 'wait-for-cooldown',
+        monitoringPreferred: true,
+        signalFreshness: 'usable-later',
+        heatState: 'cooling-required',
+        tradeoff: 'Attendre réduit le coût d’exposition avant toute nouvelle sweep.',
+      },
       rationale: 'Surveiller: le gain attendu ne justifie pas encore le coût tant que la fenêtre ne refroidit pas.',
     };
   }
@@ -328,6 +356,13 @@ function buildThirdSweepRecommendation({ secondSweepStopCondition, nextSafeSweep
       prepareThirdSweep: true,
       marginalExposureAdded,
       expectedConfidenceGain,
+      monitoringRationale: {
+        state: 'safe-action-available',
+        monitoringPreferred: false,
+        signalFreshness: 'fresh-enough',
+        heatState: 'contained',
+        tradeoff: 'Le gain de confiance attendu dépasse l’exposition marginale; ne pas rester inactif.',
+      },
       rationale: `Préparer une troisième passe prudente: ${unknownsRemaining} inconnues resteraient et le gain de confiance attendu dépasse l’exposition marginale.`,
     };
   }
@@ -338,6 +373,13 @@ function buildThirdSweepRecommendation({ secondSweepStopCondition, nextSafeSweep
     prepareThirdSweep: false,
     marginalExposureAdded: clampPercent(nextSafeSweep.estimatedExposureAdded + 1),
     expectedConfidenceGain: clampPercent(Math.min(5, unknownsRemaining * 3)),
+    monitoringRationale: {
+      state: 'low-confidence-gain',
+      monitoringPreferred: true,
+      signalFreshness: 'weak',
+      heatState: 'contained',
+      tradeoff: 'Le gain de confiance restant est inférieur au coût d’exposition marginal.',
+    },
     rationale: 'Arrêter après la seconde passe: le gain restant serait trop faible par rapport à l’exposition marginale.',
   };
 }

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -148,6 +148,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           prepareThirdSweep: false,
           marginalExposureAdded: 0,
           expectedConfidenceGain: 0,
+          monitoringRationale: {
+            state: 'surveillance-active-sufficient',
+            monitoringPreferred: true,
+            signalFreshness: 'insufficient',
+            heatState: 'stable',
+            tradeoff: 'Aucun gain de confiance attendu ne compense une nouvelle exposition.',
+          },
           rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
         },
         summary: 'Confiance +23 pts pour +10 exposition; 0 inconnue restante.',
@@ -205,6 +212,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           prepareThirdSweep: false,
           marginalExposureAdded: 0,
           expectedConfidenceGain: 0,
+          monitoringRationale: {
+            state: 'surveillance-active-sufficient',
+            monitoringPreferred: true,
+            signalFreshness: 'insufficient',
+            heatState: 'stable',
+            tradeoff: 'Aucun gain de confiance attendu ne compense une nouvelle exposition.',
+          },
           rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
         },
         summary: 'Confiance +31 pts pour +5 exposition; 0 inconnue restante.',
@@ -362,6 +376,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
       prepareThirdSweep: false,
       marginalExposureAdded: 0,
       expectedConfidenceGain: 0,
+      monitoringRationale: {
+        state: 'surveillance-active-sufficient',
+        monitoringPreferred: true,
+        signalFreshness: 'insufficient',
+        heatState: 'stable',
+        tradeoff: 'Aucun gain de confiance attendu ne compense une nouvelle exposition.',
+      },
       rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
     },
     summary: 'Aucun sweep low-exposure recommandé: signal insuffisant ou couverture déjà lisible.',
@@ -411,6 +432,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
     prepareThirdSweep: false,
     marginalExposureAdded: 9,
     expectedConfidenceGain: 3,
+    monitoringRationale: {
+      state: 'low-confidence-gain',
+      monitoringPreferred: true,
+      signalFreshness: 'weak',
+      heatState: 'contained',
+      tradeoff: 'Le gain de confiance restant est inférieur au coût d’exposition marginal.',
+    },
     rationale: 'Arrêter après la seconde passe: le gain restant serait trop faible par rapport à l’exposition marginale.',
   });
   assert.deepEqual(hot.lowExposureSweepConfidencePreview.secondSweepCandidates, [
@@ -526,6 +554,13 @@ test('buildIntrigueMapOverlay recommends preparing a third sweep only when resid
     prepareThirdSweep: true,
     marginalExposureAdded: 9,
     expectedConfidenceGain: 14,
+    monitoringRationale: {
+      state: 'safe-action-available',
+      monitoringPreferred: false,
+      signalFreshness: 'fresh-enough',
+      heatState: 'contained',
+      tradeoff: 'Le gain de confiance attendu dépasse l’exposition marginale; ne pas rester inactif.',
+    },
     rationale: 'Préparer une troisième passe prudente: 2 inconnues resteraient et le gain de confiance attendu dépasse l’exposition marginale.',
   });
 });
@@ -566,6 +601,13 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
     explanation: 'La couverture utile est déjà lisible; attendre un signal frais évite une exposition gratuite.',
   });
   assert.equal(needsSignal.thirdSweepRecommendation.state, 'monitor-only');
+  assert.deepEqual(needsSignal.thirdSweepRecommendation.monitoringRationale, {
+    state: 'await-fresh-signal',
+    monitoringPreferred: true,
+    signalFreshness: 'needs-refresh',
+    heatState: 'contained',
+    tradeoff: 'Sans signal frais, une nouvelle sweep ajouterait de l’exposition sans gain fiable.',
+  });
 
   const tooExposed = buildIntrigueMapOverlay([
     ...Array.from({ length: 6 }, (_, index) => ({
@@ -598,6 +640,7 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
   assert.equal(tooExposed.secondSweepStopCondition.continueNow, false);
   assert.match(tooExposed.secondSweepStopCondition.stopSignal, /Stop si le second sweep ajoute/);
   assert.equal(tooExposed.thirdSweepRecommendation.state, 'stop-after-second');
+  assert.equal(tooExposed.thirdSweepRecommendation.monitoringRationale.state, 'heat-too-high');
 });
 
 test('buildIntrigueMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
Delta: Implements #972.

Summary:
- Adds a fog-safe `monitoringRationale` to `thirdSweepRecommendation`.
- Explains when monitoring/no action beats another intrigue sweep using signal freshness, heat state, marginal exposure, and expected confidence gain.
- Marks safe-action-available cases so action-preferred recommendations do not contradict inaction rationale.

Tests:
- `node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js`
- `npm test` (603/603)

Zeta: PR ready for validation. Please review before any merge.