### PR TITLE
Beta: summarize post-stabilizer corridor reliability

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -506,6 +506,43 @@ function buildPostSalvageStabilizer(postSalvageRobustness) {
   };
 }
 
+function buildPostStabilizerReliability(postSalvageStabilizer) {
+  if (postSalvageStabilizer.status === 'none-required') {
+    return {
+      status: 'reliable-route',
+      remainingConstraint: null,
+      nextGesture: 'promouvoir',
+      summary: 'Route fiable: promouvoir le corridor après stabilisateur neutre.',
+    };
+  }
+
+  const remainingConstraintByStabilizer = {
+    'capacité tampon': 'capacité tampon',
+    'détour sécurisé': 'détour',
+    'lissage de charge': 'charge',
+    'protection d’étape': 'protection d’étape',
+    'réserve transportée': 'saturation',
+    'alternative de secours': 'alternative',
+  };
+  const remainingConstraint = remainingConstraintByStabilizer[postSalvageStabilizer.stabilizer] ?? 'détour';
+
+  if (postSalvageStabilizer.status === 'urgent-stabilization') {
+    return {
+      status: 'reserve-corridor',
+      remainingConstraint,
+      nextGesture: remainingConstraint === 'alternative' ? 'garder comme secours' : 'renforcer encore',
+      summary: `Corridor à garder en secours: ${remainingConstraint} reste trop fragile après stabilisateur.`,
+    };
+  }
+
+  return {
+    status: 'monitored-route',
+    remainingConstraint,
+    nextGesture: 'surveiller un tour',
+    summary: `Route utilisable sous surveillance: contrôler ${remainingConstraint} après stabilisateur.`,
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -720,6 +757,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     scenarios,
   );
   const postSalvageStabilizer = buildPostSalvageStabilizer(postSalvageRobustness);
+  const postStabilizerReliability = buildPostStabilizerReliability(postSalvageStabilizer);
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -736,6 +774,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     postSalvageDecisionComparison,
     postSalvageRobustness,
     postSalvageStabilizer,
+    postStabilizerReliability,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -567,6 +567,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         benefit: 'Aucun stabilisateur requis: le corridor reste robuste après salvage.',
         summary: 'Stabilisateur neutre: surveiller sans action supplémentaire.',
       },
+      postStabilizerReliability: {
+        status: 'reliable-route',
+        remainingConstraint: null,
+        nextGesture: 'promouvoir',
+        summary: 'Route fiable: promouvoir le corridor après stabilisateur neutre.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -721,6 +727,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       benefit: 'Aucun stabilisateur requis: le corridor reste robuste après salvage.',
       summary: 'Stabilisateur neutre: surveiller sans action supplémentaire.',
     },
+    postStabilizerReliability: {
+      status: 'reliable-route',
+      remainingConstraint: null,
+      nextGesture: 'promouvoir',
+      summary: 'Route fiable: promouvoir le corridor après stabilisateur neutre.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -825,6 +837,12 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     benefit: 'transforme l’inversion possible en flux fiable.',
     summary: 'Stabilisation urgente: alternative de secours pour éviter une perte durable.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.postStabilizerReliability, {
+    status: 'reserve-corridor',
+    remainingConstraint: 'alternative',
+    nextGesture: 'garder comme secours',
+    summary: 'Corridor à garder en secours: alternative reste trop fragile après stabilisateur.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -895,6 +913,12 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     nextGesture: 'basculer vers alternative',
     benefit: 'transforme l’inversion possible en flux fiable.',
     summary: 'Stabilisateur recommandé: alternative de secours pour fiabiliser le corridor fragile.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.postStabilizerReliability, {
+    status: 'monitored-route',
+    remainingConstraint: 'alternative',
+    nextGesture: 'surveiller un tour',
+    summary: 'Route utilisable sous surveillance: contrôler alternative après stabilisateur.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a compact reliability summary after the priority post-salvage stabilizer so the economy overlay shows whether the corridor can be promoted, needs one-turn monitoring, or should stay as a reserve.

## Changes

- Add `postStabilizerReliability` beside the B36 stabilizer readout.
- Classify reliable route, monitored route, and reserve corridor outcomes.
- Name the remaining visible constraint and short next gesture (`promouvoir`, `surveiller un tour`, `renforcer encore`, or `garder comme secours`).
- Extend economy overlay tests for reliable, monitored, and reserve reliability outcomes.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (628/628 pass)

Fixes loo469/historia#1080