### PR TITLE
Epsilon: show residual climate reserve risk

### DIFF
--- a/test/ui/climate/webAtlasResidualReserveRiskAfterSecondaryClimateDebtPayment.test.js
+++ b/test/ui/climate/webAtlasResidualReserveRiskAfterSecondaryClimateDebtPayment.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas shows residual reserve risk after secondary climate debt payment', () => {
+  assert.match(webAppSource, /function buildResidualReserveRiskAfterSecondaryClimateDebtPayment/);
+  assert.match(webAppSource, /residualReserveRiskAfterSecondaryClimateDebtPayment: null/);
+  assert.match(webAppSource, /residualReserveRiskAfterSecondaryClimateDebtPayment,/);
+
+  for (const stableKey of [
+    'state',
+    'visibleConstraint',
+    'followUpGesture',
+    'secondaryDebtKey',
+    'secondaryDebtLabel',
+    'changesNextStep',
+    'sourceWindowEffect',
+    'summary',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /réserve suffisante/);
+  assert.match(webAppSource, /réserve mince/);
+  assert.match(webAppSource, /cascade voisine exposée/);
+  assert.match(webAppSource, /saison/);
+  assert.match(webAppSource, /cascade voisine/);
+  assert.match(webAppSource, /pression régionale/);
+  assert.match(webAppSource, /dette secondaire/);
+  assert.match(webAppSource, /conflit de timing/);
+  assert.match(webAppSource, /réserve restante/);
+  assert.match(webAppSource, /garder une réserve contre la cascade voisine/);
+  assert.match(webAppSource, /conserver une réserve courte/);
+  assert.match(webAppSource, /aucun geste immédiat/);
+  assert.match(webAppSource, /Risque réserve résiduel/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9919,6 +9919,55 @@ function buildSecondaryClimateDebtNearWindowReopenEffect(secondaryClimateDebtWhe
   };
 }
 
+function buildResidualReserveRiskAfterSecondaryClimateDebtPayment(secondaryClimateDebtNearWindowReopenEffect, secondaryClimateDebtWhenReserveCostsWindow, climateRiskReboundAfterTopPayoff, decisionWindow) {
+  if (!secondaryClimateDebtNearWindowReopenEffect) {
+    return null;
+  }
+
+  const constraintText = `${secondaryClimateDebtNearWindowReopenEffect.visibleConstraint ?? ''} ${secondaryClimateDebtWhenReserveCostsWindow?.visibleConstraint ?? ''} ${secondaryClimateDebtNearWindowReopenEffect.summary ?? ''}`.toLowerCase();
+  const visibleConstraint = secondaryClimateDebtNearWindowReopenEffect.reserveStillNeeded
+    ? 'réserve restante'
+    : constraintText.includes('cascade')
+      ? 'cascade voisine'
+      : constraintText.includes('conflit') || constraintText.includes('timing')
+        ? 'conflit de timing'
+        : constraintText.includes('saison')
+          ? 'saison'
+          : constraintText.includes('pression régionale') || constraintText.includes('deadline')
+            ? 'pression régionale'
+            : constraintText.includes('dette')
+              ? 'dette secondaire'
+              : 'réserve restante';
+  const hasNeighborCascade = visibleConstraint === 'cascade voisine' || climateRiskReboundAfterTopPayoff?.state === 'rebond fort';
+  const hasTimingConflict = (decisionWindow?.conflicts?.length ?? 0) > 0;
+  const state = secondaryClimateDebtNearWindowReopenEffect.state === 'paiement insuffisant'
+    ? 'cascade voisine exposée'
+    : hasNeighborCascade || hasTimingConflict
+      ? 'cascade voisine exposée'
+      : secondaryClimateDebtNearWindowReopenEffect.reserveStillNeeded
+        ? 'réserve mince'
+        : 'réserve suffisante';
+  const followUpGesture = state === 'cascade voisine exposée'
+    ? 'garder une réserve contre la cascade voisine avant le prochain arbitrage'
+    : state === 'réserve mince'
+      ? 'conserver une réserve courte avant de déplacer la fenêtre'
+      : 'aucun geste immédiat';
+  const summary = state === 'réserve suffisante'
+    ? `Réserve suffisante: la suite reste neutre après paiement; contrainte ${visibleConstraint}.`
+    : `${state}: ${visibleConstraint} peut changer la suite; geste: ${followUpGesture}.`;
+
+  return {
+    state,
+    visibleConstraint,
+    followUpGesture,
+    secondaryDebtKey: secondaryClimateDebtNearWindowReopenEffect.secondaryDebtKey,
+    secondaryDebtLabel: secondaryClimateDebtNearWindowReopenEffect.secondaryDebtLabel,
+    changesNextStep: state !== 'réserve suffisante',
+    sourceWindowEffect: secondaryClimateDebtNearWindowReopenEffect.state,
+    summary,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -9976,6 +10025,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       climateReserveNearTermWindowCostWarning: null,
       secondaryClimateDebtWhenReserveCostsWindow: null,
       secondaryClimateDebtNearWindowReopenEffect: null,
+      residualReserveRiskAfterSecondaryClimateDebtPayment: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -10072,6 +10122,12 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     climateRiskReboundAfterTopPayoff,
     decisionWindow,
   );
+  const residualReserveRiskAfterSecondaryClimateDebtPayment = buildResidualReserveRiskAfterSecondaryClimateDebtPayment(
+    secondaryClimateDebtNearWindowReopenEffect,
+    secondaryClimateDebtWhenReserveCostsWindow,
+    climateRiskReboundAfterTopPayoff,
+    decisionWindow,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -10092,6 +10148,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     climateReserveNearTermWindowCostWarning,
     secondaryClimateDebtWhenReserveCostsWindow,
     secondaryClimateDebtNearWindowReopenEffect,
+    residualReserveRiskAfterSecondaryClimateDebtPayment,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -10133,6 +10190,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.climateReserveNearTermWindowCostWarning ? `<small><b>Coût réserve court terme</b> · ${view.climateReserveNearTermWindowCostWarning.summary}</small>` : ''}
       ${view.secondaryClimateDebtWhenReserveCostsWindow ? `<small><b>Dette secondaire réserve</b> · ${view.secondaryClimateDebtWhenReserveCostsWindow.summary}</small>` : ''}
       ${view.secondaryClimateDebtNearWindowReopenEffect ? `<small><b>Effet paiement dette secondaire</b> · ${view.secondaryClimateDebtNearWindowReopenEffect.summary}</small>` : ''}
+      ${view.residualReserveRiskAfterSecondaryClimateDebtPayment ? `<small><b>Risque réserve résiduel</b> · ${view.residualReserveRiskAfterSecondaryClimateDebtPayment.summary}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1103.

## Résumé
- ajoute le risque résiduel de réserve après paiement d’une dette climat secondaire
- classe entre réserve suffisante, réserve mince ou cascade voisine exposée
- nomme la contrainte visible et ne propose un geste court que si la suite change

## Tests
- `npm test`
