### PR TITLE
Alpha: add mini-plan conflict tradeoffs

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -383,6 +383,42 @@ export function buildMiniPlanDependencyConflicts(followUpCleanupMiniPlan = null,
     .slice(0, 3);
 }
 
+export function buildMiniPlanConflictTradeoffs(followUpCleanupMiniPlan = null, miniPlanDependencyConflicts = []) {
+  const normalizedConflicts = normalizeCleanupInput(
+    miniPlanDependencyConflicts,
+    'StrategicMapShell miniPlanDependencyConflicts',
+  );
+
+  if (!followUpCleanupMiniPlan || followUpCleanupMiniPlan.empty || normalizedConflicts.length === 0) return [];
+
+  const firstPlanStep = (followUpCleanupMiniPlan.steps ?? []).find((step) => step?.state === 'execute-cleanup')
+    ?? followUpCleanupMiniPlan.steps?.[0]
+    ?? null;
+  const miniPlanAction = String(firstPlanStep?.label ?? 'exécuter mini-plan').trim() || 'exécuter mini-plan';
+  const miniPlanCost = String(firstPlanStep?.untreatedRisk ?? 'dépendance non traitée').trim() || 'dépendance non traitée';
+
+  return normalizedConflicts
+    .map((conflict, index) => {
+      const severity = String(conflict.severity ?? 'watchable').trim() || 'watchable';
+      const blocking = severity === 'blocking';
+      const mitigation = String(conflict.mitigation ?? 'surveiller avant confirmation').trim() || 'surveiller avant confirmation';
+      const label = String(conflict.label ?? 'Dépendance visible').trim() || 'Dépendance visible';
+
+      return {
+        tradeoffId: `mini-plan-tradeoff:${conflict.residualRiskKey ?? index + 1}`,
+        conflictId: conflict.conflictId ?? null,
+        severity,
+        reason: String(conflict.reason ?? 'donnée incertaine').trim() || 'donnée incertaine',
+        recommendedChoice: blocking ? mitigation : miniPlanAction,
+        rejectedChoice: blocking ? miniPlanAction : mitigation,
+        rejectedCost: blocking ? `retarde ${miniPlanAction}` : `laisse ${label.toLowerCase()} sous surveillance`,
+        label: blocking ? `prioriser ${label.toLowerCase()}` : `continuer malgré ${label.toLowerCase()}`,
+        targetId: conflict.targetId ?? null,
+      };
+    })
+    .slice(0, 3);
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -451,6 +487,10 @@ export function buildStrategicMapShell(provinces, options = {}) {
     normalizedOptions.residualRisks,
     topFollowUpReadiness,
   );
+  const miniPlanConflictTradeoffs = buildMiniPlanConflictTradeoffs(
+    followUpCleanupMiniPlan,
+    miniPlanDependencyConflicts,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -495,6 +535,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     topFollowUpReadiness,
     followUpCleanupMiniPlan,
     miniPlanDependencyConflicts,
+    miniPlanConflictTradeoffs,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -6,6 +6,7 @@ import {
   buildFirstCleanupPayoff,
   buildFollowUpCleanupChoices,
   buildFollowUpCleanupMiniPlan,
+  buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
@@ -262,6 +263,19 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
       targetId: 'front-a',
     },
   ]);
+  assert.deepEqual(shell.miniPlanConflictTradeoffs, [
+    {
+      tradeoffId: 'mini-plan-tradeoff:supply-pressure:front-a',
+      conflictId: 'mini-plan-conflict:supply-pressure:front-a',
+      severity: 'blocking',
+      reason: 'approvisionnement tendu',
+      recommendedChoice: 'réserver le convoi court avant le mini-plan',
+      rejectedChoice: 'Scanner axe détour',
+      rejectedCost: 'retarde Scanner axe détour',
+      label: 'prioriser convoi partagé',
+      targetId: 'front-a',
+    },
+  ]);
 });
 
 test('StrategicMapShell builds a compact executable follow-up cleanup mini-plan', () => {
@@ -309,7 +323,7 @@ test('StrategicMapShell surfaces dependency conflicts around the follow-up mini-
   const miniPlan = {
     empty: false,
     steps: [
-      { riskReduced: 'axe encore exposé' },
+      { state: 'execute-cleanup', label: 'Scanner axe détour', riskReduced: 'axe encore exposé', untreatedRisk: 'loyauté basse' },
     ],
   };
   const readiness = { state: 'ready-now', residualRiskKey: 'route-exposure:front-a' };
@@ -341,6 +355,62 @@ test('StrategicMapShell surfaces dependency conflicts around the follow-up mini-
   assert.deepEqual(buildMiniPlanDependencyConflicts({ empty: true }, [
     { key: 'supply-pressure:front-a', label: 'pression ravitaillement' },
   ], readiness), []);
+});
+
+test('StrategicMapShell turns mini-plan conflicts into explicit choose-one tradeoffs', () => {
+  const miniPlan = {
+    empty: false,
+    steps: [
+      { state: 'execute-cleanup', label: 'Scanner axe détour', untreatedRisk: 'front voisin fragile' },
+    ],
+  };
+
+  assert.deepEqual(buildMiniPlanConflictTradeoffs(miniPlan, [
+    {
+      conflictId: 'mini-plan-conflict:neighbor-front:front-b',
+      severity: 'blocking',
+      label: 'Priorité voisine',
+      reason: 'ordre prioritaire reste à 88',
+      mitigation: 'caler une couverture voisine minimale',
+      residualRiskKey: 'neighbor-front:front-b',
+      targetId: 'front-b',
+    },
+    {
+      conflictId: 'mini-plan-conflict:low-loyalty:front-a',
+      severity: 'watchable',
+      label: 'Loyauté à suivre',
+      reason: 'loyauté 42',
+      mitigation: 'envoyer liaison si le plan dure',
+      residualRiskKey: 'low-loyalty:front-a',
+      targetId: 'front-a',
+    },
+  ]), [
+    {
+      tradeoffId: 'mini-plan-tradeoff:neighbor-front:front-b',
+      conflictId: 'mini-plan-conflict:neighbor-front:front-b',
+      severity: 'blocking',
+      reason: 'ordre prioritaire reste à 88',
+      recommendedChoice: 'caler une couverture voisine minimale',
+      rejectedChoice: 'Scanner axe détour',
+      rejectedCost: 'retarde Scanner axe détour',
+      label: 'prioriser priorité voisine',
+      targetId: 'front-b',
+    },
+    {
+      tradeoffId: 'mini-plan-tradeoff:low-loyalty:front-a',
+      conflictId: 'mini-plan-conflict:low-loyalty:front-a',
+      severity: 'watchable',
+      reason: 'loyauté 42',
+      recommendedChoice: 'Scanner axe détour',
+      rejectedChoice: 'envoyer liaison si le plan dure',
+      rejectedCost: 'laisse loyauté à suivre sous surveillance',
+      label: 'continuer malgré loyauté à suivre',
+      targetId: 'front-a',
+    },
+  ]);
+  assert.deepEqual(buildMiniPlanConflictTradeoffs({ empty: true }, [
+    { severity: 'blocking', residualRiskKey: 'supply-pressure:front-a' },
+  ]), []);
 });
 
 test('StrategicMapShell explains deterministic readiness blockers for the top follow-up', () => {

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -63,6 +63,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildTopFollowUpReadiness\(followUpCleanupChoices, residualRisks\)/);
   assert.match(webAppSource, /buildFollowUpCleanupMiniPlan\(followUpCleanupChoices, residualRisks, topFollowUpReadiness\)/);
   assert.match(webAppSource, /buildMiniPlanDependencyConflicts\(/);
+  assert.match(webAppSource, /buildMiniPlanConflictTradeoffs\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -93,16 +94,20 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /plan: aucun suivi sûr/);
   assert.match(webAppSource, /conflits: aucun visible/);
   assert.match(webAppSource, /miniPlanDependencyConflicts: \[\]/);
+  assert.match(webAppSource, /miniPlanConflictTradeoffs: \[\]/);
+  assert.match(webAppSource, /choix: aucun arbitrage/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
   assert.match(webAppSource, /atlas-military-fallback-order__mini-plan/);
   assert.match(webAppSource, /atlas-military-fallback-order__mini-plan-conflicts/);
+  assert.match(webAppSource, /atlas-military-fallback-order__mini-plan-tradeoffs/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
   assert.match(webAppSource, /plan: \$\{miniPlan\.steps\.map\(\(step\) => `\$\{step\.order\}\.\$\{step\.label\} › \$\{step\.riskReduced\}; reste \$\{step\.untreatedRisk\}`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /conflits: \$\{dependencyConflicts\.map\(\(conflict\) => `\$\{conflict\.severity === 'blocking' \? 'bloquant' : 'surv\.'\} \$\{conflict\.label\} › \$\{conflict\.mitigation\}`\)\.join\(' · '\)\}/);
+  assert.match(webAppSource, /choix: \$\{tradeoffs\.map\(\(tradeoff\) => `\$\{tradeoff\.severity === 'blocking' \? '★' : '○'\} \$\{tradeoff\.recommendedChoice\} \/ coût: \$\{tradeoff\.rejectedCost\}`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -118,4 +123,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__followup-readiness/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan-conflicts/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan-tradeoffs/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -7,6 +7,7 @@ import {
   buildFirstCleanupPayoff,
   buildFollowUpCleanupChoices,
   buildFollowUpCleanupMiniPlan,
+  buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
@@ -1953,6 +1954,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       topFollowUpReadiness: buildTopFollowUpReadiness([], []),
       followUpCleanupMiniPlan: buildFollowUpCleanupMiniPlan([], [], buildTopFollowUpReadiness([], [])),
       miniPlanDependencyConflicts: [],
+      miniPlanConflictTradeoffs: [],
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1972,6 +1974,10 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     residualRisks,
     topFollowUpReadiness,
   );
+  const miniPlanConflictTradeoffs = buildMiniPlanConflictTradeoffs(
+    followUpCleanupMiniPlan,
+    miniPlanDependencyConflicts,
+  );
 
   return {
     fallback: {
@@ -1988,6 +1994,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       topFollowUpReadiness,
       followUpCleanupMiniPlan,
       miniPlanDependencyConflicts,
+      miniPlanConflictTradeoffs,
     },
     safetyReason,
     crossDomainBlocker,
@@ -1999,7 +2006,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     topFollowUpReadiness,
     followUpCleanupMiniPlan,
     miniPlanDependencyConflicts,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}).`,
+    miniPlanConflictTradeoffs,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}).`,
     empty: false,
   };
 }
@@ -2030,9 +2038,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const dependencyConflictLabel = dependencyConflicts.length
     ? `conflits: ${dependencyConflicts.map((conflict) => `${conflict.severity === 'blocking' ? 'bloquant' : 'surv.'} ${conflict.label} › ${conflict.mitigation}`).join(' · ')}`
     : 'conflits: aucun visible';
+  const tradeoffs = fallback.miniPlanConflictTradeoffs ?? [];
+  const tradeoffLabel = tradeoffs.length
+    ? `choix: ${tradeoffs.map((tradeoff) => `${tradeoff.severity === 'blocking' ? '★' : '○'} ${tradeoff.recommendedChoice} / coût: ${tradeoff.rejectedCost}`).join(' · ')}`
+    : 'choix: aucun arbitrage';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="14.4" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="15.6" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2045,6 +2057,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__followup-readiness atlas-military-fallback-order__followup-readiness--${fallback.topFollowUpReadiness?.tone ?? 'neutral'}" x="23.2" y="69">${followUpReadinessLabel}</text>
       <text class="atlas-military-fallback-order__mini-plan" x="23.2" y="70.1">${miniPlanLabel}</text>
       <text class="atlas-military-fallback-order__mini-plan-conflicts" x="23.2" y="71.2">${dependencyConflictLabel}</text>
+      <text class="atlas-military-fallback-order__mini-plan-tradeoffs" x="23.2" y="72.3">${tradeoffLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11160,6 +11160,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__followup-readiness--ready { fill: #bbf7d0; }
 .atlas-military-fallback-order__mini-plan { fill: #e0f2fe; font-size: 0.47px; font-weight: 900; }
 .atlas-military-fallback-order__mini-plan-conflicts { fill: #fed7aa; font-size: 0.46px; font-weight: 900; }
+.atlas-military-fallback-order__mini-plan-tradeoffs { fill: #fef08a; font-size: 0.45px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #979.

Summary:
- adds structured `miniPlanConflictTradeoffs` from dependency conflicts around the follow-up mini-plan
- highlights recommended choice vs rejected choice cost for blocking/watchable conflicts
- renders compact choose-one tradeoff guidance in the atlas fallback panel with empty state

Tests:
- npm test

Zeta: ready for validation before merge.