### PR TITLE
Delta: summarize monitoring safety margin

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -552,6 +552,52 @@ function buildPreventiveRecoveryState({ preventiveAction }) {
   };
 }
 
+
+function buildPostRecoverySafetyMargin({ preventiveRecoveryState, preventiveAction, driftForecast }) {
+  if (driftForecast.signal === null) {
+    return {
+      level: 'insufficient-data',
+      fastestConsumingSignal: null,
+      nextAction: 'reinforce-monitoring',
+      reason: 'Données de dérive insuffisantes: renforcer le monitoring avant de mesurer une vraie marge.',
+    };
+  }
+
+  if (preventiveRecoveryState.state === 'sweep-safe-again' && preventiveAction.windowEffect === 'maintains-safe-window') {
+    return {
+      level: 'comfortable',
+      fastestConsumingSignal: driftForecast.signal,
+      nextAction: 'launch-sweep',
+      reason: `${driftForecast.signal} consomme encore la marge, mais la fenêtre reste assez protégée pour lancer le sweep.`,
+    };
+  }
+
+  if (preventiveRecoveryState.state === 'sweep-safe-again') {
+    return {
+      level: 'narrow',
+      fastestConsumingSignal: driftForecast.signal,
+      nextAction: 'wait-confirmation',
+      reason: `${driftForecast.signal} consomme vite la marge: attendre une confirmation courte avant reprise.`,
+    };
+  }
+
+  if (preventiveRecoveryState.state === 'monitor-only') {
+    return {
+      level: 'narrow',
+      fastestConsumingSignal: driftForecast.signal,
+      nextAction: 'wait-confirmation',
+      reason: `${driftForecast.signal} laisse une marge surveillable mais pas suffisante pour lancer tout de suite.`,
+    };
+  }
+
+  return {
+    level: 'absent',
+    fastestConsumingSignal: driftForecast.signal,
+    nextAction: 'reinforce-monitoring',
+    reason: `${driftForecast.signal} consomme toute la marge: renforcer le monitoring avant tout sweep.`,
+  };
+}
+
 function buildMonitoringRestartPlan({ state, monitoringPreferred, marginalExposureAdded, expectedConfidenceGain }) {
   const normalizedExposure = clampPercent(marginalExposureAdded);
   const normalizedGain = clampPercent(expectedConfidenceGain);
@@ -658,6 +704,31 @@ function withMonitoringRestartPlan(rationale, marginalExposureAdded, expectedCon
           marginalExposureAdded,
           expectedConfidenceGain,
         }),
+      }),
+    }),
+    postRecoverySafetyMargin: buildPostRecoverySafetyMargin({
+      preventiveRecoveryState: buildPreventiveRecoveryState({
+        preventiveAction: buildMonitoringPreventiveAction({
+          state: rationale.state,
+          driftForecast: buildMonitoringDriftForecast({
+            state: rationale.state,
+            marginalExposureAdded,
+            expectedConfidenceGain,
+          }),
+        }),
+      }),
+      preventiveAction: buildMonitoringPreventiveAction({
+        state: rationale.state,
+        driftForecast: buildMonitoringDriftForecast({
+          state: rationale.state,
+          marginalExposureAdded,
+          expectedConfidenceGain,
+        }),
+      }),
+      driftForecast: buildMonitoringDriftForecast({
+        state: rationale.state,
+        marginalExposureAdded,
+        expectedConfidenceGain,
       }),
     }),
   };

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -183,6 +183,12 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           nextDecision: 'continue-monitoring',
           reason: 'La checklist reste stable: maintenir le monitoring sans nouvelle exposition.',
         },
+        postRecoverySafetyMargin: {
+          level: 'insufficient-data',
+          fastestConsumingSignal: null,
+          nextAction: 'reinforce-monitoring',
+          reason: 'Données de dérive insuffisantes: renforcer le monitoring avant de mesurer une vraie marge.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -205,6 +211,12 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               targetSignal: null,
               nextDecision: 'continue-monitoring',
               reason: 'La checklist reste stable: maintenir le monitoring sans nouvelle exposition.',
+            },
+            postRecoverySafetyMargin: {
+              level: 'insufficient-data',
+              fastestConsumingSignal: null,
+              nextAction: 'reinforce-monitoring',
+              reason: 'Données de dérive insuffisantes: renforcer le monitoring avant de mesurer une vraie marge.',
             },
         monitoringChecklist: [
           {
@@ -333,6 +345,12 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           nextDecision: 'continue-monitoring',
           reason: 'La checklist reste stable: maintenir le monitoring sans nouvelle exposition.',
         },
+        postRecoverySafetyMargin: {
+          level: 'insufficient-data',
+          fastestConsumingSignal: null,
+          nextAction: 'reinforce-monitoring',
+          reason: 'Données de dérive insuffisantes: renforcer le monitoring avant de mesurer une vraie marge.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -355,6 +373,12 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               targetSignal: null,
               nextDecision: 'continue-monitoring',
               reason: 'La checklist reste stable: maintenir le monitoring sans nouvelle exposition.',
+            },
+            postRecoverySafetyMargin: {
+              level: 'insufficient-data',
+              fastestConsumingSignal: null,
+              nextAction: 'reinforce-monitoring',
+              reason: 'Données de dérive insuffisantes: renforcer le monitoring avant de mesurer une vraie marge.',
             },
         monitoringChecklist: [
           {
@@ -583,6 +607,12 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
           nextDecision: 'continue-monitoring',
           reason: 'La checklist reste stable: maintenir le monitoring sans nouvelle exposition.',
         },
+        postRecoverySafetyMargin: {
+          level: 'insufficient-data',
+          fastestConsumingSignal: null,
+          nextAction: 'reinforce-monitoring',
+          reason: 'Données de dérive insuffisantes: renforcer le monitoring avant de mesurer une vraie marge.',
+        },
         monitoringChecklist: [
           {
             signal: 'Nouveau gap',
@@ -684,6 +714,12 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
         targetSignal: 'Gain confiance',
         nextDecision: 'wait-fresh-signal',
         reason: 'La reprise reste surveillable seulement: attendre un signal frais avant tout sweep.',
+      },
+      postRecoverySafetyMargin: {
+        level: 'narrow',
+        fastestConsumingSignal: 'Gain confiance',
+        nextAction: 'wait-confirmation',
+        reason: 'Gain confiance laisse une marge surveillable mais pas suffisante pour lancer tout de suite.',
       },
       monitoringChecklist: [
         {
@@ -853,6 +889,12 @@ test('buildIntrigueMapOverlay recommends preparing a third sweep only when resid
         nextDecision: 'resume-sweep',
         reason: 'L’exposition sécurisée maintient la fenêtre sûre: le sweep peut reprendre si le signal reste lisible.',
       },
+      postRecoverySafetyMargin: {
+        level: 'comfortable',
+        fastestConsumingSignal: 'Fenêtre sûre',
+        nextAction: 'launch-sweep',
+        reason: 'Fenêtre sûre consomme encore la marge, mais la fenêtre reste assez protégée pour lancer le sweep.',
+      },
       monitoringChecklist: [
         {
           signal: 'Fenêtre sûre',
@@ -946,6 +988,12 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
       nextDecision: 'wait-fresh-signal',
       reason: 'La reprise reste surveillable seulement: attendre un signal frais avant tout sweep.',
     },
+    postRecoverySafetyMargin: {
+      level: 'narrow',
+      fastestConsumingSignal: 'Fraîcheur signal',
+      nextAction: 'wait-confirmation',
+      reason: 'Fraîcheur signal laisse une marge surveillable mais pas suffisante pour lancer tout de suite.',
+    },
     monitoringChecklist: [
       {
         signal: 'Fraîcheur signal',
@@ -997,6 +1045,12 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
   assert.match(tooExposed.secondSweepStopCondition.stopSignal, /Stop si le second sweep ajoute/);
   assert.equal(tooExposed.thirdSweepRecommendation.state, 'stop-after-second');
   assert.equal(tooExposed.thirdSweepRecommendation.monitoringRationale.state, 'heat-too-high');
+  assert.deepEqual(tooExposed.thirdSweepRecommendation.monitoringRationale.postRecoverySafetyMargin, {
+    level: 'absent',
+    fastestConsumingSignal: 'Heat',
+    nextAction: 'reinforce-monitoring',
+    reason: 'Heat consomme toute la marge: renforcer le monitoring avant tout sweep.',
+  });
 });
 
 test('buildIntrigueMapOverlay rejects invalid inputs', () => {


### PR DESCRIPTION
Delta: Implements #1042.

Summary:
- Adds `postRecoverySafetyMargin` as an extra margin detail after D32 recovery state.
- Classifies comfortable, narrow, absent, and insufficient-data margins.
- Names the checklist signal consuming the margin fastest and suggests the next fog-safe action.

Tests:
- `node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js`
- `npm test` (618/618)

Zeta: PR ready for validation. Please review before any merge.