### PR TITLE
Gamma: show fragile culture reevaluation trigger

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1100,6 +1100,35 @@ export function buildResidualCulturePostAllocationStability(residualCultureSuppo
   };
 }
 
+export function buildResidualCultureReevaluationTrigger(residualCulturePostAllocationStability) {
+  const visibleTrigger = residualCulturePostAllocationStability.dominantFactor;
+
+  if (residualCulturePostAllocationStability.status === 'durable') {
+    return {
+      status: 'none-soon',
+      visibleTrigger,
+      triggerSummary: 'pas de réévaluation proche: stabilité durable visible',
+      microDecision: null,
+    };
+  }
+
+  if (residualCulturePostAllocationStability.status === 'useful-lull') {
+    return {
+      status: 'watch-signal',
+      visibleTrigger,
+      triggerSummary: `surveiller le signal: ${visibleTrigger} peut écourter l’accalmie`,
+      microDecision: `revoir le support si ${visibleTrigger} remonte`,
+    };
+  }
+
+  return {
+    status: 'urgent',
+    visibleTrigger,
+    triggerSummary: `réévaluation urgente si ${visibleTrigger} réapparaît`,
+    microDecision: residualCulturePostAllocationStability.nextMicroDecision,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -1160,6 +1189,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const residualCultureFollowUpWindow = buildResidualCultureFollowUpWindow(residualCultureActionPayoff, residualCultureRiskNextAction);
   const residualCultureWindowClosureThreat = buildResidualCultureWindowClosureThreat(residualCultureFollowUpWindow);
   const residualCultureSupportAllocationChoice = buildResidualCultureSupportAllocationChoice(residualCultureWindowClosureThreat, postBundleCumulativeRisk);
+  const residualCulturePostAllocationStability = buildResidualCulturePostAllocationStability(residualCultureSupportAllocationChoice, residualCultureWindowClosureThreat);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -1176,7 +1206,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     residualCultureFollowUpWindow,
     residualCultureWindowClosureThreat,
     residualCultureSupportAllocationChoice,
-    residualCulturePostAllocationStability: buildResidualCulturePostAllocationStability(residualCultureSupportAllocationChoice, residualCultureWindowClosureThreat),
+    residualCulturePostAllocationStability,
+    residualCultureReevaluationTrigger: buildResidualCultureReevaluationTrigger(residualCulturePostAllocationStability),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { Culture } from '../../../src/domain/culture/Culture.js';
 import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
-import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability } from '../../../src/ui/culture/buildCultureMapOverlay.js';
+import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability, buildResidualCultureReevaluationTrigger } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
 function withoutSupportRiskPreviews(value) {
   if (Array.isArray(value)) {
@@ -959,6 +959,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         stabilitySummary: 'accalmie utile: renforcer réduit le risque lié à fatigue de médiation',
         nextMicroDecision: null,
       },
+      residualCultureReevaluationTrigger: {
+        status: 'watch-signal',
+        visibleTrigger: 'fatigue de médiation',
+        triggerSummary: 'surveiller le signal: fatigue de médiation peut écourter l’accalmie',
+        microDecision: 'revoir le support si fatigue de médiation remonte',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -1071,6 +1077,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         dominantFactor: 'aucune contrainte visible',
         stabilitySummary: 'stabilité durable: aucun support immédiat ne change la fenêtre visible',
         nextMicroDecision: null,
+      },
+      residualCultureReevaluationTrigger: {
+        status: 'none-soon',
+        visibleTrigger: 'aucune contrainte visible',
+        triggerSummary: 'pas de réévaluation proche: stabilité durable visible',
+        microDecision: null,
       },
     },
     summary: 'stabilisation complète: aucun second soutien requis',
@@ -1503,6 +1515,53 @@ test('buildResidualCulturePostAllocationStability covers durable, useful lull, a
       dominantFactor: 'support local',
       stabilitySummary: 'fragile après action: support local peut encore rouvrir la dette culturelle',
       nextMicroDecision: 'sécuriser un support local avant tout suivi',
+    },
+  );
+});
+
+test('buildResidualCultureReevaluationTrigger covers none, watch, and urgent follow-up', () => {
+  assert.deepEqual(
+    buildResidualCultureReevaluationTrigger({
+      status: 'durable',
+      dominantFactor: 'aucune contrainte visible',
+      stabilitySummary: 'stabilité durable: aucun support immédiat ne change la fenêtre visible',
+      nextMicroDecision: null,
+    }),
+    {
+      status: 'none-soon',
+      visibleTrigger: 'aucune contrainte visible',
+      triggerSummary: 'pas de réévaluation proche: stabilité durable visible',
+      microDecision: null,
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureReevaluationTrigger({
+      status: 'useful-lull',
+      dominantFactor: 'fatigue de médiation',
+      stabilitySummary: 'accalmie utile: renforcer réduit le risque lié à fatigue de médiation',
+      nextMicroDecision: null,
+    }),
+    {
+      status: 'watch-signal',
+      visibleTrigger: 'fatigue de médiation',
+      triggerSummary: 'surveiller le signal: fatigue de médiation peut écourter l’accalmie',
+      microDecision: 'revoir le support si fatigue de médiation remonte',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureReevaluationTrigger({
+      status: 'fragile-after-action',
+      dominantFactor: 'support local',
+      stabilitySummary: 'fragile après action: support local peut encore rouvrir la dette culturelle',
+      nextMicroDecision: 'sécuriser un support local avant tout suivi',
+    }),
+    {
+      status: 'urgent',
+      visibleTrigger: 'support local',
+      triggerSummary: 'réévaluation urgente si support local réapparaît',
+      microDecision: 'sécuriser un support local avant tout suivi',
     },
   );
 });


### PR DESCRIPTION
Gamma: ## Summary

Shows the visible reevaluation trigger after residual cultural stability is fragile or only a useful lull.

## Changes

- Adds `residualCultureReevaluationTrigger` near the post-allocation stability summary.
- Classifies follow-up as no near reevaluation, watch a signal, or urgent reevaluation.
- Names the visible trigger from the existing G37 dominant factor.
- Adds a micro-decision only when monitoring or urgent follow-up is useful.
- Complements G37 without recalculating stability or revealing hidden social factors.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1091