### PR TITLE
Beta: show post-salvage corridor robustness

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -428,6 +428,45 @@ function buildPostSalvageDecisionComparison(postSalvageDecisionAlert, delayOppor
   };
 }
 
+function buildPostSalvageRobustness(postSalvageDecisionAlert, postSalvageDecisionComparison, delayOpportunityCost, scenarios) {
+  const tightestScenario = scenarios
+    .slice()
+    .sort((left, right) => left.netValue - right.netValue || left.id.localeCompare(right.id))[0] ?? null;
+  const dominantConstraint = postSalvageDecisionAlert.mainConstraint ?? tightestScenario?.cause ?? null;
+
+  if (postSalvageDecisionAlert.status === 'no-additional-decision') {
+    return {
+      status: 'robust',
+      dominantConstraint,
+      nextGesture: 'surveiller',
+      needsCapacityProtection: false,
+      summary: dominantConstraint === null
+        ? 'Robuste: aucun risque de robustesse notable après salvage.'
+        : `Robuste: surveiller ${dominantConstraint}, la marge reste positive après salvage.`,
+    };
+  }
+
+  const remainingCost = delayOpportunityCost.salvageAction?.remainingCost ?? 0;
+  const isVulnerable = postSalvageDecisionComparison.waitTurnsDurableLoss && remainingCost > 2;
+  const nextGestureByRecommendation = {
+    'abandon-sequence': 'basculer vers alternative',
+    'invert-durably': 'basculer vers alternative',
+    'secure-minimal-investment': 'protéger la capacité',
+  };
+  const status = isVulnerable ? 'vulnerable' : 'fragile-usable';
+  const nextGesture = nextGestureByRecommendation[postSalvageDecisionAlert.recommendation] ?? 'surveiller';
+
+  return {
+    status,
+    dominantConstraint,
+    nextGesture,
+    needsCapacityProtection: dominantConstraint === 'capacity' || nextGesture === 'protéger la capacité',
+    summary: status === 'vulnerable'
+      ? `Vulnérable: ${dominantConstraint} menace une perte durable; ${nextGesture}.`
+      : `Fragile mais utilisable: ${dominantConstraint} reste serré; ${nextGesture}.`,
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -635,6 +674,12 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     postSalvageDecisionAlert,
     delayOpportunityCost,
   );
+  const postSalvageRobustness = buildPostSalvageRobustness(
+    postSalvageDecisionAlert,
+    postSalvageDecisionComparison,
+    delayOpportunityCost,
+    scenarios,
+  );
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -649,6 +694,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     delayOpportunityCost,
     postSalvageDecisionAlert,
     postSalvageDecisionComparison,
+    postSalvageRobustness,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -553,6 +553,13 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         waitTurnsDurableLoss: false,
         summary: 'Neutre: aucun coût d’attente notable tant que la marge reste positive.',
       },
+      postSalvageRobustness: {
+        status: 'robust',
+        dominantConstraint: 'saturation',
+        nextGesture: 'surveiller',
+        needsCapacityProtection: false,
+        summary: 'Robuste: surveiller saturation, la marge reste positive après salvage.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -693,6 +700,13 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       waitTurnsDurableLoss: false,
       summary: 'Neutre: aucun coût d’attente notable tant que la marge reste positive.',
     },
+    postSalvageRobustness: {
+      status: 'robust',
+      dominantConstraint: 'saturation',
+      nextGesture: 'surveiller',
+      needsCapacityProtection: false,
+      summary: 'Robuste: surveiller saturation, la marge reste positive après salvage.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -783,6 +797,13 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     waitTurnsDurableLoss: true,
     summary: 'abandonner ou inverser immédiatement pour éviter une perte durable: temporiser transforme la décision en perte durable.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.postSalvageRobustness, {
+    status: 'vulnerable',
+    dominantConstraint: 'alternative-plus-sure',
+    nextGesture: 'basculer vers alternative',
+    needsCapacityProtection: false,
+    summary: 'Vulnérable: alternative-plus-sure menace une perte durable; basculer vers alternative.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -839,6 +860,13 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     waitCost: 5,
     waitTurnsDurableLoss: true,
     summary: 'confirmer l’inversion vers grain:reserve-buffer: temporiser transforme la décision en perte durable.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.postSalvageRobustness, {
+    status: 'fragile-usable',
+    dominantConstraint: 'alternative-plus-sure',
+    nextGesture: 'basculer vers alternative',
+    needsCapacityProtection: false,
+    summary: 'Fragile mais utilisable: alternative-plus-sure reste serré; basculer vers alternative.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a post-salvage robustness readout so the corridor overlay shows whether the corridor is robust, fragile but usable, or still vulnerable after the B34 confirm-vs-wait decision.

## Changes

- Add `postSalvageRobustness` beside the existing post-salvage alert and comparison.
- Classify robust, fragile-usable, and vulnerable outcomes.
- Name the dominant constraint and expose a short next gesture (`surveiller`, `protéger la capacité`, or `basculer vers alternative`).
- Extend economy overlay tests for robust, fragile, and vulnerable cases.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (626/626 pass)

Fixes loo469/historia#1060