### PR TITLE
Alpha: show late fallback correction exit cost

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -879,6 +879,49 @@ export function buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibility
   };
 }
 
+function describeLateCorrectionLoss(constraint) {
+  const normalized = String(constraint ?? '').toLowerCase();
+  if (normalized.includes('tempo')) return 'tempo';
+  if (normalized.includes('position')) return 'position';
+  if (normalized.includes('opportunité')) return 'opportunité rivale';
+  if (normalized.includes('ordre')) return 'ordre engagé';
+  return 'appui';
+}
+
+export function buildMiniPlanLateCorrectionExitCost(miniPlanLastSafeCorrectionCue = null) {
+  if (!miniPlanLastSafeCorrectionCue || miniPlanLastSafeCorrectionCue.empty) {
+    return {
+      empty: true,
+      severity: 'none',
+      label: 'coût de sortie inconnu',
+      loss: null,
+      decision: null,
+    };
+  }
+
+  const severity = miniPlanLastSafeCorrectionCue.state === 'safe-correction'
+    ? 'light'
+    : miniPlanLastSafeCorrectionCue.state === 'last-correction-turn'
+      ? 'costly'
+      : 'deterrent';
+
+  return {
+    empty: false,
+    severity,
+    label: severity === 'light'
+      ? 'coût léger'
+      : severity === 'costly'
+        ? 'coûteux mais possible'
+        : 'coût dissuasif',
+    loss: describeLateCorrectionLoss(miniPlanLastSafeCorrectionCue.constraint),
+    decision: severity === 'light'
+      ? 'corriger maintenant'
+      : severity === 'costly'
+        ? 'assumer le plan'
+        : 'attendre sans nouvelle correction',
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -983,6 +1026,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanRivalResponseFallback,
   );
   const miniPlanLastSafeCorrectionCue = buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibilityCue);
+  const miniPlanLateCorrectionExitCost = buildMiniPlanLateCorrectionExitCost(miniPlanLastSafeCorrectionCue);
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -1037,6 +1081,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanConfidenceSignalCue,
     miniPlanDecisionReversibilityCue,
     miniPlanLastSafeCorrectionCue,
+    miniPlanLateCorrectionExitCost,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -10,6 +10,7 @@ import {
   buildMiniPlanConfidenceSignalCue,
   buildMiniPlanDecisionReversibilityCue,
   buildMiniPlanLastSafeCorrectionCue,
+  buildMiniPlanLateCorrectionExitCost,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -366,6 +367,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     label: 'fenêtre correction inconnue',
     constraint: null,
     nextStep: null,
+  });
+  assert.deepEqual(shell.miniPlanLateCorrectionExitCost, {
+    empty: true,
+    severity: 'none',
+    label: 'coût de sortie inconnu',
+    loss: null,
+    decision: null,
   });
 });
 
@@ -731,12 +739,20 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     constraint: 'position moins prioritaire',
     nextStep: null,
   });
-  assert.deepEqual(buildMiniPlanLastSafeCorrectionCue(reversibility), {
+  const lastSafe = buildMiniPlanLastSafeCorrectionCue(reversibility);
+  assert.deepEqual(lastSafe, {
     empty: false,
     state: 'locked-commitment',
     label: 'engagement verrouillé',
     constraint: 'position moins prioritaire',
     nextStep: null,
+  });
+  assert.deepEqual(buildMiniPlanLateCorrectionExitCost(lastSafe), {
+    empty: false,
+    severity: 'deterrent',
+    label: 'coût dissuasif',
+    loss: 'position',
+    decision: 'attendre sans nouvelle correction',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -803,12 +819,20 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     constraint: 'coût d’opportunité',
     nextStep: 'garder un ordre court en réserve',
   });
-  assert.deepEqual(buildMiniPlanLastSafeCorrectionCue(reversibility), {
+  const lastSafe = buildMiniPlanLastSafeCorrectionCue(reversibility);
+  assert.deepEqual(lastSafe, {
     empty: false,
     state: 'safe-correction',
     label: 'correction encore sûre',
     constraint: 'coût d’opportunité',
     nextStep: 'préparer correction courte',
+  });
+  assert.deepEqual(buildMiniPlanLateCorrectionExitCost(lastSafe), {
+    empty: false,
+    severity: 'light',
+    label: 'coût léger',
+    loss: 'opportunité rivale',
+    decision: 'corriger maintenant',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -866,12 +890,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     constraint: 'tempo rival',
     nextStep: 'préserver un tempo de correction',
   });
-  assert.deepEqual(buildMiniPlanLastSafeCorrectionCue(reversibility), {
+  const lastSafe = buildMiniPlanLastSafeCorrectionCue(reversibility);
+  assert.deepEqual(lastSafe, {
     empty: false,
     state: 'last-correction-turn',
     label: 'dernier tour de correction',
     constraint: 'tempo rival',
     nextStep: 'corriger maintenant ou assumer',
+  });
+  assert.deepEqual(buildMiniPlanLateCorrectionExitCost(lastSafe), {
+    empty: false,
+    severity: 'costly',
+    label: 'coûteux mais possible',
+    loss: 'tempo',
+    decision: 'assumer le plan',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -901,6 +933,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     label: 'fenêtre correction inconnue',
     constraint: null,
     nextStep: null,
+  });
+  assert.deepEqual(buildMiniPlanLateCorrectionExitCost(null), {
+    empty: true,
+    severity: 'none',
+    label: 'coût de sortie inconnu',
+    loss: null,
+    decision: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -73,6 +73,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanConfidenceSignalCue\(/);
   assert.match(webAppSource, /buildMiniPlanDecisionReversibilityCue\(/);
   assert.match(webAppSource, /buildMiniPlanLastSafeCorrectionCue\(/);
+  assert.match(webAppSource, /buildMiniPlanLateCorrectionExitCost\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -115,6 +116,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanConfidenceSignalCue: buildMiniPlanConfidenceSignalCue\(/);
   assert.match(webAppSource, /miniPlanDecisionReversibilityCue: buildMiniPlanDecisionReversibilityCue\(/);
   assert.match(webAppSource, /miniPlanLastSafeCorrectionCue: buildMiniPlanLastSafeCorrectionCue\(/);
+  assert.match(webAppSource, /miniPlanLateCorrectionExitCost: buildMiniPlanLateCorrectionExitCost\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
@@ -123,6 +125,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /confiance: non évaluée/);
   assert.match(webAppSource, /réversibilité: non évaluée/);
   assert.match(webAppSource, /dernier sûr: non évalué/);
+  assert.match(webAppSource, /sortie tardive: non évaluée/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -138,6 +141,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__confidence-signal/);
   assert.match(webAppSource, /atlas-military-fallback-order__decision-reversibility/);
   assert.match(webAppSource, /atlas-military-fallback-order__last-safe-correction/);
+  assert.match(webAppSource, /atlas-military-fallback-order__late-correction-exit-cost/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -153,6 +157,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /\$\{confidenceSignal\.label\}: \$\{confidenceSignal\.signal\} · \$\{confidenceSignal\.waitCost\}/);
   assert.match(webAppSource, /réversibilité: \$\{reversibility\.label\} · \$\{reversibility\.constraint\}\$\{reversibility\.nextStep \? ` · \$\{reversibility\.nextStep\}` : ''\}/);
   assert.match(webAppSource, /dernier sûr: \$\{lastSafeCorrection\.label\} · \$\{lastSafeCorrection\.constraint\}\$\{lastSafeCorrection\.nextStep \? ` · \$\{lastSafeCorrection\.nextStep\}` : ''\}/);
+  assert.match(webAppSource, /sortie tardive: \$\{exitCost\.label\} · perte \$\{exitCost\.loss\} · \$\{exitCost\.decision\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -178,4 +183,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__confidence-signal/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__decision-reversibility/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__last-safe-correction/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__late-correction-exit-cost/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -11,6 +11,7 @@ import {
   buildMiniPlanConfidenceSignalCue,
   buildMiniPlanDecisionReversibilityCue,
   buildMiniPlanLastSafeCorrectionCue,
+  buildMiniPlanLateCorrectionExitCost,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -2014,6 +2015,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
         buildMiniPlanRivalResponseFallback(buildMiniPlanRivalResponseComparison(null, [])),
       ),
       miniPlanLastSafeCorrectionCue: buildMiniPlanLastSafeCorrectionCue(buildMiniPlanDecisionReversibilityCue(null, null)),
+      miniPlanLateCorrectionExitCost: buildMiniPlanLateCorrectionExitCost(
+        buildMiniPlanLastSafeCorrectionCue(buildMiniPlanDecisionReversibilityCue(null, null)),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2069,6 +2073,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanRivalResponseFallback,
   );
   const miniPlanLastSafeCorrectionCue = buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibilityCue);
+  const miniPlanLateCorrectionExitCost = buildMiniPlanLateCorrectionExitCost(miniPlanLastSafeCorrectionCue);
 
   return {
     fallback: {
@@ -2095,6 +2100,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanConfidenceSignalCue,
       miniPlanDecisionReversibilityCue,
       miniPlanLastSafeCorrectionCue,
+      miniPlanLateCorrectionExitCost,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2116,7 +2122,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanConfidenceSignalCue,
     miniPlanDecisionReversibilityCue,
     miniPlanLastSafeCorrectionCue,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}).`,
+    miniPlanLateCorrectionExitCost,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}).`,
     empty: false,
   };
 }
@@ -2187,9 +2194,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const lastSafeCorrectionLabel = lastSafeCorrection && !lastSafeCorrection.empty
     ? `dernier sûr: ${lastSafeCorrection.label} · ${lastSafeCorrection.constraint}${lastSafeCorrection.nextStep ? ` · ${lastSafeCorrection.nextStep}` : ''}`
     : 'dernier sûr: non évalué';
+  const exitCost = fallback.miniPlanLateCorrectionExitCost;
+  const exitCostLabel = exitCost && !exitCost.empty
+    ? `sortie tardive: ${exitCost.label} · perte ${exitCost.loss} · ${exitCost.decision}`
+    : 'sortie tardive: non évaluée';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="26.4" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="27.6" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2212,6 +2223,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__confidence-signal atlas-military-fallback-order__confidence-signal--${confidenceSignal?.decision ?? 'none'}" x="23.2" y="80">${confidenceSignalLabel}</text>
       <text class="atlas-military-fallback-order__decision-reversibility atlas-military-fallback-order__decision-reversibility--${reversibility?.state ?? 'none'}" x="23.2" y="81.1">${reversibilityLabel}</text>
       <text class="atlas-military-fallback-order__last-safe-correction atlas-military-fallback-order__last-safe-correction--${lastSafeCorrection?.state ?? 'none'}" x="23.2" y="82.2">${lastSafeCorrectionLabel}</text>
+      <text class="atlas-military-fallback-order__late-correction-exit-cost atlas-military-fallback-order__late-correction-exit-cost--${exitCost?.severity ?? 'none'}" x="23.2" y="83.3">${exitCostLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11181,6 +11181,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__last-safe-correction { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
 .atlas-military-fallback-order__last-safe-correction--last-correction-turn { fill: #fde68a; }
 .atlas-military-fallback-order__last-safe-correction--locked-commitment { fill: #fecaca; }
+.atlas-military-fallback-order__late-correction-exit-cost { fill: #c7d2fe; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__late-correction-exit-cost--costly { fill: #fde68a; }
+.atlas-military-fallback-order__late-correction-exit-cost--deterrent { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1079.

Summary:
- adds structured `miniPlanLateCorrectionExitCost` after the last safe correction cue
- classifies late correction cost as light, costly but possible, or deterrent
- names the dominant visible loss and recommends a compact micro-decision
- keeps the overlay compact without repeating A36 correction timing

Tests:
- npm test

Zeta: ready for validation before merge.