### PR TITLE
Beta: show guarded corridor load relief

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -624,6 +624,45 @@ function buildRollbackGuardLoadMargin(monitoredCorridorRollbackGuard) {
   };
 }
 
+function buildGuardedCorridorLoadRelief(rollbackGuardLoadMargin) {
+  if (rollbackGuardLoadMargin.status === 'peak-absorbable') {
+    return {
+      status: 'no-relief-needed',
+      relief: null,
+      protectedMargin: 'marge actuelle suffisante',
+      nextGesture: 'absorber',
+      summary: 'Aucun allègement utile: la marge absorbe le prochain pic visible.',
+    };
+  }
+
+  if (rollbackGuardLoadMargin.status === 'peak-capped') {
+    const reliefByConstraint = {
+      'capacité tampon': 'réduire le pic de charge',
+      saturation: 'lisser la saturation',
+      détour: 'redistribuer par détour court',
+      charge: 'lisser la charge',
+      'protection d’étape': 'décaler une étape non critique',
+      alternative: 'déporter vers alternative de secours',
+    };
+    const relief = reliefByConstraint[rollbackGuardLoadMargin.constraint] ?? 'redistribuer la charge';
+    return {
+      status: 'relief-recommended',
+      relief,
+      protectedMargin: rollbackGuardLoadMargin.constraint,
+      nextGesture: 'plafonner le flux',
+      summary: `Allègement utile: ${relief} protège la marge sans promettre une sécurité totale.`,
+    };
+  }
+
+  return {
+    status: 'urgent-relief',
+    relief: 'activer alternative de secours',
+    protectedMargin: rollbackGuardLoadMargin.constraint,
+    nextGesture: rollbackGuardLoadMargin.nextGesture,
+    summary: `Allègement urgent: ${rollbackGuardLoadMargin.constraint} surcharge la route, garder une alternative active.`,
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -842,6 +881,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
   const monitoredCorridorPromotionRisk = buildMonitoredCorridorPromotionRisk(postStabilizerReliability);
   const monitoredCorridorRollbackGuard = buildMonitoredCorridorRollbackGuard(monitoredCorridorPromotionRisk);
   const rollbackGuardLoadMargin = buildRollbackGuardLoadMargin(monitoredCorridorRollbackGuard);
+  const guardedCorridorLoadRelief = buildGuardedCorridorLoadRelief(rollbackGuardLoadMargin);
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -862,6 +902,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     monitoredCorridorPromotionRisk,
     monitoredCorridorRollbackGuard,
     rollbackGuardLoadMargin,
+    guardedCorridorLoadRelief,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -591,6 +591,13 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         nextGesture: 'absorber',
         summary: 'Pic absorbable: la route principale garde assez de marge après garde.',
       },
+      guardedCorridorLoadRelief: {
+        status: 'no-relief-needed',
+        relief: null,
+        protectedMargin: 'marge actuelle suffisante',
+        nextGesture: 'absorber',
+        summary: 'Aucun allègement utile: la marge absorbe le prochain pic visible.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -769,6 +776,13 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       nextGesture: 'absorber',
       summary: 'Pic absorbable: la route principale garde assez de marge après garde.',
     },
+    guardedCorridorLoadRelief: {
+      status: 'no-relief-needed',
+      relief: null,
+      protectedMargin: 'marge actuelle suffisante',
+      nextGesture: 'absorber',
+      summary: 'Aucun allègement utile: la marge absorbe le prochain pic visible.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -897,6 +911,13 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     nextGesture: 'revenir en secours',
     summary: 'Surcharge probable: alternative demande une alternative active.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.guardedCorridorLoadRelief, {
+    status: 'urgent-relief',
+    relief: 'activer alternative de secours',
+    protectedMargin: 'alternative',
+    nextGesture: 'revenir en secours',
+    summary: 'Allègement urgent: alternative surcharge la route, garder une alternative active.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -991,6 +1012,13 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     constraint: 'alternative',
     nextGesture: 'plafonner le flux',
     summary: 'Pic à plafonner: alternative exige de garder la marge sous contrôle.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.guardedCorridorLoadRelief, {
+    status: 'relief-recommended',
+    relief: 'déporter vers alternative de secours',
+    protectedMargin: 'alternative',
+    nextGesture: 'plafonner le flux',
+    summary: 'Allègement utile: déporter vers alternative de secours protège la marge sans promettre une sécurité totale.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a compact next-load-relief readout for guarded monitored corridors so the economy overlay shows whether no relief is needed, a useful relief is recommended, or urgent relief is required.

## Changes

- Add `guardedCorridorLoadRelief` beside the rollback guard load margin.
- Classify no relief needed, relief recommended, and urgent relief outcomes.
- Name the useful relief/redistribution and protected margin without promising full safety.
- Extend economy overlay tests for all three relief outcomes.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (636/636 pass)

Fixes loo469/historia#1120