### PR TITLE
Epsilon: summarize follow-up climate window effect

### DIFF
--- a/test/ui/climate/webAtlasFollowUpClimateWindowChangeSummary.test.js
+++ b/test/ui/climate/webAtlasFollowUpClimateWindowChangeSummary.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas summarizes how follow-up climate payoff changes the next window', () => {
+  assert.match(webAppSource, /function buildFollowUpClimateWindowChangeSummary/);
+  assert.match(webAppSource, /followUpClimateWindowChangeSummary: null/);
+  assert.match(webAppSource, /followUpClimateWindowChangeSummary,/);
+
+  for (const stableKey of [
+    'state',
+    'effect',
+    'remainingConstraint',
+    'nextDecision',
+    'followUpDebtLabel',
+    'summary',
+    'oneSentence',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /fenêtre sûre restaurée/);
+  assert.match(webAppSource, /rebond réduit seulement/);
+  assert.match(webAppSource, /ne suffit pas encore/);
+  assert.match(webAppSource, /contrainte restante/);
+  assert.match(webAppSource, /payer maintenant/);
+  assert.match(webAppSource, /attendre une meilleure fenêtre/);
+  assert.match(webAppSource, /traiter une autre dette/);
+  assert.match(webAppSource, /accepter le risque/);
+  assert.match(webAppSource, /Fenêtre après suivi/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9464,6 +9464,50 @@ function buildFollowUpClimatePayoffRecommendation(climateRiskReboundAfterTopPayo
   };
 }
 
+function buildFollowUpClimateWindowChangeSummary(followUpClimatePayoffRecommendation, climateRiskReboundAfterTopPayoff, decisionWindow) {
+  if (!followUpClimatePayoffRecommendation || !climateRiskReboundAfterTopPayoff) {
+    return null;
+  }
+
+  const conflictCount = decisionWindow?.conflicts?.length ?? 0;
+  const hasCascade = climateRiskReboundAfterTopPayoff.secondaryDebtCause?.includes('pression de report')
+    || climateRiskReboundAfterTopPayoff.secondaryDebtCause?.includes('dette future accrue');
+  const state = followUpClimatePayoffRecommendation.state === 'recommended' && climateRiskReboundAfterTopPayoff.state === 'rebond modéré'
+    ? 'fenêtre sûre restaurée'
+    : followUpClimatePayoffRecommendation.state === 'recommended'
+      ? 'rebond réduit seulement'
+      : 'ne suffit pas encore';
+  const remainingConstraint = conflictCount > 0
+    ? 'conflit de timing externe encore visible'
+    : hasCascade
+      ? 'cascade de dette secondaire encore active'
+      : decisionWindow?.sourceDeadline
+        ? `pression régionale sur ${decisionWindow.sourceDeadline}`
+        : 'dette secondaire à confirmer';
+  const nextDecision = state === 'fenêtre sûre restaurée'
+    ? 'payer maintenant'
+    : state === 'rebond réduit seulement'
+      ? 'traiter une autre dette'
+      : conflictCount > 0
+        ? 'attendre une meilleure fenêtre'
+        : 'accepter le risque';
+  const effect = state === 'fenêtre sûre restaurée'
+    ? 'le paiement de suivi restaure une fenêtre climat sûre'
+    : state === 'rebond réduit seulement'
+      ? 'le paiement de suivi réduit le rebond sans fermer toute la dette'
+      : 'le paiement de suivi ne suffit pas encore avec les signaux actuels';
+
+  return {
+    state,
+    effect,
+    remainingConstraint,
+    nextDecision,
+    followUpDebtLabel: followUpClimatePayoffRecommendation.followUpDebtLabel,
+    summary: `${effect}; contrainte restante: ${remainingConstraint}.`,
+    oneSentence: `Décision suivante: ${nextDecision}.`,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -9514,6 +9558,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       climateDebtPayoffRiskComparison: null,
       climateRiskReboundAfterTopPayoff: null,
       followUpClimatePayoffRecommendation: null,
+      followUpClimateWindowChangeSummary: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -9575,6 +9620,11 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     decisionDebtRanking,
     nextClimateCommitment,
   );
+  const followUpClimateWindowChangeSummary = buildFollowUpClimateWindowChangeSummary(
+    followUpClimatePayoffRecommendation,
+    climateRiskReboundAfterTopPayoff,
+    decisionWindow,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -9588,6 +9638,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     climateDebtPayoffRiskComparison,
     climateRiskReboundAfterTopPayoff,
     followUpClimatePayoffRecommendation,
+    followUpClimateWindowChangeSummary,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -9622,6 +9673,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.climateDebtPayoffRiskComparison ? `<small><b>Payoff risque/coût</b> · ${view.climateDebtPayoffRiskComparison.summary} ${view.climateDebtPayoffRiskComparison.reason} ${view.climateDebtPayoffRiskComparison.necessaryDespiteLimitedReduction}</small>` : ''}
       ${view.climateRiskReboundAfterTopPayoff ? `<small><b>Rebond après payoff</b> · ${view.climateRiskReboundAfterTopPayoff.summary} ${view.climateRiskReboundAfterTopPayoff.secondaryDebtCause} ${view.climateRiskReboundAfterTopPayoff.reason}</small>` : ''}
       ${view.followUpClimatePayoffRecommendation ? `<small><b>Paiement de suivi</b> · ${view.followUpClimatePayoffRecommendation.summary} ${view.followUpClimatePayoffRecommendation.reason} Prochaine action: ${view.followUpClimatePayoffRecommendation.nextAction}</small>` : ''}
+      ${view.followUpClimateWindowChangeSummary ? `<small><b>Fenêtre après suivi</b> · ${view.followUpClimateWindowChangeSummary.summary} ${view.followUpClimateWindowChangeSummary.oneSentence}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1033.

## Résumé
- ajoute un résumé de l’effet du paiement climatique de suivi sur la prochaine fenêtre
- qualifie si la fenêtre est restaurée, seulement améliorée, ou encore insuffisante
- expose la contrainte restante et la prochaine décision courte dans la carte existante

## Tests
- `npm test`
