### PR TITLE
Alpha: show rival response risk for tradeoff

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -458,6 +458,62 @@ export function buildMiniPlanTradeoffActionPreview(followUpCleanupMiniPlan = nul
   };
 }
 
+function describeRivalResponse(reason, action) {
+  const text = `${reason} ${action}`;
+
+  if (/convoi|ravitaillement|approvisionnement/i.test(text)) return 'coupure du convoi partagé';
+  if (/front voisin|priorité|couverture/i.test(text)) return 'contre-poussée du front voisin';
+  if (/loyaut|émissaire|liaison/i.test(text)) return 'agitation locale avant liaison';
+  if (/route|axe|détour|corridor|éclaireur/i.test(text)) return 'interception du détour';
+  if (/occupation|patrouille|disput/i.test(text)) return 'reprise de zone disputée';
+
+  return 'réponse adverse imprévue';
+}
+
+export function buildMiniPlanRivalResponseRisk(miniPlanTradeoffActionPreview = null, miniPlanConflictTradeoffs = []) {
+  const normalizedTradeoffs = normalizeCleanupInput(
+    miniPlanConflictTradeoffs,
+    'StrategicMapShell miniPlanConflictTradeoffs',
+  );
+  const chosenTradeoff = normalizedTradeoffs.find(
+    (tradeoff) => tradeoff.tradeoffId === miniPlanTradeoffActionPreview?.tradeoffId,
+  ) ?? normalizedTradeoffs[0] ?? null;
+
+  if (!miniPlanTradeoffActionPreview || miniPlanTradeoffActionPreview.empty || !chosenTradeoff) {
+    return {
+      empty: true,
+      level: 'low',
+      label: 'Risque faible',
+      response: 'aucune réponse adverse lisible',
+      watch: null,
+      tradeoffId: null,
+      targetId: null,
+    };
+  }
+
+  const reason = String(chosenTradeoff.reason ?? miniPlanTradeoffActionPreview.reason ?? 'donnée incertaine').trim()
+    || 'donnée incertaine';
+  const action = String(miniPlanTradeoffActionPreview.action ?? chosenTradeoff.recommendedChoice ?? '').trim();
+  const level = chosenTradeoff.severity === 'blocking'
+    ? 'high'
+    : (/loyaut|route|axe|occupation|disput/i.test(reason) ? 'medium' : 'low');
+  const labelByLevel = {
+    high: 'Risque élevé',
+    medium: 'Risque moyen',
+    low: 'Risque faible',
+  };
+
+  return {
+    empty: false,
+    level,
+    label: labelByLevel[level],
+    response: describeRivalResponse(reason, action),
+    watch: `À surveiller: ${reason}`,
+    tradeoffId: chosenTradeoff.tradeoffId ?? null,
+    targetId: miniPlanTradeoffActionPreview.targetId ?? chosenTradeoff.targetId ?? null,
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -534,6 +590,10 @@ export function buildStrategicMapShell(provinces, options = {}) {
     followUpCleanupMiniPlan,
     miniPlanConflictTradeoffs,
   );
+  const miniPlanRivalResponseRisk = buildMiniPlanRivalResponseRisk(
+    miniPlanTradeoffActionPreview,
+    miniPlanConflictTradeoffs,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -580,6 +640,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanDependencyConflicts,
     miniPlanConflictTradeoffs,
     miniPlanTradeoffActionPreview,
+    miniPlanRivalResponseRisk,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -8,6 +8,7 @@ import {
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
+  buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
@@ -286,6 +287,15 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     prerequisite: 'approvisionnement tendu',
     expectedBenefit: 'débloque Scanner axe détour',
   });
+  assert.deepEqual(shell.miniPlanRivalResponseRisk, {
+    empty: false,
+    level: 'high',
+    label: 'Risque élevé',
+    response: 'coupure du convoi partagé',
+    watch: 'À surveiller: approvisionnement tendu',
+    tradeoffId: 'mini-plan-tradeoff:supply-pressure:front-a',
+    targetId: 'front-a',
+  });
 });
 
 test('StrategicMapShell builds a compact executable follow-up cleanup mini-plan', () => {
@@ -473,6 +483,49 @@ test('StrategicMapShell previews the action unlocked by the recommended mini-pla
     action: null,
     prerequisite: null,
     expectedBenefit: null,
+  });
+});
+
+test('StrategicMapShell shows the rival response risk that can invalidate a chosen tradeoff', () => {
+  assert.deepEqual(buildMiniPlanRivalResponseRisk({
+    empty: false,
+    reason: 'ordre prioritaire reste à 88',
+    tradeoffId: 'mini-plan-tradeoff:neighbor-front:front-b',
+    targetId: 'front-b',
+    action: 'caler une couverture voisine minimale',
+  }, [{
+    tradeoffId: 'mini-plan-tradeoff:neighbor-front:front-b',
+    severity: 'blocking',
+    reason: 'ordre prioritaire reste à 88',
+    targetId: 'front-b',
+  }]), {
+    empty: false,
+    level: 'high',
+    label: 'Risque élevé',
+    response: 'contre-poussée du front voisin',
+    watch: 'À surveiller: ordre prioritaire reste à 88',
+    tradeoffId: 'mini-plan-tradeoff:neighbor-front:front-b',
+    targetId: 'front-b',
+  });
+  assert.deepEqual(buildMiniPlanRivalResponseRisk({
+    empty: false,
+    reason: 'loyauté 42',
+    tradeoffId: 'mini-plan-tradeoff:low-loyalty:front-a',
+    targetId: 'front-a',
+    action: 'Scanner axe détour',
+  }, [{
+    tradeoffId: 'mini-plan-tradeoff:low-loyalty:front-a',
+    severity: 'watchable',
+    reason: 'loyauté 42',
+  }]).level, 'medium');
+  assert.deepEqual(buildMiniPlanRivalResponseRisk({ empty: true }, []), {
+    empty: true,
+    level: 'low',
+    label: 'Risque faible',
+    response: 'aucune réponse adverse lisible',
+    watch: null,
+    tradeoffId: null,
+    targetId: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -65,6 +65,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanDependencyConflicts\(/);
   assert.match(webAppSource, /buildMiniPlanConflictTradeoffs\(/);
   assert.match(webAppSource, /buildMiniPlanTradeoffActionPreview\(/);
+  assert.match(webAppSource, /buildMiniPlanRivalResponseRisk\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -99,6 +100,8 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /choix: aucun arbitrage/);
   assert.match(webAppSource, /action: aucun arbitrage prêt/);
   assert.match(webAppSource, /miniPlanTradeoffActionPreview: buildMiniPlanTradeoffActionPreview\(null, \[\]\)/);
+  assert.match(webAppSource, /miniPlanRivalResponseRisk: buildMiniPlanRivalResponseRisk\(buildMiniPlanTradeoffActionPreview\(null, \[\]\), \[\]\)/);
+  assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -106,6 +109,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__mini-plan-conflicts/);
   assert.match(webAppSource, /atlas-military-fallback-order__mini-plan-tradeoffs/);
   assert.match(webAppSource, /atlas-military-fallback-order__tradeoff-action/);
+  assert.match(webAppSource, /atlas-military-fallback-order__rival-response-risk/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -113,6 +117,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /conflits: \$\{dependencyConflicts\.map\(\(conflict\) => `\$\{conflict\.severity === 'blocking' \? 'bloquant' : 'surv\.'\} \$\{conflict\.label\} › \$\{conflict\.mitigation\}`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /choix: \$\{tradeoffs\.map\(\(tradeoff\) => `\$\{tradeoff\.severity === 'blocking' \? '★' : '○'\} \$\{tradeoff\.recommendedChoice\} \/ coût: \$\{tradeoff\.rejectedCost\}`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /action: \$\{actionPreview\.action\} @ \$\{actionPreview\.targetId \?\? 'front'\} · préreq \$\{actionPreview\.prerequisite\} · gain \$\{actionPreview\.expectedBenefit\}/);
+  assert.match(webAppSource, /Risque si: \$\{rivalRisk\.response\} · \$\{rivalRisk\.label\} · \$\{rivalRisk\.watch\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -130,4 +135,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan-conflicts/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan-tradeoffs/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__tradeoff-action/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__rival-response-risk/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -9,6 +9,7 @@ import {
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
+  buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
   buildTopFollowUpReadiness,
@@ -1957,6 +1958,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanDependencyConflicts: [],
       miniPlanConflictTradeoffs: [],
       miniPlanTradeoffActionPreview: buildMiniPlanTradeoffActionPreview(null, []),
+      miniPlanRivalResponseRisk: buildMiniPlanRivalResponseRisk(buildMiniPlanTradeoffActionPreview(null, []), []),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1984,6 +1986,10 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     followUpCleanupMiniPlan,
     miniPlanConflictTradeoffs,
   );
+  const miniPlanRivalResponseRisk = buildMiniPlanRivalResponseRisk(
+    miniPlanTradeoffActionPreview,
+    miniPlanConflictTradeoffs,
+  );
 
   return {
     fallback: {
@@ -2002,6 +2008,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanDependencyConflicts,
       miniPlanConflictTradeoffs,
       miniPlanTradeoffActionPreview,
+      miniPlanRivalResponseRisk,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2015,7 +2022,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanDependencyConflicts,
     miniPlanConflictTradeoffs,
     miniPlanTradeoffActionPreview,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}).`,
+    miniPlanRivalResponseRisk,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}).`,
     empty: false,
   };
 }
@@ -2054,9 +2062,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const actionPreviewLabel = actionPreview && !actionPreview.empty
     ? `action: ${actionPreview.action} @ ${actionPreview.targetId ?? 'front'} · préreq ${actionPreview.prerequisite} · gain ${actionPreview.expectedBenefit}`
     : 'action: aucun arbitrage prêt';
+  const rivalRisk = fallback.miniPlanRivalResponseRisk;
+  const rivalRiskLabel = rivalRisk && !rivalRisk.empty
+    ? `Risque si: ${rivalRisk.response} · ${rivalRisk.label} · ${rivalRisk.watch}`
+    : 'Risque si: aucun rival lisible';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="16.8" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="18" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2071,6 +2083,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__mini-plan-conflicts" x="23.2" y="71.2">${dependencyConflictLabel}</text>
       <text class="atlas-military-fallback-order__mini-plan-tradeoffs" x="23.2" y="72.3">${tradeoffLabel}</text>
       <text class="atlas-military-fallback-order__tradeoff-action" x="23.2" y="73.4">${actionPreviewLabel}</text>
+      <text class="atlas-military-fallback-order__rival-response-risk atlas-military-fallback-order__rival-response-risk--${rivalRisk?.level ?? 'low'}" x="23.2" y="74.5">${rivalRiskLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11162,6 +11162,10 @@ button { font: inherit; }
 .atlas-military-fallback-order__mini-plan-conflicts { fill: #fed7aa; font-size: 0.46px; font-weight: 900; }
 .atlas-military-fallback-order__mini-plan-tradeoffs { fill: #fef08a; font-size: 0.45px; font-weight: 900; }
 .atlas-military-fallback-order__tradeoff-action { fill: #bfdbfe; font-size: 0.44px; font-weight: 900; }
+.atlas-military-fallback-order__rival-response-risk { fill: #fde68a; font-size: 0.43px; font-weight: 900; }
+.atlas-military-fallback-order__rival-response-risk--high { fill: #fecaca; }
+.atlas-military-fallback-order__rival-response-risk--medium { fill: #fed7aa; }
+.atlas-military-fallback-order__rival-response-risk--low { fill: #bbf7d0; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #999.

Summary:
- adds structured `miniPlanRivalResponseRisk` for the chosen mini-plan tradeoff
- classifies likely rival invalidation responses as low/medium/high using existing tradeoff data
- renders the compact “Risque si...” line beside the action preview without adding a heavy panel

Tests:
- npm test

Zeta: ready for validation before merge.