### PR TITLE
Gamma: warn on residual window closure

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -961,6 +961,75 @@ export function buildResidualCultureFollowUpWindow(residualCultureActionPayoff, 
   };
 }
 
+function buildResidualCultureClosureConstraint(limitingConstraint) {
+  if (limitingConstraint === 'support local') {
+    return 'support local';
+  }
+
+  if (limitingConstraint === 'médiation') {
+    return 'fatigue de médiation';
+  }
+
+  if (limitingConstraint === 'timing') {
+    return 'timing rituel';
+  }
+
+  if (limitingConstraint === 'dépendance restante') {
+    return 'dépendance restante';
+  }
+
+  if (limitingConstraint === 'pression') {
+    return 'pression externe';
+  }
+
+  return 'aucune contrainte visible';
+}
+
+export function buildResidualCultureWindowClosureThreat(residualCultureFollowUpWindow) {
+  const visibleConstraint = buildResidualCultureClosureConstraint(residualCultureFollowUpWindow.limitingConstraint);
+
+  if (residualCultureFollowUpWindow.status === 'stable') {
+    return {
+      status: 'none',
+      visibleConstraint,
+      threatSummary: 'aucune pression notable sur la fenêtre de suivi',
+      recommendedGesture: null,
+    };
+  }
+
+  if (residualCultureFollowUpWindow.status === 'fragile-exploitable') {
+    return {
+      status: 'manageable',
+      visibleConstraint,
+      threatSummary: `${visibleConstraint} peut refermer la fenêtre si le suivi tarde`,
+      recommendedGesture: visibleConstraint === 'fatigue de médiation'
+        ? 'borner la médiation avant le prochain suivi'
+        : visibleConstraint === 'timing rituel'
+          ? 'caler le suivi sur un rythme rituel court'
+          : visibleConstraint === 'dépendance restante'
+            ? 'nommer la dépendance à lever avant enchaînement'
+            : visibleConstraint === 'support local'
+              ? 'préparer un relais local minimal'
+              : 'réduire la pression visible avant d’enchaîner',
+    };
+  }
+
+  return {
+    status: 'likely-close',
+    visibleConstraint,
+    threatSummary: `${visibleConstraint} refermera probablement la fenêtre avant un suivi sûr`,
+    recommendedGesture: visibleConstraint === 'support local'
+      ? 'sécuriser un support local avant tout suivi'
+      : visibleConstraint === 'fatigue de médiation'
+        ? 'reporter le suivi et réduire la fatigue de médiation'
+        : visibleConstraint === 'timing rituel'
+          ? 'attendre une meilleure fenêtre rituelle'
+          : visibleConstraint === 'dépendance restante'
+            ? 'lever la dépendance restante avant de rouvrir la fenêtre'
+            : 'réduire la pression externe avant de rouvrir la fenêtre',
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -1018,6 +1087,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const residualRiskAfterNextRetirement = buildResidualRiskAfterNextRetirement(dependencyRetirementRanking, nextDependencyRetirementPath, postBundleCumulativeRisk);
   const residualCultureRiskNextAction = buildResidualCultureRiskNextAction(residualRiskAfterNextRetirement);
   const residualCultureActionPayoff = buildResidualCultureActionPayoff(residualRiskAfterNextRetirement, residualCultureRiskNextAction);
+  const residualCultureFollowUpWindow = buildResidualCultureFollowUpWindow(residualCultureActionPayoff, residualCultureRiskNextAction);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -1031,7 +1101,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     residualRiskAfterNextRetirement,
     residualCultureRiskNextAction,
     residualCultureActionPayoff,
-    residualCultureFollowUpWindow: buildResidualCultureFollowUpWindow(residualCultureActionPayoff, residualCultureRiskNextAction),
+    residualCultureFollowUpWindow,
+    residualCultureWindowClosureThreat: buildResidualCultureWindowClosureThreat(residualCultureFollowUpWindow),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { Culture } from '../../../src/domain/culture/Culture.js';
 import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
-import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow } from '../../../src/ui/culture/buildCultureMapOverlay.js';
+import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
 function withoutSupportRiskPreviews(value) {
   if (Array.isArray(value)) {
@@ -941,6 +941,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         windowSummary: 'fenêtre fragile mais exploitable: médiation limite encore le suivi',
         nextDecision: 'réévaluer la médiation ou le support local au prochain tour',
       },
+      residualCultureWindowClosureThreat: {
+        status: 'manageable',
+        visibleConstraint: 'fatigue de médiation',
+        threatSummary: 'fatigue de médiation peut refermer la fenêtre si le suivi tarde',
+        recommendedGesture: 'borner la médiation avant le prochain suivi',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -1035,6 +1041,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         limitingConstraint: 'aucune contrainte résiduelle',
         windowSummary: 'fenêtre stable: le payoff permet d’enchaîner sans nouvelle dette visible',
         nextDecision: 'enchaîner le suivi culturel léger au prochain tour',
+      },
+      residualCultureWindowClosureThreat: {
+        status: 'none',
+        visibleConstraint: 'aucune contrainte visible',
+        threatSummary: 'aucune pression notable sur la fenêtre de suivi',
+        recommendedGesture: null,
       },
     },
     summary: 'stabilisation complète: aucun second soutien requis',
@@ -1305,6 +1317,53 @@ test('buildResidualCultureFollowUpWindow covers stable, fragile exploitable, and
       limitingConstraint: 'support local',
       windowSummary: 'fenêtre trop courte: support local bloque un enchaînement sûr',
       nextDecision: null,
+    },
+  );
+});
+
+test('buildResidualCultureWindowClosureThreat covers absent, manageable, and likely closure pressure', () => {
+  assert.deepEqual(
+    buildResidualCultureWindowClosureThreat({
+      status: 'stable',
+      limitingConstraint: 'aucune contrainte résiduelle',
+      windowSummary: 'fenêtre stable: le payoff permet d’enchaîner sans nouvelle dette visible',
+      nextDecision: 'enchaîner le suivi culturel léger au prochain tour',
+    }),
+    {
+      status: 'none',
+      visibleConstraint: 'aucune contrainte visible',
+      threatSummary: 'aucune pression notable sur la fenêtre de suivi',
+      recommendedGesture: null,
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureWindowClosureThreat({
+      status: 'fragile-exploitable',
+      limitingConstraint: 'médiation',
+      windowSummary: 'fenêtre fragile mais exploitable: médiation limite encore le suivi',
+      nextDecision: 'réévaluer la médiation ou le support local au prochain tour',
+    }),
+    {
+      status: 'manageable',
+      visibleConstraint: 'fatigue de médiation',
+      threatSummary: 'fatigue de médiation peut refermer la fenêtre si le suivi tarde',
+      recommendedGesture: 'borner la médiation avant le prochain suivi',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureWindowClosureThreat({
+      status: 'too-short',
+      limitingConstraint: 'support local',
+      windowSummary: 'fenêtre trop courte: support local bloque un enchaînement sûr',
+      nextDecision: null,
+    }),
+    {
+      status: 'likely-close',
+      visibleConstraint: 'support local',
+      threatSummary: 'support local refermera probablement la fenêtre avant un suivi sûr',
+      recommendedGesture: 'sécuriser un support local avant tout suivi',
     },
   );
 });


### PR DESCRIPTION
Gamma: ## Summary

Warns what social cost could close the residual culture follow-up window.

## Changes

- Adds `residualCultureWindowClosureThreat` near the follow-up window summary.
- Classifies closure pressure as none, manageable, or likely to close.
- Names the visible constraint: local support, mediation fatigue, external pressure, ritual timing, dependency, or none.
- Recommends a compact gesture only when pressure is manageable or critical.
- Reuses the G34 follow-up window instead of duplicating the payoff/window classifications.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1061