### PR TITLE
Alpha: show fallback confidence signal

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -761,6 +761,45 @@ export function buildMiniPlanReturnProtectionStatus(
   };
 }
 
+export function buildMiniPlanConfidenceSignalCue(
+  miniPlanReturnProtectionStatus = null,
+  miniPlanFallbackReturnCue = null,
+  miniPlanRivalResponseFallback = null,
+) {
+  if (!miniPlanReturnProtectionStatus || miniPlanReturnProtectionStatus.empty) {
+    return {
+      empty: true,
+      decision: 'none',
+      label: 'confiance non évaluée',
+      signal: null,
+      waitCost: null,
+    };
+  }
+
+  const decision = miniPlanReturnProtectionStatus.nextDecision === 'return-now'
+    ? 'return-confirmed'
+    : miniPlanReturnProtectionStatus.nextDecision === 'confirm-fallback'
+      ? 'hold-fallback'
+      : 'wait-confidence';
+  const signal = decision === 'return-confirmed'
+    ? 'risque initial revenu sous le fallback'
+    : decision === 'hold-fallback'
+      ? `${miniPlanReturnProtectionStatus.constraint} encore actif`
+      : miniPlanFallbackReturnCue?.condition ?? `signal sur ${miniPlanReturnProtectionStatus.constraint}`;
+
+  return {
+    empty: false,
+    decision,
+    label: decision === 'return-confirmed'
+      ? 'retour confirmé'
+      : decision === 'hold-fallback'
+        ? 'tenir fallback'
+        : 'attendre signal confiance',
+    signal,
+    waitCost: `attendre trop longtemps coûte ${miniPlanRivalResponseFallback?.cost ?? 'un tempo de coordination'}`,
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -855,6 +894,11 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanRivalResponseFallback,
     miniPlanRivalResponseComparison,
   );
+  const miniPlanConfidenceSignalCue = buildMiniPlanConfidenceSignalCue(
+    miniPlanReturnProtectionStatus,
+    miniPlanFallbackReturnCue,
+    miniPlanRivalResponseFallback,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -906,6 +950,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanRivalResponseFallback,
     miniPlanFallbackReturnCue,
     miniPlanReturnProtectionStatus,
+    miniPlanConfidenceSignalCue,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -7,6 +7,7 @@ import {
   buildFollowUpCleanupChoices,
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
+  buildMiniPlanConfidenceSignalCue,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -342,6 +343,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     constraint: null,
     nextDecision: null,
     reason: null,
+  });
+  assert.deepEqual(shell.miniPlanConfidenceSignalCue, {
+    empty: true,
+    decision: 'none',
+    label: 'confiance non évaluée',
+    signal: null,
+    waitCost: null,
   });
 });
 
@@ -682,13 +690,21 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     initialBranchId: 'mini-plan-branch:1:mini-plan-tradeoff:neighbor-front:front-b',
     fallbackBranchId: 'mini-plan-branch:2:mini-plan-tradeoff:low-loyalty:front-a',
   });
-  assert.deepEqual(buildMiniPlanReturnProtectionStatus(returnCue, fallback, comparison), {
+  const protection = buildMiniPlanReturnProtectionStatus(returnCue, fallback, comparison);
+  assert.deepEqual(protection, {
     empty: false,
     state: 'lost',
     label: 'protection perdue',
     constraint: 'contre-poussée du front voisin',
     nextDecision: 'confirm-fallback',
     reason: 'confirmer le fallback: contre-poussée du front voisin reste plus dangereux',
+  });
+  assert.deepEqual(buildMiniPlanConfidenceSignalCue(protection, returnCue, fallback), {
+    empty: false,
+    decision: 'hold-fallback',
+    label: 'tenir fallback',
+    signal: 'contre-poussée du front voisin encore actif',
+    waitCost: 'attendre trop longtemps coûte cible moins prioritaire: front-a',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -730,13 +746,21 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     initialBranchId: 'initial',
     fallbackBranchId: 'fallback',
   });
-  assert.deepEqual(buildMiniPlanReturnProtectionStatus(returnCue, fallback, comparison), {
+  const protection = buildMiniPlanReturnProtectionStatus(returnCue, fallback, comparison);
+  assert.deepEqual(protection, {
     empty: false,
     state: 'partial',
     label: 'protection partielle',
     constraint: 'agitation locale avant liaison',
     nextDecision: 'wait-signal',
     reason: 'attendre un signal: revenir quand la réponse rivale se dissipe',
+  });
+  assert.deepEqual(buildMiniPlanConfidenceSignalCue(protection, returnCue, fallback), {
+    empty: false,
+    decision: 'wait-confidence',
+    label: 'attendre signal confiance',
+    signal: 'revenir quand la réponse rivale se dissipe',
+    waitCost: 'attendre trop longtemps coûte bénéfice moindre mais risque équivalent',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -769,13 +793,21 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     ],
   };
 
-  assert.deepEqual(buildMiniPlanReturnProtectionStatus(returnCue, fallback, comparison), {
+  const protection = buildMiniPlanReturnProtectionStatus(returnCue, fallback, comparison);
+  assert.deepEqual(protection, {
     empty: false,
     state: 'kept',
     label: 'protection conservée',
     constraint: 'coupure du convoi partagé',
     nextDecision: 'return-now',
     reason: 'revenir maintenant: le risque initial ne dépasse plus le fallback',
+  });
+  assert.deepEqual(buildMiniPlanConfidenceSignalCue(protection, returnCue, fallback), {
+    empty: false,
+    decision: 'return-confirmed',
+    label: 'retour confirmé',
+    signal: 'risque initial revenu sous le fallback',
+    waitCost: 'attendre trop longtemps coûte délai avant branche initiale',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -784,6 +816,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     constraint: null,
     nextDecision: null,
     reason: null,
+  });
+  assert.deepEqual(buildMiniPlanConfidenceSignalCue(null, returnCue, fallback), {
+    empty: true,
+    decision: 'none',
+    label: 'confiance non évaluée',
+    signal: null,
+    waitCost: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -70,6 +70,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanRivalResponseFallback\(/);
   assert.match(webAppSource, /buildMiniPlanFallbackReturnCue\(/);
   assert.match(webAppSource, /buildMiniPlanReturnProtectionStatus\(/);
+  assert.match(webAppSource, /buildMiniPlanConfidenceSignalCue\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -109,11 +110,13 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanRivalResponseFallback: buildMiniPlanRivalResponseFallback\(buildMiniPlanRivalResponseComparison\(null, \[\]\)\)/);
   assert.match(webAppSource, /miniPlanFallbackReturnCue: buildMiniPlanFallbackReturnCue\(/);
   assert.match(webAppSource, /miniPlanReturnProtectionStatus: buildMiniPlanReturnProtectionStatus\(/);
+  assert.match(webAppSource, /miniPlanConfidenceSignalCue: buildMiniPlanConfidenceSignalCue\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
   assert.match(webAppSource, /retour: aucun arbitrage/);
   assert.match(webAppSource, /protection retour: non évaluée/);
+  assert.match(webAppSource, /confiance: non évaluée/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -126,6 +129,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__rival-response-fallback/);
   assert.match(webAppSource, /atlas-military-fallback-order__fallback-return-cue/);
   assert.match(webAppSource, /atlas-military-fallback-order__return-protection/);
+  assert.match(webAppSource, /atlas-military-fallback-order__confidence-signal/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -138,6 +142,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /fallback: \$\{rivalFallback\.action\} @ \$\{rivalFallback\.targetId \?\? 'front'\} · \$\{rivalFallback\.reason\} · coût \$\{rivalFallback\.cost\}/);
   assert.match(webAppSource, /\$\{fallbackReturnCue\.decision === 'keep-fallback' \? 'garder fallback' : 'retour initial'\}: \$\{fallbackReturnCue\.condition\} · coût \$\{fallbackReturnCue\.switchCost\}/);
   assert.match(webAppSource, /\$\{returnProtection\.label\}: \$\{returnProtection\.constraint\} · \$\{returnProtection\.nextDecision\}/);
+  assert.match(webAppSource, /\$\{confidenceSignal\.label\}: \$\{confidenceSignal\.signal\} · \$\{confidenceSignal\.waitCost\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -160,4 +165,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__rival-response-fallback/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__fallback-return-cue/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__return-protection/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__confidence-signal/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -8,6 +8,7 @@ import {
   buildFollowUpCleanupChoices,
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
+  buildMiniPlanConfidenceSignalCue,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -1977,6 +1978,21 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
         buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
         buildMiniPlanRivalResponseComparison(null, []),
       ),
+      miniPlanConfidenceSignalCue: buildMiniPlanConfidenceSignalCue(
+        buildMiniPlanReturnProtectionStatus(
+          buildMiniPlanFallbackReturnCue(
+            buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+            buildMiniPlanRivalResponseComparison(null, []),
+          ),
+          buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+          buildMiniPlanRivalResponseComparison(null, []),
+        ),
+        buildMiniPlanFallbackReturnCue(
+          buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+          buildMiniPlanRivalResponseComparison(null, []),
+        ),
+        buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2022,6 +2038,11 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanRivalResponseFallback,
     miniPlanRivalResponseComparison,
   );
+  const miniPlanConfidenceSignalCue = buildMiniPlanConfidenceSignalCue(
+    miniPlanReturnProtectionStatus,
+    miniPlanFallbackReturnCue,
+    miniPlanRivalResponseFallback,
+  );
 
   return {
     fallback: {
@@ -2045,6 +2066,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanRivalResponseFallback,
       miniPlanFallbackReturnCue,
       miniPlanReturnProtectionStatus,
+      miniPlanConfidenceSignalCue,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2063,7 +2085,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanRivalResponseFallback,
     miniPlanFallbackReturnCue,
     miniPlanReturnProtectionStatus,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}).`,
+    miniPlanConfidenceSignalCue,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}).`,
     empty: false,
   };
 }
@@ -2122,9 +2145,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const returnProtectionLabel = returnProtection && !returnProtection.empty
     ? `${returnProtection.label}: ${returnProtection.constraint} · ${returnProtection.nextDecision}`
     : 'protection retour: non évaluée';
+  const confidenceSignal = fallback.miniPlanConfidenceSignalCue;
+  const confidenceSignalLabel = confidenceSignal && !confidenceSignal.empty
+    ? `${confidenceSignal.label}: ${confidenceSignal.signal} · ${confidenceSignal.waitCost}`
+    : 'confiance: non évaluée';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="22.8" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="24" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2144,6 +2171,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__rival-response-fallback" x="23.2" y="76.7">${rivalFallbackLabel}</text>
       <text class="atlas-military-fallback-order__fallback-return-cue" x="23.2" y="77.8">${fallbackReturnLabel}</text>
       <text class="atlas-military-fallback-order__return-protection atlas-military-fallback-order__return-protection--${returnProtection?.state ?? 'none'}" x="23.2" y="78.9">${returnProtectionLabel}</text>
+      <text class="atlas-military-fallback-order__confidence-signal atlas-military-fallback-order__confidence-signal--${confidenceSignal?.decision ?? 'none'}" x="23.2" y="80">${confidenceSignalLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11172,6 +11172,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__return-protection { fill: #a7f3d0; font-size: 0.4px; font-weight: 900; }
 .atlas-military-fallback-order__return-protection--partial { fill: #fde68a; }
 .atlas-military-fallback-order__return-protection--lost { fill: #fecaca; }
+.atlas-military-fallback-order__confidence-signal { fill: #ddd6fe; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__confidence-signal--hold-fallback { fill: #fecaca; }
+.atlas-military-fallback-order__confidence-signal--wait-confidence { fill: #fde68a; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1049.

Summary:
- adds structured `miniPlanConfidenceSignalCue` after the return protection status
- classifies the post-return decision as return confirmed, hold fallback, or wait for confidence
- names the fog-safe signal that would change the decision
- explains the cost of waiting too long without duplicating branch comparison/protection status

Tests:
- npm test

Zeta: ready for validation before merge.