### PR TITLE
Beta: explain actionable corridor flip warnings

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -358,6 +358,35 @@ function buildPreparationBreakEven(opportunityCostComparison, capacityMobilized)
   };
 }
 
+function buildFlipActionability(flipScenario, opportunityCostComparison, capacityCost) {
+  if (flipScenario === null) {
+    return {
+      threshold: null,
+      consequence: 'continuer la séquence recommandée',
+      advice: 'Action stable: continuer la séquence recommandée tant que la marge de break-even reste positive.',
+    };
+  }
+
+  const thresholdByCause = {
+    delay: 'dès 1 tour de retard',
+    capacity: `si la marge disponible perd ${Math.max(1, opportunityCostComparison.gained.margin)} capacité`,
+    cost: 'si le coût augmente d’au moins 1 ordre',
+    saturation: `si le goulot consomme ${capacityCost} capacité avant préparation`,
+  };
+  const consequenceByCause = {
+    delay: 'inverser la priorité avant d’attendre',
+    capacity: 'sécuriser une marge avant d’agir',
+    cost: 'attendre une option moins coûteuse',
+    saturation: 'sécuriser le goulot avant toute nouvelle dépense',
+  };
+
+  return {
+    threshold: thresholdByCause[flipScenario.cause] ?? `si ${flipScenario.assumption}`,
+    consequence: consequenceByCause[flipScenario.cause] ?? 'inverser la priorité',
+    advice: `${consequenceByCause[flipScenario.cause] ?? 'Inverser la priorité'}: basculer vers ${flipScenario.alternativeOptionId} ${thresholdByCause[flipScenario.cause] ?? `si ${flipScenario.assumption}`}.`,
+  };
+}
+
 function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven, capacityMobilized) {
   if (opportunityCostComparison === null || preparationBreakEven === null) {
     return null;
@@ -396,6 +425,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     alternativeOptionId: scenario.netValue > 0 ? null : opportunityCostComparison.alternativeOptionId,
   }));
   const flipScenario = scenarios.find((scenario) => !scenario.recommendationStable) ?? null;
+  const actionability = buildFlipActionability(flipScenario, opportunityCostComparison, capacityCost);
   const flipWarning = flipScenario === null
     ? {
       status: 'stable',
@@ -404,6 +434,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
       scenarioId: null,
       alternativeOptionId: null,
       reason: `La marge de break-even reste positive dans ${scenarios.length} scénarios dérivés.`,
+      actionability,
     }
     : {
       status: 'switch',
@@ -412,6 +443,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
       scenarioId: flipScenario.id,
       alternativeOptionId: flipScenario.alternativeOptionId,
       reason: `La recommandation bascule vers ${flipScenario.alternativeOptionId} si ${flipScenario.assumption}.`,
+      actionability,
     };
 
   return {
@@ -423,6 +455,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     flipWarning,
     scenarios,
     reason: flipWarning.reason,
+    actionableAdvice: actionability.advice,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -481,6 +481,11 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         scenarioId: null,
         alternativeOptionId: null,
         reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
+        actionability: {
+          threshold: null,
+          consequence: 'continuer la séquence recommandée',
+          advice: 'Action stable: continuer la séquence recommandée tant que la marge de break-even reste positive.',
+        },
       },
       scenarios: [
         {
@@ -521,6 +526,7 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         },
       ],
       reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
+      actionableAdvice: 'Action stable: continuer la séquence recommandée tant que la marge de break-even reste positive.',
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -589,6 +595,11 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       scenarioId: null,
       alternativeOptionId: null,
       reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
+      actionability: {
+        threshold: null,
+        consequence: 'continuer la séquence recommandée',
+        advice: 'Action stable: continuer la séquence recommandée tant que la marge de break-even reste positive.',
+      },
     },
     scenarios: [
       {
@@ -629,6 +640,7 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       },
     ],
     reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
+    actionableAdvice: 'Action stable: continuer la séquence recommandée tant que la marge de break-even reste positive.',
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -663,7 +675,16 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     scenarioId: 'delay-one-turn',
     alternativeOptionId: 'grain:reserve-buffer',
     reason: 'La recommandation bascule vers grain:reserve-buffer si retard d’un tour.',
+    actionability: {
+      threshold: 'dès 1 tour de retard',
+      consequence: 'inverser la priorité avant d’attendre',
+      advice: 'inverser la priorité avant d’attendre: basculer vers grain:reserve-buffer dès 1 tour de retard.',
+    },
   });
+  assert.equal(
+    overlay.routes[0].capacitySpendPreview.timingSensitivity.actionableAdvice,
+    'inverser la priorité avant d’attendre: basculer vers grain:reserve-buffer dès 1 tour de retard.',
+  );
   assert.equal(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.summary,
     'bascule vers grain:reserve-buffer si retard d’un tour.',


### PR DESCRIPTION
## Summary

Beta: Adds concise actionability guidance to corridor flip warnings so the route detail explains when the warning should change the player’s order of action.

## Changes

- Add `flipWarning.actionability` with a threshold, practical consequence, and one-sentence advice.
- Surface `timingSensitivity.actionableAdvice` for compact corridor summaries.
- Map existing sensitivity causes to practical actions: invert priority, secure margin, wait for lower cost, or secure the bottleneck.
- Preserve stable cases with neutral guidance to continue the recommended sequence.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (610/610 pass)

Fixes loo469/historia#1000