### PR TITLE
Gamma: explain next culture retirement path

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -744,6 +744,38 @@ function buildTopRetirementRecoveryPreview(recommendedFirstRetirement, topRetire
   };
 }
 
+function buildNextDependencyRetirementPath(dependencyRetirementRanking, topRetirementReadiness, topRetirementRecoveryPreview) {
+  const nextRetirement = dependencyRetirementRanking[1] ?? null;
+
+  if (!nextRetirement) {
+    return {
+      status: 'none-safe',
+      nextRetirement: null,
+      recommendedRecoveryPath: topRetirementRecoveryPreview.expectedRecovery,
+      mainRemainingBlocker: topRetirementReadiness.blockers[0] ? { ...topRetirementReadiness.blockers[0] } : null,
+      reason: dependencyRetirementRanking.length === 0
+        ? 'aucune dette culturelle restante à convertir en retrait suivant'
+        : 'aucun retrait suivant sûr avant de confirmer la récupération prioritaire',
+    };
+  }
+
+  return {
+    status: topRetirementReadiness.status === 'blocked' ? 'conditional' : 'ready-after-recovery',
+    nextRetirement: {
+      debtId: nextRetirement.debtId,
+      type: nextRetirement.type,
+      rank: nextRetirement.rank,
+      cause: nextRetirement.cause,
+      expectedGain: nextRetirement.expectedGain,
+    },
+    recommendedRecoveryPath: topRetirementRecoveryPreview.expectedRecovery,
+    mainRemainingBlocker: topRetirementReadiness.blockers[0] ? { ...topRetirementReadiness.blockers[0] } : null,
+    reason: topRetirementReadiness.status === 'blocked'
+      ? `lever ${topRetirementReadiness.blockers[0].type} pour rendre le retrait #${nextRetirement.rank} lisible`
+      : `après récupération prioritaire, viser ${nextRetirement.cause}`,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -796,6 +828,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const dependencyRetirementRanking = rankStabilizationDependencyRetirements(uniqueDebts);
   const recommendedFirstRetirement = dependencyRetirementRanking[0] ? { ...dependencyRetirementRanking[0] } : null;
   const topRetirementReadiness = buildTopRetirementReadiness(recommendedFirstRetirement, postBundleCumulativeRisk);
+  const topRetirementRecoveryPreview = buildTopRetirementRecoveryPreview(recommendedFirstRetirement, topRetirementReadiness);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -804,7 +837,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     dependencyRetirementRanking,
     recommendedFirstRetirement,
     topRetirementReadiness,
-    topRetirementRecoveryPreview: buildTopRetirementRecoveryPreview(recommendedFirstRetirement, topRetirementReadiness),
+    topRetirementRecoveryPreview,
+    nextDependencyRetirementPath: buildNextDependencyRetirementPath(dependencyRetirementRanking, topRetirementReadiness, topRetirementRecoveryPreview),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -891,6 +891,24 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         immediacy: 'conditional',
         closesLoop: 'stabiliser la pression locale avant retrait → retire un tradeoff de support qui entretient la dette de stabilisation',
       },
+      nextDependencyRetirementPath: {
+        status: 'conditional',
+        nextRetirement: {
+          debtId: 'shared-marsh:debt:dependency:shared-marsh:culture-marsh:bundle:guided-opening',
+          type: 'bundle-dependency',
+          rank: 2,
+          cause: 'appliquer le second soutien seulement après stabilisation du premier bundle',
+          expectedGain: 'simplifie la séquence de soutien et clarifie la prochaine action culturelle',
+        },
+        recommendedRecoveryPath: 'stabilité récupérée: le tradeoff culturel cesse de nourrir la dette prioritaire',
+        mainRemainingBlocker: {
+          blockerId: 'shared-marsh:debt:incompatibility:shared-marsh:culture-marsh:bundle:guided-opening:timing',
+          type: 'timing-local-pressure',
+          reason: 'surveiller les relais savants et le rythme d’ouverture',
+          nextSmallStep: 'stabiliser la pression locale avant retrait',
+        },
+        reason: 'lever timing-local-pressure pour rendre le retrait #2 lisible',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -954,6 +972,13 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         expectedRecovery: 'aucune récupération culturelle prioritaire',
         immediacy: 'immediate',
         closesLoop: 'aucune dépendance bloquante à lever',
+      },
+      nextDependencyRetirementPath: {
+        status: 'none-safe',
+        nextRetirement: null,
+        recommendedRecoveryPath: 'aucune récupération culturelle prioritaire',
+        mainRemainingBlocker: null,
+        reason: 'aucune dette culturelle restante à convertir en retrait suivant',
       },
     },
     summary: 'stabilisation complète: aucun second soutien requis',


### PR DESCRIPTION
Gamma: ## Summary

Explains which recovery path unlocks the next culture dependency retirement after the priority retirement is addressed.

## Changes

- Adds `nextDependencyRetirementPath` to `stabilizationDebtSummary`.
- Identifies the next dependency likely to be retired after recovery.
- Shows the recommended recovery path and the main remaining blocker.
- Provides a clear none-safe state when no next retirement is safe yet.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1011