### PR TITLE
Alpha: show next-turn hold plan

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1047,6 +1047,46 @@ export function buildMiniPlanSafestTacticalFallback(miniPlanFollowThroughOpportu
   };
 }
 
+function holdPlanRiskForConstraint(constraint) {
+  if (constraint === 'tempo') return 'tempo repris par le rival';
+  if (constraint === 'fatigue') return 'fatigue transforme le repli en retard';
+  if (constraint === 'position') return 'position se rouvre';
+  if (constraint === 'appui allié') return 'appui allié se disperse';
+  if (constraint === 'ordre engagé') return 'ordre engagé se verrouille';
+  return 'fenêtre d’opportunité se referme';
+}
+
+export function buildMiniPlanNextTurnHoldPlan(miniPlanSafestTacticalFallback = null) {
+  if (!miniPlanSafestTacticalFallback || miniPlanSafestTacticalFallback.empty) {
+    return {
+      empty: true,
+      label: 'plan prochain tour non requis',
+      action: null,
+      constraint: null,
+      riskIfIgnored: null,
+    };
+  }
+
+  const constraint = miniPlanSafestTacticalFallback.constraint ?? 'fenêtre d’opportunité';
+  const action = miniPlanSafestTacticalFallback.state === 'urgent-save-opportunity'
+    ? (miniPlanSafestTacticalFallback.action === 'abandonner l’ouverture' ? 'tenir position engagée' : 'verrouiller exploitation')
+    : miniPlanSafestTacticalFallback.state === 'value-advised'
+      ? (constraint === 'position' ? 'ancrer position' : 'garder réserve courte')
+      : 'maintenir tempo';
+
+  return {
+    empty: false,
+    label: miniPlanSafestTacticalFallback.state === 'urgent-save-opportunity'
+      ? 'tenir ouverture sauvée'
+      : miniPlanSafestTacticalFallback.state === 'value-advised'
+        ? 'tenir repli de valeur'
+        : 'tenir exploitation simple',
+    action,
+    constraint,
+    riskIfIgnored: holdPlanRiskForConstraint(constraint),
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -1159,6 +1199,9 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const miniPlanSafestTacticalFallback = buildMiniPlanSafestTacticalFallback(
     miniPlanFollowThroughOpportunityTradeoff,
   );
+  const miniPlanNextTurnHoldPlan = buildMiniPlanNextTurnHoldPlan(
+    miniPlanSafestTacticalFallback,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -1217,6 +1260,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanMinimalFollowThrough,
     miniPlanFollowThroughOpportunityTradeoff,
     miniPlanSafestTacticalFallback,
+    miniPlanNextTurnHoldPlan,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -14,6 +14,7 @@ import {
   buildMiniPlanMinimalFollowThrough,
   buildMiniPlanFollowThroughOpportunityTradeoff,
   buildMiniPlanSafestTacticalFallback,
+  buildMiniPlanNextTurnHoldPlan,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -398,6 +399,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     label: 'repli inutile',
     constraint: null,
     action: null,
+  });
+  assert.deepEqual(shell.miniPlanNextTurnHoldPlan, {
+    empty: true,
+    label: 'plan prochain tour non requis',
+    action: null,
+    constraint: null,
+    riskIfIgnored: null,
   });
 });
 
@@ -795,12 +803,20 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     constraint: 'position',
     action: 'reporter l’opportunité',
   });
-  assert.deepEqual(buildMiniPlanSafestTacticalFallback(opportunityTradeoff), {
+  const tacticalFallback = buildMiniPlanSafestTacticalFallback(opportunityTradeoff);
+  assert.deepEqual(tacticalFallback, {
     empty: false,
     state: 'urgent-save-opportunity',
     label: 'repli urgent pour sauver l’opportunité',
     constraint: 'position',
     action: 'exploiter maintenant',
+  });
+  assert.deepEqual(buildMiniPlanNextTurnHoldPlan(tacticalFallback), {
+    empty: false,
+    label: 'tenir ouverture sauvée',
+    action: 'verrouiller exploitation',
+    constraint: 'position',
+    riskIfIgnored: 'position se rouvre',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -899,12 +915,20 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     constraint: 'opportunité rivale',
     action: 'suivre maintenant',
   });
-  assert.deepEqual(buildMiniPlanSafestTacticalFallback(opportunityTradeoff), {
+  const tacticalFallback = buildMiniPlanSafestTacticalFallback(opportunityTradeoff);
+  assert.deepEqual(tacticalFallback, {
     empty: false,
     state: 'unneeded',
     label: 'repli inutile',
     constraint: 'fenêtre d’opportunité',
     action: 'exploiter maintenant',
+  });
+  assert.deepEqual(buildMiniPlanNextTurnHoldPlan(tacticalFallback), {
+    empty: false,
+    label: 'tenir exploitation simple',
+    action: 'maintenir tempo',
+    constraint: 'fenêtre d’opportunité',
+    riskIfIgnored: 'fenêtre d’opportunité se referme',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -994,12 +1018,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     constraint: 'tempo',
     action: 'limiter l’engagement',
   });
-  assert.deepEqual(buildMiniPlanSafestTacticalFallback(opportunityTradeoff), {
+  const tacticalFallback = buildMiniPlanSafestTacticalFallback(opportunityTradeoff);
+  assert.deepEqual(tacticalFallback, {
     empty: false,
     state: 'value-advised',
     label: 'repli de valeur conseillé',
     constraint: 'tempo',
     action: 'sécuriser puis exploiter',
+  });
+  assert.deepEqual(buildMiniPlanNextTurnHoldPlan(tacticalFallback), {
+    empty: false,
+    label: 'tenir repli de valeur',
+    action: 'garder réserve courte',
+    constraint: 'tempo',
+    riskIfIgnored: 'tempo repris par le rival',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -1057,6 +1089,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     label: 'repli inutile',
     constraint: null,
     action: null,
+  });
+  assert.deepEqual(buildMiniPlanNextTurnHoldPlan(null), {
+    empty: true,
+    label: 'plan prochain tour non requis',
+    action: null,
+    constraint: null,
+    riskIfIgnored: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -77,6 +77,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanMinimalFollowThrough\(/);
   assert.match(webAppSource, /buildMiniPlanFollowThroughOpportunityTradeoff\(/);
   assert.match(webAppSource, /buildMiniPlanSafestTacticalFallback\(/);
+  assert.match(webAppSource, /buildMiniPlanNextTurnHoldPlan\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -123,6 +124,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanMinimalFollowThrough: buildMiniPlanMinimalFollowThrough\(/);
   assert.match(webAppSource, /miniPlanFollowThroughOpportunityTradeoff: buildMiniPlanFollowThroughOpportunityTradeoff\(/);
   assert.match(webAppSource, /miniPlanSafestTacticalFallback: buildMiniPlanSafestTacticalFallback\(/);
+  assert.match(webAppSource, /miniPlanNextTurnHoldPlan: buildMiniPlanNextTurnHoldPlan\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
@@ -135,6 +137,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /suivi minimal: non critique/);
   assert.match(webAppSource, /opportunité: aucun conflit/);
   assert.match(webAppSource, /repli tactique: inutile/);
+  assert.match(webAppSource, /tour\+1: aucun maintien requis/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -154,6 +157,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__minimal-follow-through/);
   assert.match(webAppSource, /atlas-military-fallback-order__follow-through-opportunity/);
   assert.match(webAppSource, /atlas-military-fallback-order__safest-tactical-fallback/);
+  assert.match(webAppSource, /atlas-military-fallback-order__next-turn-hold-plan/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -173,6 +177,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /suivi minimal: \$\{minimalFollowThrough\.label\} · \$\{minimalFollowThrough\.support\} · \$\{minimalFollowThrough\.action\}/);
   assert.match(webAppSource, /opportunité: \$\{opportunityTradeoff\.label\} · \$\{opportunityTradeoff\.constraint\} · \$\{opportunityTradeoff\.action\}/);
   assert.match(webAppSource, /repli tactique: \$\{safestTacticalFallback\.label\} · \$\{safestTacticalFallback\.constraint\} · \$\{safestTacticalFallback\.action\}/);
+  assert.match(webAppSource, /tour\+1: \$\{nextTurnHoldPlan\.action\} · risque \$\{nextTurnHoldPlan\.riskIfIgnored\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -202,4 +207,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__minimal-follow-through/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__follow-through-opportunity/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__safest-tactical-fallback/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__next-turn-hold-plan/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -15,6 +15,7 @@ import {
   buildMiniPlanMinimalFollowThrough,
   buildMiniPlanFollowThroughOpportunityTradeoff,
   buildMiniPlanSafestTacticalFallback,
+  buildMiniPlanNextTurnHoldPlan,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -2032,6 +2033,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanSafestTacticalFallback: buildMiniPlanSafestTacticalFallback(
         buildMiniPlanFollowThroughOpportunityTradeoff(null),
       ),
+      miniPlanNextTurnHoldPlan: buildMiniPlanNextTurnHoldPlan(
+        buildMiniPlanSafestTacticalFallback(null),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2095,6 +2099,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const miniPlanSafestTacticalFallback = buildMiniPlanSafestTacticalFallback(
     miniPlanFollowThroughOpportunityTradeoff,
   );
+  const miniPlanNextTurnHoldPlan = buildMiniPlanNextTurnHoldPlan(
+    miniPlanSafestTacticalFallback,
+  );
 
   return {
     fallback: {
@@ -2125,6 +2132,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanMinimalFollowThrough,
       miniPlanFollowThroughOpportunityTradeoff,
       miniPlanSafestTacticalFallback,
+      miniPlanNextTurnHoldPlan,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2150,7 +2158,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanMinimalFollowThrough,
     miniPlanFollowThroughOpportunityTradeoff,
     miniPlanSafestTacticalFallback,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}; repli tactique: ${miniPlanSafestTacticalFallback.empty ? 'aucun' : miniPlanSafestTacticalFallback.state}).`,
+    miniPlanNextTurnHoldPlan,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}; repli tactique: ${miniPlanSafestTacticalFallback.empty ? 'aucun' : miniPlanSafestTacticalFallback.state}; plan prochain tour: ${miniPlanNextTurnHoldPlan.empty ? 'aucun' : miniPlanNextTurnHoldPlan.action}).`,
     empty: false,
   };
 }
@@ -2237,9 +2246,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const safestTacticalFallbackLabel = safestTacticalFallback && !safestTacticalFallback.empty
     ? `repli tactique: ${safestTacticalFallback.label} · ${safestTacticalFallback.constraint} · ${safestTacticalFallback.action}`
     : 'repli tactique: inutile';
+  const nextTurnHoldPlan = fallback.miniPlanNextTurnHoldPlan;
+  const nextTurnHoldPlanLabel = nextTurnHoldPlan && !nextTurnHoldPlan.empty
+    ? `tour+1: ${nextTurnHoldPlan.action} · risque ${nextTurnHoldPlan.riskIfIgnored}`
+    : 'tour+1: aucun maintien requis';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="31.2" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="32.4" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2266,6 +2279,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__minimal-follow-through atlas-military-fallback-order__minimal-follow-through--${minimalFollowThrough?.level ?? 'none'}" x="23.2" y="84.4">${minimalFollowThroughLabel}</text>
       <text class="atlas-military-fallback-order__follow-through-opportunity atlas-military-fallback-order__follow-through-opportunity--${opportunityTradeoff?.state ?? 'no-conflict'}" x="23.2" y="85.5">${opportunityTradeoffLabel}</text>
       <text class="atlas-military-fallback-order__safest-tactical-fallback atlas-military-fallback-order__safest-tactical-fallback--${safestTacticalFallback?.state ?? 'unneeded'}" x="23.2" y="86.6">${safestTacticalFallbackLabel}</text>
+      <text class="atlas-military-fallback-order__next-turn-hold-plan" x="23.2" y="87.7">${nextTurnHoldPlanLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11193,6 +11193,7 @@ button { font: inherit; }
 .atlas-military-fallback-order__safest-tactical-fallback { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
 .atlas-military-fallback-order__safest-tactical-fallback--value-advised { fill: #fde68a; }
 .atlas-military-fallback-order__safest-tactical-fallback--urgent-save-opportunity { fill: #fecaca; }
+.atlas-military-fallback-order__next-turn-hold-plan { fill: #bfdbfe; font-size: 0.39px; font-weight: 900; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1119.

Summary:
- adds `miniPlanNextTurnHoldPlan` after the safest tactical fallback
- names the next-turn action that keeps the front stable
- surfaces the risk that returns if the hold plan is ignored
- renders the compact tour+1 cue in the war map fallback overlay

Tests:
- npm test

Zeta: ready for validation before merge.