### PR TITLE
Beta: warn on premature monitored corridor promotion

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -543,6 +543,33 @@ function buildPostStabilizerReliability(postSalvageStabilizer) {
   };
 }
 
+function buildMonitoredCorridorPromotionRisk(postStabilizerReliability) {
+  if (postStabilizerReliability.status === 'reliable-route') {
+    return {
+      status: 'safe-promotion',
+      remainingConstraint: postStabilizerReliability.remainingConstraint,
+      nextGesture: 'promouvoir',
+      summary: 'Promotion sûre: le corridor peut devenir route principale.',
+    };
+  }
+
+  if (postStabilizerReliability.status === 'reserve-corridor') {
+    return {
+      status: 'premature-promotion',
+      remainingConstraint: postStabilizerReliability.remainingConstraint,
+      nextGesture: postStabilizerReliability.nextGesture === 'garder comme secours' ? 'garder en secours' : 'renforcer d’abord',
+      summary: `Promotion prématurée: ${postStabilizerReliability.remainingConstraint} expose encore le corridor principal.`,
+    };
+  }
+
+  return {
+    status: 'limited-promotion',
+    remainingConstraint: postStabilizerReliability.remainingConstraint,
+    nextGesture: 'plafonner le flux',
+    summary: `Promotion sous limite: plafonner le flux tant que ${postStabilizerReliability.remainingConstraint} reste surveillé.`,
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -758,6 +785,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
   );
   const postSalvageStabilizer = buildPostSalvageStabilizer(postSalvageRobustness);
   const postStabilizerReliability = buildPostStabilizerReliability(postSalvageStabilizer);
+  const monitoredCorridorPromotionRisk = buildMonitoredCorridorPromotionRisk(postStabilizerReliability);
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -775,6 +803,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     postSalvageRobustness,
     postSalvageStabilizer,
     postStabilizerReliability,
+    monitoredCorridorPromotionRisk,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -573,6 +573,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         nextGesture: 'promouvoir',
         summary: 'Route fiable: promouvoir le corridor après stabilisateur neutre.',
       },
+      monitoredCorridorPromotionRisk: {
+        status: 'safe-promotion',
+        remainingConstraint: null,
+        nextGesture: 'promouvoir',
+        summary: 'Promotion sûre: le corridor peut devenir route principale.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -733,6 +739,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       nextGesture: 'promouvoir',
       summary: 'Route fiable: promouvoir le corridor après stabilisateur neutre.',
     },
+    monitoredCorridorPromotionRisk: {
+      status: 'safe-promotion',
+      remainingConstraint: null,
+      nextGesture: 'promouvoir',
+      summary: 'Promotion sûre: le corridor peut devenir route principale.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -843,6 +855,12 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     nextGesture: 'garder comme secours',
     summary: 'Corridor à garder en secours: alternative reste trop fragile après stabilisateur.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.monitoredCorridorPromotionRisk, {
+    status: 'premature-promotion',
+    remainingConstraint: 'alternative',
+    nextGesture: 'garder en secours',
+    summary: 'Promotion prématurée: alternative expose encore le corridor principal.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -919,6 +937,12 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     remainingConstraint: 'alternative',
     nextGesture: 'surveiller un tour',
     summary: 'Route utilisable sous surveillance: contrôler alternative après stabilisateur.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.monitoredCorridorPromotionRisk, {
+    status: 'limited-promotion',
+    remainingConstraint: 'alternative',
+    nextGesture: 'plafonner le flux',
+    summary: 'Promotion sous limite: plafonner le flux tant que alternative reste surveillé.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a compact promotion-risk warning for monitored corridors so the economy overlay flags when making a post-stabilizer corridor the main route is still premature.

## Changes

- Add `monitoredCorridorPromotionRisk` beside the B37 reliability summary.
- Classify safe promotion, limited promotion, and premature promotion.
- Name the remaining visible constraint and short next gesture (`promouvoir`, `plafonner le flux`, `renforcer d’abord`, or `garder en secours`).
- Extend economy overlay tests for safe, limited, and premature promotion outcomes.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (630/630 pass)

Fixes loo469/historia#1090