### PR TITLE
Epsilon: warn on restored climate deadline tradeoff

### DIFF
--- a/test/ui/climate/webAtlasRestoredClimateDeadlineTradeoffWarning.test.js
+++ b/test/ui/climate/webAtlasRestoredClimateDeadlineTradeoffWarning.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas warns when a restored climate window still leaves a deadline tradeoff', () => {
+  assert.match(webAppSource, /function buildRestoredClimateDeadlineTradeoffWarning/);
+  assert.match(webAppSource, /restoredClimateDeadlineTradeoffWarning: null/);
+  assert.match(webAppSource, /restoredClimateDeadlineTradeoffWarning,/);
+
+  for (const stableKey of [
+    'state',
+    'deadline',
+    'tradeoffName',
+    'remainingConstraint',
+    'action',
+    'summary',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /aucun tradeoff restant/);
+  assert.match(webAppSource, /tradeoff modéré/);
+  assert.match(webAppSource, /tradeoff critique/);
+  assert.match(webAppSource, /payer encore/);
+  assert.match(webAppSource, /accepter un risque court/);
+  assert.match(webAppSource, /déplacer la décision/);
+  assert.match(webAppSource, /Alerte tradeoff deadline/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9524,6 +9524,45 @@ function buildFollowUpClimateWindowChangeSummary(followUpClimatePayoffRecommenda
   };
 }
 
+function buildRestoredClimateDeadlineTradeoffWarning(followUpClimateWindowChangeSummary, remainingDeadlinePressure, decisionWindow) {
+  if (!followUpClimateWindowChangeSummary) {
+    return null;
+  }
+
+  const improvedWindow = ['fenêtre sûre restaurée', 'rebond réduit seulement'].includes(followUpClimateWindowChangeSummary.state);
+  const deadline = remainingDeadlinePressure?.deadlineStillThreatened ?? decisionWindow?.sourceDeadline ?? null;
+  const unresolvedCount = remainingDeadlinePressure?.unresolvedAfterCommitment?.length ?? 0;
+
+  if (!improvedWindow || !deadline) {
+    return {
+      state: 'aucun tradeoff restant',
+      deadline: null,
+      tradeoffName: 'aucun tradeoff restant',
+      remainingConstraint: followUpClimateWindowChangeSummary.remainingConstraint,
+      action: 'continuer la fenêtre restaurée sans arbitrage deadline supplémentaire',
+      summary: 'Aucun tradeoff deadline restant après le paiement de suivi.',
+    };
+  }
+
+  const critical = followUpClimateWindowChangeSummary.state === 'rebond réduit seulement'
+    || decisionWindow?.state === 'urgent-window'
+    || unresolvedCount > 1;
+  const state = critical ? 'tradeoff critique' : 'tradeoff modéré';
+  const tradeoffName = critical ? 'payer encore' : 'accepter un risque court';
+  const action = critical
+    ? `payer encore ${deadline} avant de déplacer la décision`
+    : `accepter un risque court sur ${deadline} ou déplacer la décision d’un tour`;
+
+  return {
+    state,
+    deadline,
+    tradeoffName,
+    remainingConstraint: followUpClimateWindowChangeSummary.remainingConstraint,
+    action,
+    summary: `${state}: ${deadline} reste menaçante; arbitrage ${tradeoffName}. Action: ${action}.`,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -9575,6 +9614,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       climateRiskReboundAfterTopPayoff: null,
       followUpClimatePayoffRecommendation: null,
       followUpClimateWindowChangeSummary: null,
+      restoredClimateDeadlineTradeoffWarning: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -9641,6 +9681,11 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     climateRiskReboundAfterTopPayoff,
     decisionWindow,
   );
+  const restoredClimateDeadlineTradeoffWarning = buildRestoredClimateDeadlineTradeoffWarning(
+    followUpClimateWindowChangeSummary,
+    remainingDeadlinePressure,
+    decisionWindow,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -9655,6 +9700,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     climateRiskReboundAfterTopPayoff,
     followUpClimatePayoffRecommendation,
     followUpClimateWindowChangeSummary,
+    restoredClimateDeadlineTradeoffWarning,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -9690,6 +9736,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.climateRiskReboundAfterTopPayoff ? `<small><b>Rebond après payoff</b> · ${view.climateRiskReboundAfterTopPayoff.summary} ${view.climateRiskReboundAfterTopPayoff.secondaryDebtCause} ${view.climateRiskReboundAfterTopPayoff.reason}</small>` : ''}
       ${view.followUpClimatePayoffRecommendation ? `<small><b>Paiement de suivi</b> · ${view.followUpClimatePayoffRecommendation.summary} ${view.followUpClimatePayoffRecommendation.reason} Prochaine action: ${view.followUpClimatePayoffRecommendation.nextAction}</small>` : ''}
       ${view.followUpClimateWindowChangeSummary ? `<small><b>Fenêtre après suivi</b> · ${view.followUpClimateWindowChangeSummary.summary} ${view.followUpClimateWindowChangeSummary.oneSentence}</small>` : ''}
+      ${view.restoredClimateDeadlineTradeoffWarning ? `<small><b>Alerte tradeoff deadline</b> · ${view.restoredClimateDeadlineTradeoffWarning.summary}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1043.

## Résumé
- ajoute une alerte de tradeoff deadline après fenêtre climat restaurée/améliorée
- distingue aucun tradeoff restant, tradeoff modéré et tradeoff critique
- nomme l’arbitrage restant et propose une action courte dans l’overlay existant

## Tests
- `npm test`
