### PR TITLE
Beta: recommend salvage for dangerous corridor delays

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -387,10 +387,41 @@ function buildFlipActionability(flipScenario, opportunityCostComparison, capacit
   };
 }
 
+function buildDangerousDelaySalvage(opportunityCostComparison, delayScenario, flipWarning) {
+  if (delayScenario === null || delayScenario.netValue > 0) {
+    return null;
+  }
+
+  const actionByCause = {
+    delay: 'invert-priority-to-alternative',
+    capacity: 'secure-capacity-margin',
+    cost: 'reduce-preparation-cost',
+    saturation: 'secure-bottleneck-capacity',
+  };
+  const labelByCause = {
+    delay: `Basculer vers ${flipWarning.alternativeOptionId}`,
+    capacity: 'Sécuriser une capacité tampon avant reprise',
+    cost: 'Réduire le coût avant de relancer la séquence',
+    saturation: 'Sécuriser le goulot avant toute dépense',
+  };
+  const remainingCost = Math.abs(delayScenario.netValue);
+
+  return {
+    id: `salvage:${opportunityCostComparison.recommendedOptionId}:${delayScenario.id}`,
+    trigger: delayScenario.id,
+    action: actionByCause[delayScenario.cause] ?? 'switch-to-alternative',
+    label: labelByCause[delayScenario.cause] ?? `Basculer vers ${flipWarning.alternativeOptionId}`,
+    alternativeOptionId: flipWarning.alternativeOptionId,
+    remainingCost,
+    summary: `${labelByCause[delayScenario.cause] ?? `Basculer vers ${flipWarning.alternativeOptionId}`}: coût restant ${remainingCost} après délai dangereux.`,
+  };
+}
+
 function buildDelayOpportunityCost(opportunityCostComparison, preparationBreakEven, delayScenario, flipWarning, capacityCost) {
   const delayedNetValue = delayScenario?.netValue ?? preparationBreakEven.netValue - capacityCost;
   const delayCost = Math.max(0, preparationBreakEven.netValue - delayedNetValue);
   const isDangerous = delayedNetValue <= 0;
+  const salvageAction = buildDangerousDelaySalvage(opportunityCostComparison, delayScenario, flipWarning);
 
   return {
     id: `delay-cost:${opportunityCostComparison.recommendedOptionId}`,
@@ -407,6 +438,7 @@ function buildDelayOpportunityCost(opportunityCostComparison, preparationBreakEv
       ? flipWarning.actionability.consequence
       : 'suivre la séquence recommandée avant de dépenser davantage',
     reason: `Le délai retire ${delayCost} marge au bénéfice de ${opportunityCostComparison.recommendedOptionId}, dérivé de la comparaison actuelle.`,
+    salvageAction,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -536,6 +536,7 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         dangerThreshold: 'danger si la marge nette tombe à 0; marge actuelle après délai: 9',
         practicalConsequence: 'suivre la séquence recommandée avant de dépenser davantage',
         reason: 'Le délai retire 5 marge au bénéfice de grain:shift-to-tools, dérivé de la comparaison actuelle.',
+        salvageAction: null,
       },
     },
   });
@@ -660,6 +661,7 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       dangerThreshold: 'danger si la marge nette tombe à 0; marge actuelle après délai: 9',
       practicalConsequence: 'suivre la séquence recommandée avant de dépenser davantage',
       reason: 'Le délai retire 5 marge au bénéfice de grain:shift-to-tools, dérivé de la comparaison actuelle.',
+      salvageAction: null,
     },
   });
   assert.deepEqual(
@@ -714,6 +716,15 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     dangerThreshold: 'dès 1 tour de retard',
     practicalConsequence: 'inverser la priorité avant d’attendre',
     reason: 'Le délai retire 2 marge au bénéfice de grain:priority-window, dérivé de la comparaison actuelle.',
+    salvageAction: {
+      id: 'salvage:grain:priority-window:delay-one-turn',
+      trigger: 'delay-one-turn',
+      action: 'invert-priority-to-alternative',
+      label: 'Basculer vers grain:reserve-buffer',
+      alternativeOptionId: 'grain:reserve-buffer',
+      remainingCost: 2,
+      summary: 'Basculer vers grain:reserve-buffer: coût restant 2 après délai dangereux.',
+    },
   });
   assert.equal(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.summary,


### PR DESCRIPTION
## Summary

Beta: Adds a salvage action for dangerous corridor delays so logistics details can suggest a short recovery move when the delayed recommendation becomes fragile or non-profitable.

## Changes

- Add `salvageAction` to `delayOpportunityCost` only when the delayed net value is dangerous.
- Map dangerous delay causes to readable recovery actions: invert priority, secure capacity, reduce cost, or secure the bottleneck.
- Keep non-dangerous delays neutral with `salvageAction: null`, preserving the primary recommendation.
- Explain the remaining cost after salvage in a concise summary.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (614/614 pass)

Fixes loo469/historia#1020