### PR TITLE
Epsilon: identify secondary climate debt

### DIFF
--- a/test/ui/climate/webAtlasSecondaryClimateDebtWhenReserveCostsWindow.test.js
+++ b/test/ui/climate/webAtlasSecondaryClimateDebtWhenReserveCostsWindow.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas identifies secondary climate debt when reserve costs a near window', () => {
+  assert.match(webAppSource, /function buildSecondaryClimateDebtWhenReserveCostsWindow/);
+  assert.match(webAppSource, /secondaryClimateDebtWhenReserveCostsWindow: null/);
+  assert.match(webAppSource, /secondaryClimateDebtWhenReserveCostsWindow,/);
+
+  for (const stableKey of [
+    'state',
+    'secondaryDebtKey',
+    'secondaryDebtLabel',
+    'visibleConstraint',
+    'shortGesture',
+    'reserveStillBest',
+    'sourceReserveCost',
+    'summary',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /dette secondaire urgente/);
+  assert.match(webAppSource, /dette à surveiller/);
+  assert.match(webAppSource, /réserve encore préférable/);
+  assert.match(webAppSource, /aucune dette prioritaire/);
+  assert.match(webAppSource, /saison/);
+  assert.match(webAppSource, /cascade voisine/);
+  assert.match(webAppSource, /pression régionale/);
+  assert.match(webAppSource, /conflit de timing/);
+  assert.match(webAppSource, /dette secondaire/);
+  assert.match(webAppSource, /fenêtre restaurée/);
+  assert.match(webAppSource, /traiter \$\{secondaryDebt\.label\} avant de garder la réserve/);
+  assert.match(webAppSource, /préparer \$\{secondaryDebt\.label\} si la fenêtre reste coûteuse/);
+  assert.match(webAppSource, /aucun geste immédiat/);
+  assert.match(webAppSource, /Dette secondaire réserve/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9780,6 +9780,70 @@ function buildClimateReserveNearTermWindowCostWarning(climateSecureWindowVsReser
   };
 }
 
+function buildSecondaryClimateDebtWhenReserveCostsWindow(climateReserveNearTermWindowCostWarning, climateRiskReboundAfterTopPayoff, decisionDebtRanking) {
+  if (!climateReserveNearTermWindowCostWarning) {
+    return null;
+  }
+
+  const rankedItems = decisionDebtRanking?.items ?? [];
+  const secondaryDebt = rankedItems.find((item) => item.key === climateRiskReboundAfterTopPayoff?.secondaryDebtKey)
+    ?? rankedItems[1]
+    ?? null;
+  const constraintText = `${climateReserveNearTermWindowCostWarning.visibleConstraint ?? ''} ${secondaryDebt?.reason ?? ''} ${climateRiskReboundAfterTopPayoff?.secondaryDebtCause ?? ''}`.toLowerCase();
+  const visibleConstraint = constraintText.includes('cascade')
+    ? 'cascade voisine'
+    : constraintText.includes('conflit') || constraintText.includes('timing')
+      ? 'conflit de timing'
+      : constraintText.includes('saison')
+        ? 'saison'
+        : constraintText.includes('pression régionale') || constraintText.includes('deadline')
+          ? 'pression régionale'
+          : constraintText.includes('fenêtre')
+            ? 'fenêtre restaurée'
+            : 'dette secondaire';
+
+  if (!secondaryDebt) {
+    return {
+      state: 'aucune dette prioritaire',
+      secondaryDebtKey: null,
+      secondaryDebtLabel: null,
+      visibleConstraint,
+      shortGesture: 'aucun geste immédiat',
+      reserveStillBest: true,
+      summary: `Aucune dette prioritaire: garder la réserve reste neutre; contrainte ${visibleConstraint}.`,
+    };
+  }
+
+  const nearCost = climateReserveNearTermWindowCostWarning.state;
+  const state = nearCost === 'fenêtre proche menacée'
+    ? 'dette secondaire urgente'
+    : nearCost === 'coût acceptable'
+      ? 'dette à surveiller'
+      : climateReserveNearTermWindowCostWarning.reserveChoice === 'garder réserve'
+        ? 'réserve encore préférable'
+        : 'aucune dette prioritaire';
+  const debtIsPriority = ['dette secondaire urgente', 'dette à surveiller'].includes(state);
+  const shortGesture = state === 'dette secondaire urgente'
+    ? `traiter ${secondaryDebt.label} avant de garder la réserve`
+    : state === 'dette à surveiller'
+      ? `préparer ${secondaryDebt.label} si la fenêtre reste coûteuse`
+      : 'aucun geste immédiat';
+  const summary = debtIsPriority
+    ? `${state}: ${secondaryDebt.label} devient prioritaire; contrainte ${visibleConstraint}; geste: ${shortGesture}.`
+    : `${state}: ${secondaryDebt.label} ne dépasse pas la valeur de réserve; contrainte ${visibleConstraint}.`;
+
+  return {
+    state,
+    secondaryDebtKey: secondaryDebt.key,
+    secondaryDebtLabel: secondaryDebt.label,
+    visibleConstraint,
+    shortGesture,
+    reserveStillBest: !debtIsPriority,
+    sourceReserveCost: nearCost,
+    summary,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -9835,6 +9899,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       safestClimateFollowThroughAfterDeadlineTradeoff: null,
       climateSecureWindowVsReserveComparison: null,
       climateReserveNearTermWindowCostWarning: null,
+      secondaryClimateDebtWhenReserveCostsWindow: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -9920,6 +9985,11 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     decisionWindow,
     climateRiskReboundAfterTopPayoff,
   );
+  const secondaryClimateDebtWhenReserveCostsWindow = buildSecondaryClimateDebtWhenReserveCostsWindow(
+    climateReserveNearTermWindowCostWarning,
+    climateRiskReboundAfterTopPayoff,
+    decisionDebtRanking,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -9938,6 +10008,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     safestClimateFollowThroughAfterDeadlineTradeoff,
     climateSecureWindowVsReserveComparison,
     climateReserveNearTermWindowCostWarning,
+    secondaryClimateDebtWhenReserveCostsWindow,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -9977,6 +10048,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.safestClimateFollowThroughAfterDeadlineTradeoff ? `<small><b>Follow-through sûr</b> · ${view.safestClimateFollowThroughAfterDeadlineTradeoff.summary} ${view.safestClimateFollowThroughAfterDeadlineTradeoff.reason}</small>` : ''}
       ${view.climateSecureWindowVsReserveComparison ? `<small><b>Sécuriser vs réserve</b> · ${view.climateSecureWindowVsReserveComparison.summary}</small>` : ''}
       ${view.climateReserveNearTermWindowCostWarning ? `<small><b>Coût réserve court terme</b> · ${view.climateReserveNearTermWindowCostWarning.summary}</small>` : ''}
+      ${view.secondaryClimateDebtWhenReserveCostsWindow ? `<small><b>Dette secondaire réserve</b> · ${view.secondaryClimateDebtWhenReserveCostsWindow.summary}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1083.

## Résumé
- identifie la dette climat secondaire quand garder la réserve coûte une fenêtre proche
- classe la priorité entre dette urgente, surveillance, réserve préférable ou aucune dette prioritaire
- nomme la contrainte visible et garde un libellé neutre quand la réserve reste meilleure

## Tests
- `npm test`
