### PR TITLE
Epsilon: recommend minimal reserve consolidation

### DIFF
--- a/test/ui/climate/webAtlasMinimalConsolidationAfterFragileClimateReservePayment.test.js
+++ b/test/ui/climate/webAtlasMinimalConsolidationAfterFragileClimateReservePayment.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas recommends minimal consolidation after fragile climate reserve payment', () => {
+  assert.match(webAppSource, /function buildMinimalConsolidationAfterFragileClimateReservePayment/);
+  assert.match(webAppSource, /minimalConsolidationAfterFragileClimateReservePayment: null/);
+  assert.match(webAppSource, /minimalConsolidationAfterFragileClimateReservePayment,/);
+
+  for (const stableKey of [
+    'state',
+    'visibleConstraint',
+    'shortGesture',
+    'changesNextStep',
+    'sourceReserveRisk',
+    'secondaryDebtKey',
+    'secondaryDebtLabel',
+    'summary',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /consolidation inutile/);
+  assert.match(webAppSource, /consolidation légère/);
+  assert.match(webAppSource, /consolidation urgente/);
+  assert.match(webAppSource, /saison/);
+  assert.match(webAppSource, /cascade voisine/);
+  assert.match(webAppSource, /pression régionale/);
+  assert.match(webAppSource, /dette secondaire/);
+  assert.match(webAppSource, /conflit de timing/);
+  assert.match(webAppSource, /réserve restante/);
+  assert.match(webAppSource, /verrouiller une réserve anti-cascade/);
+  assert.match(webAppSource, /ajouter une marge courte sans surpayer la dette climat/);
+  assert.match(webAppSource, /aucun geste immédiat/);
+  assert.match(webAppSource, /Consolidation minimale/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9982,6 +9982,50 @@ function buildResidualReserveRiskAfterSecondaryClimateDebtPayment(secondaryClima
   };
 }
 
+function buildMinimalConsolidationAfterFragileClimateReservePayment(residualReserveRiskAfterSecondaryClimateDebtPayment, secondaryClimateDebtNearWindowReopenEffect, decisionWindow) {
+  if (!residualReserveRiskAfterSecondaryClimateDebtPayment) {
+    return null;
+  }
+
+  const constraintText = `${residualReserveRiskAfterSecondaryClimateDebtPayment.visibleConstraint ?? ''} ${secondaryClimateDebtNearWindowReopenEffect?.visibleConstraint ?? ''} ${residualReserveRiskAfterSecondaryClimateDebtPayment.summary ?? ''}`.toLowerCase();
+  const visibleConstraint = constraintText.includes('cascade')
+    ? 'cascade voisine'
+    : constraintText.includes('conflit') || constraintText.includes('timing')
+      ? 'conflit de timing'
+      : constraintText.includes('saison')
+        ? 'saison'
+        : constraintText.includes('pression régionale') || constraintText.includes('deadline')
+          ? 'pression régionale'
+          : constraintText.includes('dette')
+            ? 'dette secondaire'
+            : 'réserve restante';
+  const hasTimingConflict = (decisionWindow?.conflicts?.length ?? 0) > 0;
+  const state = residualReserveRiskAfterSecondaryClimateDebtPayment.state === 'cascade voisine exposée'
+    ? 'consolidation urgente'
+    : residualReserveRiskAfterSecondaryClimateDebtPayment.state === 'réserve mince' || hasTimingConflict
+      ? 'consolidation légère'
+      : 'consolidation inutile';
+  const shortGesture = state === 'consolidation urgente'
+    ? 'verrouiller une réserve anti-cascade avant de rouvrir la fenêtre'
+    : state === 'consolidation légère'
+      ? 'ajouter une marge courte sans surpayer la dette climat'
+      : 'aucun geste immédiat';
+  const summary = state === 'consolidation inutile'
+    ? `Consolidation inutile: la réserve restante suffit; contrainte ${visibleConstraint}.`
+    : `${state}: ${visibleConstraint} modifie la suite; geste: ${shortGesture}.`;
+
+  return {
+    state,
+    visibleConstraint,
+    shortGesture,
+    changesNextStep: state !== 'consolidation inutile',
+    sourceReserveRisk: residualReserveRiskAfterSecondaryClimateDebtPayment.state,
+    secondaryDebtKey: residualReserveRiskAfterSecondaryClimateDebtPayment.secondaryDebtKey,
+    secondaryDebtLabel: residualReserveRiskAfterSecondaryClimateDebtPayment.secondaryDebtLabel,
+    summary,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -10040,6 +10084,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       secondaryClimateDebtWhenReserveCostsWindow: null,
       secondaryClimateDebtNearWindowReopenEffect: null,
       residualReserveRiskAfterSecondaryClimateDebtPayment: null,
+      minimalConsolidationAfterFragileClimateReservePayment: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -10142,6 +10187,11 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     climateRiskReboundAfterTopPayoff,
     decisionWindow,
   );
+  const minimalConsolidationAfterFragileClimateReservePayment = buildMinimalConsolidationAfterFragileClimateReservePayment(
+    residualReserveRiskAfterSecondaryClimateDebtPayment,
+    secondaryClimateDebtNearWindowReopenEffect,
+    decisionWindow,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -10163,6 +10213,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     secondaryClimateDebtWhenReserveCostsWindow,
     secondaryClimateDebtNearWindowReopenEffect,
     residualReserveRiskAfterSecondaryClimateDebtPayment,
+    minimalConsolidationAfterFragileClimateReservePayment,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -10205,6 +10256,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.secondaryClimateDebtWhenReserveCostsWindow ? `<small><b>Dette secondaire réserve</b> · ${view.secondaryClimateDebtWhenReserveCostsWindow.summary}</small>` : ''}
       ${view.secondaryClimateDebtNearWindowReopenEffect ? `<small><b>Effet paiement dette secondaire</b> · ${view.secondaryClimateDebtNearWindowReopenEffect.summary}</small>` : ''}
       ${view.residualReserveRiskAfterSecondaryClimateDebtPayment ? `<small><b>Risque réserve résiduel</b> · ${view.residualReserveRiskAfterSecondaryClimateDebtPayment.summary}</small>` : ''}
+      ${view.minimalConsolidationAfterFragileClimateReservePayment ? `<small><b>Consolidation minimale</b> · ${view.minimalConsolidationAfterFragileClimateReservePayment.summary}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1113.

## Résumé
- recommande la consolidation minimale après un paiement de dette climat qui laisse une réserve fragile
- classe entre consolidation inutile, légère ou urgente
- nomme la contrainte visible et garde un libellé neutre quand la réserve suffit

## Tests
- `npm test`
