### PR TITLE
Gamma: summarize residual culture risk

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -776,6 +776,58 @@ function buildNextDependencyRetirementPath(dependencyRetirementRanking, topRetir
   };
 }
 
+function buildResidualRiskAfterNextRetirement(dependencyRetirementRanking, nextDependencyRetirementPath, postBundleCumulativeRisk) {
+  if (dependencyRetirementRanking.length === 0) {
+    return {
+      status: 'complete',
+      principalResidualFragility: null,
+      nextActionAfterRetirement: 'aucune action culturelle supplémentaire prioritaire',
+      reason: 'aucune dette résiduelle après stabilisation',
+    };
+  }
+
+  if (!nextDependencyRetirementPath.nextRetirement) {
+    const topDebt = dependencyRetirementRanking[0];
+
+    return {
+      status: 'important-fragility',
+      principalResidualFragility: {
+        type: topDebt.type,
+        cause: topDebt.cause,
+        urgency: topDebt.urgency,
+      },
+      nextActionAfterRetirement: topDebt.nextAction,
+      reason: nextDependencyRetirementPath.reason,
+    };
+  }
+
+  const nextIndex = dependencyRetirementRanking.findIndex((debt) => debt.debtId === nextDependencyRetirementPath.nextRetirement.debtId);
+  const remainingDebts = dependencyRetirementRanking.filter((_, index) => index > nextIndex);
+  const principalResidualFragility = remainingDebts[0] ?? null;
+
+  if (!principalResidualFragility) {
+    return {
+      status: 'complete',
+      principalResidualFragility: null,
+      nextActionAfterRetirement: 'confirmer la stabilité régionale après retrait suivant',
+      reason: 'le retrait suivant absorbe la dernière dette culturelle visible',
+    };
+  }
+
+  return {
+    status: principalResidualFragility.urgency === 'high' ? 'important-fragility' : 'partial',
+    principalResidualFragility: {
+      type: principalResidualFragility.type,
+      cause: principalResidualFragility.cause,
+      urgency: principalResidualFragility.urgency,
+    },
+    nextActionAfterRetirement: principalResidualFragility.nextAction ?? postBundleCumulativeRisk.nextAttention,
+    reason: principalResidualFragility.urgency === 'high'
+      ? `fragilité importante restante: ${principalResidualFragility.cause}`
+      : `stabilisation partielle: surveiller ${principalResidualFragility.cause}`,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -829,6 +881,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const recommendedFirstRetirement = dependencyRetirementRanking[0] ? { ...dependencyRetirementRanking[0] } : null;
   const topRetirementReadiness = buildTopRetirementReadiness(recommendedFirstRetirement, postBundleCumulativeRisk);
   const topRetirementRecoveryPreview = buildTopRetirementRecoveryPreview(recommendedFirstRetirement, topRetirementReadiness);
+  const nextDependencyRetirementPath = buildNextDependencyRetirementPath(dependencyRetirementRanking, topRetirementReadiness, topRetirementRecoveryPreview);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -838,7 +891,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     recommendedFirstRetirement,
     topRetirementReadiness,
     topRetirementRecoveryPreview,
-    nextDependencyRetirementPath: buildNextDependencyRetirementPath(dependencyRetirementRanking, topRetirementReadiness, topRetirementRecoveryPreview),
+    nextDependencyRetirementPath,
+    residualRiskAfterNextRetirement: buildResidualRiskAfterNextRetirement(dependencyRetirementRanking, nextDependencyRetirementPath, postBundleCumulativeRisk),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -909,6 +909,16 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         },
         reason: 'lever timing-local-pressure pour rendre le retrait #2 lisible',
       },
+      residualRiskAfterNextRetirement: {
+        status: 'partial',
+        principalResidualFragility: {
+          type: 'regional-mediation',
+          cause: 'risque restant: isolement du support',
+          urgency: 'medium',
+        },
+        nextActionAfterRetirement: 'surveiller les relais savants et le rythme d’ouverture',
+        reason: 'stabilisation partielle: surveiller risque restant: isolement du support',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -979,6 +989,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         recommendedRecoveryPath: 'aucune récupération culturelle prioritaire',
         mainRemainingBlocker: null,
         reason: 'aucune dette culturelle restante à convertir en retrait suivant',
+      },
+      residualRiskAfterNextRetirement: {
+        status: 'complete',
+        principalResidualFragility: null,
+        nextActionAfterRetirement: 'aucune action culturelle supplémentaire prioritaire',
+        reason: 'aucune dette résiduelle après stabilisation',
       },
     },
     summary: 'stabilisation complète: aucun second soutien requis',


### PR DESCRIPTION
Gamma: ## Summary

Adds a compact residual risk summary after the next recommended culture dependency retirement.

## Changes

- Adds `residualRiskAfterNextRetirement` to `stabilizationDebtSummary`.
- Distinguishes complete stabilization, partial stabilization, and important residual fragility after the next retirement.
- Identifies the principal residual fragility and next action when risk remains.
- Keeps neutral/no-debt states explicit and compact near the existing retirement path.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1021