### PR TITLE
Alpha: show minimal fallback follow-through

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -922,6 +922,53 @@ export function buildMiniPlanLateCorrectionExitCost(miniPlanLastSafeCorrectionCu
   };
 }
 
+function followThroughSupportForLoss(loss) {
+  if (loss === 'tempo') return 'tempo';
+  if (loss === 'position') return 'position';
+  if (loss === 'opportunité rivale') return 'opportunité rivale';
+  if (loss === 'ordre engagé') return 'ordre engagé';
+  return 'appui allié';
+}
+
+export function buildMiniPlanMinimalFollowThrough(miniPlanLateCorrectionExitCost = null) {
+  if (!miniPlanLateCorrectionExitCost || miniPlanLateCorrectionExitCost.empty) {
+    return {
+      empty: true,
+      level: 'none',
+      label: 'aucun suivi critique',
+      support: null,
+      action: null,
+    };
+  }
+
+  const level = miniPlanLateCorrectionExitCost.severity === 'deterrent'
+    ? 'urgent'
+    : miniPlanLateCorrectionExitCost.severity === 'costly'
+      ? 'advised'
+      : 'none';
+  const support = followThroughSupportForLoss(miniPlanLateCorrectionExitCost.loss);
+
+  return {
+    empty: false,
+    level,
+    label: level === 'urgent'
+      ? 'suivi urgent'
+      : level === 'advised'
+        ? 'suivi conseillé'
+        : 'aucun suivi critique',
+    support,
+    action: support === 'tempo'
+      ? 'consolider'
+      : support === 'position'
+        ? 'protéger position'
+        : support === 'ordre engagé'
+          ? 'confirmer ordre'
+          : support === 'opportunité rivale'
+            ? 'surveiller'
+            : 'économiser fatigue',
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -1027,6 +1074,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
   );
   const miniPlanLastSafeCorrectionCue = buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibilityCue);
   const miniPlanLateCorrectionExitCost = buildMiniPlanLateCorrectionExitCost(miniPlanLastSafeCorrectionCue);
+  const miniPlanMinimalFollowThrough = buildMiniPlanMinimalFollowThrough(miniPlanLateCorrectionExitCost);
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -1082,6 +1130,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanDecisionReversibilityCue,
     miniPlanLastSafeCorrectionCue,
     miniPlanLateCorrectionExitCost,
+    miniPlanMinimalFollowThrough,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -11,6 +11,7 @@ import {
   buildMiniPlanDecisionReversibilityCue,
   buildMiniPlanLastSafeCorrectionCue,
   buildMiniPlanLateCorrectionExitCost,
+  buildMiniPlanMinimalFollowThrough,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -374,6 +375,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     label: 'coût de sortie inconnu',
     loss: null,
     decision: null,
+  });
+  assert.deepEqual(shell.miniPlanMinimalFollowThrough, {
+    empty: true,
+    level: 'none',
+    label: 'aucun suivi critique',
+    support: null,
+    action: null,
   });
 });
 
@@ -747,12 +755,20 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     constraint: 'position moins prioritaire',
     nextStep: null,
   });
-  assert.deepEqual(buildMiniPlanLateCorrectionExitCost(lastSafe), {
+  const exitCost = buildMiniPlanLateCorrectionExitCost(lastSafe);
+  assert.deepEqual(exitCost, {
     empty: false,
     severity: 'deterrent',
     label: 'coût dissuasif',
     loss: 'position',
     decision: 'attendre sans nouvelle correction',
+  });
+  assert.deepEqual(buildMiniPlanMinimalFollowThrough(exitCost), {
+    empty: false,
+    level: 'urgent',
+    label: 'suivi urgent',
+    support: 'position',
+    action: 'protéger position',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -827,12 +843,20 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     constraint: 'coût d’opportunité',
     nextStep: 'préparer correction courte',
   });
-  assert.deepEqual(buildMiniPlanLateCorrectionExitCost(lastSafe), {
+  const exitCost = buildMiniPlanLateCorrectionExitCost(lastSafe);
+  assert.deepEqual(exitCost, {
     empty: false,
     severity: 'light',
     label: 'coût léger',
     loss: 'opportunité rivale',
     decision: 'corriger maintenant',
+  });
+  assert.deepEqual(buildMiniPlanMinimalFollowThrough(exitCost), {
+    empty: false,
+    level: 'none',
+    label: 'aucun suivi critique',
+    support: 'opportunité rivale',
+    action: 'surveiller',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -898,12 +922,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     constraint: 'tempo rival',
     nextStep: 'corriger maintenant ou assumer',
   });
-  assert.deepEqual(buildMiniPlanLateCorrectionExitCost(lastSafe), {
+  const exitCost = buildMiniPlanLateCorrectionExitCost(lastSafe);
+  assert.deepEqual(exitCost, {
     empty: false,
     severity: 'costly',
     label: 'coûteux mais possible',
     loss: 'tempo',
     decision: 'assumer le plan',
+  });
+  assert.deepEqual(buildMiniPlanMinimalFollowThrough(exitCost), {
+    empty: false,
+    level: 'advised',
+    label: 'suivi conseillé',
+    support: 'tempo',
+    action: 'consolider',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -940,6 +972,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     label: 'coût de sortie inconnu',
     loss: null,
     decision: null,
+  });
+  assert.deepEqual(buildMiniPlanMinimalFollowThrough(null), {
+    empty: true,
+    level: 'none',
+    label: 'aucun suivi critique',
+    support: null,
+    action: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -74,6 +74,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanDecisionReversibilityCue\(/);
   assert.match(webAppSource, /buildMiniPlanLastSafeCorrectionCue\(/);
   assert.match(webAppSource, /buildMiniPlanLateCorrectionExitCost\(/);
+  assert.match(webAppSource, /buildMiniPlanMinimalFollowThrough\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -117,6 +118,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanDecisionReversibilityCue: buildMiniPlanDecisionReversibilityCue\(/);
   assert.match(webAppSource, /miniPlanLastSafeCorrectionCue: buildMiniPlanLastSafeCorrectionCue\(/);
   assert.match(webAppSource, /miniPlanLateCorrectionExitCost: buildMiniPlanLateCorrectionExitCost\(/);
+  assert.match(webAppSource, /miniPlanMinimalFollowThrough: buildMiniPlanMinimalFollowThrough\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
@@ -126,6 +128,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /réversibilité: non évaluée/);
   assert.match(webAppSource, /dernier sûr: non évalué/);
   assert.match(webAppSource, /sortie tardive: non évaluée/);
+  assert.match(webAppSource, /suivi minimal: non critique/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -142,6 +145,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__decision-reversibility/);
   assert.match(webAppSource, /atlas-military-fallback-order__last-safe-correction/);
   assert.match(webAppSource, /atlas-military-fallback-order__late-correction-exit-cost/);
+  assert.match(webAppSource, /atlas-military-fallback-order__minimal-follow-through/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -158,6 +162,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /réversibilité: \$\{reversibility\.label\} · \$\{reversibility\.constraint\}\$\{reversibility\.nextStep \? ` · \$\{reversibility\.nextStep\}` : ''\}/);
   assert.match(webAppSource, /dernier sûr: \$\{lastSafeCorrection\.label\} · \$\{lastSafeCorrection\.constraint\}\$\{lastSafeCorrection\.nextStep \? ` · \$\{lastSafeCorrection\.nextStep\}` : ''\}/);
   assert.match(webAppSource, /sortie tardive: \$\{exitCost\.label\} · perte \$\{exitCost\.loss\} · \$\{exitCost\.decision\}/);
+  assert.match(webAppSource, /suivi minimal: \$\{minimalFollowThrough\.label\} · \$\{minimalFollowThrough\.support\} · \$\{minimalFollowThrough\.action\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -184,4 +189,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__decision-reversibility/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__last-safe-correction/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__late-correction-exit-cost/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__minimal-follow-through/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -12,6 +12,7 @@ import {
   buildMiniPlanDecisionReversibilityCue,
   buildMiniPlanLastSafeCorrectionCue,
   buildMiniPlanLateCorrectionExitCost,
+  buildMiniPlanMinimalFollowThrough,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -2018,6 +2019,11 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanLateCorrectionExitCost: buildMiniPlanLateCorrectionExitCost(
         buildMiniPlanLastSafeCorrectionCue(buildMiniPlanDecisionReversibilityCue(null, null)),
       ),
+      miniPlanMinimalFollowThrough: buildMiniPlanMinimalFollowThrough(
+        buildMiniPlanLateCorrectionExitCost(
+          buildMiniPlanLastSafeCorrectionCue(buildMiniPlanDecisionReversibilityCue(null, null)),
+        ),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2074,6 +2080,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   );
   const miniPlanLastSafeCorrectionCue = buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibilityCue);
   const miniPlanLateCorrectionExitCost = buildMiniPlanLateCorrectionExitCost(miniPlanLastSafeCorrectionCue);
+  const miniPlanMinimalFollowThrough = buildMiniPlanMinimalFollowThrough(miniPlanLateCorrectionExitCost);
 
   return {
     fallback: {
@@ -2101,6 +2108,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanDecisionReversibilityCue,
       miniPlanLastSafeCorrectionCue,
       miniPlanLateCorrectionExitCost,
+      miniPlanMinimalFollowThrough,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2123,7 +2131,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanDecisionReversibilityCue,
     miniPlanLastSafeCorrectionCue,
     miniPlanLateCorrectionExitCost,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}).`,
+    miniPlanMinimalFollowThrough,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}).`,
     empty: false,
   };
 }
@@ -2198,9 +2207,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const exitCostLabel = exitCost && !exitCost.empty
     ? `sortie tardive: ${exitCost.label} · perte ${exitCost.loss} · ${exitCost.decision}`
     : 'sortie tardive: non évaluée';
+  const minimalFollowThrough = fallback.miniPlanMinimalFollowThrough;
+  const minimalFollowThroughLabel = minimalFollowThrough && !minimalFollowThrough.empty
+    ? `suivi minimal: ${minimalFollowThrough.label} · ${minimalFollowThrough.support} · ${minimalFollowThrough.action}`
+    : 'suivi minimal: non critique';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="27.6" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="28.8" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2224,6 +2237,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__decision-reversibility atlas-military-fallback-order__decision-reversibility--${reversibility?.state ?? 'none'}" x="23.2" y="81.1">${reversibilityLabel}</text>
       <text class="atlas-military-fallback-order__last-safe-correction atlas-military-fallback-order__last-safe-correction--${lastSafeCorrection?.state ?? 'none'}" x="23.2" y="82.2">${lastSafeCorrectionLabel}</text>
       <text class="atlas-military-fallback-order__late-correction-exit-cost atlas-military-fallback-order__late-correction-exit-cost--${exitCost?.severity ?? 'none'}" x="23.2" y="83.3">${exitCostLabel}</text>
+      <text class="atlas-military-fallback-order__minimal-follow-through atlas-military-fallback-order__minimal-follow-through--${minimalFollowThrough?.level ?? 'none'}" x="23.2" y="84.4">${minimalFollowThroughLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11184,6 +11184,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__late-correction-exit-cost { fill: #c7d2fe; font-size: 0.39px; font-weight: 900; }
 .atlas-military-fallback-order__late-correction-exit-cost--costly { fill: #fde68a; }
 .atlas-military-fallback-order__late-correction-exit-cost--deterrent { fill: #fecaca; }
+.atlas-military-fallback-order__minimal-follow-through { fill: #bae6fd; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__minimal-follow-through--advised { fill: #fde68a; }
+.atlas-military-fallback-order__minimal-follow-through--urgent { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1089.

Summary:
- adds structured `miniPlanMinimalFollowThrough` after the late correction exit cost
- classifies follow-through as no critical follow-up, advised, or urgent
- names the visible support to secure and proposes a compact action
- keeps the overlay compact without repeating A37 exit-cost severity

Tests:
- npm test

Zeta: ready for validation before merge.