### PR TITLE
Alpha: show rival response fallback branch

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -574,6 +574,60 @@ export function buildMiniPlanRivalResponseComparison(followUpCleanupMiniPlan = n
   };
 }
 
+function describeFallbackCost(fallbackBranch, initialBranch) {
+  if (!fallbackBranch || !initialBranch) return 'coût incertain';
+  if (fallbackBranch.targetId && initialBranch.targetId && fallbackBranch.targetId !== initialBranch.targetId) {
+    return `cible moins prioritaire: ${fallbackBranch.targetId}`;
+  }
+  if (fallbackBranch.riskLevel === initialBranch.riskLevel) return 'bénéfice moindre mais risque équivalent';
+  return `délai avant ${initialBranch.action ?? 'branche initiale'}`;
+}
+
+export function buildMiniPlanRivalResponseFallback(miniPlanRivalResponseComparison = null) {
+  if (!miniPlanRivalResponseComparison || miniPlanRivalResponseComparison.empty) {
+    return {
+      empty: true,
+      fallbackBranchId: null,
+      action: null,
+      reason: 'aucun fallback requis',
+      cost: null,
+      targetId: null,
+    };
+  }
+
+  const branches = normalizeCleanupInput(
+    miniPlanRivalResponseComparison.branches ?? [],
+    'StrategicMapShell miniPlanRivalResponseComparison.branches',
+  );
+  const initialBranch = branches[0] ?? null;
+  const fallbackBranch = branches.find((branch) => branch.recommended && branch.branchId !== initialBranch?.branchId)
+    ?? branches
+      .filter((branch) => branch.branchId !== initialBranch?.branchId)
+      .sort((left, right) => compareRivalRiskLevel(left.riskLevel) - compareRivalRiskLevel(right.riskLevel)
+        || left.branchId.localeCompare(right.branchId))[0]
+    ?? null;
+
+  if (!fallbackBranch || !initialBranch || compareRivalRiskLevel(initialBranch.riskLevel) < 3) {
+    return {
+      empty: true,
+      fallbackBranchId: null,
+      action: null,
+      reason: 'branche recommandée encore sûre',
+      cost: null,
+      targetId: null,
+    };
+  }
+
+  return {
+    empty: false,
+    fallbackBranchId: fallbackBranch.branchId,
+    action: fallbackBranch.action,
+    reason: `${fallbackBranch.rivalResponse} reste ${fallbackBranch.riskLevel}, contre ${initialBranch.rivalResponse}`,
+    cost: describeFallbackCost(fallbackBranch, initialBranch),
+    targetId: fallbackBranch.targetId ?? null,
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -658,6 +712,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     followUpCleanupMiniPlan,
     miniPlanConflictTradeoffs,
   );
+  const miniPlanRivalResponseFallback = buildMiniPlanRivalResponseFallback(miniPlanRivalResponseComparison);
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -706,6 +761,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanTradeoffActionPreview,
     miniPlanRivalResponseRisk,
     miniPlanRivalResponseComparison,
+    miniPlanRivalResponseFallback,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -9,6 +9,7 @@ import {
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
+  buildMiniPlanRivalResponseFallback,
   buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
@@ -315,6 +316,14 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
       },
     ],
   });
+  assert.deepEqual(shell.miniPlanRivalResponseFallback, {
+    empty: true,
+    fallbackBranchId: null,
+    action: null,
+    reason: 'branche recommandée encore sûre',
+    cost: null,
+    targetId: null,
+  });
 });
 
 test('StrategicMapShell builds a compact executable follow-up cleanup mini-plan', () => {
@@ -606,6 +615,53 @@ test('StrategicMapShell compares rival responses across mini-plan branches befor
     recommendationChanged: false,
     reason: 'aucune branche à comparer',
     branches: [],
+  });
+});
+
+test('StrategicMapShell shows safest fallback when rival response invalidates the recommended branch', () => {
+  const comparison = {
+    empty: false,
+    recommendationChanged: true,
+    branches: [
+      {
+        branchId: 'mini-plan-branch:1:mini-plan-tradeoff:neighbor-front:front-b',
+        tradeoffId: 'mini-plan-tradeoff:neighbor-front:front-b',
+        recommended: false,
+        action: 'caler une couverture voisine minimale',
+        rivalResponse: 'contre-poussée du front voisin',
+        riskLevel: 'high',
+        targetId: 'front-b',
+      },
+      {
+        branchId: 'mini-plan-branch:2:mini-plan-tradeoff:low-loyalty:front-a',
+        tradeoffId: 'mini-plan-tradeoff:low-loyalty:front-a',
+        recommended: true,
+        action: 'Scanner axe détour',
+        rivalResponse: 'agitation locale avant liaison',
+        riskLevel: 'medium',
+        targetId: 'front-a',
+      },
+    ],
+  };
+
+  assert.deepEqual(buildMiniPlanRivalResponseFallback(comparison), {
+    empty: false,
+    fallbackBranchId: 'mini-plan-branch:2:mini-plan-tradeoff:low-loyalty:front-a',
+    action: 'Scanner axe détour',
+    reason: 'agitation locale avant liaison reste medium, contre contre-poussée du front voisin',
+    cost: 'cible moins prioritaire: front-a',
+    targetId: 'front-a',
+  });
+  assert.deepEqual(buildMiniPlanRivalResponseFallback({
+    empty: false,
+    branches: [{ branchId: 'one', action: 'A', rivalResponse: 'r', riskLevel: 'medium' }],
+  }), {
+    empty: true,
+    fallbackBranchId: null,
+    action: null,
+    reason: 'branche recommandée encore sûre',
+    cost: null,
+    targetId: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -67,6 +67,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanTradeoffActionPreview\(/);
   assert.match(webAppSource, /buildMiniPlanRivalResponseRisk\(/);
   assert.match(webAppSource, /buildMiniPlanRivalResponseComparison\(/);
+  assert.match(webAppSource, /buildMiniPlanRivalResponseFallback\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -103,8 +104,10 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanTradeoffActionPreview: buildMiniPlanTradeoffActionPreview\(null, \[\]\)/);
   assert.match(webAppSource, /miniPlanRivalResponseRisk: buildMiniPlanRivalResponseRisk\(buildMiniPlanTradeoffActionPreview\(null, \[\]\), \[\]\)/);
   assert.match(webAppSource, /miniPlanRivalResponseComparison: buildMiniPlanRivalResponseComparison\(null, \[\]\)/);
+  assert.match(webAppSource, /miniPlanRivalResponseFallback: buildMiniPlanRivalResponseFallback\(buildMiniPlanRivalResponseComparison\(null, \[\]\)\)/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
+  assert.match(webAppSource, /fallback: aucun repli requis/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -114,6 +117,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__tradeoff-action/);
   assert.match(webAppSource, /atlas-military-fallback-order__rival-response-risk/);
   assert.match(webAppSource, /atlas-military-fallback-order__rival-branch-comparison/);
+  assert.match(webAppSource, /atlas-military-fallback-order__rival-response-fallback/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -123,6 +127,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /action: \$\{actionPreview\.action\} @ \$\{actionPreview\.targetId \?\? 'front'\} · préreq \$\{actionPreview\.prerequisite\} · gain \$\{actionPreview\.expectedBenefit\}/);
   assert.match(webAppSource, /Risque si: \$\{rivalRisk\.response\} · \$\{rivalRisk\.label\} · \$\{rivalRisk\.watch\}/);
   assert.match(webAppSource, /branches: \$\{rivalComparison\.branches\.map\(\(branch\) => `\$\{branch\.recommended \? '★' : '○'\} \$\{branch\.action\} → \$\{branch\.rivalResponse\} \(\$\{branch\.riskLevel\}\)`\)\.join\(' · '\)\}\$\{rivalComparison\.recommendationChanged \? ' · reco change' : ' · reco stable'\}/);
+  assert.match(webAppSource, /fallback: \$\{rivalFallback\.action\} @ \$\{rivalFallback\.targetId \?\? 'front'\} · \$\{rivalFallback\.reason\} · coût \$\{rivalFallback\.cost\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -142,4 +147,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__tradeoff-action/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__rival-response-risk/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__rival-branch-comparison/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__rival-response-fallback/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -10,6 +10,7 @@ import {
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
+  buildMiniPlanRivalResponseFallback,
   buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
@@ -1961,6 +1962,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanTradeoffActionPreview: buildMiniPlanTradeoffActionPreview(null, []),
       miniPlanRivalResponseRisk: buildMiniPlanRivalResponseRisk(buildMiniPlanTradeoffActionPreview(null, []), []),
       miniPlanRivalResponseComparison: buildMiniPlanRivalResponseComparison(null, []),
+      miniPlanRivalResponseFallback: buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1996,6 +1998,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     followUpCleanupMiniPlan,
     miniPlanConflictTradeoffs,
   );
+  const miniPlanRivalResponseFallback = buildMiniPlanRivalResponseFallback(miniPlanRivalResponseComparison);
 
   return {
     fallback: {
@@ -2016,6 +2019,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanTradeoffActionPreview,
       miniPlanRivalResponseRisk,
       miniPlanRivalResponseComparison,
+      miniPlanRivalResponseFallback,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2031,7 +2035,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanTradeoffActionPreview,
     miniPlanRivalResponseRisk,
     miniPlanRivalResponseComparison,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}).`,
+    miniPlanRivalResponseFallback,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}).`,
     empty: false,
   };
 }
@@ -2078,9 +2083,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const rivalComparisonLabel = rivalComparison && !rivalComparison.empty
     ? `branches: ${rivalComparison.branches.map((branch) => `${branch.recommended ? '★' : '○'} ${branch.action} → ${branch.rivalResponse} (${branch.riskLevel})`).join(' · ')}${rivalComparison.recommendationChanged ? ' · reco change' : ' · reco stable'}`
     : 'branches: aucune comparaison';
+  const rivalFallback = fallback.miniPlanRivalResponseFallback;
+  const rivalFallbackLabel = rivalFallback && !rivalFallback.empty
+    ? `fallback: ${rivalFallback.action} @ ${rivalFallback.targetId ?? 'front'} · ${rivalFallback.reason} · coût ${rivalFallback.cost}`
+    : 'fallback: aucun repli requis';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="19.2" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="20.4" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2097,6 +2106,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__tradeoff-action" x="23.2" y="73.4">${actionPreviewLabel}</text>
       <text class="atlas-military-fallback-order__rival-response-risk atlas-military-fallback-order__rival-response-risk--${rivalRisk?.level ?? 'low'}" x="23.2" y="74.5">${rivalRiskLabel}</text>
       <text class="atlas-military-fallback-order__rival-branch-comparison" x="23.2" y="75.6">${rivalComparisonLabel}</text>
+      <text class="atlas-military-fallback-order__rival-response-fallback" x="23.2" y="76.7">${rivalFallbackLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11167,6 +11167,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__rival-response-risk--medium { fill: #fed7aa; }
 .atlas-military-fallback-order__rival-response-risk--low { fill: #bbf7d0; }
 .atlas-military-fallback-order__rival-branch-comparison { fill: #c4b5fd; font-size: 0.42px; font-weight: 900; }
+.atlas-military-fallback-order__rival-response-fallback { fill: #bae6fd; font-size: 0.41px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1019.

Summary:
- adds structured `miniPlanRivalResponseFallback` when the recommended branch becomes too risky
- selects the safest fallback branch from the existing rival-response comparison
- explains why the fallback resists better and shows its main cost without duplicating the branch comparison
- renders a compact fallback line near the rival branch comparison

Tests:
- npm test

Zeta: ready for validation before merge.