### PR TITLE
Gamma: recommend minimal delayed culture support

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1158,6 +1158,35 @@ export function buildResidualCultureReevaluationDelayCost(residualCultureReevalu
   };
 }
 
+export function buildResidualCultureMinimalDelayedSupport(residualCultureReevaluationDelayCost) {
+  const visibleConstraint = residualCultureReevaluationDelayCost.visibleConstraint;
+
+  if (residualCultureReevaluationDelayCost.status === 'neutral-wait') {
+    return {
+      status: 'none-needed',
+      visibleConstraint,
+      recommendedSupport: 'aucun support minimal requis',
+      microDecision: null,
+    };
+  }
+
+  if (residualCultureReevaluationDelayCost.status === 'manageable-cost') {
+    return {
+      status: 'light-support-enough',
+      visibleConstraint,
+      recommendedSupport: `support léger suffisant sur ${visibleConstraint}`,
+      microDecision: residualCultureReevaluationDelayCost.microDecision,
+    };
+  }
+
+  return {
+    status: 'immediate-support-required',
+    visibleConstraint,
+    recommendedSupport: `soutien immédiat requis pour stabiliser ${visibleConstraint}`,
+    microDecision: residualCultureReevaluationDelayCost.microDecision,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -1220,6 +1249,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const residualCultureSupportAllocationChoice = buildResidualCultureSupportAllocationChoice(residualCultureWindowClosureThreat, postBundleCumulativeRisk);
   const residualCulturePostAllocationStability = buildResidualCulturePostAllocationStability(residualCultureSupportAllocationChoice, residualCultureWindowClosureThreat);
   const residualCultureReevaluationTrigger = buildResidualCultureReevaluationTrigger(residualCulturePostAllocationStability);
+  const residualCultureReevaluationDelayCost = buildResidualCultureReevaluationDelayCost(residualCultureReevaluationTrigger);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -1238,7 +1268,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     residualCultureSupportAllocationChoice,
     residualCulturePostAllocationStability,
     residualCultureReevaluationTrigger,
-    residualCultureReevaluationDelayCost: buildResidualCultureReevaluationDelayCost(residualCultureReevaluationTrigger),
+    residualCultureReevaluationDelayCost,
+    residualCultureMinimalDelayedSupport: buildResidualCultureMinimalDelayedSupport(residualCultureReevaluationDelayCost),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { Culture } from '../../../src/domain/culture/Culture.js';
 import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
-import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability, buildResidualCultureReevaluationTrigger, buildResidualCultureReevaluationDelayCost } from '../../../src/ui/culture/buildCultureMapOverlay.js';
+import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability, buildResidualCultureReevaluationTrigger, buildResidualCultureReevaluationDelayCost, buildResidualCultureMinimalDelayedSupport } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
 function withoutSupportRiskPreviews(value) {
   if (Array.isArray(value)) {
@@ -971,6 +971,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         delayConsequence: 'coût social gérable: fatigue de médiation peut réduire l’accalmie',
         microDecision: 'revoir le support si fatigue de médiation remonte',
       },
+      residualCultureMinimalDelayedSupport: {
+        status: 'light-support-enough',
+        visibleConstraint: 'fatigue de médiation',
+        recommendedSupport: 'support léger suffisant sur fatigue de médiation',
+        microDecision: 'revoir le support si fatigue de médiation remonte',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -1094,6 +1100,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         status: 'neutral-wait',
         visibleConstraint: 'aucune contrainte visible',
         delayConsequence: 'attente neutre: aucun coût social visible à court terme',
+        microDecision: null,
+      },
+      residualCultureMinimalDelayedSupport: {
+        status: 'none-needed',
+        visibleConstraint: 'aucune contrainte visible',
+        recommendedSupport: 'aucun support minimal requis',
         microDecision: null,
       },
     },
@@ -1620,6 +1632,53 @@ test('buildResidualCultureReevaluationDelayCost covers neutral, manageable, and 
       status: 'worsening-fragility',
       visibleConstraint: 'support local',
       delayConsequence: 'fragilité qui s’aggrave: support local peut rouvrir la dette avant correction',
+      microDecision: 'sécuriser un support local avant tout suivi',
+    },
+  );
+});
+
+test('buildResidualCultureMinimalDelayedSupport covers none, light, and immediate support', () => {
+  assert.deepEqual(
+    buildResidualCultureMinimalDelayedSupport({
+      status: 'neutral-wait',
+      visibleConstraint: 'aucune contrainte visible',
+      delayConsequence: 'attente neutre: aucun coût social visible à court terme',
+      microDecision: null,
+    }),
+    {
+      status: 'none-needed',
+      visibleConstraint: 'aucune contrainte visible',
+      recommendedSupport: 'aucun support minimal requis',
+      microDecision: null,
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureMinimalDelayedSupport({
+      status: 'manageable-cost',
+      visibleConstraint: 'fatigue de médiation',
+      delayConsequence: 'coût social gérable: fatigue de médiation peut réduire l’accalmie',
+      microDecision: 'revoir le support si fatigue de médiation remonte',
+    }),
+    {
+      status: 'light-support-enough',
+      visibleConstraint: 'fatigue de médiation',
+      recommendedSupport: 'support léger suffisant sur fatigue de médiation',
+      microDecision: 'revoir le support si fatigue de médiation remonte',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureMinimalDelayedSupport({
+      status: 'worsening-fragility',
+      visibleConstraint: 'support local',
+      delayConsequence: 'fragilité qui s’aggrave: support local peut rouvrir la dette avant correction',
+      microDecision: 'sécuriser un support local avant tout suivi',
+    }),
+    {
+      status: 'immediate-support-required',
+      visibleConstraint: 'support local',
+      recommendedSupport: 'soutien immédiat requis pour stabiliser support local',
       microDecision: 'sécuriser un support local avant tout suivi',
     },
   );


### PR DESCRIPTION
Gamma: ## Summary

Recommends the minimal visible support needed after delayed culture reevaluation becomes costly.

## Changes

- Adds `residualCultureMinimalDelayedSupport` near the reevaluation delay cost.
- Classifies support as none needed, light support enough, or immediate support required.
- Names the visible constraint from the existing G39 delay cost.
- Adds a micro-decision only when support changes the follow-up.
- Complements G39 without recalculating delay cost or exposing hidden social factors.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1111