### PR TITLE
Delta: add intrigue monitoring checklist

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -274,6 +274,58 @@ function buildSecondSweepStopCondition({ nextSafeSweep, unknownsRemaining, sabot
 }
 
 
+
+function buildMonitoringChecklist({ state, monitoringPreferred, marginalExposureAdded, expectedConfidenceGain }) {
+  const exposure = clampPercent(marginalExposureAdded);
+  const confidenceGain = clampPercent(expectedConfidenceGain);
+
+  if (state === 'safe-action-available') {
+    return [
+      { signal: 'Fenêtre sûre', status: 'déclencheur potentiel', note: 'Relancer si elle reste stable.' },
+      { signal: 'Heat', status: 'calme', note: 'Basculer en surveillance si le heat remonte.' },
+      { signal: 'Gain confiance', status: 'déclencheur potentiel', note: `+${confidenceGain} attendu dépasse +${exposure} exposition.` },
+    ];
+  }
+
+  if (state === 'await-fresh-signal') {
+    return [
+      { signal: 'Fraîcheur signal', status: 'à surveiller', note: 'Attendre un signal récent avant reprise.' },
+      { signal: 'Fenêtre low-risk', status: 'à surveiller', note: 'Relancer seulement si un gap lisible réapparaît.' },
+      { signal: 'Exposition', status: 'calme', note: `Rester sous +${Math.max(3, exposure)} exposition marginale.` },
+    ];
+  }
+
+  if (state === 'heat-too-high') {
+    return [
+      { signal: 'Heat', status: 'à surveiller', note: 'Attendre une baisse nette avant reprise.' },
+      { signal: 'Exposition', status: 'à surveiller', note: `+${exposure} marginal reste trop élevé.` },
+      { signal: 'Gain confiance', status: 'calme', note: 'Aucun gain fiable ne justifie la relance.' },
+    ];
+  }
+
+  if (state === 'wait-for-cooldown') {
+    return [
+      { signal: 'Cooldown heat', status: 'à surveiller', note: 'Relancer si la fenêtre refroidit.' },
+      { signal: 'Gap visible', status: 'déclencheur potentiel', note: 'Reprendre si le gap reste lisible après cooldown.' },
+      { signal: 'Exposition', status: 'à surveiller', note: `Comparer +${exposure} exposition au gain +${confidenceGain}.` },
+    ];
+  }
+
+  if (state === 'low-confidence-gain') {
+    return [
+      { signal: 'Gain confiance', status: 'à surveiller', note: `Relancer si le gain dépasse +${confidenceGain}.` },
+      { signal: 'Signaux frais', status: 'déclencheur potentiel', note: 'Deux signaux convergents peuvent rouvrir une sweep.' },
+      { signal: 'Heat', status: 'calme', note: 'Surveillance suffisante tant que le heat reste contenu.' },
+    ];
+  }
+
+  return [
+    { signal: 'Nouveau gap', status: monitoringPreferred ? 'à surveiller' : 'calme', note: 'Relancer seulement avec un gap fog-safe lisible.' },
+    { signal: 'Fraîcheur signal', status: 'à surveiller', note: 'Confirmer que le signal n’est pas périmé.' },
+    { signal: 'Exposition', status: 'calme', note: 'Ne pas ajouter d’exposition sans gain concret.' },
+  ];
+}
+
 function buildMonitoringRestartPlan({ state, monitoringPreferred, marginalExposureAdded, expectedConfidenceGain }) {
   const normalizedExposure = clampPercent(marginalExposureAdded);
   const normalizedGain = clampPercent(expectedConfidenceGain);
@@ -347,6 +399,12 @@ function withMonitoringRestartPlan(rationale, marginalExposureAdded, expectedCon
   return {
     ...rationale,
     ...buildMonitoringRestartPlan({
+      state: rationale.state,
+      monitoringPreferred: rationale.monitoringPreferred,
+      marginalExposureAdded,
+      expectedConfidenceGain,
+    }),
+    monitoringChecklist: buildMonitoringChecklist({
       state: rationale.state,
       monitoringPreferred: rationale.monitoringPreferred,
       marginalExposureAdded,

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -160,6 +160,40 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               'Continuer à surveiller sans nouveau gap lisible.',
             ],
             sweepRestartComparison: 'Surveiller reste préférable tant qu’aucun gain de confiance concret n’apparaît.',
+        monitoringChecklist: [
+          {
+            signal: 'Nouveau gap',
+            status: 'à surveiller',
+            note: 'Relancer seulement avec un gap fog-safe lisible.',
+          },
+          {
+            signal: 'Fraîcheur signal',
+            status: 'à surveiller',
+            note: 'Confirmer que le signal n’est pas périmé.',
+          },
+          {
+            signal: 'Exposition',
+            status: 'calme',
+            note: 'Ne pas ajouter d’exposition sans gain concret.',
+          },
+        ],
+            monitoringChecklist: [
+              {
+                signal: 'Nouveau gap',
+                status: 'à surveiller',
+                note: 'Relancer seulement avec un gap fog-safe lisible.',
+              },
+              {
+                signal: 'Fraîcheur signal',
+                status: 'à surveiller',
+                note: 'Confirmer que le signal n’est pas périmé.',
+              },
+              {
+                signal: 'Exposition',
+                status: 'calme',
+                note: 'Ne pas ajouter d’exposition sans gain concret.',
+              },
+            ],
           },
           rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
         },
@@ -230,6 +264,40 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               'Continuer à surveiller sans nouveau gap lisible.',
             ],
             sweepRestartComparison: 'Surveiller reste préférable tant qu’aucun gain de confiance concret n’apparaît.',
+        monitoringChecklist: [
+          {
+            signal: 'Nouveau gap',
+            status: 'à surveiller',
+            note: 'Relancer seulement avec un gap fog-safe lisible.',
+          },
+          {
+            signal: 'Fraîcheur signal',
+            status: 'à surveiller',
+            note: 'Confirmer que le signal n’est pas périmé.',
+          },
+          {
+            signal: 'Exposition',
+            status: 'calme',
+            note: 'Ne pas ajouter d’exposition sans gain concret.',
+          },
+        ],
+            monitoringChecklist: [
+              {
+                signal: 'Nouveau gap',
+                status: 'à surveiller',
+                note: 'Relancer seulement avec un gap fog-safe lisible.',
+              },
+              {
+                signal: 'Fraîcheur signal',
+                status: 'à surveiller',
+                note: 'Confirmer que le signal n’est pas périmé.',
+              },
+              {
+                signal: 'Exposition',
+                status: 'calme',
+                note: 'Ne pas ajouter d’exposition sans gain concret.',
+              },
+            ],
           },
           rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
         },
@@ -400,6 +468,23 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
           'Continuer à surveiller sans nouveau gap lisible.',
         ],
         sweepRestartComparison: 'Surveiller reste préférable tant qu’aucun gain de confiance concret n’apparaît.',
+        monitoringChecklist: [
+          {
+            signal: 'Nouveau gap',
+            status: 'à surveiller',
+            note: 'Relancer seulement avec un gap fog-safe lisible.',
+          },
+          {
+            signal: 'Fraîcheur signal',
+            status: 'à surveiller',
+            note: 'Confirmer que le signal n’est pas périmé.',
+          },
+          {
+            signal: 'Exposition',
+            status: 'calme',
+            note: 'Ne pas ajouter d’exposition sans gain concret.',
+          },
+        ],
       },
       rationale: 'Aucun troisième sweep à préparer: la seconde passe n’a pas de fenêtre sûre.',
     },
@@ -462,6 +547,23 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
         'Continuer à surveiller tant que le gain reste marginal.',
       ],
       sweepRestartComparison: 'Surveiller bat la relance: +3 confiance attendue reste trop faible pour +9 exposition.',
+      monitoringChecklist: [
+        {
+          signal: 'Gain confiance',
+          status: 'à surveiller',
+          note: 'Relancer si le gain dépasse +3.',
+        },
+        {
+          signal: 'Signaux frais',
+          status: 'déclencheur potentiel',
+          note: 'Deux signaux convergents peuvent rouvrir une sweep.',
+        },
+        {
+          signal: 'Heat',
+          status: 'calme',
+          note: 'Surveillance suffisante tant que le heat reste contenu.',
+        },
+      ],
     },
     rationale: 'Arrêter après la seconde passe: le gain restant serait trop faible par rapport à l’exposition marginale.',
   });
@@ -590,6 +692,23 @@ test('buildIntrigueMapOverlay recommends preparing a third sweep only when resid
         'Basculer en surveillance si le heat remonte avant l’ordre.',
       ],
       sweepRestartComparison: 'Relancer bat la surveillance: +14 confiance attendue pour +9 exposition.',
+      monitoringChecklist: [
+        {
+          signal: 'Fenêtre sûre',
+          status: 'déclencheur potentiel',
+          note: 'Relancer si elle reste stable.',
+        },
+        {
+          signal: 'Heat',
+          status: 'calme',
+          note: 'Basculer en surveillance si le heat remonte.',
+        },
+        {
+          signal: 'Gain confiance',
+          status: 'déclencheur potentiel',
+          note: '+14 attendu dépasse +9 exposition.',
+        },
+      ],
     },
     rationale: 'Préparer une troisième passe prudente: 2 inconnues resteraient et le gain de confiance attendu dépasse l’exposition marginale.',
   });
@@ -643,6 +762,23 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
       'Continuer à surveiller si la fraîcheur reste insuffisante.',
     ],
     sweepRestartComparison: 'Surveiller bat la relance: le signal est trop ancien pour justifier une nouvelle exposition.',
+    monitoringChecklist: [
+      {
+        signal: 'Fraîcheur signal',
+        status: 'à surveiller',
+        note: 'Attendre un signal récent avant reprise.',
+      },
+      {
+        signal: 'Fenêtre low-risk',
+        status: 'à surveiller',
+        note: 'Relancer seulement si un gap lisible réapparaît.',
+      },
+      {
+        signal: 'Exposition',
+        status: 'calme',
+        note: 'Rester sous +8 exposition marginale.',
+      },
+    ],
   });
 
   const tooExposed = buildIntrigueMapOverlay([


### PR DESCRIPTION
Delta: Implements #992.

Summary:
- Adds a compact fog-safe `monitoringChecklist` to `thirdSweepRecommendation.monitoringRationale`.
- Marks each signal as calm, watch, or potential trigger across fresh-signal, heat, cooldown, low-gain, and safe-action states.
- Keeps checklist guidance focused on signal freshness, heat, exposure, and confidence without hidden-cause leakage.

Tests:
- `node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js`
- `npm test` (607/607)

Zeta: PR ready for validation. Please review before any merge.