### PR TITLE
Alpha: warn on follow-through opportunity tradeoff

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -969,6 +969,41 @@ export function buildMiniPlanMinimalFollowThrough(miniPlanLateCorrectionExitCost
   };
 }
 
+export function buildMiniPlanFollowThroughOpportunityTradeoff(miniPlanMinimalFollowThrough = null) {
+  if (!miniPlanMinimalFollowThrough || miniPlanMinimalFollowThrough.empty) {
+    return {
+      empty: true,
+      state: 'no-conflict',
+      label: 'suivi sans conflit',
+      constraint: null,
+      action: null,
+    };
+  }
+
+  const state = miniPlanMinimalFollowThrough.level === 'urgent'
+    ? 'opportunity-threatened'
+    : miniPlanMinimalFollowThrough.level === 'advised'
+      ? 'manageable-conflict'
+      : 'no-conflict';
+  const constraint = miniPlanMinimalFollowThrough.support ?? 'appui allié';
+
+  return {
+    empty: false,
+    state,
+    label: state === 'opportunity-threatened'
+      ? 'opportunité menacée'
+      : state === 'manageable-conflict'
+        ? 'conflit gérable'
+        : 'suivi sans conflit',
+    constraint,
+    action: state === 'opportunity-threatened'
+      ? 'reporter l’opportunité'
+      : state === 'manageable-conflict'
+        ? (constraint === 'tempo' ? 'limiter l’engagement' : 'sécuriser puis exploiter')
+        : 'suivre maintenant',
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -1075,6 +1110,9 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const miniPlanLastSafeCorrectionCue = buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibilityCue);
   const miniPlanLateCorrectionExitCost = buildMiniPlanLateCorrectionExitCost(miniPlanLastSafeCorrectionCue);
   const miniPlanMinimalFollowThrough = buildMiniPlanMinimalFollowThrough(miniPlanLateCorrectionExitCost);
+  const miniPlanFollowThroughOpportunityTradeoff = buildMiniPlanFollowThroughOpportunityTradeoff(
+    miniPlanMinimalFollowThrough,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -1131,6 +1169,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanLastSafeCorrectionCue,
     miniPlanLateCorrectionExitCost,
     miniPlanMinimalFollowThrough,
+    miniPlanFollowThroughOpportunityTradeoff,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -12,6 +12,7 @@ import {
   buildMiniPlanLastSafeCorrectionCue,
   buildMiniPlanLateCorrectionExitCost,
   buildMiniPlanMinimalFollowThrough,
+  buildMiniPlanFollowThroughOpportunityTradeoff,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -381,6 +382,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     level: 'none',
     label: 'aucun suivi critique',
     support: null,
+    action: null,
+  });
+  assert.deepEqual(shell.miniPlanFollowThroughOpportunityTradeoff, {
+    empty: true,
+    state: 'no-conflict',
+    label: 'suivi sans conflit',
+    constraint: null,
     action: null,
   });
 });
@@ -763,12 +771,20 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     loss: 'position',
     decision: 'attendre sans nouvelle correction',
   });
-  assert.deepEqual(buildMiniPlanMinimalFollowThrough(exitCost), {
+  const followThrough = buildMiniPlanMinimalFollowThrough(exitCost);
+  assert.deepEqual(followThrough, {
     empty: false,
     level: 'urgent',
     label: 'suivi urgent',
     support: 'position',
     action: 'protéger position',
+  });
+  assert.deepEqual(buildMiniPlanFollowThroughOpportunityTradeoff(followThrough), {
+    empty: false,
+    state: 'opportunity-threatened',
+    label: 'opportunité menacée',
+    constraint: 'position',
+    action: 'reporter l’opportunité',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -851,12 +867,20 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     loss: 'opportunité rivale',
     decision: 'corriger maintenant',
   });
-  assert.deepEqual(buildMiniPlanMinimalFollowThrough(exitCost), {
+  const followThrough = buildMiniPlanMinimalFollowThrough(exitCost);
+  assert.deepEqual(followThrough, {
     empty: false,
     level: 'none',
     label: 'aucun suivi critique',
     support: 'opportunité rivale',
     action: 'surveiller',
+  });
+  assert.deepEqual(buildMiniPlanFollowThroughOpportunityTradeoff(followThrough), {
+    empty: false,
+    state: 'no-conflict',
+    label: 'suivi sans conflit',
+    constraint: 'opportunité rivale',
+    action: 'suivre maintenant',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -930,12 +954,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     loss: 'tempo',
     decision: 'assumer le plan',
   });
-  assert.deepEqual(buildMiniPlanMinimalFollowThrough(exitCost), {
+  const followThrough = buildMiniPlanMinimalFollowThrough(exitCost);
+  assert.deepEqual(followThrough, {
     empty: false,
     level: 'advised',
     label: 'suivi conseillé',
     support: 'tempo',
     action: 'consolider',
+  });
+  assert.deepEqual(buildMiniPlanFollowThroughOpportunityTradeoff(followThrough), {
+    empty: false,
+    state: 'manageable-conflict',
+    label: 'conflit gérable',
+    constraint: 'tempo',
+    action: 'limiter l’engagement',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -978,6 +1010,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     level: 'none',
     label: 'aucun suivi critique',
     support: null,
+    action: null,
+  });
+  assert.deepEqual(buildMiniPlanFollowThroughOpportunityTradeoff(null), {
+    empty: true,
+    state: 'no-conflict',
+    label: 'suivi sans conflit',
+    constraint: null,
     action: null,
   });
 });

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -75,6 +75,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanLastSafeCorrectionCue\(/);
   assert.match(webAppSource, /buildMiniPlanLateCorrectionExitCost\(/);
   assert.match(webAppSource, /buildMiniPlanMinimalFollowThrough\(/);
+  assert.match(webAppSource, /buildMiniPlanFollowThroughOpportunityTradeoff\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -119,6 +120,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanLastSafeCorrectionCue: buildMiniPlanLastSafeCorrectionCue\(/);
   assert.match(webAppSource, /miniPlanLateCorrectionExitCost: buildMiniPlanLateCorrectionExitCost\(/);
   assert.match(webAppSource, /miniPlanMinimalFollowThrough: buildMiniPlanMinimalFollowThrough\(/);
+  assert.match(webAppSource, /miniPlanFollowThroughOpportunityTradeoff: buildMiniPlanFollowThroughOpportunityTradeoff\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
@@ -129,6 +131,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /dernier sûr: non évalué/);
   assert.match(webAppSource, /sortie tardive: non évaluée/);
   assert.match(webAppSource, /suivi minimal: non critique/);
+  assert.match(webAppSource, /opportunité: aucun conflit/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -146,6 +149,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__last-safe-correction/);
   assert.match(webAppSource, /atlas-military-fallback-order__late-correction-exit-cost/);
   assert.match(webAppSource, /atlas-military-fallback-order__minimal-follow-through/);
+  assert.match(webAppSource, /atlas-military-fallback-order__follow-through-opportunity/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -163,6 +167,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /dernier sûr: \$\{lastSafeCorrection\.label\} · \$\{lastSafeCorrection\.constraint\}\$\{lastSafeCorrection\.nextStep \? ` · \$\{lastSafeCorrection\.nextStep\}` : ''\}/);
   assert.match(webAppSource, /sortie tardive: \$\{exitCost\.label\} · perte \$\{exitCost\.loss\} · \$\{exitCost\.decision\}/);
   assert.match(webAppSource, /suivi minimal: \$\{minimalFollowThrough\.label\} · \$\{minimalFollowThrough\.support\} · \$\{minimalFollowThrough\.action\}/);
+  assert.match(webAppSource, /opportunité: \$\{opportunityTradeoff\.label\} · \$\{opportunityTradeoff\.constraint\} · \$\{opportunityTradeoff\.action\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -190,4 +195,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__last-safe-correction/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__late-correction-exit-cost/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__minimal-follow-through/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__follow-through-opportunity/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -13,6 +13,7 @@ import {
   buildMiniPlanLastSafeCorrectionCue,
   buildMiniPlanLateCorrectionExitCost,
   buildMiniPlanMinimalFollowThrough,
+  buildMiniPlanFollowThroughOpportunityTradeoff,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -2024,6 +2025,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
           buildMiniPlanLastSafeCorrectionCue(buildMiniPlanDecisionReversibilityCue(null, null)),
         ),
       ),
+      miniPlanFollowThroughOpportunityTradeoff: buildMiniPlanFollowThroughOpportunityTradeoff(
+        buildMiniPlanMinimalFollowThrough(null),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2081,6 +2085,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const miniPlanLastSafeCorrectionCue = buildMiniPlanLastSafeCorrectionCue(miniPlanDecisionReversibilityCue);
   const miniPlanLateCorrectionExitCost = buildMiniPlanLateCorrectionExitCost(miniPlanLastSafeCorrectionCue);
   const miniPlanMinimalFollowThrough = buildMiniPlanMinimalFollowThrough(miniPlanLateCorrectionExitCost);
+  const miniPlanFollowThroughOpportunityTradeoff = buildMiniPlanFollowThroughOpportunityTradeoff(
+    miniPlanMinimalFollowThrough,
+  );
 
   return {
     fallback: {
@@ -2109,6 +2116,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanLastSafeCorrectionCue,
       miniPlanLateCorrectionExitCost,
       miniPlanMinimalFollowThrough,
+      miniPlanFollowThroughOpportunityTradeoff,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2132,7 +2140,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanLastSafeCorrectionCue,
     miniPlanLateCorrectionExitCost,
     miniPlanMinimalFollowThrough,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}).`,
+    miniPlanFollowThroughOpportunityTradeoff,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}).`,
     empty: false,
   };
 }
@@ -2211,9 +2220,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const minimalFollowThroughLabel = minimalFollowThrough && !minimalFollowThrough.empty
     ? `suivi minimal: ${minimalFollowThrough.label} · ${minimalFollowThrough.support} · ${minimalFollowThrough.action}`
     : 'suivi minimal: non critique';
+  const opportunityTradeoff = fallback.miniPlanFollowThroughOpportunityTradeoff;
+  const opportunityTradeoffLabel = opportunityTradeoff && !opportunityTradeoff.empty
+    ? `opportunité: ${opportunityTradeoff.label} · ${opportunityTradeoff.constraint} · ${opportunityTradeoff.action}`
+    : 'opportunité: aucun conflit';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="28.8" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="30" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2238,6 +2251,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__last-safe-correction atlas-military-fallback-order__last-safe-correction--${lastSafeCorrection?.state ?? 'none'}" x="23.2" y="82.2">${lastSafeCorrectionLabel}</text>
       <text class="atlas-military-fallback-order__late-correction-exit-cost atlas-military-fallback-order__late-correction-exit-cost--${exitCost?.severity ?? 'none'}" x="23.2" y="83.3">${exitCostLabel}</text>
       <text class="atlas-military-fallback-order__minimal-follow-through atlas-military-fallback-order__minimal-follow-through--${minimalFollowThrough?.level ?? 'none'}" x="23.2" y="84.4">${minimalFollowThroughLabel}</text>
+      <text class="atlas-military-fallback-order__follow-through-opportunity atlas-military-fallback-order__follow-through-opportunity--${opportunityTradeoff?.state ?? 'no-conflict'}" x="23.2" y="85.5">${opportunityTradeoffLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11187,6 +11187,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__minimal-follow-through { fill: #bae6fd; font-size: 0.39px; font-weight: 900; }
 .atlas-military-fallback-order__minimal-follow-through--advised { fill: #fde68a; }
 .atlas-military-fallback-order__minimal-follow-through--urgent { fill: #fecaca; }
+.atlas-military-fallback-order__follow-through-opportunity { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__follow-through-opportunity--manageable-conflict { fill: #fde68a; }
+.atlas-military-fallback-order__follow-through-opportunity--opportunity-threatened { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1099.

Summary:
- adds structured `miniPlanFollowThroughOpportunityTradeoff` after minimal follow-through
- classifies the opportunity tradeoff as no conflict, manageable conflict, or opportunity threatened
- names the visible constraint and recommends a compact action
- keeps the overlay compact without repeating A38 follow-through level

Tests:
- npm test

Zeta: ready for validation before merge.