### PR TITLE
Gamma: summarize culture stabilization debt

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -623,6 +623,62 @@ function buildNextSafeSupportBundle(supportBundles, recommendedFirstBundle, post
   };
 }
 
+function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
+  const debts = [];
+
+  dependencies.forEach((dependency) => {
+    debts.push({
+      debtId: `${regionId}:debt:dependency:${dependency.toBundleId ?? 'missing-support'}`,
+      type: dependency.toBundleId ? 'bundle-dependency' : 'missing-support',
+      cause: dependency.reason,
+      urgency: dependency.toBundleId ? 'medium' : 'high',
+      nextAction: dependency.toBundleId
+        ? 'séquencer les supports avant tout nouveau bundle'
+        : 'identifier un support culturel compatible avant relance',
+    });
+  });
+
+  incompatibilities.forEach((incompatibility) => {
+    debts.push({
+      debtId: `${regionId}:debt:incompatibility:${incompatibility.bundleId}`,
+      type: 'bundle-incompatibility',
+      cause: incompatibility.tradeoff,
+      urgency: status === 'future-debt' ? 'high' : 'medium',
+      nextAction: incompatibility.mitigation,
+    });
+  });
+
+  mediationRegionIds.forEach((mediationRegionId) => {
+    debts.push({
+      debtId: `${mediationRegionId}:debt:mediation:${postBundleCumulativeRisk.remainingPriority}`,
+      type: 'regional-mediation',
+      cause: `risque restant: ${postBundleCumulativeRisk.remainingPriority}`,
+      urgency: 'medium',
+      nextAction: postBundleCumulativeRisk.nextAttention,
+    });
+  });
+
+  fragileRegionIds.forEach((fragileRegionId) => {
+    debts.push({
+      debtId: `${fragileRegionId}:debt:fragile:${postBundleCumulativeRisk.remainingPriority}`,
+      type: 'fragile-culture',
+      cause: `culture encore fragile: ${postBundleCumulativeRisk.remainingPriority}`,
+      urgency: 'high',
+      nextAction: postBundleCumulativeRisk.nextAttention,
+    });
+  });
+
+  const uniqueDebts = debts
+    .filter((debt, index, list) => list.findIndex((candidate) => candidate.debtId === debt.debtId) === index)
+    .slice(0, 3);
+
+  return {
+    status: uniqueDebts.length > 0 ? 'open' : 'neutral',
+    count: uniqueDebts.length,
+    debts: uniqueDebts,
+  };
+}
+
 function buildCultureStabilizationSummary(regionId, recommendedFirstBundle, nextSafeSupportBundle, postBundleCumulativeRisk) {
   if (postBundleCumulativeRisk.status === 'neutral') {
     return {
@@ -634,24 +690,29 @@ function buildCultureStabilizationSummary(regionId, recommendedFirstBundle, next
       mediationRegionIds: [],
       dependencies: [],
       incompatibilities: [],
+      stabilizationDebtSummary: buildStabilizationDebtSummary('complete', regionId, [], [], [], [], postBundleCumulativeRisk),
       summary: 'stabilisation complète: aucun second soutien requis',
     };
   }
 
   if (!nextSafeSupportBundle) {
+    const dependencies = recommendedFirstBundle ? [{
+      fromBundleId: recommendedFirstBundle.bundleId,
+      toBundleId: null,
+      reason: 'aucun second soutien sûr disponible après le premier bundle',
+    }] : [];
+    const fragileRegionIds = [regionId];
+
     return {
       status: 'future-debt',
       beforeSecondBundle: postBundleCumulativeRisk.after,
       afterSecondBundle: postBundleCumulativeRisk.after,
       stableRegionIds: [],
-      fragileRegionIds: [regionId],
+      fragileRegionIds,
       mediationRegionIds: [],
-      dependencies: recommendedFirstBundle ? [{
-        fromBundleId: recommendedFirstBundle.bundleId,
-        toBundleId: null,
-        reason: 'aucun second soutien sûr disponible après le premier bundle',
-      }] : [],
+      dependencies,
       incompatibilities: [],
+      stabilizationDebtSummary: buildStabilizationDebtSummary('future-debt', regionId, dependencies, [], [], fragileRegionIds, postBundleCumulativeRisk),
       summary: `dette future: ${postBundleCumulativeRisk.remainingPriority} reste prioritaire`,
     };
   }
@@ -669,24 +730,30 @@ function buildCultureStabilizationSummary(regionId, recommendedFirstBundle, next
   const tradeoffNeedsMediation = nextSafeSupportBundle.tradeoffToWatch.includes('sous surveillance')
     || nextSafeSupportBundle.tradeoffToWatch.includes('ouverture -')
     || nextSafeSupportBundle.tradeoffToWatch.includes('recherche ralentie');
+  const stableRegionIds = status === 'complete' ? [regionId] : [];
+  const fragileRegionIds = afterSecondScore >= 55 ? [regionId] : [];
+  const mediationRegionIds = afterSecondScore >= 30 && afterSecondScore < 55 ? [regionId] : [];
+  const dependencies = [{
+    fromBundleId: recommendedFirstBundle.bundleId,
+    toBundleId: nextSafeSupportBundle.bundleId,
+    reason: 'appliquer le second soutien seulement après stabilisation du premier bundle',
+  }];
+  const incompatibilities = tradeoffNeedsMediation ? [{
+    bundleId: nextSafeSupportBundle.bundleId,
+    tradeoff: nextSafeSupportBundle.tradeoffToWatch,
+    mitigation: 'médiation ultérieure recommandée avant d’empiler un troisième soutien',
+  }] : [];
 
   return {
     status,
     beforeSecondBundle: postBundleCumulativeRisk.after,
     afterSecondBundle,
-    stableRegionIds: status === 'complete' ? [regionId] : [],
-    fragileRegionIds: afterSecondScore >= 55 ? [regionId] : [],
-    mediationRegionIds: afterSecondScore >= 30 && afterSecondScore < 55 ? [regionId] : [],
-    dependencies: [{
-      fromBundleId: recommendedFirstBundle.bundleId,
-      toBundleId: nextSafeSupportBundle.bundleId,
-      reason: 'appliquer le second soutien seulement après stabilisation du premier bundle',
-    }],
-    incompatibilities: tradeoffNeedsMediation ? [{
-      bundleId: nextSafeSupportBundle.bundleId,
-      tradeoff: nextSafeSupportBundle.tradeoffToWatch,
-      mitigation: 'médiation ultérieure recommandée avant d’empiler un troisième soutien',
-    }] : [],
+    stableRegionIds,
+    fragileRegionIds,
+    mediationRegionIds,
+    dependencies,
+    incompatibilities,
+    stabilizationDebtSummary: buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk),
     summary: status === 'complete'
       ? 'stabilisation complète après le second soutien'
       : status === 'partial'

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -804,6 +804,33 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         mitigation: 'médiation ultérieure recommandée avant d’empiler un troisième soutien',
       },
     ],
+    stabilizationDebtSummary: {
+      status: 'open',
+      count: 3,
+      debts: [
+        {
+          debtId: 'shared-marsh:debt:dependency:shared-marsh:culture-marsh:bundle:guided-opening',
+          type: 'bundle-dependency',
+          cause: 'appliquer le second soutien seulement après stabilisation du premier bundle',
+          urgency: 'medium',
+          nextAction: 'séquencer les supports avant tout nouveau bundle',
+        },
+        {
+          debtId: 'shared-marsh:debt:incompatibility:shared-marsh:culture-marsh:bundle:guided-opening',
+          type: 'bundle-incompatibility',
+          cause: 'ouverture + / cohésion sous surveillance',
+          urgency: 'medium',
+          nextAction: 'médiation ultérieure recommandée avant d’empiler un troisième soutien',
+        },
+        {
+          debtId: 'shared-marsh:debt:mediation:isolement du support',
+          type: 'regional-mediation',
+          cause: 'risque restant: isolement du support',
+          urgency: 'medium',
+          nextAction: 'surveiller les relais savants et le rythme d’ouverture',
+        },
+      ],
+    },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
   assert.deepEqual(stable.supportBundles, undefined);
@@ -849,6 +876,11 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
     mediationRegionIds: [],
     dependencies: [],
     incompatibilities: [],
+    stabilizationDebtSummary: {
+      status: 'neutral',
+      count: 0,
+      debts: [],
+    },
     summary: 'stabilisation complète: aucun second soutien requis',
   });
 });


### PR DESCRIPTION
Gamma: ## Summary

Adds a compact stabilization debt summary to the post-second-bundle culture stabilization payload so players can see bundle-created debt without rereading every support option.

## Changes

- Adds `stabilizationDebtSummary` inside `cultureStabilizationSummary`.
- Lists up to three debts from dependencies, incompatibilities, mediation follow-up, fragile culture, or missing safe support.
- Includes visible cause, urgency, and next action for each debt.
- Keeps neutral/stable cases explicit with `status: neutral` and an empty debt list.
- Preserves existing trust/dissent and regional risk cues.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#971