### PR TITLE
Alpha: show return protection status

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -690,6 +690,77 @@ export function buildMiniPlanFallbackReturnCue(
   };
 }
 
+function protectionDecisionForRisk(initialRisk, fallbackRisk) {
+  if (initialRisk <= Math.max(1, fallbackRisk - 1)) return 'return-now';
+  if (initialRisk <= fallbackRisk) return 'wait-signal';
+  return 'confirm-fallback';
+}
+
+export function buildMiniPlanReturnProtectionStatus(
+  miniPlanFallbackReturnCue = null,
+  miniPlanRivalResponseFallback = null,
+  miniPlanRivalResponseComparison = null,
+) {
+  if (!miniPlanFallbackReturnCue || miniPlanFallbackReturnCue.empty
+    || !miniPlanRivalResponseFallback || miniPlanRivalResponseFallback.empty
+    || !miniPlanRivalResponseComparison || miniPlanRivalResponseComparison.empty) {
+    return {
+      empty: true,
+      state: 'none',
+      label: 'protection non évaluée',
+      constraint: null,
+      nextDecision: null,
+      reason: null,
+    };
+  }
+
+  const branches = normalizeCleanupInput(
+    miniPlanRivalResponseComparison.branches ?? [],
+    'StrategicMapShell miniPlanRivalResponseComparison.branches',
+  );
+  const initialBranch = branches.find((branch) => branch.branchId === miniPlanFallbackReturnCue.initialBranchId)
+    ?? branches[0]
+    ?? null;
+  const fallbackBranch = branches.find((branch) => branch.branchId === miniPlanRivalResponseFallback.fallbackBranchId)
+    ?? null;
+  if (!initialBranch || !fallbackBranch) {
+    return {
+      empty: true,
+      state: 'none',
+      label: 'protection non évaluée',
+      constraint: null,
+      nextDecision: null,
+      reason: null,
+    };
+  }
+
+  const initialRisk = compareRivalRiskLevel(initialBranch.riskLevel);
+  const fallbackRisk = compareRivalRiskLevel(fallbackBranch.riskLevel);
+  const nextDecision = protectionDecisionForRisk(initialRisk, fallbackRisk);
+  const state = nextDecision === 'return-now'
+    ? 'kept'
+    : nextDecision === 'wait-signal'
+      ? 'partial'
+      : 'lost';
+
+  return {
+    empty: false,
+    state,
+    label: state === 'kept'
+      ? 'protection conservée'
+      : state === 'partial'
+        ? 'protection partielle'
+        : 'protection perdue',
+    constraint: initialBranch.rivalResponse ?? fallbackBranch.rivalResponse ?? 'réponse rivale',
+    nextDecision,
+    reason: nextDecision === 'return-now'
+      ? 'revenir maintenant: le risque initial ne dépasse plus le fallback'
+      : nextDecision === 'wait-signal'
+        ? `attendre un signal: ${miniPlanFallbackReturnCue.condition}`
+        : `confirmer le fallback: ${initialBranch.rivalResponse} reste plus dangereux`,
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -779,6 +850,11 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanRivalResponseFallback,
     miniPlanRivalResponseComparison,
   );
+  const miniPlanReturnProtectionStatus = buildMiniPlanReturnProtectionStatus(
+    miniPlanFallbackReturnCue,
+    miniPlanRivalResponseFallback,
+    miniPlanRivalResponseComparison,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -829,6 +905,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanRivalResponseComparison,
     miniPlanRivalResponseFallback,
     miniPlanFallbackReturnCue,
+    miniPlanReturnProtectionStatus,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -11,6 +11,7 @@ import {
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
   buildMiniPlanFallbackReturnCue,
+  buildMiniPlanReturnProtectionStatus,
   buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
@@ -333,6 +334,14 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     reason: null,
     initialBranchId: null,
     fallbackBranchId: null,
+  });
+  assert.deepEqual(shell.miniPlanReturnProtectionStatus, {
+    empty: true,
+    state: 'none',
+    label: 'protection non évaluée',
+    constraint: null,
+    nextDecision: null,
+    reason: null,
   });
 });
 
@@ -663,7 +672,8 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     cost: 'cible moins prioritaire: front-a',
     targetId: 'front-a',
   });
-  assert.deepEqual(buildMiniPlanFallbackReturnCue(fallback, comparison), {
+  const returnCue = buildMiniPlanFallbackReturnCue(fallback, comparison);
+  assert.deepEqual(returnCue, {
     empty: false,
     decision: 'keep-fallback',
     condition: 'revenir quand front-b devient moins exposée',
@@ -671,6 +681,14 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     reason: 'garder le fallback tant que contre-poussée du front voisin reste high',
     initialBranchId: 'mini-plan-branch:1:mini-plan-tradeoff:neighbor-front:front-b',
     fallbackBranchId: 'mini-plan-branch:2:mini-plan-tradeoff:low-loyalty:front-a',
+  });
+  assert.deepEqual(buildMiniPlanReturnProtectionStatus(returnCue, fallback, comparison), {
+    empty: false,
+    state: 'lost',
+    label: 'protection perdue',
+    constraint: 'contre-poussée du front voisin',
+    nextDecision: 'confirm-fallback',
+    reason: 'confirmer le fallback: contre-poussée du front voisin reste plus dangereux',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -702,7 +720,8 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     ],
   };
 
-  assert.deepEqual(buildMiniPlanFallbackReturnCue(fallback, comparison), {
+  const returnCue = buildMiniPlanFallbackReturnCue(fallback, comparison);
+  assert.deepEqual(returnCue, {
     empty: false,
     decision: 'return-initial',
     condition: 'revenir quand la réponse rivale se dissipe',
@@ -710,6 +729,14 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     reason: 'revenir à la branche initiale si son risque retombe au niveau medium',
     initialBranchId: 'initial',
     fallbackBranchId: 'fallback',
+  });
+  assert.deepEqual(buildMiniPlanReturnProtectionStatus(returnCue, fallback, comparison), {
+    empty: false,
+    state: 'partial',
+    label: 'protection partielle',
+    constraint: 'agitation locale avant liaison',
+    nextDecision: 'wait-signal',
+    reason: 'attendre un signal: revenir quand la réponse rivale se dissipe',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -719,6 +746,44 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     reason: null,
     initialBranchId: null,
     fallbackBranchId: null,
+  });
+});
+
+test('StrategicMapShell reports whether returning keeps rival-response protection', () => {
+  const fallback = {
+    empty: false,
+    fallbackBranchId: 'fallback',
+    cost: 'délai avant branche initiale',
+  };
+  const returnCue = {
+    empty: false,
+    initialBranchId: 'initial',
+    fallbackBranchId: 'fallback',
+    condition: 'revenir quand le délai rival est absorbé',
+  };
+  const comparison = {
+    empty: false,
+    branches: [
+      { branchId: 'initial', rivalResponse: 'coupure du convoi partagé', riskLevel: 'low' },
+      { branchId: 'fallback', rivalResponse: 'veille adverse', riskLevel: 'medium' },
+    ],
+  };
+
+  assert.deepEqual(buildMiniPlanReturnProtectionStatus(returnCue, fallback, comparison), {
+    empty: false,
+    state: 'kept',
+    label: 'protection conservée',
+    constraint: 'coupure du convoi partagé',
+    nextDecision: 'return-now',
+    reason: 'revenir maintenant: le risque initial ne dépasse plus le fallback',
+  });
+  assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
+    empty: true,
+    state: 'none',
+    label: 'protection non évaluée',
+    constraint: null,
+    nextDecision: null,
+    reason: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -69,6 +69,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanRivalResponseComparison\(/);
   assert.match(webAppSource, /buildMiniPlanRivalResponseFallback\(/);
   assert.match(webAppSource, /buildMiniPlanFallbackReturnCue\(/);
+  assert.match(webAppSource, /buildMiniPlanReturnProtectionStatus\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -107,10 +108,12 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanRivalResponseComparison: buildMiniPlanRivalResponseComparison\(null, \[\]\)/);
   assert.match(webAppSource, /miniPlanRivalResponseFallback: buildMiniPlanRivalResponseFallback\(buildMiniPlanRivalResponseComparison\(null, \[\]\)\)/);
   assert.match(webAppSource, /miniPlanFallbackReturnCue: buildMiniPlanFallbackReturnCue\(/);
+  assert.match(webAppSource, /miniPlanReturnProtectionStatus: buildMiniPlanReturnProtectionStatus\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
   assert.match(webAppSource, /retour: aucun arbitrage/);
+  assert.match(webAppSource, /protection retour: non évaluée/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -122,6 +125,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__rival-branch-comparison/);
   assert.match(webAppSource, /atlas-military-fallback-order__rival-response-fallback/);
   assert.match(webAppSource, /atlas-military-fallback-order__fallback-return-cue/);
+  assert.match(webAppSource, /atlas-military-fallback-order__return-protection/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -133,6 +137,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /branches: \$\{rivalComparison\.branches\.map\(\(branch\) => `\$\{branch\.recommended \? '★' : '○'\} \$\{branch\.action\} → \$\{branch\.rivalResponse\} \(\$\{branch\.riskLevel\}\)`\)\.join\(' · '\)\}\$\{rivalComparison\.recommendationChanged \? ' · reco change' : ' · reco stable'\}/);
   assert.match(webAppSource, /fallback: \$\{rivalFallback\.action\} @ \$\{rivalFallback\.targetId \?\? 'front'\} · \$\{rivalFallback\.reason\} · coût \$\{rivalFallback\.cost\}/);
   assert.match(webAppSource, /\$\{fallbackReturnCue\.decision === 'keep-fallback' \? 'garder fallback' : 'retour initial'\}: \$\{fallbackReturnCue\.condition\} · coût \$\{fallbackReturnCue\.switchCost\}/);
+  assert.match(webAppSource, /\$\{returnProtection\.label\}: \$\{returnProtection\.constraint\} · \$\{returnProtection\.nextDecision\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -154,4 +159,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__rival-branch-comparison/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__rival-response-fallback/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__fallback-return-cue/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__return-protection/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -12,6 +12,7 @@ import {
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
   buildMiniPlanFallbackReturnCue,
+  buildMiniPlanReturnProtectionStatus,
   buildMiniPlanRivalResponseRisk,
   buildMiniPlanTradeoffActionPreview,
   buildStrategicMapShell,
@@ -1968,6 +1969,14 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
         buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
         buildMiniPlanRivalResponseComparison(null, []),
       ),
+      miniPlanReturnProtectionStatus: buildMiniPlanReturnProtectionStatus(
+        buildMiniPlanFallbackReturnCue(
+          buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+          buildMiniPlanRivalResponseComparison(null, []),
+        ),
+        buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+        buildMiniPlanRivalResponseComparison(null, []),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2008,6 +2017,11 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanRivalResponseFallback,
     miniPlanRivalResponseComparison,
   );
+  const miniPlanReturnProtectionStatus = buildMiniPlanReturnProtectionStatus(
+    miniPlanFallbackReturnCue,
+    miniPlanRivalResponseFallback,
+    miniPlanRivalResponseComparison,
+  );
 
   return {
     fallback: {
@@ -2030,6 +2044,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanRivalResponseComparison,
       miniPlanRivalResponseFallback,
       miniPlanFallbackReturnCue,
+      miniPlanReturnProtectionStatus,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2047,7 +2062,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanRivalResponseComparison,
     miniPlanRivalResponseFallback,
     miniPlanFallbackReturnCue,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}).`,
+    miniPlanReturnProtectionStatus,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}).`,
     empty: false,
   };
 }
@@ -2102,9 +2118,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const fallbackReturnLabel = fallbackReturnCue && !fallbackReturnCue.empty
     ? `${fallbackReturnCue.decision === 'keep-fallback' ? 'garder fallback' : 'retour initial'}: ${fallbackReturnCue.condition} · coût ${fallbackReturnCue.switchCost}`
     : 'retour: aucun arbitrage';
+  const returnProtection = fallback.miniPlanReturnProtectionStatus;
+  const returnProtectionLabel = returnProtection && !returnProtection.empty
+    ? `${returnProtection.label}: ${returnProtection.constraint} · ${returnProtection.nextDecision}`
+    : 'protection retour: non évaluée';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="21.6" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="22.8" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2123,6 +2143,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__rival-branch-comparison" x="23.2" y="75.6">${rivalComparisonLabel}</text>
       <text class="atlas-military-fallback-order__rival-response-fallback" x="23.2" y="76.7">${rivalFallbackLabel}</text>
       <text class="atlas-military-fallback-order__fallback-return-cue" x="23.2" y="77.8">${fallbackReturnLabel}</text>
+      <text class="atlas-military-fallback-order__return-protection atlas-military-fallback-order__return-protection--${returnProtection?.state ?? 'none'}" x="23.2" y="78.9">${returnProtectionLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11169,6 +11169,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__rival-branch-comparison { fill: #c4b5fd; font-size: 0.42px; font-weight: 900; }
 .atlas-military-fallback-order__rival-response-fallback { fill: #bae6fd; font-size: 0.41px; font-weight: 900; }
 .atlas-military-fallback-order__fallback-return-cue { fill: #fde68a; font-size: 0.4px; font-weight: 900; }
+.atlas-military-fallback-order__return-protection { fill: #a7f3d0; font-size: 0.4px; font-weight: 900; }
+.atlas-military-fallback-order__return-protection--partial { fill: #fde68a; }
+.atlas-military-fallback-order__return-protection--lost { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1039.

Summary:
- adds structured `miniPlanReturnProtectionStatus` from existing comparison/fallback/return cue data
- reports whether returning keeps, partially keeps, or loses rival-response protection
- names the rival constraint and recommends the next safe micro-decision
- renders a compact protection line near the fallback return cue without duplicating branch comparison

Tests:
- npm test

Zeta: ready for validation before merge.