### PR TITLE
Alpha: compare rival responses across mini-plan branches

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -514,6 +514,66 @@ export function buildMiniPlanRivalResponseRisk(miniPlanTradeoffActionPreview = n
   };
 }
 
+function compareRivalRiskLevel(level) {
+  return ({ low: 1, medium: 2, high: 3 }[level] ?? 1);
+}
+
+export function buildMiniPlanRivalResponseComparison(followUpCleanupMiniPlan = null, miniPlanConflictTradeoffs = []) {
+  const normalizedTradeoffs = normalizeCleanupInput(
+    miniPlanConflictTradeoffs,
+    'StrategicMapShell miniPlanConflictTradeoffs',
+  );
+
+  if (!followUpCleanupMiniPlan || followUpCleanupMiniPlan.empty || normalizedTradeoffs.length === 0) {
+    return {
+      empty: true,
+      recommendedTradeoffId: null,
+      recommendationChanged: false,
+      reason: 'aucune branche à comparer',
+      branches: [],
+    };
+  }
+
+  const branches = normalizedTradeoffs.slice(0, 3).map((tradeoff, index) => {
+    const preview = buildMiniPlanTradeoffActionPreview(followUpCleanupMiniPlan, [tradeoff]);
+    const risk = buildMiniPlanRivalResponseRisk(preview, [tradeoff]);
+
+    return {
+      branchId: `mini-plan-branch:${index + 1}:${tradeoff.tradeoffId ?? 'unknown'}`,
+      tradeoffId: tradeoff.tradeoffId ?? null,
+      recommended: index === 0,
+      action: preview.action,
+      rivalResponse: risk.response,
+      riskLevel: risk.level,
+      reason: risk.watch ?? tradeoff.reason ?? 'donnée incertaine',
+      targetId: preview.targetId ?? tradeoff.targetId ?? null,
+    };
+  });
+  const initialBranch = branches[0];
+  const saferBranch = branches
+    .slice()
+    .sort((left, right) => compareRivalRiskLevel(left.riskLevel) - compareRivalRiskLevel(right.riskLevel)
+      || left.branchId.localeCompare(right.branchId))[0] ?? initialBranch;
+  const recommendationChanged = Boolean(
+    initialBranch && saferBranch && compareRivalRiskLevel(saferBranch.riskLevel) < compareRivalRiskLevel(initialBranch.riskLevel),
+  );
+
+  return {
+    empty: false,
+    recommendedTradeoffId: recommendationChanged ? saferBranch.tradeoffId : initialBranch?.tradeoffId ?? null,
+    recommendationChanged,
+    reason: recommendationChanged
+      ? `${initialBranch.rivalResponse} rend la branche initiale trop risquée`
+      : 'branche recommandée robuste face aux réponses listées',
+    branches: branches.map((branch) => ({
+      ...branch,
+      recommended: recommendationChanged
+        ? branch.tradeoffId === saferBranch.tradeoffId
+        : branch.tradeoffId === initialBranch?.tradeoffId,
+    })),
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -594,6 +654,10 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanTradeoffActionPreview,
     miniPlanConflictTradeoffs,
   );
+  const miniPlanRivalResponseComparison = buildMiniPlanRivalResponseComparison(
+    followUpCleanupMiniPlan,
+    miniPlanConflictTradeoffs,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -641,6 +705,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanConflictTradeoffs,
     miniPlanTradeoffActionPreview,
     miniPlanRivalResponseRisk,
+    miniPlanRivalResponseComparison,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -8,6 +8,7 @@ import {
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
+  buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
@@ -296,6 +297,24 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     tradeoffId: 'mini-plan-tradeoff:supply-pressure:front-a',
     targetId: 'front-a',
   });
+  assert.deepEqual(shell.miniPlanRivalResponseComparison, {
+    empty: false,
+    recommendedTradeoffId: 'mini-plan-tradeoff:supply-pressure:front-a',
+    recommendationChanged: false,
+    reason: 'branche recommandée robuste face aux réponses listées',
+    branches: [
+      {
+        branchId: 'mini-plan-branch:1:mini-plan-tradeoff:supply-pressure:front-a',
+        tradeoffId: 'mini-plan-tradeoff:supply-pressure:front-a',
+        recommended: true,
+        action: 'réserver le convoi court avant le mini-plan',
+        rivalResponse: 'coupure du convoi partagé',
+        riskLevel: 'high',
+        reason: 'À surveiller: approvisionnement tendu',
+        targetId: 'front-a',
+      },
+    ],
+  });
 });
 
 test('StrategicMapShell builds a compact executable follow-up cleanup mini-plan', () => {
@@ -526,6 +545,67 @@ test('StrategicMapShell shows the rival response risk that can invalidate a chos
     watch: null,
     tradeoffId: null,
     targetId: null,
+  });
+});
+
+test('StrategicMapShell compares rival responses across mini-plan branches before commitment', () => {
+  const miniPlan = {
+    empty: false,
+    targetId: 'front-a',
+    steps: [
+      { state: 'execute-cleanup', label: 'Scanner axe détour', riskReduced: 'axe encore exposé' },
+    ],
+  };
+  const comparison = buildMiniPlanRivalResponseComparison(miniPlan, [
+    {
+      tradeoffId: 'mini-plan-tradeoff:neighbor-front:front-b',
+      severity: 'blocking',
+      reason: 'ordre prioritaire reste à 88',
+      recommendedChoice: 'caler une couverture voisine minimale',
+      rejectedChoice: 'Scanner axe détour',
+      targetId: 'front-b',
+    },
+    {
+      tradeoffId: 'mini-plan-tradeoff:low-loyalty:front-a',
+      severity: 'watchable',
+      reason: 'loyauté 42',
+      recommendedChoice: 'Scanner axe détour',
+      rejectedChoice: 'envoyer liaison si le plan dure',
+      targetId: 'front-a',
+    },
+  ]);
+
+  assert.equal(comparison.recommendationChanged, true);
+  assert.equal(comparison.recommendedTradeoffId, 'mini-plan-tradeoff:low-loyalty:front-a');
+  assert.equal(comparison.reason, 'contre-poussée du front voisin rend la branche initiale trop risquée');
+  assert.deepEqual(comparison.branches, [
+    {
+      branchId: 'mini-plan-branch:1:mini-plan-tradeoff:neighbor-front:front-b',
+      tradeoffId: 'mini-plan-tradeoff:neighbor-front:front-b',
+      recommended: false,
+      action: 'caler une couverture voisine minimale',
+      rivalResponse: 'contre-poussée du front voisin',
+      riskLevel: 'high',
+      reason: 'À surveiller: ordre prioritaire reste à 88',
+      targetId: 'front-b',
+    },
+    {
+      branchId: 'mini-plan-branch:2:mini-plan-tradeoff:low-loyalty:front-a',
+      tradeoffId: 'mini-plan-tradeoff:low-loyalty:front-a',
+      recommended: true,
+      action: 'Scanner axe détour',
+      rivalResponse: 'agitation locale avant liaison',
+      riskLevel: 'medium',
+      reason: 'À surveiller: loyauté 42',
+      targetId: 'front-a',
+    },
+  ]);
+  assert.deepEqual(buildMiniPlanRivalResponseComparison({ empty: true }, []), {
+    empty: true,
+    recommendedTradeoffId: null,
+    recommendationChanged: false,
+    reason: 'aucune branche à comparer',
+    branches: [],
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -66,6 +66,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanConflictTradeoffs\(/);
   assert.match(webAppSource, /buildMiniPlanTradeoffActionPreview\(/);
   assert.match(webAppSource, /buildMiniPlanRivalResponseRisk\(/);
+  assert.match(webAppSource, /buildMiniPlanRivalResponseComparison\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -101,7 +102,9 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /action: aucun arbitrage prêt/);
   assert.match(webAppSource, /miniPlanTradeoffActionPreview: buildMiniPlanTradeoffActionPreview\(null, \[\]\)/);
   assert.match(webAppSource, /miniPlanRivalResponseRisk: buildMiniPlanRivalResponseRisk\(buildMiniPlanTradeoffActionPreview\(null, \[\]\), \[\]\)/);
+  assert.match(webAppSource, /miniPlanRivalResponseComparison: buildMiniPlanRivalResponseComparison\(null, \[\]\)/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
+  assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -110,6 +113,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__mini-plan-tradeoffs/);
   assert.match(webAppSource, /atlas-military-fallback-order__tradeoff-action/);
   assert.match(webAppSource, /atlas-military-fallback-order__rival-response-risk/);
+  assert.match(webAppSource, /atlas-military-fallback-order__rival-branch-comparison/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -118,6 +122,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /choix: \$\{tradeoffs\.map\(\(tradeoff\) => `\$\{tradeoff\.severity === 'blocking' \? '★' : '○'\} \$\{tradeoff\.recommendedChoice\} \/ coût: \$\{tradeoff\.rejectedCost\}`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /action: \$\{actionPreview\.action\} @ \$\{actionPreview\.targetId \?\? 'front'\} · préreq \$\{actionPreview\.prerequisite\} · gain \$\{actionPreview\.expectedBenefit\}/);
   assert.match(webAppSource, /Risque si: \$\{rivalRisk\.response\} · \$\{rivalRisk\.label\} · \$\{rivalRisk\.watch\}/);
+  assert.match(webAppSource, /branches: \$\{rivalComparison\.branches\.map\(\(branch\) => `\$\{branch\.recommended \? '★' : '○'\} \$\{branch\.action\} → \$\{branch\.rivalResponse\} \(\$\{branch\.riskLevel\}\)`\)\.join\(' · '\)\}\$\{rivalComparison\.recommendationChanged \? ' · reco change' : ' · reco stable'\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -136,4 +141,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__mini-plan-tradeoffs/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__tradeoff-action/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__rival-response-risk/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__rival-branch-comparison/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -9,6 +9,7 @@ import {
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
+  buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
@@ -1959,6 +1960,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanConflictTradeoffs: [],
       miniPlanTradeoffActionPreview: buildMiniPlanTradeoffActionPreview(null, []),
       miniPlanRivalResponseRisk: buildMiniPlanRivalResponseRisk(buildMiniPlanTradeoffActionPreview(null, []), []),
+      miniPlanRivalResponseComparison: buildMiniPlanRivalResponseComparison(null, []),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1990,6 +1992,10 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanTradeoffActionPreview,
     miniPlanConflictTradeoffs,
   );
+  const miniPlanRivalResponseComparison = buildMiniPlanRivalResponseComparison(
+    followUpCleanupMiniPlan,
+    miniPlanConflictTradeoffs,
+  );
 
   return {
     fallback: {
@@ -2009,6 +2015,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanConflictTradeoffs,
       miniPlanTradeoffActionPreview,
       miniPlanRivalResponseRisk,
+      miniPlanRivalResponseComparison,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2023,7 +2030,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanConflictTradeoffs,
     miniPlanTradeoffActionPreview,
     miniPlanRivalResponseRisk,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}).`,
+    miniPlanRivalResponseComparison,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}).`,
     empty: false,
   };
 }
@@ -2066,9 +2074,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const rivalRiskLabel = rivalRisk && !rivalRisk.empty
     ? `Risque si: ${rivalRisk.response} · ${rivalRisk.label} · ${rivalRisk.watch}`
     : 'Risque si: aucun rival lisible';
+  const rivalComparison = fallback.miniPlanRivalResponseComparison;
+  const rivalComparisonLabel = rivalComparison && !rivalComparison.empty
+    ? `branches: ${rivalComparison.branches.map((branch) => `${branch.recommended ? '★' : '○'} ${branch.action} → ${branch.rivalResponse} (${branch.riskLevel})`).join(' · ')}${rivalComparison.recommendationChanged ? ' · reco change' : ' · reco stable'}`
+    : 'branches: aucune comparaison';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="18" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="19.2" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2084,6 +2096,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__mini-plan-tradeoffs" x="23.2" y="72.3">${tradeoffLabel}</text>
       <text class="atlas-military-fallback-order__tradeoff-action" x="23.2" y="73.4">${actionPreviewLabel}</text>
       <text class="atlas-military-fallback-order__rival-response-risk atlas-military-fallback-order__rival-response-risk--${rivalRisk?.level ?? 'low'}" x="23.2" y="74.5">${rivalRiskLabel}</text>
+      <text class="atlas-military-fallback-order__rival-branch-comparison" x="23.2" y="75.6">${rivalComparisonLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11166,6 +11166,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__rival-response-risk--high { fill: #fecaca; }
 .atlas-military-fallback-order__rival-response-risk--medium { fill: #fed7aa; }
 .atlas-military-fallback-order__rival-response-risk--low { fill: #bbf7d0; }
+.atlas-military-fallback-order__rival-branch-comparison { fill: #c4b5fd; font-size: 0.42px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1009.

Summary:
- adds structured `miniPlanRivalResponseComparison` across available mini-plan tradeoff branches
- shows each branch action, dominant rival response, risk level, reason, and target
- flags when the recommended branch changes because a rival response makes the initial branch too risky
- renders a compact branch comparison near the existing rival-risk/action preview

Tests:
- npm test

Zeta: ready for validation before merge.