### PR TITLE
Beta: show corridor timing sensitivity

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -358,6 +358,49 @@ function buildPreparationBreakEven(opportunityCostComparison, capacityMobilized)
   };
 }
 
+function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven, capacityMobilized) {
+  if (opportunityCostComparison === null || preparationBreakEven === null) {
+    return null;
+  }
+
+  const capacityCost = Math.max(1, capacityMobilized);
+  const scenarios = [
+    {
+      id: 'delay-one-turn',
+      assumption: 'retard d’un tour',
+      netValue: preparationBreakEven.netValue - capacityCost,
+    },
+    {
+      id: 'lower-capacity',
+      assumption: 'capacité moindre',
+      netValue: preparationBreakEven.netValue - opportunityCostComparison.gained.margin,
+    },
+    {
+      id: 'higher-effort-cost',
+      assumption: 'coût légèrement plus élevé',
+      netValue: preparationBreakEven.netValue - 1,
+    },
+  ].map((scenario) => ({
+    ...scenario,
+    recommendationStable: scenario.netValue > 0,
+    outcome: scenario.netValue > 0 ? 'stable' : 'switch-to-alternative',
+    alternativeOptionId: scenario.netValue > 0 ? null : opportunityCostComparison.alternativeOptionId,
+  }));
+  const fragileScenario = scenarios.find((scenario) => !scenario.recommendationStable) ?? null;
+
+  return {
+    id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
+    summary: fragileScenario === null
+      ? 'Recommandation robuste aux hypothèses testées.'
+      : `Recommandation fragile si ${fragileScenario.assumption}.`,
+    status: fragileScenario === null ? 'robust' : 'fragile',
+    scenarios,
+    reason: fragileScenario === null
+      ? `La marge de break-even reste positive dans ${scenarios.length} scénarios dérivés.`
+      : `Basculer vers ${fragileScenario.alternativeOptionId} si cette contrainte se confirme.`,
+  };
+}
+
 function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLevel, capacityMobilized) {
   if (preparationOptions.length < 2) {
     return null;
@@ -397,6 +440,7 @@ function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLeve
     alternativeValueProtected,
     routeRiskLevel,
   );
+  const preparationBreakEven = buildPreparationBreakEven(opportunityCostComparison, capacityMobilized);
 
   return {
     id: `best-value:${best.option.id}`,
@@ -409,7 +453,8 @@ function buildBestValuePreparation(preparationOptions, routeValue, routeRiskLeve
     cheaperAcceptable,
     sequence: buildPreparationSequence(best.option, cheaperAcceptable, best.estimatedValueProtected),
     opportunityCostComparison,
-    preparationBreakEven: buildPreparationBreakEven(opportunityCostComparison, capacityMobilized),
+    preparationBreakEven,
+    timingSensitivity: buildTimingSensitivity(opportunityCostComparison, preparationBreakEven, capacityMobilized),
   };
 }
 
@@ -482,6 +527,7 @@ function buildCapacitySpendPreview(route, spendPlan) {
     preparationSequence: bestValuePreparation?.sequence ?? [],
     opportunityCostComparison: bestValuePreparation?.opportunityCostComparison ?? null,
     preparationBreakEven: bestValuePreparation?.preparationBreakEven ?? null,
+    timingSensitivity: bestValuePreparation?.timingSensitivity ?? null,
     state: capacityMobilized === 0
       ? 'no-spend'
       : capacityRemaining === 0

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -156,6 +156,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         preparationSequence: [],
         opportunityCostComparison: null,
         preparationBreakEven: null,
+        timingSensitivity: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'wood', currentCapacity: 3, capacityMobilized: 0, capacityRemaining: 3 },
@@ -197,6 +198,7 @@ test('buildEconomyMapOverlay builds stable city and route overlays', () => {
         preparationSequence: [],
         opportunityCostComparison: null,
         preparationBreakEven: null,
+        timingSensitivity: null,
         state: 'no-spend',
         resources: [
           { resourceId: 'fish', currentCapacity: 4, capacityMobilized: 0, capacityRemaining: 4 },
@@ -267,6 +269,7 @@ test('buildEconomyMapOverlay supports plain payloads and style overrides', () =>
     preparationSequence: [],
     opportunityCostComparison: null,
     preparationBreakEven: null,
+    timingSensitivity: null,
     state: 'no-spend',
     resources: [
       { resourceId: 'salt', currentCapacity: 9, capacityMobilized: 0, capacityRemaining: 9 },
@@ -356,6 +359,7 @@ test('buildEconomyMapOverlay previews capacity spent by recommended unlocks', ()
     preparationSequence: [],
     opportunityCostComparison: null,
     preparationBreakEven: null,
+    timingSensitivity: null,
     state: 'remaining-margin',
     resources: [
       { resourceId: 'grain', currentCapacity: 5, capacityMobilized: 4, capacityRemaining: 1 },
@@ -466,6 +470,38 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       netValue: 14,
       reason: 'Rentable maintenant: 10 valeur protégée et 5 marge couvrent 1 effort différé.',
     },
+    timingSensitivity: {
+      id: 'timing-sensitivity:grain:shift-to-tools',
+      summary: 'Recommandation robuste aux hypothèses testées.',
+      status: 'robust',
+      scenarios: [
+        {
+          id: 'delay-one-turn',
+          assumption: 'retard d’un tour',
+          netValue: 9,
+          recommendationStable: true,
+          outcome: 'stable',
+          alternativeOptionId: null,
+        },
+        {
+          id: 'lower-capacity',
+          assumption: 'capacité moindre',
+          netValue: 13,
+          recommendationStable: true,
+          outcome: 'stable',
+          alternativeOptionId: null,
+        },
+        {
+          id: 'higher-effort-cost',
+          assumption: 'coût légèrement plus élevé',
+          netValue: 13,
+          recommendationStable: true,
+          outcome: 'stable',
+          alternativeOptionId: null,
+        },
+      ],
+      reason: 'La marge de break-even reste positive dans 3 scénarios dérivés.',
+    },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
     {
@@ -521,6 +557,38 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
     turnLimit: 0,
     netValue: 14,
     reason: 'Rentable maintenant: 10 valeur protégée et 5 marge couvrent 1 effort différé.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity, {
+    id: 'timing-sensitivity:grain:shift-to-tools',
+    summary: 'Recommandation robuste aux hypothèses testées.',
+    status: 'robust',
+    scenarios: [
+      {
+        id: 'delay-one-turn',
+        assumption: 'retard d’un tour',
+        netValue: 9,
+        recommendationStable: true,
+        outcome: 'stable',
+        alternativeOptionId: null,
+      },
+      {
+        id: 'lower-capacity',
+        assumption: 'capacité moindre',
+        netValue: 13,
+        recommendationStable: true,
+        outcome: 'stable',
+        alternativeOptionId: null,
+      },
+      {
+        id: 'higher-effort-cost',
+        assumption: 'coût légèrement plus élevé',
+        netValue: 13,
+        recommendationStable: true,
+        outcome: 'stable',
+        alternativeOptionId: null,
+      },
+    ],
+    reason: 'La marge de break-even reste positive dans 3 scénarios dérivés.',
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,


### PR DESCRIPTION
## Summary

Beta: Adds a deterministic `timingSensitivity` summary for recommended corridor preparation so the route details can explain whether the break-even timing remains robust when assumptions move.

## Changes

- Derive delay, lower-capacity, and higher-effort sensitivity scenarios from existing `opportunityCostComparison` and `preparationBreakEven` data.
- Surface whether the recommendation stays stable or should switch to the compared alternative.
- Expose the summary on both `bestValuePreparation.timingSensitivity` and `capacitySpendPreview.timingSensitivity`.
- Keep no-comparison states neutral with `null`.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (605/605 pass)

Fixes loo469/historia#980