### PR TITLE
Beta: show fragile corridor stabilizer

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -467,6 +467,45 @@ function buildPostSalvageRobustness(postSalvageDecisionAlert, postSalvageDecisio
   };
 }
 
+function buildPostSalvageStabilizer(postSalvageRobustness) {
+  if (postSalvageRobustness.status === 'robust') {
+    return {
+      status: 'none-required',
+      stabilizer: null,
+      nextGesture: 'surveiller',
+      benefit: 'Aucun stabilisateur requis: le corridor reste robuste après salvage.',
+      summary: 'Stabilisateur neutre: surveiller sans action supplémentaire.',
+    };
+  }
+
+  const stabilizerByConstraint = {
+    capacity: 'capacité tampon',
+    saturation: 'lissage de charge',
+    delay: 'protection d’étape',
+    cost: 'réserve transportée',
+    'alternative-plus-sure': 'alternative de secours',
+  };
+  const benefitByStabilizer = {
+    'capacité tampon': 'absorbe la prochaine contrainte de capacité avant rupture.',
+    'lissage de charge': 'réduit la saturation du goulot sans changer la priorité.',
+    'protection d’étape': 'garde la fenêtre active malgré le prochain délai.',
+    'réserve transportée': 'couvre le coût restant sans relancer toute la séquence.',
+    'alternative de secours': 'transforme l’inversion possible en flux fiable.',
+  };
+  const stabilizer = stabilizerByConstraint[postSalvageRobustness.dominantConstraint] ?? 'détour sécurisé';
+  const isUrgent = postSalvageRobustness.status === 'vulnerable';
+
+  return {
+    status: isUrgent ? 'urgent-stabilization' : 'stabilizer-recommended',
+    stabilizer,
+    nextGesture: postSalvageRobustness.nextGesture,
+    benefit: benefitByStabilizer[stabilizer] ?? 'sécurise un détour fiable avant la prochaine contrainte.',
+    summary: isUrgent
+      ? `Stabilisation urgente: ${stabilizer} pour éviter une perte durable.`
+      : `Stabilisateur recommandé: ${stabilizer} pour fiabiliser le corridor fragile.`,
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -680,6 +719,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     delayOpportunityCost,
     scenarios,
   );
+  const postSalvageStabilizer = buildPostSalvageStabilizer(postSalvageRobustness);
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -695,6 +735,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     postSalvageDecisionAlert,
     postSalvageDecisionComparison,
     postSalvageRobustness,
+    postSalvageStabilizer,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -560,6 +560,13 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         needsCapacityProtection: false,
         summary: 'Robuste: surveiller saturation, la marge reste positive après salvage.',
       },
+      postSalvageStabilizer: {
+        status: 'none-required',
+        stabilizer: null,
+        nextGesture: 'surveiller',
+        benefit: 'Aucun stabilisateur requis: le corridor reste robuste après salvage.',
+        summary: 'Stabilisateur neutre: surveiller sans action supplémentaire.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -707,6 +714,13 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       needsCapacityProtection: false,
       summary: 'Robuste: surveiller saturation, la marge reste positive après salvage.',
     },
+    postSalvageStabilizer: {
+      status: 'none-required',
+      stabilizer: null,
+      nextGesture: 'surveiller',
+      benefit: 'Aucun stabilisateur requis: le corridor reste robuste après salvage.',
+      summary: 'Stabilisateur neutre: surveiller sans action supplémentaire.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -804,6 +818,13 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     needsCapacityProtection: false,
     summary: 'Vulnérable: alternative-plus-sure menace une perte durable; basculer vers alternative.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.postSalvageStabilizer, {
+    status: 'urgent-stabilization',
+    stabilizer: 'alternative de secours',
+    nextGesture: 'basculer vers alternative',
+    benefit: 'transforme l’inversion possible en flux fiable.',
+    summary: 'Stabilisation urgente: alternative de secours pour éviter une perte durable.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -867,6 +888,13 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     nextGesture: 'basculer vers alternative',
     needsCapacityProtection: false,
     summary: 'Fragile mais utilisable: alternative-plus-sure reste serré; basculer vers alternative.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.postSalvageStabilizer, {
+    status: 'stabilizer-recommended',
+    stabilizer: 'alternative de secours',
+    nextGesture: 'basculer vers alternative',
+    benefit: 'transforme l’inversion possible en flux fiable.',
+    summary: 'Stabilisateur recommandé: alternative de secours pour fiabiliser le corridor fragile.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a compact post-salvage stabilizer readout so fragile corridors show the next concrete step to become reliable.

## Changes

- Add `postSalvageStabilizer` beside the B35 robustness readout.
- Classify no stabilizer required, stabilizer recommended, and urgent stabilization.
- Name the dominant stabilizer from the remaining constraint, including alternative fallback, load smoothing, capacity buffer, carried reserve, and step protection.
- Extend economy overlay tests for robust, recommended, and urgent stabilizer outcomes.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (626/626 pass)

Fixes loo469/historia#1070