### PR TITLE
Epsilon: compare climate window security reserve

### DIFF
--- a/test/ui/climate/webAtlasClimateSecureWindowVsReserveComparison.test.js
+++ b/test/ui/climate/webAtlasClimateSecureWindowVsReserveComparison.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas compares securing restored climate window against keeping reserve', () => {
+  assert.match(webAppSource, /function buildClimateSecureWindowVsReserveComparison/);
+  assert.match(webAppSource, /climateSecureWindowVsReserveComparison: null/);
+  assert.match(webAppSource, /climateSecureWindowVsReserveComparison,/);
+
+  for (const stableKey of [
+    'state',
+    'dominantConstraint',
+    'secureOption',
+    'reserveOption',
+    'avoidedRisk',
+    'sourceFollowThrough',
+    'windowState',
+    'summary',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /sécuriser maintenant/);
+  assert.match(webAppSource, /garder réserve/);
+  assert.match(webAppSource, /attendre sans risque notable/);
+  assert.match(webAppSource, /dette secondaire/);
+  assert.match(webAppSource, /saison/);
+  assert.match(webAppSource, /cascade voisine/);
+  assert.match(webAppSource, /pression régionale/);
+  assert.match(webAppSource, /conflit de timing/);
+  assert.match(webAppSource, /évite que la fenêtre restaurée se referme/);
+  assert.match(webAppSource, /évite de consommer la marge nécessaire/);
+  assert.match(webAppSource, /aucun arbitrage réel visible/);
+  assert.match(webAppSource, /Sécuriser vs réserve/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9653,6 +9653,45 @@ function buildSafestClimateFollowThroughAfterDeadlineTradeoff(restoredClimateDea
   };
 }
 
+function buildClimateSecureWindowVsReserveComparison(safestClimateFollowThroughAfterDeadlineTradeoff, climateRiskReboundAfterTopPayoff, decisionWindow) {
+  if (!safestClimateFollowThroughAfterDeadlineTradeoff) {
+    return null;
+  }
+
+  const constraintText = `${safestClimateFollowThroughAfterDeadlineTradeoff.dominantConstraint ?? ''} ${climateRiskReboundAfterTopPayoff?.secondaryDebtCause ?? ''}`.toLowerCase();
+  const dominantConstraint = constraintText.includes('cascade')
+    ? 'cascade voisine'
+    : constraintText.includes('conflit') || constraintText.includes('timing')
+      ? 'conflit de timing'
+      : constraintText.includes('saison')
+        ? 'saison'
+        : constraintText.includes('pression régionale') || constraintText.includes('deadline')
+          ? 'pression régionale'
+          : 'dette secondaire';
+  const hasNeighborCascade = dominantConstraint === 'cascade voisine' || climateRiskReboundAfterTopPayoff?.state === 'rebond fort';
+  const recommendation = safestClimateFollowThroughAfterDeadlineTradeoff.state === 'follow-through absent'
+    ? 'attendre sans risque notable'
+    : hasNeighborCascade || safestClimateFollowThroughAfterDeadlineTradeoff.action === 'déplacer la décision'
+      ? 'garder réserve'
+      : 'sécuriser maintenant';
+  const avoidedRisk = recommendation === 'sécuriser maintenant'
+    ? 'évite que la fenêtre restaurée se referme sur la deadline active'
+    : recommendation === 'garder réserve'
+      ? 'évite de consommer la marge nécessaire contre une cascade voisine'
+      : 'aucun arbitrage réel visible: garder l’état actuel reste neutre';
+
+  return {
+    state: recommendation,
+    dominantConstraint,
+    secureOption: 'sécuriser la fenêtre restaurée',
+    reserveOption: 'garder une réserve contre cascade voisine',
+    avoidedRisk,
+    sourceFollowThrough: safestClimateFollowThroughAfterDeadlineTradeoff.action,
+    windowState: decisionWindow?.state ?? null,
+    summary: `${recommendation}: ${avoidedRisk}. Contrainte dominante: ${dominantConstraint}.`,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -9706,6 +9745,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       followUpClimateWindowChangeSummary: null,
       restoredClimateDeadlineTradeoffWarning: null,
       safestClimateFollowThroughAfterDeadlineTradeoff: null,
+      climateSecureWindowVsReserveComparison: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -9781,6 +9821,11 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     restoredClimateDeadlineTradeoffWarning,
     followUpClimateWindowChangeSummary,
   );
+  const climateSecureWindowVsReserveComparison = buildClimateSecureWindowVsReserveComparison(
+    safestClimateFollowThroughAfterDeadlineTradeoff,
+    climateRiskReboundAfterTopPayoff,
+    decisionWindow,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -9797,6 +9842,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     followUpClimateWindowChangeSummary,
     restoredClimateDeadlineTradeoffWarning,
     safestClimateFollowThroughAfterDeadlineTradeoff,
+    climateSecureWindowVsReserveComparison,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -9834,6 +9880,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.followUpClimateWindowChangeSummary ? `<small><b>Fenêtre après suivi</b> · ${view.followUpClimateWindowChangeSummary.summary} ${view.followUpClimateWindowChangeSummary.oneSentence}</small>` : ''}
       ${view.restoredClimateDeadlineTradeoffWarning ? `<small><b>Alerte tradeoff deadline</b> · ${view.restoredClimateDeadlineTradeoffWarning.summary}</small>` : ''}
       ${view.safestClimateFollowThroughAfterDeadlineTradeoff ? `<small><b>Follow-through sûr</b> · ${view.safestClimateFollowThroughAfterDeadlineTradeoff.summary} ${view.safestClimateFollowThroughAfterDeadlineTradeoff.reason}</small>` : ''}
+      ${view.climateSecureWindowVsReserveComparison ? `<small><b>Sécuriser vs réserve</b> · ${view.climateSecureWindowVsReserveComparison.summary}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1063.

## Résumé
- compare sécuriser la fenêtre climat restaurée avec garder une réserve contre cascade voisine
- classe la suite en sécuriser maintenant, garder réserve, ou attendre sans risque notable
- nomme la contrainte dominante et le risque évité sans recalculer le payoff existant

## Tests
- `npm test`
