### PR TITLE
Delta: recommend preventive monitoring action

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -433,6 +433,70 @@ function buildMonitoringDriftForecast({ state, marginalExposureAdded, expectedCo
   };
 }
 
+
+function buildMonitoringPreventiveAction({ state, driftForecast }) {
+  if (driftForecast.state !== 'drift-risk') {
+    return {
+      action: 'hold-monitoring',
+      targetSignal: null,
+      windowEffect: 'maintains-safe-window',
+      reason: 'Aucune micro-action requise: la checklist reste stable avant le prochain signal.',
+    };
+  }
+
+  if (state === 'safe-action-available') {
+    return {
+      action: 'secure-exposure',
+      targetSignal: driftForecast.signal,
+      windowEffect: 'maintains-safe-window',
+      reason: 'Sécuriser l’exposition maintenant garde la fenêtre sûre ouverte sans révéler de cible.',
+    };
+  }
+
+  if (state === 'await-fresh-signal') {
+    return {
+      action: 'wait-fresh-signal',
+      targetSignal: driftForecast.signal,
+      windowEffect: 'delays-safe-window',
+      reason: 'Attendre un signal frais évite de relancer sur une information qui dérive.',
+    };
+  }
+
+  if (state === 'heat-too-high') {
+    return {
+      action: 'reduce-heat',
+      targetSignal: driftForecast.signal,
+      windowEffect: 'delays-safe-window',
+      reason: 'Réduire le heat avant reprise protège la fenêtre sûre contre une exposition trop haute.',
+    };
+  }
+
+  if (state === 'wait-for-cooldown') {
+    return {
+      action: 'secure-exposure',
+      targetSignal: driftForecast.signal,
+      windowEffect: 'advances-safe-window',
+      reason: 'Sécuriser le gap visible pendant le cooldown peut avancer la prochaine reprise sûre.',
+    };
+  }
+
+  if (state === 'low-confidence-gain') {
+    return {
+      action: 'wait-fresh-signal',
+      targetSignal: driftForecast.signal,
+      windowEffect: 'advances-safe-window',
+      reason: 'Attendre des signaux frais peut transformer un gain marginal en reprise sûre.',
+    };
+  }
+
+  return {
+    action: 'delay-sweep',
+    targetSignal: driftForecast.signal,
+    windowEffect: 'delays-safe-window',
+    reason: 'Retarder le sweep évite de casser la fenêtre sûre sur une dérive non stabilisée.',
+  };
+}
+
 function buildMonitoringRestartPlan({ state, monitoringPreferred, marginalExposureAdded, expectedConfidenceGain }) {
   const normalizedExposure = clampPercent(marginalExposureAdded);
   const normalizedGain = clampPercent(expectedConfidenceGain);
@@ -522,6 +586,14 @@ function withMonitoringRestartPlan(rationale, marginalExposureAdded, expectedCon
       state: rationale.state,
       marginalExposureAdded,
       expectedConfidenceGain,
+    }),
+    preventiveAction: buildMonitoringPreventiveAction({
+      state: rationale.state,
+      driftForecast: buildMonitoringDriftForecast({
+        state: rationale.state,
+        marginalExposureAdded,
+        expectedConfidenceGain,
+      }),
     }),
   };
 }

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -171,6 +171,12 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           direction: 'no-change',
           reason: 'Aucune dérive probable avant le prochain signal: le calendrier de sweep reste inchangé.',
         },
+        preventiveAction: {
+          action: 'hold-monitoring',
+          targetSignal: null,
+          windowEffect: 'maintains-safe-window',
+          reason: 'Aucune micro-action requise: la checklist reste stable avant le prochain signal.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -181,6 +187,12 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               state: 'stable-for-now',
               direction: 'no-change',
               reason: 'Aucune dérive probable avant le prochain signal: le calendrier de sweep reste inchangé.',
+            },
+            preventiveAction: {
+              action: 'hold-monitoring',
+              targetSignal: null,
+              windowEffect: 'maintains-safe-window',
+              reason: 'Aucune micro-action requise: la checklist reste stable avant le prochain signal.',
             },
         monitoringChecklist: [
           {
@@ -297,6 +309,12 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           direction: 'no-change',
           reason: 'Aucune dérive probable avant le prochain signal: le calendrier de sweep reste inchangé.',
         },
+        preventiveAction: {
+          action: 'hold-monitoring',
+          targetSignal: null,
+          windowEffect: 'maintains-safe-window',
+          reason: 'Aucune micro-action requise: la checklist reste stable avant le prochain signal.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -307,6 +325,12 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               state: 'stable-for-now',
               direction: 'no-change',
               reason: 'Aucune dérive probable avant le prochain signal: le calendrier de sweep reste inchangé.',
+            },
+            preventiveAction: {
+              action: 'hold-monitoring',
+              targetSignal: null,
+              windowEffect: 'maintains-safe-window',
+              reason: 'Aucune micro-action requise: la checklist reste stable avant le prochain signal.',
             },
         monitoringChecklist: [
           {
@@ -523,6 +547,12 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
           direction: 'no-change',
           reason: 'Aucune dérive probable avant le prochain signal: le calendrier de sweep reste inchangé.',
         },
+        preventiveAction: {
+          action: 'hold-monitoring',
+          targetSignal: null,
+          windowEffect: 'maintains-safe-window',
+          reason: 'Aucune micro-action requise: la checklist reste stable avant le prochain signal.',
+        },
         monitoringChecklist: [
           {
             signal: 'Nouveau gap',
@@ -612,6 +642,12 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
         state: 'drift-risk',
         direction: 'advances-next-sweep',
         reason: 'Des signaux frais peuvent faire passer le gain attendu au-dessus de +3.',
+      },
+      preventiveAction: {
+        action: 'wait-fresh-signal',
+        targetSignal: 'Gain confiance',
+        windowEffect: 'advances-safe-window',
+        reason: 'Attendre des signaux frais peut transformer un gain marginal en reprise sûre.',
       },
       monitoringChecklist: [
         {
@@ -769,6 +805,12 @@ test('buildIntrigueMapOverlay recommends preparing a third sweep only when resid
         direction: 'retards-next-sweep',
         reason: 'Si la fenêtre sûre se referme, le prochain sweep doit attendre un nouveau créneau low-risk.',
       },
+      preventiveAction: {
+        action: 'secure-exposure',
+        targetSignal: 'Fenêtre sûre',
+        windowEffect: 'maintains-safe-window',
+        reason: 'Sécuriser l’exposition maintenant garde la fenêtre sûre ouverte sans révéler de cible.',
+      },
       monitoringChecklist: [
         {
           signal: 'Fenêtre sûre',
@@ -849,6 +891,12 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
       state: 'drift-risk',
       direction: 'retards-next-sweep',
       reason: 'Le signal risque de périmer avant confirmation, ce qui retarde la prochaine relance sûre.',
+    },
+    preventiveAction: {
+      action: 'wait-fresh-signal',
+      targetSignal: 'Fraîcheur signal',
+      windowEffect: 'delays-safe-window',
+      reason: 'Attendre un signal frais évite de relancer sur une information qui dérive.',
     },
     monitoringChecklist: [
       {


### PR DESCRIPTION
Delta: Implements #1022.

Summary:
- Adds `preventiveAction` alongside the monitoring checklist/drift forecast.
- Recommends fog-safe micro-actions: wait for fresh signal, reduce heat, secure exposure, delay sweep, or hold monitoring.
- Links each action to the drifting checklist signal and marks whether it maintains, advances, or delays the safe sweep window.

Tests:
- `node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js`
- `npm test` (615/615)

Zeta: PR ready for validation. Please review before any merge.