### PR TITLE
Gamma: recommend residual culture action

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -828,6 +828,45 @@ function buildResidualRiskAfterNextRetirement(dependencyRetirementRanking, nextD
   };
 }
 
+function buildResidualCultureRiskNextAction(residualRiskAfterNextRetirement) {
+  const fragility = residualRiskAfterNextRetirement.principalResidualFragility;
+
+  if (!fragility) {
+    return {
+      status: 'none-safe',
+      actionType: 'none',
+      recommendedAction: 'aucune action secondaire sûre requise',
+      reason: residualRiskAfterNextRetirement.reason,
+    };
+  }
+
+  const actionType = fragility.type === 'regional-mediation'
+    ? 'mediation'
+    : fragility.type === 'missing-support'
+      ? 'local-support'
+      : fragility.type === 'bundle-incompatibility'
+        ? 'timing-pause'
+        : fragility.type === 'bundle-dependency'
+          ? 'culture-lock'
+          : 'pressure-reduction';
+  const recommendedAction = actionType === 'mediation'
+    ? 'ouvrir une médiation locale courte après le retrait suivant'
+    : actionType === 'local-support'
+      ? 'préparer un support local compatible avant nouvelle réduction de dette'
+      : actionType === 'timing-pause'
+        ? 'marquer une pause de timing pour absorber le tradeoff culturel'
+        : actionType === 'culture-lock'
+          ? 'lever le verrou culturel avant de séquencer un autre soutien'
+          : 'réduire la pression régionale avant d’empiler un nouveau retrait';
+
+  return {
+    status: residualRiskAfterNextRetirement.status === 'important-fragility' ? 'recommended' : 'optional',
+    actionType,
+    recommendedAction,
+    reason: `bon second pas: ${fragility.cause} reste ${fragility.urgency}`,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -882,6 +921,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const topRetirementReadiness = buildTopRetirementReadiness(recommendedFirstRetirement, postBundleCumulativeRisk);
   const topRetirementRecoveryPreview = buildTopRetirementRecoveryPreview(recommendedFirstRetirement, topRetirementReadiness);
   const nextDependencyRetirementPath = buildNextDependencyRetirementPath(dependencyRetirementRanking, topRetirementReadiness, topRetirementRecoveryPreview);
+  const residualRiskAfterNextRetirement = buildResidualRiskAfterNextRetirement(dependencyRetirementRanking, nextDependencyRetirementPath, postBundleCumulativeRisk);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -892,7 +932,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     topRetirementReadiness,
     topRetirementRecoveryPreview,
     nextDependencyRetirementPath,
-    residualRiskAfterNextRetirement: buildResidualRiskAfterNextRetirement(dependencyRetirementRanking, nextDependencyRetirementPath, postBundleCumulativeRisk),
+    residualRiskAfterNextRetirement,
+    residualCultureRiskNextAction: buildResidualCultureRiskNextAction(residualRiskAfterNextRetirement),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -919,6 +919,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         nextActionAfterRetirement: 'surveiller les relais savants et le rythme d’ouverture',
         reason: 'stabilisation partielle: surveiller risque restant: isolement du support',
       },
+      residualCultureRiskNextAction: {
+        status: 'optional',
+        actionType: 'mediation',
+        recommendedAction: 'ouvrir une médiation locale courte après le retrait suivant',
+        reason: 'bon second pas: risque restant: isolement du support reste medium',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -994,6 +1000,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         status: 'complete',
         principalResidualFragility: null,
         nextActionAfterRetirement: 'aucune action culturelle supplémentaire prioritaire',
+        reason: 'aucune dette résiduelle après stabilisation',
+      },
+      residualCultureRiskNextAction: {
+        status: 'none-safe',
+        actionType: 'none',
+        recommendedAction: 'aucune action secondaire sûre requise',
         reason: 'aucune dette résiduelle après stabilisation',
       },
     },


### PR DESCRIPTION
Gamma: ## Summary

Recommends a compact next action for the residual culture risk that remains after the next dependency retirement.

## Changes

- Adds `residualCultureRiskNextAction` to `stabilizationDebtSummary`.
- Selects an action type from the dominant residual fragility: mediation, local support, timing pause, culture lock, pressure reduction, or none.
- Explains why the action is the right second step after the recommended retirement.
- Keeps no-action cases explicit when no safe secondary action is available.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1031