### PR TITLE
Epsilon: recommend safest climate follow-through

### DIFF
--- a/test/ui/climate/webAtlasSafestClimateFollowThroughAfterDeadlineTradeoff.test.js
+++ b/test/ui/climate/webAtlasSafestClimateFollowThroughAfterDeadlineTradeoff.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas recommends safest climate follow-through after restored-window deadline tradeoff', () => {
+  assert.match(webAppSource, /function buildSafestClimateFollowThroughAfterDeadlineTradeoff/);
+  assert.match(webAppSource, /safestClimateFollowThroughAfterDeadlineTradeoff: null/);
+  assert.match(webAppSource, /safestClimateFollowThroughAfterDeadlineTradeoff,/);
+
+  for (const stableKey of [
+    'state',
+    'action',
+    'dominantConstraint',
+    'sourceTradeoff',
+    'windowState',
+    'reason',
+    'summary',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /follow-through critique/);
+  assert.match(webAppSource, /follow-through modéré/);
+  assert.match(webAppSource, /follow-through absent/);
+  assert.match(webAppSource, /payer encore/);
+  assert.match(webAppSource, /verrouiller la fenêtre/);
+  assert.match(webAppSource, /accepter un risque court/);
+  assert.match(webAppSource, /déplacer la décision/);
+  assert.match(webAppSource, /attendre/);
+  assert.match(webAppSource, /dette secondaire/);
+  assert.match(webAppSource, /saison/);
+  assert.match(webAppSource, /cascade/);
+  assert.match(webAppSource, /pression régionale/);
+  assert.match(webAppSource, /conflit de timing/);
+  assert.match(webAppSource, /Follow-through sûr/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9584,6 +9584,47 @@ function buildRestoredClimateDeadlineTradeoffWarning(followUpClimateWindowChange
   };
 }
 
+function buildSafestClimateFollowThroughAfterDeadlineTradeoff(restoredClimateDeadlineTradeoffWarning, followUpClimateWindowChangeSummary) {
+  if (!restoredClimateDeadlineTradeoffWarning) {
+    return null;
+  }
+
+  const constraintText = `${restoredClimateDeadlineTradeoffWarning.remainingConstraint ?? ''} ${restoredClimateDeadlineTradeoffWarning.summary ?? ''}`.toLowerCase();
+  const dominantConstraint = constraintText.includes('cascade')
+    ? 'cascade'
+    : constraintText.includes('conflit') || constraintText.includes('timing')
+      ? 'conflit de timing'
+      : constraintText.includes('saison')
+        ? 'saison'
+        : constraintText.includes('pression régionale') || constraintText.includes('deadline')
+          ? 'pression régionale'
+          : 'dette secondaire';
+  const actionByTradeoff = {
+    'tradeoff critique': 'payer encore',
+    'tradeoff modéré': dominantConstraint === 'conflit de timing' ? 'déplacer la décision' : 'accepter un risque court',
+    'aucun tradeoff restant': 'attendre',
+  };
+  const action = actionByTradeoff[restoredClimateDeadlineTradeoffWarning.state] ?? 'verrouiller la fenêtre';
+  const label = restoredClimateDeadlineTradeoffWarning.state === 'tradeoff critique'
+    ? 'follow-through critique'
+    : restoredClimateDeadlineTradeoffWarning.state === 'tradeoff modéré'
+      ? 'follow-through modéré'
+      : 'follow-through absent';
+  const reason = restoredClimateDeadlineTradeoffWarning.state === 'aucun tradeoff restant'
+    ? 'aucune suite immédiate nécessaire: la fenêtre restaurée ne laisse pas de deadline concurrente visible'
+    : `${action} limite ${dominantConstraint} sans rouvrir le détail du payoff climat.`;
+
+  return {
+    state: label,
+    action,
+    dominantConstraint,
+    sourceTradeoff: restoredClimateDeadlineTradeoffWarning.state,
+    windowState: followUpClimateWindowChangeSummary?.state ?? null,
+    reason,
+    summary: `${label}: ${action}; contrainte dominante ${dominantConstraint}.`,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -9636,6 +9677,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       followUpClimatePayoffRecommendation: null,
       followUpClimateWindowChangeSummary: null,
       restoredClimateDeadlineTradeoffWarning: null,
+      safestClimateFollowThroughAfterDeadlineTradeoff: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -9707,6 +9749,10 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     remainingDeadlinePressure,
     decisionWindow,
   );
+  const safestClimateFollowThroughAfterDeadlineTradeoff = buildSafestClimateFollowThroughAfterDeadlineTradeoff(
+    restoredClimateDeadlineTradeoffWarning,
+    followUpClimateWindowChangeSummary,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -9722,6 +9768,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     followUpClimatePayoffRecommendation,
     followUpClimateWindowChangeSummary,
     restoredClimateDeadlineTradeoffWarning,
+    safestClimateFollowThroughAfterDeadlineTradeoff,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -9758,6 +9805,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.followUpClimatePayoffRecommendation ? `<small><b>Paiement de suivi</b> · ${view.followUpClimatePayoffRecommendation.summary} ${view.followUpClimatePayoffRecommendation.reason} Prochaine action: ${view.followUpClimatePayoffRecommendation.nextAction}</small>` : ''}
       ${view.followUpClimateWindowChangeSummary ? `<small><b>Fenêtre après suivi</b> · ${view.followUpClimateWindowChangeSummary.summary} ${view.followUpClimateWindowChangeSummary.oneSentence}</small>` : ''}
       ${view.restoredClimateDeadlineTradeoffWarning ? `<small><b>Alerte tradeoff deadline</b> · ${view.restoredClimateDeadlineTradeoffWarning.summary}</small>` : ''}
+      ${view.safestClimateFollowThroughAfterDeadlineTradeoff ? `<small><b>Follow-through sûr</b> · ${view.safestClimateFollowThroughAfterDeadlineTradeoff.summary} ${view.safestClimateFollowThroughAfterDeadlineTradeoff.reason}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1053.

## Résumé
- ajoute une recommandation de follow-through après tradeoff deadline sur fenêtre restaurée
- distingue les suites critique, modérée et absente avec action courte
- nomme la contrainte dominante sans dupliquer le détail payoff/rebond existant

## Tests
- `npm test`
