### PR TITLE
Alpha: show last safe fallback correction

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -845,6 +845,40 @@ export function buildMiniPlanDecisionReversibilityCue(
   };
 }
 
+export function buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibilityCue = null) {
+  if (!miniPlanDecisionReversibilityCue || miniPlanDecisionReversibilityCue.empty) {
+    return {
+      empty: true,
+      state: 'none',
+      label: 'fenêtre correction inconnue',
+      constraint: null,
+      nextStep: null,
+    };
+  }
+
+  const state = miniPlanDecisionReversibilityCue.state === 'reversible'
+    ? 'safe-correction'
+    : miniPlanDecisionReversibilityCue.state === 'costly'
+      ? 'last-correction-turn'
+      : 'locked-commitment';
+
+  return {
+    empty: false,
+    state,
+    label: state === 'safe-correction'
+      ? 'correction encore sûre'
+      : state === 'last-correction-turn'
+        ? 'dernier tour de correction'
+        : 'engagement verrouillé',
+    constraint: miniPlanDecisionReversibilityCue.constraint ?? 'fenêtre d’ordre',
+    nextStep: state === 'safe-correction'
+      ? 'préparer correction courte'
+      : state === 'last-correction-turn'
+        ? 'corriger maintenant ou assumer'
+        : null,
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -948,6 +982,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanConfidenceSignalCue,
     miniPlanRivalResponseFallback,
   );
+  const miniPlanLastSafeCorrectionCue = buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibilityCue);
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -1001,6 +1036,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanReturnProtectionStatus,
     miniPlanConfidenceSignalCue,
     miniPlanDecisionReversibilityCue,
+    miniPlanLastSafeCorrectionCue,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -9,6 +9,7 @@ import {
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanConfidenceSignalCue,
   buildMiniPlanDecisionReversibilityCue,
+  buildMiniPlanLastSafeCorrectionCue,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -356,6 +357,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     empty: true,
     state: 'none',
     label: 'réversibilité non évaluée',
+    constraint: null,
+    nextStep: null,
+  });
+  assert.deepEqual(shell.miniPlanLastSafeCorrectionCue, {
+    empty: true,
+    state: 'none',
+    label: 'fenêtre correction inconnue',
     constraint: null,
     nextStep: null,
   });
@@ -715,10 +723,18 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     signal: 'contre-poussée du front voisin encore actif',
     waitCost: 'attendre trop longtemps coûte cible moins prioritaire: front-a',
   });
-  assert.deepEqual(buildMiniPlanDecisionReversibilityCue(confidence, fallback), {
+  const reversibility = buildMiniPlanDecisionReversibilityCue(confidence, fallback);
+  assert.deepEqual(reversibility, {
     empty: false,
     state: 'locked',
     label: 'quasi verrouillée',
+    constraint: 'position moins prioritaire',
+    nextStep: null,
+  });
+  assert.deepEqual(buildMiniPlanLastSafeCorrectionCue(reversibility), {
+    empty: false,
+    state: 'locked-commitment',
+    label: 'engagement verrouillé',
     constraint: 'position moins prioritaire',
     nextStep: null,
   });
@@ -779,12 +795,20 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     signal: 'revenir quand la réponse rivale se dissipe',
     waitCost: 'attendre trop longtemps coûte bénéfice moindre mais risque équivalent',
   });
-  assert.deepEqual(buildMiniPlanDecisionReversibilityCue(confidence, fallback), {
+  const reversibility = buildMiniPlanDecisionReversibilityCue(confidence, fallback);
+  assert.deepEqual(reversibility, {
     empty: false,
     state: 'reversible',
     label: 'réversible',
     constraint: 'coût d’opportunité',
     nextStep: 'garder un ordre court en réserve',
+  });
+  assert.deepEqual(buildMiniPlanLastSafeCorrectionCue(reversibility), {
+    empty: false,
+    state: 'safe-correction',
+    label: 'correction encore sûre',
+    constraint: 'coût d’opportunité',
+    nextStep: 'préparer correction courte',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -834,12 +858,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     signal: 'risque initial revenu sous le fallback',
     waitCost: 'attendre trop longtemps coûte délai avant branche initiale',
   });
-  assert.deepEqual(buildMiniPlanDecisionReversibilityCue(confidence, fallback), {
+  const reversibility = buildMiniPlanDecisionReversibilityCue(confidence, fallback);
+  assert.deepEqual(reversibility, {
     empty: false,
     state: 'costly',
     label: 'correction coûteuse',
     constraint: 'tempo rival',
     nextStep: 'préserver un tempo de correction',
+  });
+  assert.deepEqual(buildMiniPlanLastSafeCorrectionCue(reversibility), {
+    empty: false,
+    state: 'last-correction-turn',
+    label: 'dernier tour de correction',
+    constraint: 'tempo rival',
+    nextStep: 'corriger maintenant ou assumer',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -860,6 +892,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     empty: true,
     state: 'none',
     label: 'réversibilité non évaluée',
+    constraint: null,
+    nextStep: null,
+  });
+  assert.deepEqual(buildMiniPlanLastSafeCorrectionCue(null), {
+    empty: true,
+    state: 'none',
+    label: 'fenêtre correction inconnue',
     constraint: null,
     nextStep: null,
   });

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -72,6 +72,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanReturnProtectionStatus\(/);
   assert.match(webAppSource, /buildMiniPlanConfidenceSignalCue\(/);
   assert.match(webAppSource, /buildMiniPlanDecisionReversibilityCue\(/);
+  assert.match(webAppSource, /buildMiniPlanLastSafeCorrectionCue\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -113,6 +114,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanReturnProtectionStatus: buildMiniPlanReturnProtectionStatus\(/);
   assert.match(webAppSource, /miniPlanConfidenceSignalCue: buildMiniPlanConfidenceSignalCue\(/);
   assert.match(webAppSource, /miniPlanDecisionReversibilityCue: buildMiniPlanDecisionReversibilityCue\(/);
+  assert.match(webAppSource, /miniPlanLastSafeCorrectionCue: buildMiniPlanLastSafeCorrectionCue\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
@@ -120,6 +122,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /protection retour: non évaluée/);
   assert.match(webAppSource, /confiance: non évaluée/);
   assert.match(webAppSource, /réversibilité: non évaluée/);
+  assert.match(webAppSource, /dernier sûr: non évalué/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -134,6 +137,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__return-protection/);
   assert.match(webAppSource, /atlas-military-fallback-order__confidence-signal/);
   assert.match(webAppSource, /atlas-military-fallback-order__decision-reversibility/);
+  assert.match(webAppSource, /atlas-military-fallback-order__last-safe-correction/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -148,6 +152,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /\$\{returnProtection\.label\}: \$\{returnProtection\.constraint\} · \$\{returnProtection\.nextDecision\}/);
   assert.match(webAppSource, /\$\{confidenceSignal\.label\}: \$\{confidenceSignal\.signal\} · \$\{confidenceSignal\.waitCost\}/);
   assert.match(webAppSource, /réversibilité: \$\{reversibility\.label\} · \$\{reversibility\.constraint\}\$\{reversibility\.nextStep \? ` · \$\{reversibility\.nextStep\}` : ''\}/);
+  assert.match(webAppSource, /dernier sûr: \$\{lastSafeCorrection\.label\} · \$\{lastSafeCorrection\.constraint\}\$\{lastSafeCorrection\.nextStep \? ` · \$\{lastSafeCorrection\.nextStep\}` : ''\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -172,4 +177,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__return-protection/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__confidence-signal/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__decision-reversibility/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__last-safe-correction/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -10,6 +10,7 @@ import {
   buildMiniPlanConflictTradeoffs,
   buildMiniPlanConfidenceSignalCue,
   buildMiniPlanDecisionReversibilityCue,
+  buildMiniPlanLastSafeCorrectionCue,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -2012,6 +2013,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
         ),
         buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
       ),
+      miniPlanLastSafeCorrectionCue: buildMiniPlanLastSafeCorrectionCue(buildMiniPlanDecisionReversibilityCue(null, null)),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2066,6 +2068,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanConfidenceSignalCue,
     miniPlanRivalResponseFallback,
   );
+  const miniPlanLastSafeCorrectionCue = buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibilityCue);
 
   return {
     fallback: {
@@ -2091,6 +2094,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanReturnProtectionStatus,
       miniPlanConfidenceSignalCue,
       miniPlanDecisionReversibilityCue,
+      miniPlanLastSafeCorrectionCue,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2111,7 +2115,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanReturnProtectionStatus,
     miniPlanConfidenceSignalCue,
     miniPlanDecisionReversibilityCue,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}).`,
+    miniPlanLastSafeCorrectionCue,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}).`,
     empty: false,
   };
 }
@@ -2178,9 +2183,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const reversibilityLabel = reversibility && !reversibility.empty
     ? `réversibilité: ${reversibility.label} · ${reversibility.constraint}${reversibility.nextStep ? ` · ${reversibility.nextStep}` : ''}`
     : 'réversibilité: non évaluée';
+  const lastSafeCorrection = fallback.miniPlanLastSafeCorrectionCue;
+  const lastSafeCorrectionLabel = lastSafeCorrection && !lastSafeCorrection.empty
+    ? `dernier sûr: ${lastSafeCorrection.label} · ${lastSafeCorrection.constraint}${lastSafeCorrection.nextStep ? ` · ${lastSafeCorrection.nextStep}` : ''}`
+    : 'dernier sûr: non évalué';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="25.2" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="26.4" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2202,6 +2211,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__return-protection atlas-military-fallback-order__return-protection--${returnProtection?.state ?? 'none'}" x="23.2" y="78.9">${returnProtectionLabel}</text>
       <text class="atlas-military-fallback-order__confidence-signal atlas-military-fallback-order__confidence-signal--${confidenceSignal?.decision ?? 'none'}" x="23.2" y="80">${confidenceSignalLabel}</text>
       <text class="atlas-military-fallback-order__decision-reversibility atlas-military-fallback-order__decision-reversibility--${reversibility?.state ?? 'none'}" x="23.2" y="81.1">${reversibilityLabel}</text>
+      <text class="atlas-military-fallback-order__last-safe-correction atlas-military-fallback-order__last-safe-correction--${lastSafeCorrection?.state ?? 'none'}" x="23.2" y="82.2">${lastSafeCorrectionLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11178,6 +11178,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__decision-reversibility { fill: #bfdbfe; font-size: 0.39px; font-weight: 900; }
 .atlas-military-fallback-order__decision-reversibility--costly { fill: #fde68a; }
 .atlas-military-fallback-order__decision-reversibility--locked { fill: #fecaca; }
+.atlas-military-fallback-order__last-safe-correction { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__last-safe-correction--last-correction-turn { fill: #fde68a; }
+.atlas-military-fallback-order__last-safe-correction--locked-commitment { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1069.

Summary:
- adds structured `miniPlanLastSafeCorrectionCue` after the reversibility cue
- classifies correction timing as still safe, last correction turn, or locked commitment
- names the visible locking constraint and suggests a short next step only while correction remains realistic
- keeps the overlay compact without repeating the A35 reversibility classification

Tests:
- npm test

Zeta: ready for validation before merge.