### PR TITLE
Alpha: surface mini-plan dependency conflicts

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -292,6 +292,97 @@ export function buildFollowUpCleanupMiniPlan(followUpCleanupChoices = [], residu
   };
 }
 
+function getMiniPlanConflictProfile(risk) {
+  const riskKey = String(risk.key ?? '').trim();
+  const riskType = riskKey.split(':')[0];
+  const reason = String(risk.reason ?? risk.label ?? '').trim();
+
+  if (riskType === 'supply-pressure' || /ravitaillement|approvisionnement|convoi/i.test(reason)) {
+    return {
+      severity: 'blocking',
+      label: 'Convoi partagé',
+      mitigation: 'réserver le convoi court avant le mini-plan',
+    };
+  }
+
+  if (riskType === 'neighbor-front' || /front voisin|priorité|ordre/i.test(reason)) {
+    return {
+      severity: 'blocking',
+      label: 'Priorité voisine',
+      mitigation: 'caler une couverture voisine minimale',
+    };
+  }
+
+  if (riskType === 'contested-occupation' || /occupation|disput/i.test(reason)) {
+    return {
+      severity: 'watchable',
+      label: 'Occupation fragile',
+      mitigation: 'garder patrouille locale en réserve',
+    };
+  }
+
+  if (riskType === 'low-loyalty' || /loyaut|émissaire/i.test(reason)) {
+    return {
+      severity: 'watchable',
+      label: 'Loyauté à suivre',
+      mitigation: 'envoyer liaison si le plan dure',
+    };
+  }
+
+  if (riskType === 'route-exposure' || /route|axe|détour|corridor/i.test(reason)) {
+    return {
+      severity: 'watchable',
+      label: 'Axe partagé',
+      mitigation: 'surveiller le détour pendant exécution',
+    };
+  }
+
+  return {
+    severity: 'watchable',
+    label: 'Dépendance visible',
+    mitigation: 'surveiller avant confirmation',
+  };
+}
+
+export function buildMiniPlanDependencyConflicts(followUpCleanupMiniPlan = null, residualRisks = [], topFollowUpReadiness = null) {
+  const normalizedRisks = normalizeCleanupInput(residualRisks, 'StrategicMapShell residualRisks');
+
+  if (!followUpCleanupMiniPlan || followUpCleanupMiniPlan.empty) return [];
+
+  const plannedRiskLabels = new Set((followUpCleanupMiniPlan.steps ?? [])
+    .map((step) => String(step.riskReduced ?? '').trim())
+    .filter(Boolean));
+  const readinessRiskKey = String(topFollowUpReadiness?.residualRiskKey ?? '').trim();
+
+  return normalizedRisks
+    .filter((risk) => {
+      const riskKey = String(risk.key ?? '').trim();
+      const label = String(risk.label ?? '').trim();
+
+      return riskKey !== readinessRiskKey && !plannedRiskLabels.has(label);
+    })
+    .map((risk) => {
+      const riskKey = String(risk.key ?? '').trim();
+      const profile = getMiniPlanConflictProfile(risk);
+
+      return {
+        conflictId: `mini-plan-conflict:${riskKey || 'unknown'}`,
+        severity: profile.severity,
+        label: profile.label,
+        reason: String(risk.reason ?? risk.label ?? 'donnée incertaine').trim() || 'donnée incertaine',
+        mitigation: profile.mitigation,
+        residualRiskKey: riskKey,
+        targetId: getRiskLocationId(riskKey),
+      };
+    })
+    .sort((left, right) => {
+      const severityRank = { blocking: 0, watchable: 1 };
+      return (severityRank[left.severity] ?? 2) - (severityRank[right.severity] ?? 2)
+        || left.residualRiskKey.localeCompare(right.residualRiskKey);
+    })
+    .slice(0, 3);
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -355,6 +446,11 @@ export function buildStrategicMapShell(provinces, options = {}) {
     normalizedOptions.residualRisks,
     topFollowUpReadiness,
   );
+  const miniPlanDependencyConflicts = buildMiniPlanDependencyConflicts(
+    followUpCleanupMiniPlan,
+    normalizedOptions.residualRisks,
+    topFollowUpReadiness,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -398,6 +494,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     followUpCleanupChoices,
     topFollowUpReadiness,
     followUpCleanupMiniPlan,
+    miniPlanDependencyConflicts,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -6,6 +6,7 @@ import {
   buildFirstCleanupPayoff,
   buildFollowUpCleanupChoices,
   buildFollowUpCleanupMiniPlan,
+  buildMiniPlanDependencyConflicts,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
 } from '../../../src/ui/war/StrategicMapShell.js';
@@ -250,6 +251,17 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
       },
     ],
   });
+  assert.deepEqual(shell.miniPlanDependencyConflicts, [
+    {
+      conflictId: 'mini-plan-conflict:supply-pressure:front-a',
+      severity: 'blocking',
+      label: 'Convoi partagé',
+      reason: 'approvisionnement tendu',
+      mitigation: 'réserver le convoi court avant le mini-plan',
+      residualRiskKey: 'supply-pressure:front-a',
+      targetId: 'front-a',
+    },
+  ]);
 });
 
 test('StrategicMapShell builds a compact executable follow-up cleanup mini-plan', () => {
@@ -291,6 +303,44 @@ test('StrategicMapShell builds a compact executable follow-up cleanup mini-plan'
     targetId: null,
     steps: [],
   });
+});
+
+test('StrategicMapShell surfaces dependency conflicts around the follow-up mini-plan', () => {
+  const miniPlan = {
+    empty: false,
+    steps: [
+      { riskReduced: 'axe encore exposé' },
+    ],
+  };
+  const readiness = { state: 'ready-now', residualRiskKey: 'route-exposure:front-a' };
+
+  assert.deepEqual(buildMiniPlanDependencyConflicts(miniPlan, [
+    { key: 'route-exposure:front-a', label: 'axe encore exposé', reason: 'exposition route 21' },
+    { key: 'neighbor-front:front-b', label: 'front voisin fragile', reason: 'ordre prioritaire reste à 88' },
+    { key: 'low-loyalty:front-a', label: 'loyauté basse', reason: 'loyauté 42' },
+  ], readiness), [
+    {
+      conflictId: 'mini-plan-conflict:neighbor-front:front-b',
+      severity: 'blocking',
+      label: 'Priorité voisine',
+      reason: 'ordre prioritaire reste à 88',
+      mitigation: 'caler une couverture voisine minimale',
+      residualRiskKey: 'neighbor-front:front-b',
+      targetId: 'front-b',
+    },
+    {
+      conflictId: 'mini-plan-conflict:low-loyalty:front-a',
+      severity: 'watchable',
+      label: 'Loyauté à suivre',
+      reason: 'loyauté 42',
+      mitigation: 'envoyer liaison si le plan dure',
+      residualRiskKey: 'low-loyalty:front-a',
+      targetId: 'front-a',
+    },
+  ]);
+  assert.deepEqual(buildMiniPlanDependencyConflicts({ empty: true }, [
+    { key: 'supply-pressure:front-a', label: 'pression ravitaillement' },
+  ], readiness), []);
 });
 
 test('StrategicMapShell explains deterministic readiness blockers for the top follow-up', () => {

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -62,6 +62,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildFollowUpCleanupChoices\(cleanupOrders, residualRisks, firstCleanupPayoff\)/);
   assert.match(webAppSource, /buildTopFollowUpReadiness\(followUpCleanupChoices, residualRisks\)/);
   assert.match(webAppSource, /buildFollowUpCleanupMiniPlan\(followUpCleanupChoices, residualRisks, topFollowUpReadiness\)/);
+  assert.match(webAppSource, /buildMiniPlanDependencyConflicts\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -90,14 +91,18 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /suivi: aucun cleanup utile/);
   assert.match(webAppSource, /readiness: aucun suivi sûr/);
   assert.match(webAppSource, /plan: aucun suivi sûr/);
+  assert.match(webAppSource, /conflits: aucun visible/);
+  assert.match(webAppSource, /miniPlanDependencyConflicts: \[\]/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
   assert.match(webAppSource, /atlas-military-fallback-order__mini-plan/);
+  assert.match(webAppSource, /atlas-military-fallback-order__mini-plan-conflicts/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
   assert.match(webAppSource, /plan: \$\{miniPlan\.steps\.map\(\(step\) => `\$\{step\.order\}\.\$\{step\.label\} › \$\{step\.riskReduced\}; reste \$\{step\.untreatedRisk\}`\)\.join\(' · '\)\}/);
+  assert.match(webAppSource, /conflits: \$\{dependencyConflicts\.map\(\(conflict\) => `\$\{conflict\.severity === 'blocking' \? 'bloquant' : 'surv\.'\} \$\{conflict\.label\} › \$\{conflict\.mitigation\}`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -112,4 +117,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__cleanup-followups/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__followup-readiness/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan-conflicts/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -7,6 +7,7 @@ import {
   buildFirstCleanupPayoff,
   buildFollowUpCleanupChoices,
   buildFollowUpCleanupMiniPlan,
+  buildMiniPlanDependencyConflicts,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
 } from '../src/ui/war/StrategicMapShell.js';
@@ -1951,6 +1952,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       followUpCleanupChoices: [],
       topFollowUpReadiness: buildTopFollowUpReadiness([], []),
       followUpCleanupMiniPlan: buildFollowUpCleanupMiniPlan([], [], buildTopFollowUpReadiness([], [])),
+      miniPlanDependencyConflicts: [],
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1965,6 +1967,11 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const followUpCleanupChoices = buildFollowUpCleanupChoices(cleanupOrders, residualRisks, firstCleanupPayoff);
   const topFollowUpReadiness = buildTopFollowUpReadiness(followUpCleanupChoices, residualRisks);
   const followUpCleanupMiniPlan = buildFollowUpCleanupMiniPlan(followUpCleanupChoices, residualRisks, topFollowUpReadiness);
+  const miniPlanDependencyConflicts = buildMiniPlanDependencyConflicts(
+    followUpCleanupMiniPlan,
+    residualRisks,
+    topFollowUpReadiness,
+  );
 
   return {
     fallback: {
@@ -1980,6 +1987,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       followUpCleanupChoices,
       topFollowUpReadiness,
       followUpCleanupMiniPlan,
+      miniPlanDependencyConflicts,
     },
     safetyReason,
     crossDomainBlocker,
@@ -1990,7 +1998,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     followUpCleanupChoices,
     topFollowUpReadiness,
     followUpCleanupMiniPlan,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes).`,
+    miniPlanDependencyConflicts,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}).`,
     empty: false,
   };
 }
@@ -2017,9 +2026,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const miniPlanLabel = miniPlan && !miniPlan.empty
     ? `plan: ${miniPlan.steps.map((step) => `${step.order}.${step.label} › ${step.riskReduced}; reste ${step.untreatedRisk}`).join(' · ')}`
     : 'plan: aucun suivi sûr';
+  const dependencyConflicts = fallback.miniPlanDependencyConflicts ?? [];
+  const dependencyConflictLabel = dependencyConflicts.length
+    ? `conflits: ${dependencyConflicts.map((conflict) => `${conflict.severity === 'blocking' ? 'bloquant' : 'surv.'} ${conflict.label} › ${conflict.mitigation}`).join(' · ')}`
+    : 'conflits: aucun visible';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="13.2" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="14.4" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2031,6 +2044,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__cleanup-followups" x="23.2" y="67.9">${followUpCleanupLabel}</text>
       <text class="atlas-military-fallback-order__followup-readiness atlas-military-fallback-order__followup-readiness--${fallback.topFollowUpReadiness?.tone ?? 'neutral'}" x="23.2" y="69">${followUpReadinessLabel}</text>
       <text class="atlas-military-fallback-order__mini-plan" x="23.2" y="70.1">${miniPlanLabel}</text>
+      <text class="atlas-military-fallback-order__mini-plan-conflicts" x="23.2" y="71.2">${dependencyConflictLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11159,6 +11159,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__followup-readiness--danger { fill: #fecaca; }
 .atlas-military-fallback-order__followup-readiness--ready { fill: #bbf7d0; }
 .atlas-military-fallback-order__mini-plan { fill: #e0f2fe; font-size: 0.47px; font-weight: 900; }
+.atlas-military-fallback-order__mini-plan-conflicts { fill: #fed7aa; font-size: 0.46px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #969.

Summary:
- adds structured `miniPlanDependencyConflicts` for blocking/watchable dependencies around the follow-up mini-plan
- filters out the readiness blocker/planned risk so conflicts explain surrounding dependencies instead of duplicating readiness
- renders compact conflict guidance in the atlas fallback panel with neutral empty state

Tests:
- npm test

Zeta: ready for validation before merge.