### PR TITLE
Beta: show rollback guard load margin

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -597,6 +597,33 @@ function buildMonitoredCorridorRollbackGuard(monitoredCorridorPromotionRisk) {
   };
 }
 
+function buildRollbackGuardLoadMargin(monitoredCorridorRollbackGuard) {
+  if (monitoredCorridorRollbackGuard.status === 'rollback-unneeded') {
+    return {
+      status: 'peak-absorbable',
+      constraint: monitoredCorridorRollbackGuard.constraint,
+      nextGesture: 'absorber',
+      summary: 'Pic absorbable: la route principale garde assez de marge après garde.',
+    };
+  }
+
+  if (monitoredCorridorRollbackGuard.status === 'guard-recommended') {
+    return {
+      status: 'peak-capped',
+      constraint: monitoredCorridorRollbackGuard.constraint,
+      nextGesture: 'plafonner le flux',
+      summary: `Pic à plafonner: ${monitoredCorridorRollbackGuard.constraint} exige de garder la marge sous contrôle.`,
+    };
+  }
+
+  return {
+    status: 'overload-likely',
+    constraint: monitoredCorridorRollbackGuard.constraint,
+    nextGesture: monitoredCorridorRollbackGuard.nextGesture === 'revenir en secours' ? 'revenir en secours' : 'activer alternative',
+    summary: `Surcharge probable: ${monitoredCorridorRollbackGuard.constraint} demande une alternative active.`,
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -814,6 +841,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
   const postStabilizerReliability = buildPostStabilizerReliability(postSalvageStabilizer);
   const monitoredCorridorPromotionRisk = buildMonitoredCorridorPromotionRisk(postStabilizerReliability);
   const monitoredCorridorRollbackGuard = buildMonitoredCorridorRollbackGuard(monitoredCorridorPromotionRisk);
+  const rollbackGuardLoadMargin = buildRollbackGuardLoadMargin(monitoredCorridorRollbackGuard);
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -833,6 +861,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     postStabilizerReliability,
     monitoredCorridorPromotionRisk,
     monitoredCorridorRollbackGuard,
+    rollbackGuardLoadMargin,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -585,6 +585,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         nextGesture: 'promouvoir sans garde',
         summary: 'Rollback inutile: la promotion peut avancer sans garde dédiée.',
       },
+      rollbackGuardLoadMargin: {
+        status: 'peak-absorbable',
+        constraint: null,
+        nextGesture: 'absorber',
+        summary: 'Pic absorbable: la route principale garde assez de marge après garde.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -757,6 +763,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       nextGesture: 'promouvoir sans garde',
       summary: 'Rollback inutile: la promotion peut avancer sans garde dédiée.',
     },
+    rollbackGuardLoadMargin: {
+      status: 'peak-absorbable',
+      constraint: null,
+      nextGesture: 'absorber',
+      summary: 'Pic absorbable: la route principale garde assez de marge après garde.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -879,6 +891,12 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     nextGesture: 'revenir en secours',
     summary: 'Rollback prêt requis: alternative impose une alternative avant promotion.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.rollbackGuardLoadMargin, {
+    status: 'overload-likely',
+    constraint: 'alternative',
+    nextGesture: 'revenir en secours',
+    summary: 'Surcharge probable: alternative demande une alternative active.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -967,6 +985,12 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     constraint: 'alternative',
     nextGesture: 'plafonner avec garde',
     summary: 'Garde conseillée: plafonner le flux et surveiller alternative.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.rollbackGuardLoadMargin, {
+    status: 'peak-capped',
+    constraint: 'alternative',
+    nextGesture: 'plafonner le flux',
+    summary: 'Pic à plafonner: alternative exige de garder la marge sous contrôle.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a compact load-margin readout after the monitored corridor rollback guard so the economy overlay shows whether the next load spike is absorbable, capped, or likely to overload.

## Changes

- Add `rollbackGuardLoadMargin` beside the B39 rollback guard.
- Classify peak absorbable, peak capped, and overload likely outcomes.
- Keep the visible constraint and short next gesture (`absorber`, `plafonner le flux`, `activer alternative`, or `revenir en secours`).
- Extend economy overlay tests for all three load-margin outcomes.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (635/635 pass)

Fixes loo469/historia#1110