### PR TITLE
Beta: show corridor delay opportunity cost

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -387,6 +387,29 @@ function buildFlipActionability(flipScenario, opportunityCostComparison, capacit
   };
 }
 
+function buildDelayOpportunityCost(opportunityCostComparison, preparationBreakEven, delayScenario, flipWarning, capacityCost) {
+  const delayedNetValue = delayScenario?.netValue ?? preparationBreakEven.netValue - capacityCost;
+  const delayCost = Math.max(0, preparationBreakEven.netValue - delayedNetValue);
+  const isDangerous = delayedNetValue <= 0;
+
+  return {
+    id: `delay-cost:${opportunityCostComparison.recommendedOptionId}`,
+    recommendedOptionId: opportunityCostComparison.recommendedOptionId,
+    cost: delayCost,
+    delayedNetValue,
+    summary: isDangerous
+      ? `Attendre coûte ${delayCost} valeur et rend le délai dangereux.`
+      : `Attendre coûte ${delayCost} valeur mais garde ${delayedNetValue} marge nette.`,
+    dangerThreshold: isDangerous
+      ? (flipWarning.actionability.threshold ?? 'dès le prochain retard')
+      : `danger si la marge nette tombe à 0; marge actuelle après délai: ${delayedNetValue}`,
+    practicalConsequence: isDangerous
+      ? flipWarning.actionability.consequence
+      : 'suivre la séquence recommandée avant de dépenser davantage',
+    reason: `Le délai retire ${delayCost} marge au bénéfice de ${opportunityCostComparison.recommendedOptionId}, dérivé de la comparaison actuelle.`,
+  };
+}
+
 function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven, capacityMobilized) {
   if (opportunityCostComparison === null || preparationBreakEven === null) {
     return null;
@@ -445,6 +468,13 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
       reason: `La recommandation bascule vers ${flipScenario.alternativeOptionId} si ${flipScenario.assumption}.`,
       actionability,
     };
+  const delayOpportunityCost = buildDelayOpportunityCost(
+    opportunityCostComparison,
+    preparationBreakEven,
+    scenarios.find((scenario) => scenario.id === 'delay-one-turn') ?? null,
+    flipWarning,
+    capacityCost,
+  );
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -456,6 +486,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     scenarios,
     reason: flipWarning.reason,
     actionableAdvice: actionability.advice,
+    delayOpportunityCost,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -527,6 +527,16 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       ],
       reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
       actionableAdvice: 'Action stable: continuer la séquence recommandée tant que la marge de break-even reste positive.',
+      delayOpportunityCost: {
+        id: 'delay-cost:grain:shift-to-tools',
+        recommendedOptionId: 'grain:shift-to-tools',
+        cost: 5,
+        delayedNetValue: 9,
+        summary: 'Attendre coûte 5 valeur mais garde 9 marge nette.',
+        dangerThreshold: 'danger si la marge nette tombe à 0; marge actuelle après délai: 9',
+        practicalConsequence: 'suivre la séquence recommandée avant de dépenser davantage',
+        reason: 'Le délai retire 5 marge au bénéfice de grain:shift-to-tools, dérivé de la comparaison actuelle.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -641,6 +651,16 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
     ],
     reason: 'La marge de break-even reste positive dans 4 scénarios dérivés.',
     actionableAdvice: 'Action stable: continuer la séquence recommandée tant que la marge de break-even reste positive.',
+    delayOpportunityCost: {
+      id: 'delay-cost:grain:shift-to-tools',
+      recommendedOptionId: 'grain:shift-to-tools',
+      cost: 5,
+      delayedNetValue: 9,
+      summary: 'Attendre coûte 5 valeur mais garde 9 marge nette.',
+      dangerThreshold: 'danger si la marge nette tombe à 0; marge actuelle après délai: 9',
+      practicalConsequence: 'suivre la séquence recommandée avant de dépenser davantage',
+      reason: 'Le délai retire 5 marge au bénéfice de grain:shift-to-tools, dérivé de la comparaison actuelle.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -685,6 +705,16 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     overlay.routes[0].capacitySpendPreview.timingSensitivity.actionableAdvice,
     'inverser la priorité avant d’attendre: basculer vers grain:reserve-buffer dès 1 tour de retard.',
   );
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.delayOpportunityCost, {
+    id: 'delay-cost:grain:priority-window',
+    recommendedOptionId: 'grain:priority-window',
+    cost: 2,
+    delayedNetValue: -2,
+    summary: 'Attendre coûte 2 valeur et rend le délai dangereux.',
+    dangerThreshold: 'dès 1 tour de retard',
+    practicalConsequence: 'inverser la priorité avant d’attendre',
+    reason: 'Le délai retire 2 marge au bénéfice de grain:priority-window, dérivé de la comparaison actuelle.',
+  });
   assert.equal(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.summary,
     'bascule vers grain:reserve-buffer si retard d’un tour.',


### PR DESCRIPTION
## Summary

Beta: Adds a corridor delay opportunity-cost summary so the logistics view explains what the player loses or risks by postponing the recommended sequence.

## Changes

- Derive `delayOpportunityCost` from the recommended sequence’s break-even margin and the existing one-turn delay sensitivity scenario.
- Tie the cost back to the current recommended option instead of a standalone metric.
- Show the dangerous-delay threshold and practical consequence while preserving existing flip warnings.
- Cover stable and dangerous delay cases in deterministic economy overlay tests.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (612/612 pass)

Fixes loo469/historia#1010