### PR TITLE
Delta: show minimal monitoring resume signal

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -734,6 +734,47 @@ function buildMonitoringSafeCadence({ monitoringMarginResponsePriority }) {
   };
 }
 
+
+function buildMonitoringMinimalResumeSignal({ monitoringSafeCadence }) {
+  if (monitoringSafeCadence.cadence === 'sweep-now') {
+    return {
+      prerequisite: 'already-safe',
+      visibleFactor: monitoringSafeCadence.cadenceFactor,
+      action: 'resume-sweep',
+      label: 'Signal minimal: reprise sûre.',
+      reason: 'La fenêtre visible suffit déjà: reprendre sans ajouter de révélation cachée.',
+    };
+  }
+
+  if (monitoringSafeCadence.cadence === 'refresh-then-sweep') {
+    return {
+      prerequisite: 'fresh-signal-required',
+      visibleFactor: monitoringSafeCadence.cadenceFactor,
+      action: 'wait-signal',
+      label: 'Signal minimal: donnée fraîche.',
+      reason: 'Attendre une confirmation fraîche avant de reprendre le sweep contraint.',
+    };
+  }
+
+  if (monitoringSafeCadence.cadence === 'space-for-heat') {
+    return {
+      prerequisite: 'heat-reduction-required',
+      visibleFactor: 'Heat',
+      action: 'reduce-heat',
+      label: 'Signal minimal: heat réduit.',
+      reason: 'Réduire le heat visible avant toute reprise de sweep.',
+    };
+  }
+
+  return {
+    prerequisite: 'sufficient-margin',
+    visibleFactor: monitoringSafeCadence.cadenceFactor,
+    action: 'maintain-surveillance',
+    label: 'Signal minimal: marge suffisante.',
+    reason: 'Maintenir la surveillance jusqu’à une marge lisible, sans forcer la reprise.',
+  };
+}
+
 function buildMonitoringRestartPlan({ state, monitoringPreferred, marginalExposureAdded, expectedConfidenceGain }) {
   const normalizedExposure = clampPercent(marginalExposureAdded);
   const normalizedGain = clampPercent(expectedConfidenceGain);
@@ -1015,6 +1056,69 @@ function withMonitoringRestartPlan(rationale, marginalExposureAdded, expectedCon
             state: rationale.state,
             marginalExposureAdded,
             expectedConfidenceGain,
+          }),
+        }),
+      }),
+    }),
+    monitoringMinimalResumeSignal: buildMonitoringMinimalResumeSignal({
+      monitoringSafeCadence: buildMonitoringSafeCadence({
+        monitoringMarginResponsePriority: buildMonitoringMarginResponsePriority({
+          postRecoveryMarginDecay: buildPostRecoveryMarginDecay({
+            postRecoverySafetyMargin: buildPostRecoverySafetyMargin({
+              preventiveRecoveryState: buildPreventiveRecoveryState({
+                preventiveAction: buildMonitoringPreventiveAction({
+                  state: rationale.state,
+                  driftForecast: buildMonitoringDriftForecast({
+                    state: rationale.state,
+                    marginalExposureAdded,
+                    expectedConfidenceGain,
+                  }),
+                }),
+              }),
+              preventiveAction: buildMonitoringPreventiveAction({
+                state: rationale.state,
+                driftForecast: buildMonitoringDriftForecast({
+                  state: rationale.state,
+                  marginalExposureAdded,
+                  expectedConfidenceGain,
+                }),
+              }),
+              driftForecast: buildMonitoringDriftForecast({
+                state: rationale.state,
+                marginalExposureAdded,
+                expectedConfidenceGain,
+              }),
+            }),
+            driftForecast: buildMonitoringDriftForecast({
+              state: rationale.state,
+              marginalExposureAdded,
+              expectedConfidenceGain,
+            }),
+          }),
+          postRecoverySafetyMargin: buildPostRecoverySafetyMargin({
+            preventiveRecoveryState: buildPreventiveRecoveryState({
+              preventiveAction: buildMonitoringPreventiveAction({
+                state: rationale.state,
+                driftForecast: buildMonitoringDriftForecast({
+                  state: rationale.state,
+                  marginalExposureAdded,
+                  expectedConfidenceGain,
+                }),
+              }),
+            }),
+            preventiveAction: buildMonitoringPreventiveAction({
+              state: rationale.state,
+              driftForecast: buildMonitoringDriftForecast({
+                state: rationale.state,
+                marginalExposureAdded,
+                expectedConfidenceGain,
+              }),
+            }),
+            driftForecast: buildMonitoringDriftForecast({
+              state: rationale.state,
+              marginalExposureAdded,
+              expectedConfidenceGain,
+            }),
           }),
         }),
       }),

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -208,6 +208,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           label: 'Cadence: attendre sans urgence.',
           reason: 'Aucune fenêtre sûre immédiate: maintenir la surveillance sans forcer le rythme.',
         },
+        monitoringMinimalResumeSignal: {
+          prerequisite: 'sufficient-margin',
+          visibleFactor: 'Données insuffisantes',
+          action: 'maintain-surveillance',
+          label: 'Signal minimal: marge suffisante.',
+          reason: 'Maintenir la surveillance jusqu’à une marge lisible, sans forcer la reprise.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -255,6 +262,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               cadenceFactor: 'Données insuffisantes',
               label: 'Cadence: attendre sans urgence.',
               reason: 'Aucune fenêtre sûre immédiate: maintenir la surveillance sans forcer le rythme.',
+            },
+            monitoringMinimalResumeSignal: {
+              prerequisite: 'sufficient-margin',
+              visibleFactor: 'Données insuffisantes',
+              action: 'maintain-surveillance',
+              label: 'Signal minimal: marge suffisante.',
+              reason: 'Maintenir la surveillance jusqu’à une marge lisible, sans forcer la reprise.',
             },
         monitoringChecklist: [
           {
@@ -408,6 +422,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           label: 'Cadence: attendre sans urgence.',
           reason: 'Aucune fenêtre sûre immédiate: maintenir la surveillance sans forcer le rythme.',
         },
+        monitoringMinimalResumeSignal: {
+          prerequisite: 'sufficient-margin',
+          visibleFactor: 'Données insuffisantes',
+          action: 'maintain-surveillance',
+          label: 'Signal minimal: marge suffisante.',
+          reason: 'Maintenir la surveillance jusqu’à une marge lisible, sans forcer la reprise.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -455,6 +476,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               cadenceFactor: 'Données insuffisantes',
               label: 'Cadence: attendre sans urgence.',
               reason: 'Aucune fenêtre sûre immédiate: maintenir la surveillance sans forcer le rythme.',
+            },
+            monitoringMinimalResumeSignal: {
+              prerequisite: 'sufficient-margin',
+              visibleFactor: 'Données insuffisantes',
+              action: 'maintain-surveillance',
+              label: 'Signal minimal: marge suffisante.',
+              reason: 'Maintenir la surveillance jusqu’à une marge lisible, sans forcer la reprise.',
             },
         monitoringChecklist: [
           {
@@ -708,6 +736,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
           label: 'Cadence: attendre sans urgence.',
           reason: 'Aucune fenêtre sûre immédiate: maintenir la surveillance sans forcer le rythme.',
         },
+        monitoringMinimalResumeSignal: {
+          prerequisite: 'sufficient-margin',
+          visibleFactor: 'Données insuffisantes',
+          action: 'maintain-surveillance',
+          label: 'Signal minimal: marge suffisante.',
+          reason: 'Maintenir la surveillance jusqu’à une marge lisible, sans forcer la reprise.',
+        },
         monitoringChecklist: [
           {
             signal: 'Nouveau gap',
@@ -834,6 +869,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
         cadenceFactor: 'Gain confiance',
         label: 'Cadence: rafraîchir puis sweep.',
         reason: 'Qualité du signal pilote le tempo: confirmer, puis relancer court.',
+      },
+      monitoringMinimalResumeSignal: {
+        prerequisite: 'fresh-signal-required',
+        visibleFactor: 'Gain confiance',
+        action: 'wait-signal',
+        label: 'Signal minimal: donnée fraîche.',
+        reason: 'Attendre une confirmation fraîche avant de reprendre le sweep contraint.',
       },
       monitoringChecklist: [
         {
@@ -1028,6 +1070,13 @@ test('buildIntrigueMapOverlay recommends preparing a third sweep only when resid
         label: 'Cadence: sweep maintenant.',
         reason: 'Fenêtre visible encore ouverte: lancer avant le prochain tick de dérive.',
       },
+      monitoringMinimalResumeSignal: {
+        prerequisite: 'already-safe',
+        visibleFactor: 'Fenêtre sûre',
+        action: 'resume-sweep',
+        label: 'Signal minimal: reprise sûre.',
+        reason: 'La fenêtre visible suffit déjà: reprendre sans ajouter de révélation cachée.',
+      },
       monitoringChecklist: [
         {
           signal: 'Fenêtre sûre',
@@ -1146,6 +1195,13 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
       label: 'Cadence: rafraîchir puis sweep.',
       reason: 'Qualité du signal pilote le tempo: confirmer, puis relancer court.',
     },
+    monitoringMinimalResumeSignal: {
+      prerequisite: 'fresh-signal-required',
+      visibleFactor: 'Fraîcheur signal',
+      action: 'wait-signal',
+      label: 'Signal minimal: donnée fraîche.',
+      reason: 'Attendre une confirmation fraîche avant de reprendre le sweep contraint.',
+    },
     monitoringChecklist: [
       {
         signal: 'Fraîcheur signal',
@@ -1221,6 +1277,13 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
     cadenceFactor: 'Heat',
     label: 'Cadence: espacer pour heat.',
     reason: 'Espacer les sweeps laisse la pression visible retomber avant reprise.',
+  });
+  assert.deepEqual(tooExposed.thirdSweepRecommendation.monitoringRationale.monitoringMinimalResumeSignal, {
+    prerequisite: 'heat-reduction-required',
+    visibleFactor: 'Heat',
+    action: 'reduce-heat',
+    label: 'Signal minimal: heat réduit.',
+    reason: 'Réduire le heat visible avant toute reprise de sweep.',
   });
 });
 


### PR DESCRIPTION
Delta: Implements #1082.

Summary:
- Adds `monitoringMinimalResumeSignal` after the D36 safe cadence.
- Classifies the resume prerequisite as fresh signal, heat reduction, sufficient margin, or already safe.
- Names the visible factor and provides a short fog-safe action for the map overlay.

Tests:
- `node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js`
- `npm test` (629/629)

Zeta: PR ready for validation. Please review before any merge.