### PR TITLE
Alpha: preview chosen tradeoff action

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -395,7 +395,6 @@ export function buildMiniPlanConflictTradeoffs(followUpCleanupMiniPlan = null, m
     ?? followUpCleanupMiniPlan.steps?.[0]
     ?? null;
   const miniPlanAction = String(firstPlanStep?.label ?? 'exécuter mini-plan').trim() || 'exécuter mini-plan';
-  const miniPlanCost = String(firstPlanStep?.untreatedRisk ?? 'dépendance non traitée').trim() || 'dépendance non traitée';
 
   return normalizedConflicts
     .map((conflict, index) => {
@@ -417,6 +416,46 @@ export function buildMiniPlanConflictTradeoffs(followUpCleanupMiniPlan = null, m
       };
     })
     .slice(0, 3);
+}
+
+export function buildMiniPlanTradeoffActionPreview(followUpCleanupMiniPlan = null, miniPlanConflictTradeoffs = []) {
+  const normalizedTradeoffs = normalizeCleanupInput(
+    miniPlanConflictTradeoffs,
+    'StrategicMapShell miniPlanConflictTradeoffs',
+  );
+  const chosenTradeoff = normalizedTradeoffs[0] ?? null;
+
+  if (!chosenTradeoff || !followUpCleanupMiniPlan || followUpCleanupMiniPlan.empty) {
+    return {
+      empty: true,
+      reason: 'aucun arbitrage actionnable',
+      tradeoffId: null,
+      targetId: null,
+      action: null,
+      prerequisite: null,
+      expectedBenefit: null,
+    };
+  }
+
+  const firstPlanStep = (followUpCleanupMiniPlan.steps ?? []).find((step) => step?.state === 'execute-cleanup')
+    ?? followUpCleanupMiniPlan.steps?.[0]
+    ?? null;
+  const action = String(chosenTradeoff.recommendedChoice ?? firstPlanStep?.label ?? 'confirmer arbitrage').trim()
+    || 'confirmer arbitrage';
+  const riskReduced = String(firstPlanStep?.riskReduced ?? '').trim();
+  const expectedBenefit = chosenTradeoff.severity === 'blocking'
+    ? `débloque ${chosenTradeoff.rejectedChoice ?? 'le mini-plan'}`
+    : (riskReduced ? `réduit ${riskReduced}` : `confirme ${action}`);
+
+  return {
+    empty: false,
+    reason: chosenTradeoff.reason ?? 'donnée incertaine',
+    tradeoffId: chosenTradeoff.tradeoffId ?? null,
+    targetId: chosenTradeoff.targetId ?? followUpCleanupMiniPlan.targetId ?? null,
+    action,
+    prerequisite: chosenTradeoff.reason ?? firstPlanStep?.prerequisite ?? 'donnée incertaine',
+    expectedBenefit,
+  };
 }
 
 function buildLegend(renderedProvinces, options) {
@@ -491,6 +530,10 @@ export function buildStrategicMapShell(provinces, options = {}) {
     followUpCleanupMiniPlan,
     miniPlanDependencyConflicts,
   );
+  const miniPlanTradeoffActionPreview = buildMiniPlanTradeoffActionPreview(
+    followUpCleanupMiniPlan,
+    miniPlanConflictTradeoffs,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -536,6 +579,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     followUpCleanupMiniPlan,
     miniPlanDependencyConflicts,
     miniPlanConflictTradeoffs,
+    miniPlanTradeoffActionPreview,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -8,6 +8,7 @@ import {
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
+  buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
 } from '../../../src/ui/war/StrategicMapShell.js';
@@ -276,6 +277,15 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
       targetId: 'front-a',
     },
   ]);
+  assert.deepEqual(shell.miniPlanTradeoffActionPreview, {
+    empty: false,
+    reason: 'approvisionnement tendu',
+    tradeoffId: 'mini-plan-tradeoff:supply-pressure:front-a',
+    targetId: 'front-a',
+    action: 'réserver le convoi court avant le mini-plan',
+    prerequisite: 'approvisionnement tendu',
+    expectedBenefit: 'débloque Scanner axe détour',
+  });
 });
 
 test('StrategicMapShell builds a compact executable follow-up cleanup mini-plan', () => {
@@ -411,6 +421,59 @@ test('StrategicMapShell turns mini-plan conflicts into explicit choose-one trade
   assert.deepEqual(buildMiniPlanConflictTradeoffs({ empty: true }, [
     { severity: 'blocking', residualRiskKey: 'supply-pressure:front-a' },
   ]), []);
+});
+
+test('StrategicMapShell previews the action unlocked by the recommended mini-plan tradeoff', () => {
+  const miniPlan = {
+    empty: false,
+    targetId: 'front-a',
+    steps: [
+      {
+        state: 'execute-cleanup',
+        label: 'Scanner axe détour',
+        prerequisite: 'éclaireurs disponibles',
+        riskReduced: 'axe encore exposé',
+      },
+    ],
+  };
+
+  assert.deepEqual(buildMiniPlanTradeoffActionPreview(miniPlan, [
+    {
+      tradeoffId: 'mini-plan-tradeoff:neighbor-front:front-b',
+      severity: 'blocking',
+      reason: 'ordre prioritaire reste à 88',
+      recommendedChoice: 'caler une couverture voisine minimale',
+      rejectedChoice: 'Scanner axe détour',
+      targetId: 'front-b',
+    },
+  ]), {
+    empty: false,
+    reason: 'ordre prioritaire reste à 88',
+    tradeoffId: 'mini-plan-tradeoff:neighbor-front:front-b',
+    targetId: 'front-b',
+    action: 'caler une couverture voisine minimale',
+    prerequisite: 'ordre prioritaire reste à 88',
+    expectedBenefit: 'débloque Scanner axe détour',
+  });
+  assert.deepEqual(buildMiniPlanTradeoffActionPreview(miniPlan, [
+    {
+      tradeoffId: 'mini-plan-tradeoff:low-loyalty:front-a',
+      severity: 'watchable',
+      reason: 'loyauté 42',
+      recommendedChoice: 'Scanner axe détour',
+      rejectedChoice: 'envoyer liaison si le plan dure',
+      targetId: 'front-a',
+    },
+  ]).expectedBenefit, 'réduit axe encore exposé');
+  assert.deepEqual(buildMiniPlanTradeoffActionPreview({ empty: true }, []), {
+    empty: true,
+    reason: 'aucun arbitrage actionnable',
+    tradeoffId: null,
+    targetId: null,
+    action: null,
+    prerequisite: null,
+    expectedBenefit: null,
+  });
 });
 
 test('StrategicMapShell explains deterministic readiness blockers for the top follow-up', () => {

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -64,6 +64,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildFollowUpCleanupMiniPlan\(followUpCleanupChoices, residualRisks, topFollowUpReadiness\)/);
   assert.match(webAppSource, /buildMiniPlanDependencyConflicts\(/);
   assert.match(webAppSource, /buildMiniPlanConflictTradeoffs\(/);
+  assert.match(webAppSource, /buildMiniPlanTradeoffActionPreview\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -96,18 +97,22 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanDependencyConflicts: \[\]/);
   assert.match(webAppSource, /miniPlanConflictTradeoffs: \[\]/);
   assert.match(webAppSource, /choix: aucun arbitrage/);
+  assert.match(webAppSource, /action: aucun arbitrage prêt/);
+  assert.match(webAppSource, /miniPlanTradeoffActionPreview: buildMiniPlanTradeoffActionPreview\(null, \[\]\)/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
   assert.match(webAppSource, /atlas-military-fallback-order__mini-plan/);
   assert.match(webAppSource, /atlas-military-fallback-order__mini-plan-conflicts/);
   assert.match(webAppSource, /atlas-military-fallback-order__mini-plan-tradeoffs/);
+  assert.match(webAppSource, /atlas-military-fallback-order__tradeoff-action/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
   assert.match(webAppSource, /plan: \$\{miniPlan\.steps\.map\(\(step\) => `\$\{step\.order\}\.\$\{step\.label\} › \$\{step\.riskReduced\}; reste \$\{step\.untreatedRisk\}`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /conflits: \$\{dependencyConflicts\.map\(\(conflict\) => `\$\{conflict\.severity === 'blocking' \? 'bloquant' : 'surv\.'\} \$\{conflict\.label\} › \$\{conflict\.mitigation\}`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /choix: \$\{tradeoffs\.map\(\(tradeoff\) => `\$\{tradeoff\.severity === 'blocking' \? '★' : '○'\} \$\{tradeoff\.recommendedChoice\} \/ coût: \$\{tradeoff\.rejectedCost\}`\)\.join\(' · '\)\}/);
+  assert.match(webAppSource, /action: \$\{actionPreview\.action\} @ \$\{actionPreview\.targetId \?\? 'front'\} · préreq \$\{actionPreview\.prerequisite\} · gain \$\{actionPreview\.expectedBenefit\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -124,4 +129,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan-conflicts/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan-tradeoffs/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__tradeoff-action/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -9,6 +9,7 @@ import {
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
+  buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
 } from '../src/ui/war/StrategicMapShell.js';
@@ -1955,6 +1956,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       followUpCleanupMiniPlan: buildFollowUpCleanupMiniPlan([], [], buildTopFollowUpReadiness([], [])),
       miniPlanDependencyConflicts: [],
       miniPlanConflictTradeoffs: [],
+      miniPlanTradeoffActionPreview: buildMiniPlanTradeoffActionPreview(null, []),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1978,6 +1980,10 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     followUpCleanupMiniPlan,
     miniPlanDependencyConflicts,
   );
+  const miniPlanTradeoffActionPreview = buildMiniPlanTradeoffActionPreview(
+    followUpCleanupMiniPlan,
+    miniPlanConflictTradeoffs,
+  );
 
   return {
     fallback: {
@@ -1995,6 +2001,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       followUpCleanupMiniPlan,
       miniPlanDependencyConflicts,
       miniPlanConflictTradeoffs,
+      miniPlanTradeoffActionPreview,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2007,7 +2014,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     followUpCleanupMiniPlan,
     miniPlanDependencyConflicts,
     miniPlanConflictTradeoffs,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}).`,
+    miniPlanTradeoffActionPreview,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}).`,
     empty: false,
   };
 }
@@ -2042,9 +2050,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const tradeoffLabel = tradeoffs.length
     ? `choix: ${tradeoffs.map((tradeoff) => `${tradeoff.severity === 'blocking' ? '★' : '○'} ${tradeoff.recommendedChoice} / coût: ${tradeoff.rejectedCost}`).join(' · ')}`
     : 'choix: aucun arbitrage';
+  const actionPreview = fallback.miniPlanTradeoffActionPreview;
+  const actionPreviewLabel = actionPreview && !actionPreview.empty
+    ? `action: ${actionPreview.action} @ ${actionPreview.targetId ?? 'front'} · préreq ${actionPreview.prerequisite} · gain ${actionPreview.expectedBenefit}`
+    : 'action: aucun arbitrage prêt';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="15.6" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="16.8" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2058,6 +2070,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__mini-plan" x="23.2" y="70.1">${miniPlanLabel}</text>
       <text class="atlas-military-fallback-order__mini-plan-conflicts" x="23.2" y="71.2">${dependencyConflictLabel}</text>
       <text class="atlas-military-fallback-order__mini-plan-tradeoffs" x="23.2" y="72.3">${tradeoffLabel}</text>
+      <text class="atlas-military-fallback-order__tradeoff-action" x="23.2" y="73.4">${actionPreviewLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11161,6 +11161,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__mini-plan { fill: #e0f2fe; font-size: 0.47px; font-weight: 900; }
 .atlas-military-fallback-order__mini-plan-conflicts { fill: #fed7aa; font-size: 0.46px; font-weight: 900; }
 .atlas-military-fallback-order__mini-plan-tradeoffs { fill: #fef08a; font-size: 0.45px; font-weight: 900; }
+.atlas-military-fallback-order__tradeoff-action { fill: #bfdbfe; font-size: 0.44px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #989.

Summary:
- adds structured `miniPlanTradeoffActionPreview` for the recommended military tradeoff
- exposes the next action, target province/front, blocking prerequisite, and expected benefit
- renders a compact action preview in the atlas fallback panel without repeating incompatible options

Tests:
- npm test

Zeta: ready for validation before merge.