### PR TITLE
Beta: show monitored corridor rollback guard

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -570,6 +570,33 @@ function buildMonitoredCorridorPromotionRisk(postStabilizerReliability) {
   };
 }
 
+function buildMonitoredCorridorRollbackGuard(monitoredCorridorPromotionRisk) {
+  if (monitoredCorridorPromotionRisk.status === 'safe-promotion') {
+    return {
+      status: 'rollback-unneeded',
+      constraint: monitoredCorridorPromotionRisk.remainingConstraint,
+      nextGesture: 'promouvoir sans garde',
+      summary: 'Rollback inutile: la promotion peut avancer sans garde dédiée.',
+    };
+  }
+
+  if (monitoredCorridorPromotionRisk.status === 'limited-promotion') {
+    return {
+      status: 'guard-recommended',
+      constraint: monitoredCorridorPromotionRisk.remainingConstraint,
+      nextGesture: 'plafonner avec garde',
+      summary: `Garde conseillée: plafonner le flux et surveiller ${monitoredCorridorPromotionRisk.remainingConstraint}.`,
+    };
+  }
+
+  return {
+    status: 'rollback-ready-required',
+    constraint: monitoredCorridorPromotionRisk.remainingConstraint,
+    nextGesture: monitoredCorridorPromotionRisk.nextGesture === 'garder en secours' ? 'revenir en secours' : 'préparer alternative',
+    summary: `Rollback prêt requis: ${monitoredCorridorPromotionRisk.remainingConstraint} impose une alternative avant promotion.`,
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -786,6 +813,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
   const postSalvageStabilizer = buildPostSalvageStabilizer(postSalvageRobustness);
   const postStabilizerReliability = buildPostStabilizerReliability(postSalvageStabilizer);
   const monitoredCorridorPromotionRisk = buildMonitoredCorridorPromotionRisk(postStabilizerReliability);
+  const monitoredCorridorRollbackGuard = buildMonitoredCorridorRollbackGuard(monitoredCorridorPromotionRisk);
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -804,6 +832,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     postSalvageStabilizer,
     postStabilizerReliability,
     monitoredCorridorPromotionRisk,
+    monitoredCorridorRollbackGuard,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -579,6 +579,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         nextGesture: 'promouvoir',
         summary: 'Promotion sûre: le corridor peut devenir route principale.',
       },
+      monitoredCorridorRollbackGuard: {
+        status: 'rollback-unneeded',
+        constraint: null,
+        nextGesture: 'promouvoir sans garde',
+        summary: 'Rollback inutile: la promotion peut avancer sans garde dédiée.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -745,6 +751,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       nextGesture: 'promouvoir',
       summary: 'Promotion sûre: le corridor peut devenir route principale.',
     },
+    monitoredCorridorRollbackGuard: {
+      status: 'rollback-unneeded',
+      constraint: null,
+      nextGesture: 'promouvoir sans garde',
+      summary: 'Rollback inutile: la promotion peut avancer sans garde dédiée.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -861,6 +873,12 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     nextGesture: 'garder en secours',
     summary: 'Promotion prématurée: alternative expose encore le corridor principal.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.monitoredCorridorRollbackGuard, {
+    status: 'rollback-ready-required',
+    constraint: 'alternative',
+    nextGesture: 'revenir en secours',
+    summary: 'Rollback prêt requis: alternative impose une alternative avant promotion.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -943,6 +961,12 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     remainingConstraint: 'alternative',
     nextGesture: 'plafonner le flux',
     summary: 'Promotion sous limite: plafonner le flux tant que alternative reste surveillé.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.monitoredCorridorRollbackGuard, {
+    status: 'guard-recommended',
+    constraint: 'alternative',
+    nextGesture: 'plafonner avec garde',
+    summary: 'Garde conseillée: plafonner le flux et surveiller alternative.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a compact rollback guard after monitored corridor promotion so the economy overlay shows whether no guard is needed, a guard is recommended, or a rollback-ready alternative is required.

## Changes

- Add `monitoredCorridorRollbackGuard` beside the B38 promotion risk.
- Classify rollback unneeded, guard recommended, and rollback-ready required.
- Name the visible constraint and short next gesture (`promouvoir sans garde`, `plafonner avec garde`, `préparer alternative`, or `revenir en secours`).
- Extend economy overlay tests for all three rollback guard outcomes.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (632/632 pass)

Fixes loo469/historia#1100