### PR TITLE
Gamma: show residual payoff follow-up window

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -905,6 +905,62 @@ export function buildResidualCultureActionPayoff(residualRiskAfterNextRetirement
   };
 }
 
+function buildResidualCultureWindowConstraint(residualCultureRiskNextAction, remainingFragility) {
+  if (!remainingFragility) {
+    return 'aucune contrainte résiduelle';
+  }
+
+  if (residualCultureRiskNextAction.actionType === 'local-support' || remainingFragility.type === 'missing-support') {
+    return 'support local';
+  }
+
+  if (residualCultureRiskNextAction.actionType === 'mediation' || remainingFragility.type === 'regional-mediation') {
+    return 'médiation';
+  }
+
+  if (residualCultureRiskNextAction.actionType === 'timing-pause' || remainingFragility.type === 'bundle-incompatibility') {
+    return 'timing';
+  }
+
+  if (residualCultureRiskNextAction.actionType === 'culture-lock' || remainingFragility.type === 'bundle-dependency') {
+    return 'dépendance restante';
+  }
+
+  return 'pression';
+}
+
+export function buildResidualCultureFollowUpWindow(residualCultureActionPayoff, residualCultureRiskNextAction) {
+  const limitingConstraint = buildResidualCultureWindowConstraint(
+    residualCultureRiskNextAction,
+    residualCultureActionPayoff.remainingFragility,
+  );
+
+  if (residualCultureActionPayoff.status === 'complete') {
+    return {
+      status: 'stable',
+      limitingConstraint,
+      windowSummary: 'fenêtre stable: le payoff permet d’enchaîner sans nouvelle dette visible',
+      nextDecision: 'enchaîner le suivi culturel léger au prochain tour',
+    };
+  }
+
+  if (residualCultureActionPayoff.status === 'partial') {
+    return {
+      status: 'fragile-exploitable',
+      limitingConstraint,
+      windowSummary: `fenêtre fragile mais exploitable: ${limitingConstraint} limite encore le suivi`,
+      nextDecision: residualCultureActionPayoff.nextDecision,
+    };
+  }
+
+  return {
+    status: 'too-short',
+    limitingConstraint,
+    windowSummary: `fenêtre trop courte: ${limitingConstraint} bloque un enchaînement sûr`,
+    nextDecision: null,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -961,6 +1017,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const nextDependencyRetirementPath = buildNextDependencyRetirementPath(dependencyRetirementRanking, topRetirementReadiness, topRetirementRecoveryPreview);
   const residualRiskAfterNextRetirement = buildResidualRiskAfterNextRetirement(dependencyRetirementRanking, nextDependencyRetirementPath, postBundleCumulativeRisk);
   const residualCultureRiskNextAction = buildResidualCultureRiskNextAction(residualRiskAfterNextRetirement);
+  const residualCultureActionPayoff = buildResidualCultureActionPayoff(residualRiskAfterNextRetirement, residualCultureRiskNextAction);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -973,7 +1030,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     nextDependencyRetirementPath,
     residualRiskAfterNextRetirement,
     residualCultureRiskNextAction,
-    residualCultureActionPayoff: buildResidualCultureActionPayoff(residualRiskAfterNextRetirement, residualCultureRiskNextAction),
+    residualCultureActionPayoff,
+    residualCultureFollowUpWindow: buildResidualCultureFollowUpWindow(residualCultureActionPayoff, residualCultureRiskNextAction),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { Culture } from '../../../src/domain/culture/Culture.js';
 import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
-import { buildCultureMapOverlay, buildResidualCultureActionPayoff } from '../../../src/ui/culture/buildCultureMapOverlay.js';
+import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
 function withoutSupportRiskPreviews(value) {
   if (Array.isArray(value)) {
@@ -935,6 +935,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         },
         nextDecision: 'réévaluer la médiation ou le support local au prochain tour',
       },
+      residualCultureFollowUpWindow: {
+        status: 'fragile-exploitable',
+        limitingConstraint: 'médiation',
+        windowSummary: 'fenêtre fragile mais exploitable: médiation limite encore le suivi',
+        nextDecision: 'réévaluer la médiation ou le support local au prochain tour',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -1023,6 +1029,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         expectedEffect: 'stabilisation complète: aucune fragilité résiduelle à traiter',
         remainingFragility: null,
         nextDecision: null,
+      },
+      residualCultureFollowUpWindow: {
+        status: 'stable',
+        limitingConstraint: 'aucune contrainte résiduelle',
+        windowSummary: 'fenêtre stable: le payoff permet d’enchaîner sans nouvelle dette visible',
+        nextDecision: 'enchaîner le suivi culturel léger au prochain tour',
       },
     },
     summary: 'stabilisation complète: aucun second soutien requis',
@@ -1229,6 +1241,70 @@ test('buildResidualCultureActionPayoff covers complete, partial, and insufficien
         urgency: 'high',
       },
       nextDecision: 'choisir entre support local immédiat ou pause de timing prolongée',
+    },
+  );
+});
+
+test('buildResidualCultureFollowUpWindow covers stable, fragile exploitable, and too-short windows', () => {
+  assert.deepEqual(
+    buildResidualCultureFollowUpWindow(
+      {
+        status: 'complete',
+        expectedEffect: 'stabilisation complète: aucune fragilité résiduelle à traiter',
+        remainingFragility: null,
+        nextDecision: null,
+      },
+      { status: 'none-safe', actionType: 'none' },
+    ),
+    {
+      status: 'stable',
+      limitingConstraint: 'aucune contrainte résiduelle',
+      windowSummary: 'fenêtre stable: le payoff permet d’enchaîner sans nouvelle dette visible',
+      nextDecision: 'enchaîner le suivi culturel léger au prochain tour',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureFollowUpWindow(
+      {
+        status: 'partial',
+        expectedEffect: 'réduction partielle attendue: risque restant: isolement du support',
+        remainingFragility: {
+          type: 'regional-mediation',
+          cause: 'risque restant: isolement du support',
+          urgency: 'medium',
+        },
+        nextDecision: 'réévaluer la médiation ou le support local au prochain tour',
+      },
+      { status: 'optional', actionType: 'mediation' },
+    ),
+    {
+      status: 'fragile-exploitable',
+      limitingConstraint: 'médiation',
+      windowSummary: 'fenêtre fragile mais exploitable: médiation limite encore le suivi',
+      nextDecision: 'réévaluer la médiation ou le support local au prochain tour',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureFollowUpWindow(
+      {
+        status: 'insufficient',
+        expectedEffect: 'achat de temps: aucun second soutien sûr disponible après le premier bundle reste trop urgente',
+        remainingFragility: {
+          type: 'missing-support',
+          cause: 'aucun second soutien sûr disponible après le premier bundle',
+          urgency: 'high',
+        },
+        nextDecision: 'choisir entre support local immédiat ou pause de timing prolongée',
+      },
+      { status: 'recommended', actionType: 'local-support' },
+    ),
+    {
+      status: 'too-short',
+      limitingConstraint: 'support local',
+      windowSummary: 'fenêtre trop courte: support local bloque un enchaînement sûr',
+      nextDecision: null,
     },
   );
 });


### PR DESCRIPTION
Gamma: ## Summary

Shows whether the residual culture action payoff opens a stable follow-up window.

## Changes

- Adds `residualCultureFollowUpWindow` next to the residual payoff summary.
- Classifies the follow-up window as stable, fragile-but-exploitable, or too short.
- Names the limiting constraint (support local, mediation, pressure, timing, dependency, or none).
- Provides a compact next decision only when the window is exploitable.
- Reuses the G31/G32/G33 residual risk, next action, and payoff instead of recalculating the culture plan.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1051