### PR TITLE
Epsilon: compare climate debt payoff risk

### DIFF
--- a/test/ui/climate/webAtlasClimateDebtPayoffRiskComparison.test.js
+++ b/test/ui/climate/webAtlasClimateDebtPayoffRiskComparison.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas compares top climate debt payoff against next-window risk reduction', () => {
+  assert.match(webAppSource, /function buildClimateDebtPayoffRiskComparison/);
+  assert.match(webAppSource, /climateDebtPayoffRiskComparison: null/);
+  assert.match(webAppSource, /climateDebtPayoffRiskComparison,/);
+
+  for (const stableKey of [
+    'choiceKey',
+    'costLabel',
+    'payoff',
+    'riskReduction',
+    'nextWindowStatus',
+    'necessaryDespiteLimitedReduction',
+    'summary',
+    'reason',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /Payoff risque\/coût/);
+  assert.match(webAppSource, /Payoff \$\{payoff\}/);
+  assert.match(webAppSource, /fort/);
+  assert.match(webAppSource, /correct/);
+  assert.match(webAppSource, /faible/);
+  assert.match(webAppSource, /réduction immédiate limitée/);
+  assert.match(webAppSource, /Paiement nécessaire malgré le gain limité/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9315,6 +9315,41 @@ function buildTopClimateDebtNextWindowEffect(topClimateDebtPaymentExplanation, d
   };
 }
 
+function buildClimateDebtPayoffRiskComparison(topClimateDebtPaymentExplanation, topClimateDebtNextWindowEffect, decisionDebtRanking, cheapestSafeCommitment) {
+  const topChoice = decisionDebtRanking?.items?.[0] ?? null;
+
+  if (!topClimateDebtPaymentExplanation || !topClimateDebtNextWindowEffect || !topChoice || !cheapestSafeCommitment) {
+    return null;
+  }
+
+  const costLabel = `${cheapestSafeCommitment.cost}, effort ${cheapestSafeCommitment.effortScore}`;
+  const conflictCount = topChoice.signals?.conflicts?.length ?? 0;
+  const payoff = topClimateDebtNextWindowEffect.status === 'plus sûre' && topChoice.estimatedDownstreamDebt === 'basse'
+    ? 'fort'
+    : topClimateDebtNextWindowEffect.status === 'encore fragile' || conflictCount > 0
+      ? 'faible'
+      : 'correct';
+  const riskReduction = payoff === 'fort'
+    ? 'réduction nette du risque de prochaine fenêtre'
+    : payoff === 'correct'
+      ? 'réduction utile mais encore dépendante du prochain arbitrage'
+      : 'réduction immédiate limitée par les conflits ou la dette restante';
+  const necessaryDespiteLimitedReduction = payoff === 'faible'
+    ? 'Paiement nécessaire malgré le gain limité: il évite que la dette haute verrouille la fenêtre suivante.'
+    : 'Paiement cohérent avec le gain attendu sur la fenêtre suivante.';
+
+  return {
+    choiceKey: topChoice.key,
+    costLabel,
+    payoff,
+    riskReduction,
+    nextWindowStatus: topClimateDebtNextWindowEffect.status,
+    necessaryDespiteLimitedReduction,
+    summary: `Payoff ${payoff}: ${costLabel} contre ${riskReduction}.`,
+    reason: `${topClimateDebtPaymentExplanation.choiceLabel} convertit ${topClimateDebtPaymentExplanation.pressureReduced} en fenêtre ${topClimateDebtNextWindowEffect.status}.`,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -9362,6 +9397,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       decisionDebtRanking: { state: 'neutral', items: [], summary: 'Aucun classement de dette climat: aucune fenêtre de décision active.', uncertainty: 'données insuffisantes' },
       topClimateDebtPaymentExplanation: null,
       topClimateDebtNextWindowEffect: null,
+      climateDebtPayoffRiskComparison: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -9407,6 +9443,12 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     decisionDebtRanking,
     decisionWindow,
   );
+  const climateDebtPayoffRiskComparison = buildClimateDebtPayoffRiskComparison(
+    topClimateDebtPaymentExplanation,
+    topClimateDebtNextWindowEffect,
+    decisionDebtRanking,
+    cheapestSafeCommitment,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -9417,6 +9459,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     decisionDebtRanking,
     topClimateDebtPaymentExplanation,
     topClimateDebtNextWindowEffect,
+    climateDebtPayoffRiskComparison,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -9448,6 +9491,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.decisionDebtRanking?.items?.length ? `<small><b>Dette aval classée</b> · ${view.decisionDebtRanking.items.map((item) => `${item.rank}. ${item.label}: dette ${item.estimatedDownstreamDebt}, ${item.mainRisk}`).join(' | ')} · ${view.decisionDebtRanking.uncertainty}</small>` : ''}
       ${view.topClimateDebtPaymentExplanation ? `<small><b>Pourquoi payer #1</b> · ${view.topClimateDebtPaymentExplanation.reason} ${view.topClimateDebtPaymentExplanation.riskIfDeferred}</small>` : ''}
       ${view.topClimateDebtNextWindowEffect ? `<small><b>Effet fenêtre suivante</b> · ${view.topClimateDebtNextWindowEffect.summary} ${view.topClimateDebtNextWindowEffect.oneSentence}</small>` : ''}
+      ${view.climateDebtPayoffRiskComparison ? `<small><b>Payoff risque/coût</b> · ${view.climateDebtPayoffRiskComparison.summary} ${view.climateDebtPayoffRiskComparison.reason} ${view.climateDebtPayoffRiskComparison.necessaryDespiteLimitedReduction}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1003.

## Résumé
- ajoute une comparaison coût/bénéfice pour le paiement climat prioritaire
- qualifie le payoff en fort, correct ou faible selon la réduction de risque de la prochaine fenêtre
- explicite le cas où le paiement reste nécessaire malgré une réduction immédiate limitée

## Tests
- `npm test`
