### PR TITLE
Gamma: preview culture dependency recovery

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -704,6 +704,46 @@ function buildTopRetirementReadiness(recommendedFirstRetirement, postBundleCumul
   };
 }
 
+function buildTopRetirementRecoveryPreview(recommendedFirstRetirement, topRetirementReadiness) {
+  if (!recommendedFirstRetirement) {
+    return {
+      status: 'neutral',
+      recoveryType: 'none',
+      expectedRecovery: 'aucune récupération culturelle prioritaire',
+      immediacy: 'immediate',
+      closesLoop: 'aucune dépendance bloquante à lever',
+    };
+  }
+
+  const recoveryType = recommendedFirstRetirement.type === 'bundle-incompatibility'
+    ? 'stability'
+    : recommendedFirstRetirement.type === 'missing-support'
+      ? 'support'
+      : recommendedFirstRetirement.type === 'bundle-dependency'
+        ? 'unlock'
+        : 'margin';
+  const immediacy = topRetirementReadiness.status === 'blocked'
+    ? 'conditional'
+    : recommendedFirstRetirement.type === 'regional-mediation' || recommendedFirstRetirement.type === 'fragile-culture'
+      ? 'partial'
+      : 'immediate';
+  const expectedRecovery = recoveryType === 'stability'
+    ? 'stabilité récupérée: le tradeoff culturel cesse de nourrir la dette prioritaire'
+    : recoveryType === 'support'
+      ? 'soutien récupéré: un second bundle sûr peut redevenir lisible'
+      : recoveryType === 'unlock'
+        ? 'verrou culturel levé: la séquence de soutien devient plus simple'
+        : 'marge récupérée: la pression régionale prioritaire diminue';
+
+  return {
+    status: 'preview',
+    recoveryType,
+    expectedRecovery,
+    immediacy,
+    closesLoop: `${topRetirementReadiness.nextSmallStep} → ${recommendedFirstRetirement.expectedGain}`,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -755,6 +795,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
 
   const dependencyRetirementRanking = rankStabilizationDependencyRetirements(uniqueDebts);
   const recommendedFirstRetirement = dependencyRetirementRanking[0] ? { ...dependencyRetirementRanking[0] } : null;
+  const topRetirementReadiness = buildTopRetirementReadiness(recommendedFirstRetirement, postBundleCumulativeRisk);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -762,7 +803,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     debts: uniqueDebts,
     dependencyRetirementRanking,
     recommendedFirstRetirement,
-    topRetirementReadiness: buildTopRetirementReadiness(recommendedFirstRetirement, postBundleCumulativeRisk),
+    topRetirementReadiness,
+    topRetirementRecoveryPreview: buildTopRetirementRecoveryPreview(recommendedFirstRetirement, topRetirementReadiness),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -884,6 +884,13 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         ],
         nextSmallStep: 'stabiliser la pression locale avant retrait',
       },
+      topRetirementRecoveryPreview: {
+        status: 'preview',
+        recoveryType: 'stability',
+        expectedRecovery: 'stabilité récupérée: le tradeoff culturel cesse de nourrir la dette prioritaire',
+        immediacy: 'conditional',
+        closesLoop: 'stabiliser la pression locale avant retrait → retire un tradeoff de support qui entretient la dette de stabilisation',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -940,6 +947,13 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         status: 'ready',
         blockers: [],
         nextSmallStep: 'aucune dépendance prioritaire à retirer',
+      },
+      topRetirementRecoveryPreview: {
+        status: 'neutral',
+        recoveryType: 'none',
+        expectedRecovery: 'aucune récupération culturelle prioritaire',
+        immediacy: 'immediate',
+        closesLoop: 'aucune dépendance bloquante à lever',
       },
     },
     summary: 'stabilisation complète: aucun second soutien requis',


### PR DESCRIPTION
Gamma: ## Summary

Adds a short recovery preview after retiring the top culture dependency so the map closes the loop from blocked dependency to expected benefit.

## Changes

- Adds `topRetirementRecoveryPreview` next to `topRetirementReadiness` in `stabilizationDebtSummary`.
- Surfaces expected recovery as stability, support, margin, unlock, or neutral.
- Marks recovery immediacy as immediate, partial, or conditional based on blockers/readiness.
- Keeps neutral/no-debt states explicit.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1001