### PR TITLE
Alpha: show fallback return cue

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -628,6 +628,68 @@ export function buildMiniPlanRivalResponseFallback(miniPlanRivalResponseComparis
   };
 }
 
+function describeFallbackReturnCondition(initialBranch, fallbackBranch, fallback) {
+  const rivalResponse = initialBranch?.rivalResponse ?? 'réponse rivale';
+  const cost = fallback?.cost ?? '';
+  if (String(cost).startsWith('cible moins prioritaire')) return `revenir quand ${initialBranch?.targetId ?? 'la cible initiale'} devient moins exposée`;
+  if (String(cost).startsWith('délai')) return 'revenir quand le délai rival est absorbé';
+  if (String(rivalResponse).includes('convoi') || String(rivalResponse).includes('coupure')) return 'revenir quand le prérequis logistique est sécurisé';
+  if (String(rivalResponse).includes('agitation')) return 'revenir quand la réponse rivale se dissipe';
+  return 'revenir quand la réponse rivale baisse';
+}
+
+export function buildMiniPlanFallbackReturnCue(
+  miniPlanRivalResponseFallback = null,
+  miniPlanRivalResponseComparison = null,
+) {
+  if (!miniPlanRivalResponseFallback || miniPlanRivalResponseFallback.empty
+    || !miniPlanRivalResponseComparison || miniPlanRivalResponseComparison.empty) {
+    return {
+      empty: true,
+      decision: 'none',
+      condition: 'aucun retour à arbitrer',
+      switchCost: null,
+      reason: null,
+      initialBranchId: null,
+      fallbackBranchId: null,
+    };
+  }
+
+  const branches = normalizeCleanupInput(
+    miniPlanRivalResponseComparison.branches ?? [],
+    'StrategicMapShell miniPlanRivalResponseComparison.branches',
+  );
+  const initialBranch = branches[0] ?? null;
+  const fallbackBranch = branches.find((branch) => branch.branchId === miniPlanRivalResponseFallback.fallbackBranchId) ?? null;
+  if (!initialBranch || !fallbackBranch) {
+    return {
+      empty: true,
+      decision: 'none',
+      condition: 'fallback incomplet',
+      switchCost: null,
+      reason: null,
+      initialBranchId: null,
+      fallbackBranchId: miniPlanRivalResponseFallback.fallbackBranchId ?? null,
+    };
+  }
+
+  const initialRisk = compareRivalRiskLevel(initialBranch.riskLevel);
+  const fallbackRisk = compareRivalRiskLevel(fallbackBranch.riskLevel);
+  const shouldKeepFallback = initialRisk > fallbackRisk;
+
+  return {
+    empty: false,
+    decision: shouldKeepFallback ? 'keep-fallback' : 'return-initial',
+    condition: describeFallbackReturnCondition(initialBranch, fallbackBranch, miniPlanRivalResponseFallback),
+    switchCost: `changer encore consomme ${miniPlanRivalResponseFallback.cost ?? 'un tempo de coordination'}`,
+    reason: shouldKeepFallback
+      ? `garder le fallback tant que ${initialBranch.rivalResponse} reste ${initialBranch.riskLevel}`
+      : `revenir à la branche initiale si son risque retombe au niveau ${fallbackBranch.riskLevel}`,
+    initialBranchId: initialBranch.branchId,
+    fallbackBranchId: fallbackBranch.branchId,
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -713,6 +775,10 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanConflictTradeoffs,
   );
   const miniPlanRivalResponseFallback = buildMiniPlanRivalResponseFallback(miniPlanRivalResponseComparison);
+  const miniPlanFallbackReturnCue = buildMiniPlanFallbackReturnCue(
+    miniPlanRivalResponseFallback,
+    miniPlanRivalResponseComparison,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -762,6 +828,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanRivalResponseRisk,
     miniPlanRivalResponseComparison,
     miniPlanRivalResponseFallback,
+    miniPlanFallbackReturnCue,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -10,6 +10,7 @@ import {
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
+  buildMiniPlanFallbackReturnCue,
   buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
@@ -323,6 +324,15 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     reason: 'branche recommandée encore sûre',
     cost: null,
     targetId: null,
+  });
+  assert.deepEqual(shell.miniPlanFallbackReturnCue, {
+    empty: true,
+    decision: 'none',
+    condition: 'aucun retour à arbitrer',
+    switchCost: null,
+    reason: null,
+    initialBranchId: null,
+    fallbackBranchId: null,
   });
 });
 
@@ -644,13 +654,23 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     ],
   };
 
-  assert.deepEqual(buildMiniPlanRivalResponseFallback(comparison), {
+  const fallback = buildMiniPlanRivalResponseFallback(comparison);
+  assert.deepEqual(fallback, {
     empty: false,
     fallbackBranchId: 'mini-plan-branch:2:mini-plan-tradeoff:low-loyalty:front-a',
     action: 'Scanner axe détour',
     reason: 'agitation locale avant liaison reste medium, contre contre-poussée du front voisin',
     cost: 'cible moins prioritaire: front-a',
     targetId: 'front-a',
+  });
+  assert.deepEqual(buildMiniPlanFallbackReturnCue(fallback, comparison), {
+    empty: false,
+    decision: 'keep-fallback',
+    condition: 'revenir quand front-b devient moins exposée',
+    switchCost: 'changer encore consomme cible moins prioritaire: front-a',
+    reason: 'garder le fallback tant que contre-poussée du front voisin reste high',
+    initialBranchId: 'mini-plan-branch:1:mini-plan-tradeoff:neighbor-front:front-b',
+    fallbackBranchId: 'mini-plan-branch:2:mini-plan-tradeoff:low-loyalty:front-a',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -662,6 +682,43 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     reason: 'branche recommandée encore sûre',
     cost: null,
     targetId: null,
+  });
+});
+
+test('StrategicMapShell distinguishes keeping fallback from returning to original branch', () => {
+  const fallback = {
+    empty: false,
+    fallbackBranchId: 'fallback',
+    action: 'retour initial surveillé',
+    reason: 'risque abaissé',
+    cost: 'bénéfice moindre mais risque équivalent',
+    targetId: 'front-a',
+  };
+  const comparison = {
+    empty: false,
+    branches: [
+      { branchId: 'initial', action: 'branche initiale', rivalResponse: 'agitation locale avant liaison', riskLevel: 'medium', targetId: 'front-a' },
+      { branchId: 'fallback', action: 'fallback', rivalResponse: 'veille adverse', riskLevel: 'medium', targetId: 'front-a' },
+    ],
+  };
+
+  assert.deepEqual(buildMiniPlanFallbackReturnCue(fallback, comparison), {
+    empty: false,
+    decision: 'return-initial',
+    condition: 'revenir quand la réponse rivale se dissipe',
+    switchCost: 'changer encore consomme bénéfice moindre mais risque équivalent',
+    reason: 'revenir à la branche initiale si son risque retombe au niveau medium',
+    initialBranchId: 'initial',
+    fallbackBranchId: 'fallback',
+  });
+  assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
+    empty: true,
+    decision: 'none',
+    condition: 'aucun retour à arbitrer',
+    switchCost: null,
+    reason: null,
+    initialBranchId: null,
+    fallbackBranchId: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -68,6 +68,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanRivalResponseRisk\(/);
   assert.match(webAppSource, /buildMiniPlanRivalResponseComparison\(/);
   assert.match(webAppSource, /buildMiniPlanRivalResponseFallback\(/);
+  assert.match(webAppSource, /buildMiniPlanFallbackReturnCue\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -105,9 +106,11 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanRivalResponseRisk: buildMiniPlanRivalResponseRisk\(buildMiniPlanTradeoffActionPreview\(null, \[\]\), \[\]\)/);
   assert.match(webAppSource, /miniPlanRivalResponseComparison: buildMiniPlanRivalResponseComparison\(null, \[\]\)/);
   assert.match(webAppSource, /miniPlanRivalResponseFallback: buildMiniPlanRivalResponseFallback\(buildMiniPlanRivalResponseComparison\(null, \[\]\)\)/);
+  assert.match(webAppSource, /miniPlanFallbackReturnCue: buildMiniPlanFallbackReturnCue\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
+  assert.match(webAppSource, /retour: aucun arbitrage/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -118,6 +121,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__rival-response-risk/);
   assert.match(webAppSource, /atlas-military-fallback-order__rival-branch-comparison/);
   assert.match(webAppSource, /atlas-military-fallback-order__rival-response-fallback/);
+  assert.match(webAppSource, /atlas-military-fallback-order__fallback-return-cue/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -128,6 +132,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /Risque si: \$\{rivalRisk\.response\} · \$\{rivalRisk\.label\} · \$\{rivalRisk\.watch\}/);
   assert.match(webAppSource, /branches: \$\{rivalComparison\.branches\.map\(\(branch\) => `\$\{branch\.recommended \? '★' : '○'\} \$\{branch\.action\} → \$\{branch\.rivalResponse\} \(\$\{branch\.riskLevel\}\)`\)\.join\(' · '\)\}\$\{rivalComparison\.recommendationChanged \? ' · reco change' : ' · reco stable'\}/);
   assert.match(webAppSource, /fallback: \$\{rivalFallback\.action\} @ \$\{rivalFallback\.targetId \?\? 'front'\} · \$\{rivalFallback\.reason\} · coût \$\{rivalFallback\.cost\}/);
+  assert.match(webAppSource, /\$\{fallbackReturnCue\.decision === 'keep-fallback' \? 'garder fallback' : 'retour initial'\}: \$\{fallbackReturnCue\.condition\} · coût \$\{fallbackReturnCue\.switchCost\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -148,4 +153,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__rival-response-risk/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__rival-branch-comparison/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__rival-response-fallback/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__fallback-return-cue/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -11,6 +11,7 @@ import {
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
+  buildMiniPlanFallbackReturnCue,
   buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
@@ -1963,6 +1964,10 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanRivalResponseRisk: buildMiniPlanRivalResponseRisk(buildMiniPlanTradeoffActionPreview(null, []), []),
       miniPlanRivalResponseComparison: buildMiniPlanRivalResponseComparison(null, []),
       miniPlanRivalResponseFallback: buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+      miniPlanFallbackReturnCue: buildMiniPlanFallbackReturnCue(
+        buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+        buildMiniPlanRivalResponseComparison(null, []),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -1999,6 +2004,10 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanConflictTradeoffs,
   );
   const miniPlanRivalResponseFallback = buildMiniPlanRivalResponseFallback(miniPlanRivalResponseComparison);
+  const miniPlanFallbackReturnCue = buildMiniPlanFallbackReturnCue(
+    miniPlanRivalResponseFallback,
+    miniPlanRivalResponseComparison,
+  );
 
   return {
     fallback: {
@@ -2020,6 +2029,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanRivalResponseRisk,
       miniPlanRivalResponseComparison,
       miniPlanRivalResponseFallback,
+      miniPlanFallbackReturnCue,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2036,7 +2046,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanRivalResponseRisk,
     miniPlanRivalResponseComparison,
     miniPlanRivalResponseFallback,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}).`,
+    miniPlanFallbackReturnCue,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}).`,
     empty: false,
   };
 }
@@ -2087,9 +2098,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const rivalFallbackLabel = rivalFallback && !rivalFallback.empty
     ? `fallback: ${rivalFallback.action} @ ${rivalFallback.targetId ?? 'front'} · ${rivalFallback.reason} · coût ${rivalFallback.cost}`
     : 'fallback: aucun repli requis';
+  const fallbackReturnCue = fallback.miniPlanFallbackReturnCue;
+  const fallbackReturnLabel = fallbackReturnCue && !fallbackReturnCue.empty
+    ? `${fallbackReturnCue.decision === 'keep-fallback' ? 'garder fallback' : 'retour initial'}: ${fallbackReturnCue.condition} · coût ${fallbackReturnCue.switchCost}`
+    : 'retour: aucun arbitrage';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="20.4" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="21.6" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2107,6 +2122,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__rival-response-risk atlas-military-fallback-order__rival-response-risk--${rivalRisk?.level ?? 'low'}" x="23.2" y="74.5">${rivalRiskLabel}</text>
       <text class="atlas-military-fallback-order__rival-branch-comparison" x="23.2" y="75.6">${rivalComparisonLabel}</text>
       <text class="atlas-military-fallback-order__rival-response-fallback" x="23.2" y="76.7">${rivalFallbackLabel}</text>
+      <text class="atlas-military-fallback-order__fallback-return-cue" x="23.2" y="77.8">${fallbackReturnLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11168,6 +11168,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__rival-response-risk--low { fill: #bbf7d0; }
 .atlas-military-fallback-order__rival-branch-comparison { fill: #c4b5fd; font-size: 0.42px; font-weight: 900; }
 .atlas-military-fallback-order__rival-response-fallback { fill: #bae6fd; font-size: 0.41px; font-weight: 900; }
+.atlas-military-fallback-order__fallback-return-cue { fill: #fde68a; font-size: 0.4px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1029.

Summary:
- adds structured `miniPlanFallbackReturnCue` beside the rival-response fallback
- distinguishes keeping the fallback from returning to the original branch
- explains the fog-safe return condition and the cost of switching branches again
- renders a compact return cue near the existing fallback without duplicating branch comparison

Tests:
- npm test

Zeta: ready for validation before merge.