### PR TITLE
Gamma: show post-allocation culture stability

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1062,6 +1062,44 @@ export function buildResidualCultureSupportAllocationChoice(residualCultureWindo
   };
 }
 
+export function buildResidualCulturePostAllocationStability(residualCultureSupportAllocationChoice, residualCultureWindowClosureThreat) {
+  const dominantFactor = residualCultureSupportAllocationChoice.dominantConstraint;
+
+  if (residualCultureSupportAllocationChoice.recommendation === 'wait-neutral') {
+    return {
+      status: 'durable',
+      dominantFactor,
+      stabilitySummary: 'stabilité durable: aucun support immédiat ne change la fenêtre visible',
+      nextMicroDecision: null,
+    };
+  }
+
+  if (residualCultureSupportAllocationChoice.recommendation === 'keep-support') {
+    return {
+      status: 'useful-lull',
+      dominantFactor,
+      stabilitySummary: `accalmie utile: le support reste disponible pour ${dominantFactor}`,
+      nextMicroDecision: null,
+    };
+  }
+
+  if (residualCultureWindowClosureThreat.status === 'likely-close') {
+    return {
+      status: 'fragile-after-action',
+      dominantFactor,
+      stabilitySummary: `fragile après action: ${dominantFactor} peut encore rouvrir la dette culturelle`,
+      nextMicroDecision: residualCultureWindowClosureThreat.recommendedGesture,
+    };
+  }
+
+  return {
+    status: 'useful-lull',
+    dominantFactor,
+    stabilitySummary: `accalmie utile: renforcer réduit le risque lié à ${dominantFactor}`,
+    nextMicroDecision: null,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -1121,6 +1159,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const residualCultureActionPayoff = buildResidualCultureActionPayoff(residualRiskAfterNextRetirement, residualCultureRiskNextAction);
   const residualCultureFollowUpWindow = buildResidualCultureFollowUpWindow(residualCultureActionPayoff, residualCultureRiskNextAction);
   const residualCultureWindowClosureThreat = buildResidualCultureWindowClosureThreat(residualCultureFollowUpWindow);
+  const residualCultureSupportAllocationChoice = buildResidualCultureSupportAllocationChoice(residualCultureWindowClosureThreat, postBundleCumulativeRisk);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -1136,7 +1175,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     residualCultureActionPayoff,
     residualCultureFollowUpWindow,
     residualCultureWindowClosureThreat,
-    residualCultureSupportAllocationChoice: buildResidualCultureSupportAllocationChoice(residualCultureWindowClosureThreat, postBundleCumulativeRisk),
+    residualCultureSupportAllocationChoice,
+    residualCulturePostAllocationStability: buildResidualCulturePostAllocationStability(residualCultureSupportAllocationChoice, residualCultureWindowClosureThreat),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { Culture } from '../../../src/domain/culture/Culture.js';
 import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
-import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice } from '../../../src/ui/culture/buildCultureMapOverlay.js';
+import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
 function withoutSupportRiskPreviews(value) {
   if (Array.isArray(value)) {
@@ -953,6 +953,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         riskAvoided: 'évite de perdre une fenêtre encore exploitable sous fatigue de médiation',
         summary: 'renforcer maintenant: la fenêtre reste utile mais socialement coûteuse',
       },
+      residualCulturePostAllocationStability: {
+        status: 'useful-lull',
+        dominantFactor: 'fatigue de médiation',
+        stabilitySummary: 'accalmie utile: renforcer réduit le risque lié à fatigue de médiation',
+        nextMicroDecision: null,
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -1059,6 +1065,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         dominantConstraint: 'aucune contrainte visible',
         riskAvoided: 'aucun coût notable évité par un renfort immédiat',
         summary: 'attendre sans coût notable: la fenêtre ne réclame pas de support dédié',
+      },
+      residualCulturePostAllocationStability: {
+        status: 'durable',
+        dominantFactor: 'aucune contrainte visible',
+        stabilitySummary: 'stabilité durable: aucun support immédiat ne change la fenêtre visible',
+        nextMicroDecision: null,
       },
     },
     summary: 'stabilisation complète: aucun second soutien requis',
@@ -1432,6 +1444,65 @@ test('buildResidualCultureSupportAllocationChoice compares reinforcing, keeping 
       dominantConstraint: 'aucune contrainte visible',
       riskAvoided: 'aucun coût notable évité par un renfort immédiat',
       summary: 'attendre sans coût notable: la fenêtre ne réclame pas de support dédié',
+    },
+  );
+});
+
+test('buildResidualCulturePostAllocationStability covers durable, useful lull, and fragile outcomes', () => {
+  assert.deepEqual(
+    buildResidualCulturePostAllocationStability(
+      {
+        recommendation: 'wait-neutral',
+        dominantConstraint: 'aucune contrainte visible',
+        riskAvoided: 'aucun coût notable évité par un renfort immédiat',
+        summary: 'attendre sans coût notable: la fenêtre ne réclame pas de support dédié',
+      },
+      { status: 'none', recommendedGesture: null },
+    ),
+    {
+      status: 'durable',
+      dominantFactor: 'aucune contrainte visible',
+      stabilitySummary: 'stabilité durable: aucun support immédiat ne change la fenêtre visible',
+      nextMicroDecision: null,
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCulturePostAllocationStability(
+      {
+        recommendation: 'keep-support',
+        dominantConstraint: 'autre foyer visible',
+        riskAvoided: 'évite de détourner le support du risque pression frontalière',
+        summary: 'garder le support: la fenêtre résiduelle ne subit pas de pression notable',
+      },
+      { status: 'none', recommendedGesture: null },
+    ),
+    {
+      status: 'useful-lull',
+      dominantFactor: 'autre foyer visible',
+      stabilitySummary: 'accalmie utile: le support reste disponible pour autre foyer visible',
+      nextMicroDecision: null,
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCulturePostAllocationStability(
+      {
+        recommendation: 'reinforce-now',
+        dominantConstraint: 'support local',
+        riskAvoided: 'évite que support local ferme la fenêtre de suivi',
+        summary: 'renforcer maintenant: la fenêtre reste utile mais socialement coûteuse',
+      },
+      {
+        status: 'likely-close',
+        recommendedGesture: 'sécuriser un support local avant tout suivi',
+      },
+    ),
+    {
+      status: 'fragile-after-action',
+      dominantFactor: 'support local',
+      stabilitySummary: 'fragile après action: support local peut encore rouvrir la dette culturelle',
+      nextMicroDecision: 'sécuriser un support local avant tout suivi',
     },
   );
 });


### PR DESCRIPTION
Gamma: ## Summary

Shows expected cultural stability after the residual support allocation choice.

## Changes

- Adds `residualCulturePostAllocationStability` near the residual support allocation choice.
- Classifies the outcome as durable, useful lull, or fragile after action.
- Names the visible dominant factor from the existing G36 choice/threat context.
- Adds a next micro-decision only when stability remains fragile.
- Complements G36 without recalculating the support allocation or exposing hidden social factors.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1081