### PR TITLE
Beta: compare corridor salvage confirm vs wait

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -387,6 +387,47 @@ function buildFlipActionability(flipScenario, opportunityCostComparison, capacit
   };
 }
 
+function buildPostSalvageDecisionComparison(postSalvageDecisionAlert, delayOpportunityCost) {
+  if (postSalvageDecisionAlert.status === 'no-additional-decision') {
+    return {
+      status: 'neutral',
+      confirmNow: 'continuer sans coût d’attente notable',
+      wait: 'temporiser reste acceptable tant que la marge nette reste positive',
+      recommendation: 'continue',
+      dominantConstraint: postSalvageDecisionAlert.mainConstraint,
+      waitTurnsDurableLoss: false,
+      summary: 'Neutre: aucun coût d’attente notable tant que la marge reste positive.',
+    };
+  }
+
+  const remainingCost = delayOpportunityCost.salvageAction?.remainingCost ?? delayOpportunityCost.cost;
+  const waitCost = delayOpportunityCost.cost + remainingCost;
+  const waitTurnsDurableLoss = postSalvageDecisionAlert.recommendation !== 'secure-minimal-investment';
+  const confirmNowByRecommendation = {
+    'abandon-sequence': 'abandonner ou inverser immédiatement pour éviter une perte durable',
+    'invert-durably': `confirmer l’inversion vers ${delayOpportunityCost.salvageAction?.alternativeOptionId ?? 'l’alternative'}`,
+    'secure-minimal-investment': 'confirmer le complément minimal avant nouvelle dépense',
+  };
+  const waitByRecommendation = {
+    'abandon-sequence': `attendre ajoute ${waitCost} coût et fige la perte durable`,
+    'invert-durably': `attendre ajoute ${waitCost} coût et rend l’alternative plus sûre durablement`,
+    'secure-minimal-investment': `attendre ajoute ${waitCost} coût avant de retrouver une marge`,
+  };
+
+  return {
+    status: waitTurnsDurableLoss ? 'wait-dangerous' : 'confirm-beneficial',
+    confirmNow: confirmNowByRecommendation[postSalvageDecisionAlert.recommendation],
+    wait: waitByRecommendation[postSalvageDecisionAlert.recommendation],
+    recommendation: postSalvageDecisionAlert.recommendation,
+    dominantConstraint: postSalvageDecisionAlert.mainConstraint,
+    waitCost,
+    waitTurnsDurableLoss,
+    summary: waitTurnsDurableLoss
+      ? `${confirmNowByRecommendation[postSalvageDecisionAlert.recommendation]}: temporiser transforme la décision en perte durable.`
+      : `${confirmNowByRecommendation[postSalvageDecisionAlert.recommendation]}: temporiser augmente seulement le coût de reprise.`,
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -590,6 +631,10 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     capacityCost,
   );
   const postSalvageDecisionAlert = buildPostSalvageDecisionAlert(delayOpportunityCost.salvageAction);
+  const postSalvageDecisionComparison = buildPostSalvageDecisionComparison(
+    postSalvageDecisionAlert,
+    delayOpportunityCost,
+  );
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -603,6 +648,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     actionableAdvice: actionability.advice,
     delayOpportunityCost,
     postSalvageDecisionAlert,
+    postSalvageDecisionComparison,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -544,6 +544,15 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         mainConstraint: null,
         summary: 'Aucune décision abandon/inversion requise: la séquence reste rentable après délai.',
       },
+      postSalvageDecisionComparison: {
+        status: 'neutral',
+        confirmNow: 'continuer sans coût d’attente notable',
+        wait: 'temporiser reste acceptable tant que la marge nette reste positive',
+        recommendation: 'continue',
+        dominantConstraint: null,
+        waitTurnsDurableLoss: false,
+        summary: 'Neutre: aucun coût d’attente notable tant que la marge reste positive.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -675,6 +684,15 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       mainConstraint: null,
       summary: 'Aucune décision abandon/inversion requise: la séquence reste rentable après délai.',
     },
+    postSalvageDecisionComparison: {
+      status: 'neutral',
+      confirmNow: 'continuer sans coût d’attente notable',
+      wait: 'temporiser reste acceptable tant que la marge nette reste positive',
+      recommendation: 'continue',
+      dominantConstraint: null,
+      waitTurnsDurableLoss: false,
+      summary: 'Neutre: aucun coût d’attente notable tant que la marge reste positive.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -755,6 +773,16 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     mainConstraint: 'alternative-plus-sure',
     summary: 'Abandonner la séquence: alternative-plus-sure garde le coût restant trop élevé.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.postSalvageDecisionComparison, {
+    status: 'wait-dangerous',
+    confirmNow: 'abandonner ou inverser immédiatement pour éviter une perte durable',
+    wait: 'attendre ajoute 8 coût et fige la perte durable',
+    recommendation: 'abandon-sequence',
+    dominantConstraint: 'alternative-plus-sure',
+    waitCost: 8,
+    waitTurnsDurableLoss: true,
+    summary: 'abandonner ou inverser immédiatement pour éviter une perte durable: temporiser transforme la décision en perte durable.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -801,6 +829,16 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     recommendation: 'invert-durably',
     mainConstraint: 'alternative-plus-sure',
     summary: 'Inverser durablement: grain:reserve-buffer reste plus sûr malgré le salvage.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.postSalvageDecisionComparison, {
+    status: 'wait-dangerous',
+    confirmNow: 'confirmer l’inversion vers grain:reserve-buffer',
+    wait: 'attendre ajoute 5 coût et rend l’alternative plus sûre durablement',
+    recommendation: 'invert-durably',
+    dominantConstraint: 'alternative-plus-sure',
+    waitCost: 5,
+    waitTurnsDurableLoss: true,
+    summary: 'confirmer l’inversion vers grain:reserve-buffer: temporiser transforme la décision en perte durable.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a short post-salvage decision comparison so the corridor overlay can weigh confirming now against waiting after the B33 abandon/invert alert.

## Changes

- Add `postSalvageDecisionComparison` beside the B33 `postSalvageDecisionAlert`.
- Compare confirm-now vs wait paths for neutral, confirm-beneficial, and wait-dangerous cases.
- Tie the comparison to the remaining dominant constraint and flag durable-loss waiting.
- Extend economy overlay tests for neutral, dangerous abandon, and durable inversion outcomes.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (624/624 pass)

Fixes loo469/historia#1050