### PR TITLE
Epsilon: warn on climate reserve window cost

### DIFF
--- a/test/ui/climate/webAtlasClimateReserveNearTermWindowCostWarning.test.js
+++ b/test/ui/climate/webAtlasClimateReserveNearTermWindowCostWarning.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas warns when keeping climate reserve creates a near-term window cost', () => {
+  assert.match(webAppSource, /function buildClimateReserveNearTermWindowCostWarning/);
+  assert.match(webAppSource, /climateReserveNearTermWindowCostWarning: null/);
+  assert.match(webAppSource, /climateReserveNearTermWindowCostWarning,/);
+
+  for (const stableKey of [
+    'state',
+    'visibleConstraint',
+    'recommendedGesture',
+    'reserveChoice',
+    'windowState',
+    'summary',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /aucun coût proche/);
+  assert.match(webAppSource, /coût acceptable/);
+  assert.match(webAppSource, /fenêtre proche menacée/);
+  assert.match(webAppSource, /saison/);
+  assert.match(webAppSource, /cascade voisine/);
+  assert.match(webAppSource, /dette secondaire/);
+  assert.match(webAppSource, /pression régionale/);
+  assert.match(webAppSource, /conflit de timing/);
+  assert.match(webAppSource, /fenêtre restaurée/);
+  assert.match(webAppSource, /sécuriser la fenêtre maintenant/);
+  assert.match(webAppSource, /réserver un paiement court au prochain tour/);
+  assert.match(webAppSource, /aucun geste immédiat/);
+  assert.match(webAppSource, /Coût réserve court terme/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9722,6 +9722,54 @@ function buildClimateSecureWindowVsReserveComparison(safestClimateFollowThroughA
   };
 }
 
+function buildClimateReserveNearTermWindowCostWarning(climateSecureWindowVsReserveComparison, decisionWindow, climateRiskReboundAfterTopPayoff) {
+  if (!climateSecureWindowVsReserveComparison) {
+    return null;
+  }
+
+  const constraintText = `${climateSecureWindowVsReserveComparison.dominantConstraint ?? ''} ${climateSecureWindowVsReserveComparison.summary ?? ''}`.toLowerCase();
+  const visibleConstraint = constraintText.includes('cascade')
+    ? 'cascade voisine'
+    : constraintText.includes('conflit') || constraintText.includes('timing')
+      ? 'conflit de timing'
+      : constraintText.includes('saison')
+        ? 'saison'
+        : constraintText.includes('pression régionale') || constraintText.includes('deadline')
+          ? 'pression régionale'
+          : constraintText.includes('fenêtre')
+            ? 'fenêtre restaurée'
+            : 'dette secondaire';
+  const keepingReserve = climateSecureWindowVsReserveComparison.state === 'garder réserve';
+  const shouldSecure = climateSecureWindowVsReserveComparison.state === 'sécuriser maintenant';
+  const windowThreatened = decisionWindow?.state === 'urgent-window' || climateRiskReboundAfterTopPayoff?.state === 'rebond fort';
+  const state = !keepingReserve && !shouldSecure
+    ? 'aucun coût proche'
+    : shouldSecure && windowThreatened
+      ? 'fenêtre proche menacée'
+      : shouldSecure
+        ? 'coût acceptable'
+        : windowThreatened
+          ? 'coût acceptable'
+          : 'aucun coût proche';
+  const recommendedGesture = state === 'fenêtre proche menacée'
+    ? 'sécuriser la fenêtre maintenant'
+    : state === 'coût acceptable'
+      ? 'réserver un paiement court au prochain tour'
+      : 'aucun geste immédiat';
+  const summary = state === 'aucun coût proche'
+    ? `Réserve neutre: aucun coût de fenêtre proche visible; contrainte ${visibleConstraint}.`
+    : `${state}: garder la réserve expose ${visibleConstraint}; geste: ${recommendedGesture}.`;
+
+  return {
+    state,
+    visibleConstraint,
+    recommendedGesture,
+    reserveChoice: climateSecureWindowVsReserveComparison.state,
+    windowState: decisionWindow?.state ?? null,
+    summary,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -9776,6 +9824,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       restoredClimateDeadlineTradeoffWarning: null,
       safestClimateFollowThroughAfterDeadlineTradeoff: null,
       climateSecureWindowVsReserveComparison: null,
+      climateReserveNearTermWindowCostWarning: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -9856,6 +9905,11 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     climateRiskReboundAfterTopPayoff,
     decisionWindow,
   );
+  const climateReserveNearTermWindowCostWarning = buildClimateReserveNearTermWindowCostWarning(
+    climateSecureWindowVsReserveComparison,
+    decisionWindow,
+    climateRiskReboundAfterTopPayoff,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -9873,6 +9927,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     restoredClimateDeadlineTradeoffWarning,
     safestClimateFollowThroughAfterDeadlineTradeoff,
     climateSecureWindowVsReserveComparison,
+    climateReserveNearTermWindowCostWarning,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -9911,6 +9966,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.restoredClimateDeadlineTradeoffWarning ? `<small><b>Alerte tradeoff deadline</b> · ${view.restoredClimateDeadlineTradeoffWarning.summary}</small>` : ''}
       ${view.safestClimateFollowThroughAfterDeadlineTradeoff ? `<small><b>Follow-through sûr</b> · ${view.safestClimateFollowThroughAfterDeadlineTradeoff.summary} ${view.safestClimateFollowThroughAfterDeadlineTradeoff.reason}</small>` : ''}
       ${view.climateSecureWindowVsReserveComparison ? `<small><b>Sécuriser vs réserve</b> · ${view.climateSecureWindowVsReserveComparison.summary}</small>` : ''}
+      ${view.climateReserveNearTermWindowCostWarning ? `<small><b>Coût réserve court terme</b> · ${view.climateReserveNearTermWindowCostWarning.summary}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1073.

## Résumé
- ajoute un avertissement quand garder la réserve climat crée un coût de fenêtre proche
- classe le coût en aucun coût proche, coût acceptable ou fenêtre proche menacée
- nomme la contrainte visible et propose un geste court seulement quand le coût le justifie

## Tests
- `npm test`
