### PR TITLE
Beta: warn on corridor sensitivity flips

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -368,17 +368,26 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     {
       id: 'delay-one-turn',
       assumption: 'retard d’un tour',
+      cause: 'delay',
       netValue: preparationBreakEven.netValue - capacityCost,
     },
     {
       id: 'lower-capacity',
       assumption: 'capacité moindre',
+      cause: 'capacity',
       netValue: preparationBreakEven.netValue - opportunityCostComparison.gained.margin,
     },
     {
       id: 'higher-effort-cost',
       assumption: 'coût légèrement plus élevé',
+      cause: 'cost',
       netValue: preparationBreakEven.netValue - 1,
+    },
+    {
+      id: 'bottleneck-saturation',
+      assumption: 'saturation du goulot',
+      cause: 'saturation',
+      netValue: preparationBreakEven.netValue - capacityCost - Math.max(1, opportunityCostComparison.deferred.effort),
     },
   ].map((scenario) => ({
     ...scenario,
@@ -386,18 +395,34 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     outcome: scenario.netValue > 0 ? 'stable' : 'switch-to-alternative',
     alternativeOptionId: scenario.netValue > 0 ? null : opportunityCostComparison.alternativeOptionId,
   }));
-  const fragileScenario = scenarios.find((scenario) => !scenario.recommendationStable) ?? null;
+  const flipScenario = scenarios.find((scenario) => !scenario.recommendationStable) ?? null;
+  const flipWarning = flipScenario === null
+    ? {
+      status: 'stable',
+      summary: 'stable',
+      cause: null,
+      scenarioId: null,
+      alternativeOptionId: null,
+      reason: `La marge de break-even reste positive dans ${scenarios.length} scénarios dérivés.`,
+    }
+    : {
+      status: 'switch',
+      summary: `bascule vers ${flipScenario.alternativeOptionId}`,
+      cause: flipScenario.cause,
+      scenarioId: flipScenario.id,
+      alternativeOptionId: flipScenario.alternativeOptionId,
+      reason: `La recommandation bascule vers ${flipScenario.alternativeOptionId} si ${flipScenario.assumption}.`,
+    };
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
-    summary: fragileScenario === null
-      ? 'Recommandation robuste aux hypothèses testées.'
-      : `Recommandation fragile si ${fragileScenario.assumption}.`,
-    status: fragileScenario === null ? 'robust' : 'fragile',
+    summary: flipScenario === null
+      ? 'stable: recommandation robuste aux hypothèses testées.'
+      : `bascule vers ${flipScenario.alternativeOptionId} si ${flipScenario.assumption}.`,
+    status: flipScenario === null ? 'stable' : 'fragile',
+    flipWarning,
     scenarios,
-    reason: fragileScenario === null
-      ? `La marge de break-even reste positive dans ${scenarios.length} scénarios dérivés.`
-      : `Basculer vers ${fragileScenario.alternativeOptionId} si cette contrainte se confirme.`,
+    reason: flipWarning.reason,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -472,12 +472,21 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
     },
     timingSensitivity: {
       id: 'timing-sensitivity:grain:shift-to-tools',
-      summary: 'Recommandation robuste aux hypothèses testées.',
-      status: 'robust',
+      summary: 'stable: recommandation robuste aux hypothèses testées.',
+      status: 'stable',
+      flipWarning: {
+        status: 'stable',
+        summary: 'stable',
+        cause: null,
+        scenarioId: null,
+        alternativeOptionId: null,
+        reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
+      },
       scenarios: [
         {
           id: 'delay-one-turn',
           assumption: 'retard d’un tour',
+          cause: 'delay',
           netValue: 9,
           recommendationStable: true,
           outcome: 'stable',
@@ -486,6 +495,7 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         {
           id: 'lower-capacity',
           assumption: 'capacité moindre',
+          cause: 'capacity',
           netValue: 13,
           recommendationStable: true,
           outcome: 'stable',
@@ -494,13 +504,23 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         {
           id: 'higher-effort-cost',
           assumption: 'coût légèrement plus élevé',
+          cause: 'cost',
           netValue: 13,
           recommendationStable: true,
           outcome: 'stable',
           alternativeOptionId: null,
         },
+        {
+          id: 'bottleneck-saturation',
+          assumption: 'saturation du goulot',
+          cause: 'saturation',
+          netValue: 8,
+          recommendationStable: true,
+          outcome: 'stable',
+          alternativeOptionId: null,
+        },
       ],
-      reason: 'La marge de break-even reste positive dans 3 scénarios dérivés.',
+      reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -560,12 +580,21 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity, {
     id: 'timing-sensitivity:grain:shift-to-tools',
-    summary: 'Recommandation robuste aux hypothèses testées.',
-    status: 'robust',
+    summary: 'stable: recommandation robuste aux hypothèses testées.',
+    status: 'stable',
+    flipWarning: {
+      status: 'stable',
+      summary: 'stable',
+      cause: null,
+      scenarioId: null,
+      alternativeOptionId: null,
+      reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
+    },
     scenarios: [
       {
         id: 'delay-one-turn',
         assumption: 'retard d’un tour',
+        cause: 'delay',
         netValue: 9,
         recommendationStable: true,
         outcome: 'stable',
@@ -574,6 +603,7 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       {
         id: 'lower-capacity',
         assumption: 'capacité moindre',
+        cause: 'capacity',
         netValue: 13,
         recommendationStable: true,
         outcome: 'stable',
@@ -582,17 +612,76 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       {
         id: 'higher-effort-cost',
         assumption: 'coût légèrement plus élevé',
+        cause: 'cost',
         netValue: 13,
         recommendationStable: true,
         outcome: 'stable',
         alternativeOptionId: null,
       },
+      {
+        id: 'bottleneck-saturation',
+        assumption: 'saturation du goulot',
+        cause: 'saturation',
+        netValue: 8,
+        recommendationStable: true,
+        outcome: 'stable',
+        alternativeOptionId: null,
+      },
     ],
-    reason: 'La marge de break-even reste positive dans 3 scénarios dérivés.',
+    reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
     overlay.routes[0].capacitySpendPreview.bestValuePreparation,
+  );
+});
+
+
+test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback sequence', () => {
+  const overlay = buildEconomyMapOverlay([], [
+    {
+      id: 'route-saturated',
+      name: 'Saturated Road',
+      stopCityIds: ['city-a', 'city-b'],
+      distance: 2,
+      capacityByResource: { grain: 2 },
+      transportMode: 'land',
+      riskLevel: 100,
+    },
+  ], {
+    recommendedUnlockByRouteId: {
+      'route-saturated': {
+        mobilizedByResource: { grain: 2 },
+      },
+    },
+  });
+
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.flipWarning, {
+    status: 'switch',
+    summary: 'bascule vers grain:reserve-buffer',
+    cause: 'delay',
+    scenarioId: 'delay-one-turn',
+    alternativeOptionId: 'grain:reserve-buffer',
+    reason: 'La recommandation bascule vers grain:reserve-buffer si retard d’un tour.',
+  });
+  assert.equal(
+    overlay.routes[0].capacitySpendPreview.timingSensitivity.summary,
+    'bascule vers grain:reserve-buffer si retard d’un tour.',
+  );
+  assert.equal(overlay.routes[0].capacitySpendPreview.timingSensitivity.status, 'fragile');
+  assert.deepEqual(
+    overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
+      scenario.id,
+      scenario.cause,
+      scenario.outcome,
+      scenario.alternativeOptionId,
+    ]),
+    [
+      ['delay-one-turn', 'delay', 'switch-to-alternative', 'grain:reserve-buffer'],
+      ['lower-capacity', 'capacity', 'switch-to-alternative', 'grain:reserve-buffer'],
+      ['higher-effort-cost', 'cost', 'switch-to-alternative', 'grain:reserve-buffer'],
+      ['bottleneck-saturation', 'saturation', 'switch-to-alternative', 'grain:reserve-buffer'],
+    ],
   );
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds an explicit flip warning to corridor timing sensitivity so route details can show when a changed assumption makes the recommendation switch to the fallback sequence.

## Changes

- Add `flipWarning` with short `stable` / `bascule vers …` wording.
- Tag sensitivity scenarios with primary causes: delay, capacity, cost, and saturation.
- Add a saturation scenario derived from existing break-even/opportunity-cost data.
- Keep stable recommendations clearly marked while exposing the first fragile switching scenario.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (608/608 pass)

Fixes loo469/historia#990