### PR TITLE
Alpha: compare tactical fallback value

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1004,6 +1004,49 @@ export function buildMiniPlanFollowThroughOpportunityTradeoff(miniPlanMinimalFol
   };
 }
 
+function normalizeTacticalFallbackConstraint(constraint) {
+  return constraint === 'opportunité rivale'
+    ? 'fenêtre d’opportunité'
+    : constraint;
+}
+
+export function buildMiniPlanSafestTacticalFallback(miniPlanFollowThroughOpportunityTradeoff = null) {
+  if (!miniPlanFollowThroughOpportunityTradeoff || miniPlanFollowThroughOpportunityTradeoff.empty) {
+    return {
+      empty: true,
+      state: 'unneeded',
+      label: 'repli inutile',
+      constraint: null,
+      action: null,
+    };
+  }
+
+  const constraint = normalizeTacticalFallbackConstraint(
+    miniPlanFollowThroughOpportunityTradeoff.constraint ?? 'fenêtre d’opportunité',
+  );
+  const state = miniPlanFollowThroughOpportunityTradeoff.state === 'opportunity-threatened'
+    ? 'urgent-save-opportunity'
+    : miniPlanFollowThroughOpportunityTradeoff.state === 'manageable-conflict'
+      ? 'value-advised'
+      : 'unneeded';
+
+  return {
+    empty: false,
+    state,
+    label: state === 'urgent-save-opportunity'
+      ? 'repli urgent pour sauver l’opportunité'
+      : state === 'value-advised'
+        ? 'repli de valeur conseillé'
+        : 'repli inutile',
+    constraint,
+    action: state === 'urgent-save-opportunity'
+      ? (constraint === 'ordre engagé' ? 'abandonner l’ouverture' : 'exploiter maintenant')
+      : state === 'value-advised'
+        ? (constraint === 'position' ? 'préserver position' : 'sécuriser puis exploiter')
+        : 'exploiter maintenant',
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -1113,6 +1156,9 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const miniPlanFollowThroughOpportunityTradeoff = buildMiniPlanFollowThroughOpportunityTradeoff(
     miniPlanMinimalFollowThrough,
   );
+  const miniPlanSafestTacticalFallback = buildMiniPlanSafestTacticalFallback(
+    miniPlanFollowThroughOpportunityTradeoff,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -1170,6 +1216,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanLateCorrectionExitCost,
     miniPlanMinimalFollowThrough,
     miniPlanFollowThroughOpportunityTradeoff,
+    miniPlanSafestTacticalFallback,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -13,6 +13,7 @@ import {
   buildMiniPlanLateCorrectionExitCost,
   buildMiniPlanMinimalFollowThrough,
   buildMiniPlanFollowThroughOpportunityTradeoff,
+  buildMiniPlanSafestTacticalFallback,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -388,6 +389,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     empty: true,
     state: 'no-conflict',
     label: 'suivi sans conflit',
+    constraint: null,
+    action: null,
+  });
+  assert.deepEqual(shell.miniPlanSafestTacticalFallback, {
+    empty: true,
+    state: 'unneeded',
+    label: 'repli inutile',
     constraint: null,
     action: null,
   });
@@ -779,12 +787,20 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     support: 'position',
     action: 'protéger position',
   });
-  assert.deepEqual(buildMiniPlanFollowThroughOpportunityTradeoff(followThrough), {
+  const opportunityTradeoff = buildMiniPlanFollowThroughOpportunityTradeoff(followThrough);
+  assert.deepEqual(opportunityTradeoff, {
     empty: false,
     state: 'opportunity-threatened',
     label: 'opportunité menacée',
     constraint: 'position',
     action: 'reporter l’opportunité',
+  });
+  assert.deepEqual(buildMiniPlanSafestTacticalFallback(opportunityTradeoff), {
+    empty: false,
+    state: 'urgent-save-opportunity',
+    label: 'repli urgent pour sauver l’opportunité',
+    constraint: 'position',
+    action: 'exploiter maintenant',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -875,12 +891,20 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     support: 'opportunité rivale',
     action: 'surveiller',
   });
-  assert.deepEqual(buildMiniPlanFollowThroughOpportunityTradeoff(followThrough), {
+  const opportunityTradeoff = buildMiniPlanFollowThroughOpportunityTradeoff(followThrough);
+  assert.deepEqual(opportunityTradeoff, {
     empty: false,
     state: 'no-conflict',
     label: 'suivi sans conflit',
     constraint: 'opportunité rivale',
     action: 'suivre maintenant',
+  });
+  assert.deepEqual(buildMiniPlanSafestTacticalFallback(opportunityTradeoff), {
+    empty: false,
+    state: 'unneeded',
+    label: 'repli inutile',
+    constraint: 'fenêtre d’opportunité',
+    action: 'exploiter maintenant',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -962,12 +986,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     support: 'tempo',
     action: 'consolider',
   });
-  assert.deepEqual(buildMiniPlanFollowThroughOpportunityTradeoff(followThrough), {
+  const opportunityTradeoff = buildMiniPlanFollowThroughOpportunityTradeoff(followThrough);
+  assert.deepEqual(opportunityTradeoff, {
     empty: false,
     state: 'manageable-conflict',
     label: 'conflit gérable',
     constraint: 'tempo',
     action: 'limiter l’engagement',
+  });
+  assert.deepEqual(buildMiniPlanSafestTacticalFallback(opportunityTradeoff), {
+    empty: false,
+    state: 'value-advised',
+    label: 'repli de valeur conseillé',
+    constraint: 'tempo',
+    action: 'sécuriser puis exploiter',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -1016,6 +1048,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     empty: true,
     state: 'no-conflict',
     label: 'suivi sans conflit',
+    constraint: null,
+    action: null,
+  });
+  assert.deepEqual(buildMiniPlanSafestTacticalFallback(null), {
+    empty: true,
+    state: 'unneeded',
+    label: 'repli inutile',
     constraint: null,
     action: null,
   });

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -76,6 +76,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanLateCorrectionExitCost\(/);
   assert.match(webAppSource, /buildMiniPlanMinimalFollowThrough\(/);
   assert.match(webAppSource, /buildMiniPlanFollowThroughOpportunityTradeoff\(/);
+  assert.match(webAppSource, /buildMiniPlanSafestTacticalFallback\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -121,6 +122,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanLateCorrectionExitCost: buildMiniPlanLateCorrectionExitCost\(/);
   assert.match(webAppSource, /miniPlanMinimalFollowThrough: buildMiniPlanMinimalFollowThrough\(/);
   assert.match(webAppSource, /miniPlanFollowThroughOpportunityTradeoff: buildMiniPlanFollowThroughOpportunityTradeoff\(/);
+  assert.match(webAppSource, /miniPlanSafestTacticalFallback: buildMiniPlanSafestTacticalFallback\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
@@ -132,6 +134,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /sortie tardive: non évaluée/);
   assert.match(webAppSource, /suivi minimal: non critique/);
   assert.match(webAppSource, /opportunité: aucun conflit/);
+  assert.match(webAppSource, /repli tactique: inutile/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -150,6 +153,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__late-correction-exit-cost/);
   assert.match(webAppSource, /atlas-military-fallback-order__minimal-follow-through/);
   assert.match(webAppSource, /atlas-military-fallback-order__follow-through-opportunity/);
+  assert.match(webAppSource, /atlas-military-fallback-order__safest-tactical-fallback/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -168,6 +172,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /sortie tardive: \$\{exitCost\.label\} · perte \$\{exitCost\.loss\} · \$\{exitCost\.decision\}/);
   assert.match(webAppSource, /suivi minimal: \$\{minimalFollowThrough\.label\} · \$\{minimalFollowThrough\.support\} · \$\{minimalFollowThrough\.action\}/);
   assert.match(webAppSource, /opportunité: \$\{opportunityTradeoff\.label\} · \$\{opportunityTradeoff\.constraint\} · \$\{opportunityTradeoff\.action\}/);
+  assert.match(webAppSource, /repli tactique: \$\{safestTacticalFallback\.label\} · \$\{safestTacticalFallback\.constraint\} · \$\{safestTacticalFallback\.action\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -196,4 +201,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__late-correction-exit-cost/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__minimal-follow-through/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__follow-through-opportunity/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__safest-tactical-fallback/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14,6 +14,7 @@ import {
   buildMiniPlanLateCorrectionExitCost,
   buildMiniPlanMinimalFollowThrough,
   buildMiniPlanFollowThroughOpportunityTradeoff,
+  buildMiniPlanSafestTacticalFallback,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -2028,6 +2029,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanFollowThroughOpportunityTradeoff: buildMiniPlanFollowThroughOpportunityTradeoff(
         buildMiniPlanMinimalFollowThrough(null),
       ),
+      miniPlanSafestTacticalFallback: buildMiniPlanSafestTacticalFallback(
+        buildMiniPlanFollowThroughOpportunityTradeoff(null),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2088,6 +2092,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const miniPlanFollowThroughOpportunityTradeoff = buildMiniPlanFollowThroughOpportunityTradeoff(
     miniPlanMinimalFollowThrough,
   );
+  const miniPlanSafestTacticalFallback = buildMiniPlanSafestTacticalFallback(
+    miniPlanFollowThroughOpportunityTradeoff,
+  );
 
   return {
     fallback: {
@@ -2117,6 +2124,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanLateCorrectionExitCost,
       miniPlanMinimalFollowThrough,
       miniPlanFollowThroughOpportunityTradeoff,
+      miniPlanSafestTacticalFallback,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2141,7 +2149,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanLateCorrectionExitCost,
     miniPlanMinimalFollowThrough,
     miniPlanFollowThroughOpportunityTradeoff,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}).`,
+    miniPlanSafestTacticalFallback,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}; repli tactique: ${miniPlanSafestTacticalFallback.empty ? 'aucun' : miniPlanSafestTacticalFallback.state}).`,
     empty: false,
   };
 }
@@ -2224,9 +2233,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const opportunityTradeoffLabel = opportunityTradeoff && !opportunityTradeoff.empty
     ? `opportunité: ${opportunityTradeoff.label} · ${opportunityTradeoff.constraint} · ${opportunityTradeoff.action}`
     : 'opportunité: aucun conflit';
+  const safestTacticalFallback = fallback.miniPlanSafestTacticalFallback;
+  const safestTacticalFallbackLabel = safestTacticalFallback && !safestTacticalFallback.empty
+    ? `repli tactique: ${safestTacticalFallback.label} · ${safestTacticalFallback.constraint} · ${safestTacticalFallback.action}`
+    : 'repli tactique: inutile';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="30" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="31.2" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2252,6 +2265,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__late-correction-exit-cost atlas-military-fallback-order__late-correction-exit-cost--${exitCost?.severity ?? 'none'}" x="23.2" y="83.3">${exitCostLabel}</text>
       <text class="atlas-military-fallback-order__minimal-follow-through atlas-military-fallback-order__minimal-follow-through--${minimalFollowThrough?.level ?? 'none'}" x="23.2" y="84.4">${minimalFollowThroughLabel}</text>
       <text class="atlas-military-fallback-order__follow-through-opportunity atlas-military-fallback-order__follow-through-opportunity--${opportunityTradeoff?.state ?? 'no-conflict'}" x="23.2" y="85.5">${opportunityTradeoffLabel}</text>
+      <text class="atlas-military-fallback-order__safest-tactical-fallback atlas-military-fallback-order__safest-tactical-fallback--${safestTacticalFallback?.state ?? 'unneeded'}" x="23.2" y="86.6">${safestTacticalFallbackLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11190,6 +11190,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__follow-through-opportunity { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
 .atlas-military-fallback-order__follow-through-opportunity--manageable-conflict { fill: #fde68a; }
 .atlas-military-fallback-order__follow-through-opportunity--opportunity-threatened { fill: #fecaca; }
+.atlas-military-fallback-order__safest-tactical-fallback { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__safest-tactical-fallback--value-advised { fill: #fde68a; }
+.atlas-military-fallback-order__safest-tactical-fallback--urgent-save-opportunity { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1109.

Summary:
- adds `miniPlanSafestTacticalFallback` after the follow-through opportunity tradeoff
- classifies tactical fallback value as unneeded, value-advised, or urgent-save-opportunity
- names the visible constraint and compact action without repeating A39 labels
- renders the compact cue in the war map fallback overlay

Tests:
- npm test

Zeta: ready for validation before merge.