### PR TITLE
Gamma: show culture reevaluation delay cost

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1129,6 +1129,35 @@ export function buildResidualCultureReevaluationTrigger(residualCulturePostAlloc
   };
 }
 
+export function buildResidualCultureReevaluationDelayCost(residualCultureReevaluationTrigger) {
+  const visibleConstraint = residualCultureReevaluationTrigger.visibleTrigger;
+
+  if (residualCultureReevaluationTrigger.status === 'none-soon') {
+    return {
+      status: 'neutral-wait',
+      visibleConstraint,
+      delayConsequence: 'attente neutre: aucun coût social visible à court terme',
+      microDecision: null,
+    };
+  }
+
+  if (residualCultureReevaluationTrigger.status === 'watch-signal') {
+    return {
+      status: 'manageable-cost',
+      visibleConstraint,
+      delayConsequence: `coût social gérable: ${visibleConstraint} peut réduire l’accalmie`,
+      microDecision: residualCultureReevaluationTrigger.microDecision,
+    };
+  }
+
+  return {
+    status: 'worsening-fragility',
+    visibleConstraint,
+    delayConsequence: `fragilité qui s’aggrave: ${visibleConstraint} peut rouvrir la dette avant correction`,
+    microDecision: residualCultureReevaluationTrigger.microDecision,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -1190,6 +1219,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const residualCultureWindowClosureThreat = buildResidualCultureWindowClosureThreat(residualCultureFollowUpWindow);
   const residualCultureSupportAllocationChoice = buildResidualCultureSupportAllocationChoice(residualCultureWindowClosureThreat, postBundleCumulativeRisk);
   const residualCulturePostAllocationStability = buildResidualCulturePostAllocationStability(residualCultureSupportAllocationChoice, residualCultureWindowClosureThreat);
+  const residualCultureReevaluationTrigger = buildResidualCultureReevaluationTrigger(residualCulturePostAllocationStability);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -1207,7 +1237,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     residualCultureWindowClosureThreat,
     residualCultureSupportAllocationChoice,
     residualCulturePostAllocationStability,
-    residualCultureReevaluationTrigger: buildResidualCultureReevaluationTrigger(residualCulturePostAllocationStability),
+    residualCultureReevaluationTrigger,
+    residualCultureReevaluationDelayCost: buildResidualCultureReevaluationDelayCost(residualCultureReevaluationTrigger),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { Culture } from '../../../src/domain/culture/Culture.js';
 import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
-import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability, buildResidualCultureReevaluationTrigger } from '../../../src/ui/culture/buildCultureMapOverlay.js';
+import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability, buildResidualCultureReevaluationTrigger, buildResidualCultureReevaluationDelayCost } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
 function withoutSupportRiskPreviews(value) {
   if (Array.isArray(value)) {
@@ -965,6 +965,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         triggerSummary: 'surveiller le signal: fatigue de médiation peut écourter l’accalmie',
         microDecision: 'revoir le support si fatigue de médiation remonte',
       },
+      residualCultureReevaluationDelayCost: {
+        status: 'manageable-cost',
+        visibleConstraint: 'fatigue de médiation',
+        delayConsequence: 'coût social gérable: fatigue de médiation peut réduire l’accalmie',
+        microDecision: 'revoir le support si fatigue de médiation remonte',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -1082,6 +1088,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         status: 'none-soon',
         visibleTrigger: 'aucune contrainte visible',
         triggerSummary: 'pas de réévaluation proche: stabilité durable visible',
+        microDecision: null,
+      },
+      residualCultureReevaluationDelayCost: {
+        status: 'neutral-wait',
+        visibleConstraint: 'aucune contrainte visible',
+        delayConsequence: 'attente neutre: aucun coût social visible à court terme',
         microDecision: null,
       },
     },
@@ -1561,6 +1573,53 @@ test('buildResidualCultureReevaluationTrigger covers none, watch, and urgent fol
       status: 'urgent',
       visibleTrigger: 'support local',
       triggerSummary: 'réévaluation urgente si support local réapparaît',
+      microDecision: 'sécuriser un support local avant tout suivi',
+    },
+  );
+});
+
+test('buildResidualCultureReevaluationDelayCost covers neutral, manageable, and worsening delays', () => {
+  assert.deepEqual(
+    buildResidualCultureReevaluationDelayCost({
+      status: 'none-soon',
+      visibleTrigger: 'aucune contrainte visible',
+      triggerSummary: 'pas de réévaluation proche: stabilité durable visible',
+      microDecision: null,
+    }),
+    {
+      status: 'neutral-wait',
+      visibleConstraint: 'aucune contrainte visible',
+      delayConsequence: 'attente neutre: aucun coût social visible à court terme',
+      microDecision: null,
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureReevaluationDelayCost({
+      status: 'watch-signal',
+      visibleTrigger: 'fatigue de médiation',
+      triggerSummary: 'surveiller le signal: fatigue de médiation peut écourter l’accalmie',
+      microDecision: 'revoir le support si fatigue de médiation remonte',
+    }),
+    {
+      status: 'manageable-cost',
+      visibleConstraint: 'fatigue de médiation',
+      delayConsequence: 'coût social gérable: fatigue de médiation peut réduire l’accalmie',
+      microDecision: 'revoir le support si fatigue de médiation remonte',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureReevaluationDelayCost({
+      status: 'urgent',
+      visibleTrigger: 'support local',
+      triggerSummary: 'réévaluation urgente si support local réapparaît',
+      microDecision: 'sécuriser un support local avant tout suivi',
+    }),
+    {
+      status: 'worsening-fragility',
+      visibleConstraint: 'support local',
+      delayConsequence: 'fragilité qui s’aggrave: support local peut rouvrir la dette avant correction',
       microDecision: 'sécuriser un support local avant tout suivi',
     },
   );


### PR DESCRIPTION
Gamma: ## Summary

Shows the visible cost of delaying fragile cultural reevaluation.

## Changes

- Adds `residualCultureReevaluationDelayCost` near the reevaluation trigger summary.
- Classifies delay as neutral wait, manageable social cost, or worsening fragility.
- Names the visible constraint from the existing G38 trigger.
- Adds a micro-decision only when the delay has a real cost.
- Complements G38 without recalculating the trigger or revealing hidden social factors.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1101