### PR TITLE
Gamma: show top culture dependency blockers

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -666,6 +666,44 @@ function rankStabilizationDependencyRetirements(debts) {
     }));
 }
 
+function buildTopRetirementReadiness(recommendedFirstRetirement, postBundleCumulativeRisk) {
+  if (!recommendedFirstRetirement) {
+    return {
+      status: 'ready',
+      blockers: [],
+      nextSmallStep: 'aucune dépendance prioritaire à retirer',
+    };
+  }
+
+  const blockers = [];
+
+  if (recommendedFirstRetirement.blockedUntilSupport || recommendedFirstRetirement.type === 'missing-support') {
+    blockers.push({
+      blockerId: `${recommendedFirstRetirement.debtId}:support`,
+      type: 'support-prerequisite',
+      reason: 'support culturel préalable manquant',
+      nextSmallStep: 'identifier un support compatible avant retrait',
+    });
+  }
+
+  if (recommendedFirstRetirement.type === 'bundle-incompatibility' || recommendedFirstRetirement.type === 'regional-mediation') {
+    blockers.push({
+      blockerId: `${recommendedFirstRetirement.debtId}:timing`,
+      type: 'timing-local-pressure',
+      reason: postBundleCumulativeRisk.nextAttention,
+      nextSmallStep: 'stabiliser la pression locale avant retrait',
+    });
+  }
+
+  const limitedBlockers = blockers.slice(0, 2);
+
+  return {
+    status: limitedBlockers.length > 0 ? 'blocked' : 'ready',
+    blockers: limitedBlockers,
+    nextSmallStep: limitedBlockers[0]?.nextSmallStep ?? recommendedFirstRetirement.nextAction,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -716,13 +754,15 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     .slice(0, 3);
 
   const dependencyRetirementRanking = rankStabilizationDependencyRetirements(uniqueDebts);
+  const recommendedFirstRetirement = dependencyRetirementRanking[0] ? { ...dependencyRetirementRanking[0] } : null;
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
     count: uniqueDebts.length,
     debts: uniqueDebts,
     dependencyRetirementRanking,
-    recommendedFirstRetirement: dependencyRetirementRanking[0] ? { ...dependencyRetirementRanking[0] } : null,
+    recommendedFirstRetirement,
+    topRetirementReadiness: buildTopRetirementReadiness(recommendedFirstRetirement, postBundleCumulativeRisk),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -872,6 +872,18 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         expectedGain: 'retire un tradeoff de support qui entretient la dette de stabilisation',
         blockedUntilSupport: false,
       },
+      topRetirementReadiness: {
+        status: 'blocked',
+        blockers: [
+          {
+            blockerId: 'shared-marsh:debt:incompatibility:shared-marsh:culture-marsh:bundle:guided-opening:timing',
+            type: 'timing-local-pressure',
+            reason: 'surveiller les relais savants et le rythme d’ouverture',
+            nextSmallStep: 'stabiliser la pression locale avant retrait',
+          },
+        ],
+        nextSmallStep: 'stabiliser la pression locale avant retrait',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -924,6 +936,11 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
       debts: [],
       dependencyRetirementRanking: [],
       recommendedFirstRetirement: null,
+      topRetirementReadiness: {
+        status: 'ready',
+        blockers: [],
+        nextSmallStep: 'aucune dépendance prioritaire à retirer',
+      },
     },
     summary: 'stabilisation complète: aucun second soutien requis',
   });


### PR DESCRIPTION
Gamma: ## Summary

Adds readiness blockers for the top culture dependency retirement so the map can show why the priority debt is or is not immediately removable.

## Changes

- Adds `topRetirementReadiness` to `stabilizationDebtSummary`.
- Distinguishes support-prerequisite blockers from timing/local-pressure blockers.
- Provides the next small step to clear the first blocker.
- Keeps neutral/no-debt summaries ready with no blockers.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#991