### PR TITLE
Alpha: show fallback decision reversibility

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -800,6 +800,51 @@ export function buildMiniPlanConfidenceSignalCue(
   };
 }
 
+function extractReversibilityConstraint(miniPlanRivalResponseFallback) {
+  const cost = String(miniPlanRivalResponseFallback?.cost ?? '').trim();
+  if (cost.includes('cible moins prioritaire')) return 'position moins prioritaire';
+  if (cost.includes('délai')) return 'tempo rival';
+  if (cost.includes('bénéfice moindre')) return 'coût d’opportunité';
+  return 'fenêtre d’ordre';
+}
+
+export function buildMiniPlanDecisionReversibilityCue(
+  miniPlanConfidenceSignalCue = null,
+  miniPlanRivalResponseFallback = null,
+) {
+  if (!miniPlanConfidenceSignalCue || miniPlanConfidenceSignalCue.empty) {
+    return {
+      empty: true,
+      state: 'none',
+      label: 'réversibilité non évaluée',
+      constraint: null,
+      nextStep: null,
+    };
+  }
+
+  const state = miniPlanConfidenceSignalCue.decision === 'wait-confidence'
+    ? 'reversible'
+    : miniPlanConfidenceSignalCue.decision === 'return-confirmed'
+      ? 'costly'
+      : 'locked';
+
+  return {
+    empty: false,
+    state,
+    label: state === 'reversible'
+      ? 'réversible'
+      : state === 'costly'
+        ? 'correction coûteuse'
+        : 'quasi verrouillée',
+    constraint: extractReversibilityConstraint(miniPlanRivalResponseFallback),
+    nextStep: state === 'reversible'
+      ? 'garder un ordre court en réserve'
+      : state === 'costly'
+        ? 'préserver un tempo de correction'
+        : null,
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -899,6 +944,10 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanFallbackReturnCue,
     miniPlanRivalResponseFallback,
   );
+  const miniPlanDecisionReversibilityCue = buildMiniPlanDecisionReversibilityCue(
+    miniPlanConfidenceSignalCue,
+    miniPlanRivalResponseFallback,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -951,6 +1000,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanFallbackReturnCue,
     miniPlanReturnProtectionStatus,
     miniPlanConfidenceSignalCue,
+    miniPlanDecisionReversibilityCue,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -8,6 +8,7 @@ import {
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanConfidenceSignalCue,
+  buildMiniPlanDecisionReversibilityCue,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -350,6 +351,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     label: 'confiance non évaluée',
     signal: null,
     waitCost: null,
+  });
+  assert.deepEqual(shell.miniPlanDecisionReversibilityCue, {
+    empty: true,
+    state: 'none',
+    label: 'réversibilité non évaluée',
+    constraint: null,
+    nextStep: null,
   });
 });
 
@@ -699,12 +707,20 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     nextDecision: 'confirm-fallback',
     reason: 'confirmer le fallback: contre-poussée du front voisin reste plus dangereux',
   });
-  assert.deepEqual(buildMiniPlanConfidenceSignalCue(protection, returnCue, fallback), {
+  const confidence = buildMiniPlanConfidenceSignalCue(protection, returnCue, fallback);
+  assert.deepEqual(confidence, {
     empty: false,
     decision: 'hold-fallback',
     label: 'tenir fallback',
     signal: 'contre-poussée du front voisin encore actif',
     waitCost: 'attendre trop longtemps coûte cible moins prioritaire: front-a',
+  });
+  assert.deepEqual(buildMiniPlanDecisionReversibilityCue(confidence, fallback), {
+    empty: false,
+    state: 'locked',
+    label: 'quasi verrouillée',
+    constraint: 'position moins prioritaire',
+    nextStep: null,
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -755,12 +771,20 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     nextDecision: 'wait-signal',
     reason: 'attendre un signal: revenir quand la réponse rivale se dissipe',
   });
-  assert.deepEqual(buildMiniPlanConfidenceSignalCue(protection, returnCue, fallback), {
+  const confidence = buildMiniPlanConfidenceSignalCue(protection, returnCue, fallback);
+  assert.deepEqual(confidence, {
     empty: false,
     decision: 'wait-confidence',
     label: 'attendre signal confiance',
     signal: 'revenir quand la réponse rivale se dissipe',
     waitCost: 'attendre trop longtemps coûte bénéfice moindre mais risque équivalent',
+  });
+  assert.deepEqual(buildMiniPlanDecisionReversibilityCue(confidence, fallback), {
+    empty: false,
+    state: 'reversible',
+    label: 'réversible',
+    constraint: 'coût d’opportunité',
+    nextStep: 'garder un ordre court en réserve',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -802,12 +826,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     nextDecision: 'return-now',
     reason: 'revenir maintenant: le risque initial ne dépasse plus le fallback',
   });
-  assert.deepEqual(buildMiniPlanConfidenceSignalCue(protection, returnCue, fallback), {
+  const confidence = buildMiniPlanConfidenceSignalCue(protection, returnCue, fallback);
+  assert.deepEqual(confidence, {
     empty: false,
     decision: 'return-confirmed',
     label: 'retour confirmé',
     signal: 'risque initial revenu sous le fallback',
     waitCost: 'attendre trop longtemps coûte délai avant branche initiale',
+  });
+  assert.deepEqual(buildMiniPlanDecisionReversibilityCue(confidence, fallback), {
+    empty: false,
+    state: 'costly',
+    label: 'correction coûteuse',
+    constraint: 'tempo rival',
+    nextStep: 'préserver un tempo de correction',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -823,6 +855,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     label: 'confiance non évaluée',
     signal: null,
     waitCost: null,
+  });
+  assert.deepEqual(buildMiniPlanDecisionReversibilityCue(null, fallback), {
+    empty: true,
+    state: 'none',
+    label: 'réversibilité non évaluée',
+    constraint: null,
+    nextStep: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -71,6 +71,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanFallbackReturnCue\(/);
   assert.match(webAppSource, /buildMiniPlanReturnProtectionStatus\(/);
   assert.match(webAppSource, /buildMiniPlanConfidenceSignalCue\(/);
+  assert.match(webAppSource, /buildMiniPlanDecisionReversibilityCue\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -111,12 +112,14 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanFallbackReturnCue: buildMiniPlanFallbackReturnCue\(/);
   assert.match(webAppSource, /miniPlanReturnProtectionStatus: buildMiniPlanReturnProtectionStatus\(/);
   assert.match(webAppSource, /miniPlanConfidenceSignalCue: buildMiniPlanConfidenceSignalCue\(/);
+  assert.match(webAppSource, /miniPlanDecisionReversibilityCue: buildMiniPlanDecisionReversibilityCue\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
   assert.match(webAppSource, /retour: aucun arbitrage/);
   assert.match(webAppSource, /protection retour: non évaluée/);
   assert.match(webAppSource, /confiance: non évaluée/);
+  assert.match(webAppSource, /réversibilité: non évaluée/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -130,6 +133,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__fallback-return-cue/);
   assert.match(webAppSource, /atlas-military-fallback-order__return-protection/);
   assert.match(webAppSource, /atlas-military-fallback-order__confidence-signal/);
+  assert.match(webAppSource, /atlas-military-fallback-order__decision-reversibility/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -143,6 +147,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /\$\{fallbackReturnCue\.decision === 'keep-fallback' \? 'garder fallback' : 'retour initial'\}: \$\{fallbackReturnCue\.condition\} · coût \$\{fallbackReturnCue\.switchCost\}/);
   assert.match(webAppSource, /\$\{returnProtection\.label\}: \$\{returnProtection\.constraint\} · \$\{returnProtection\.nextDecision\}/);
   assert.match(webAppSource, /\$\{confidenceSignal\.label\}: \$\{confidenceSignal\.signal\} · \$\{confidenceSignal\.waitCost\}/);
+  assert.match(webAppSource, /réversibilité: \$\{reversibility\.label\} · \$\{reversibility\.constraint\}\$\{reversibility\.nextStep \? ` · \$\{reversibility\.nextStep\}` : ''\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -166,4 +171,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__fallback-return-cue/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__return-protection/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__confidence-signal/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__decision-reversibility/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -9,6 +9,7 @@ import {
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanConfidenceSignalCue,
+  buildMiniPlanDecisionReversibilityCue,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -1993,6 +1994,24 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
         ),
         buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
       ),
+      miniPlanDecisionReversibilityCue: buildMiniPlanDecisionReversibilityCue(
+        buildMiniPlanConfidenceSignalCue(
+          buildMiniPlanReturnProtectionStatus(
+            buildMiniPlanFallbackReturnCue(
+              buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+              buildMiniPlanRivalResponseComparison(null, []),
+            ),
+            buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+            buildMiniPlanRivalResponseComparison(null, []),
+          ),
+          buildMiniPlanFallbackReturnCue(
+            buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+            buildMiniPlanRivalResponseComparison(null, []),
+          ),
+          buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+        ),
+        buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2043,6 +2062,10 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanFallbackReturnCue,
     miniPlanRivalResponseFallback,
   );
+  const miniPlanDecisionReversibilityCue = buildMiniPlanDecisionReversibilityCue(
+    miniPlanConfidenceSignalCue,
+    miniPlanRivalResponseFallback,
+  );
 
   return {
     fallback: {
@@ -2067,6 +2090,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanFallbackReturnCue,
       miniPlanReturnProtectionStatus,
       miniPlanConfidenceSignalCue,
+      miniPlanDecisionReversibilityCue,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2086,7 +2110,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanFallbackReturnCue,
     miniPlanReturnProtectionStatus,
     miniPlanConfidenceSignalCue,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}).`,
+    miniPlanDecisionReversibilityCue,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}).`,
     empty: false,
   };
 }
@@ -2149,9 +2174,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const confidenceSignalLabel = confidenceSignal && !confidenceSignal.empty
     ? `${confidenceSignal.label}: ${confidenceSignal.signal} · ${confidenceSignal.waitCost}`
     : 'confiance: non évaluée';
+  const reversibility = fallback.miniPlanDecisionReversibilityCue;
+  const reversibilityLabel = reversibility && !reversibility.empty
+    ? `réversibilité: ${reversibility.label} · ${reversibility.constraint}${reversibility.nextStep ? ` · ${reversibility.nextStep}` : ''}`
+    : 'réversibilité: non évaluée';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="24" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="25.2" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2172,6 +2201,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__fallback-return-cue" x="23.2" y="77.8">${fallbackReturnLabel}</text>
       <text class="atlas-military-fallback-order__return-protection atlas-military-fallback-order__return-protection--${returnProtection?.state ?? 'none'}" x="23.2" y="78.9">${returnProtectionLabel}</text>
       <text class="atlas-military-fallback-order__confidence-signal atlas-military-fallback-order__confidence-signal--${confidenceSignal?.decision ?? 'none'}" x="23.2" y="80">${confidenceSignalLabel}</text>
+      <text class="atlas-military-fallback-order__decision-reversibility atlas-military-fallback-order__decision-reversibility--${reversibility?.state ?? 'none'}" x="23.2" y="81.1">${reversibilityLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11175,6 +11175,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__confidence-signal { fill: #ddd6fe; font-size: 0.39px; font-weight: 900; }
 .atlas-military-fallback-order__confidence-signal--hold-fallback { fill: #fecaca; }
 .atlas-military-fallback-order__confidence-signal--wait-confidence { fill: #fde68a; }
+.atlas-military-fallback-order__decision-reversibility { fill: #bfdbfe; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__decision-reversibility--costly { fill: #fde68a; }
+.atlas-military-fallback-order__decision-reversibility--locked { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1059.

Summary:
- adds structured `miniPlanDecisionReversibilityCue` after the confidence signal
- classifies fallback/return decisions as reversible, costly to correct, or quasi locked
- names the visible reversibility constraint without repeating A33/A34 status text
- suggests a short next step only when correction remains realistic

Tests:
- npm test

Zeta: ready for validation before merge.