### PR TITLE
Alpha: show hold release cue

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1087,6 +1087,51 @@ export function buildMiniPlanNextTurnHoldPlan(miniPlanSafestTacticalFallback = n
   };
 }
 
+function holdReleaseConstraintForPlan(nextTurnHoldPlan) {
+  if (nextTurnHoldPlan.constraint === 'position') return 'front exposé';
+  if (nextTurnHoldPlan.constraint === 'appui allié') return 'support absent';
+  if (nextTurnHoldPlan.constraint === 'fenêtre d’opportunité') return 'opportunité encore fragile';
+  return 'menace voisine';
+}
+
+function holdReleaseActionForConstraint(constraint) {
+  if (constraint === 'front exposé') return 'tenir écran';
+  if (constraint === 'support absent') return 'rappeler support';
+  if (constraint === 'opportunité encore fragile') return 'confirmer ouverture';
+  return 'surveiller voisin';
+}
+
+export function buildMiniPlanHoldReleaseCue(miniPlanNextTurnHoldPlan = null) {
+  if (!miniPlanNextTurnHoldPlan || miniPlanNextTurnHoldPlan.empty) {
+    return {
+      empty: true,
+      state: 'safe-release',
+      label: 'relâchement sûr',
+      constraint: null,
+      action: null,
+    };
+  }
+
+  const constraint = holdReleaseConstraintForPlan(miniPlanNextTurnHoldPlan);
+  const state = miniPlanNextTurnHoldPlan.label === 'tenir ouverture sauvée'
+    ? 'hold-required'
+    : miniPlanNextTurnHoldPlan.label === 'tenir repli de valeur'
+      ? 'cautious-release'
+      : 'safe-release';
+
+  return {
+    empty: false,
+    state,
+    label: state === 'hold-required'
+      ? 'maintien encore requis'
+      : state === 'cautious-release'
+        ? 'relâchement prudent possible'
+        : 'relâchement sûr',
+    constraint,
+    action: state === 'safe-release' ? null : holdReleaseActionForConstraint(constraint),
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -1202,6 +1247,9 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const miniPlanNextTurnHoldPlan = buildMiniPlanNextTurnHoldPlan(
     miniPlanSafestTacticalFallback,
   );
+  const miniPlanHoldReleaseCue = buildMiniPlanHoldReleaseCue(
+    miniPlanNextTurnHoldPlan,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -1261,6 +1309,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanFollowThroughOpportunityTradeoff,
     miniPlanSafestTacticalFallback,
     miniPlanNextTurnHoldPlan,
+    miniPlanHoldReleaseCue,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -15,6 +15,7 @@ import {
   buildMiniPlanFollowThroughOpportunityTradeoff,
   buildMiniPlanSafestTacticalFallback,
   buildMiniPlanNextTurnHoldPlan,
+  buildMiniPlanHoldReleaseCue,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -406,6 +407,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     action: null,
     constraint: null,
     riskIfIgnored: null,
+  });
+  assert.deepEqual(shell.miniPlanHoldReleaseCue, {
+    empty: true,
+    state: 'safe-release',
+    label: 'relâchement sûr',
+    constraint: null,
+    action: null,
   });
 });
 
@@ -811,12 +819,20 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     constraint: 'position',
     action: 'exploiter maintenant',
   });
-  assert.deepEqual(buildMiniPlanNextTurnHoldPlan(tacticalFallback), {
+  const holdPlan = buildMiniPlanNextTurnHoldPlan(tacticalFallback);
+  assert.deepEqual(holdPlan, {
     empty: false,
     label: 'tenir ouverture sauvée',
     action: 'verrouiller exploitation',
     constraint: 'position',
     riskIfIgnored: 'position se rouvre',
+  });
+  assert.deepEqual(buildMiniPlanHoldReleaseCue(holdPlan), {
+    empty: false,
+    state: 'hold-required',
+    label: 'maintien encore requis',
+    constraint: 'front exposé',
+    action: 'tenir écran',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -923,12 +939,20 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     constraint: 'fenêtre d’opportunité',
     action: 'exploiter maintenant',
   });
-  assert.deepEqual(buildMiniPlanNextTurnHoldPlan(tacticalFallback), {
+  const holdPlan = buildMiniPlanNextTurnHoldPlan(tacticalFallback);
+  assert.deepEqual(holdPlan, {
     empty: false,
     label: 'tenir exploitation simple',
     action: 'maintenir tempo',
     constraint: 'fenêtre d’opportunité',
     riskIfIgnored: 'fenêtre d’opportunité se referme',
+  });
+  assert.deepEqual(buildMiniPlanHoldReleaseCue(holdPlan), {
+    empty: false,
+    state: 'safe-release',
+    label: 'relâchement sûr',
+    constraint: 'opportunité encore fragile',
+    action: null,
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -1026,12 +1050,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     constraint: 'tempo',
     action: 'sécuriser puis exploiter',
   });
-  assert.deepEqual(buildMiniPlanNextTurnHoldPlan(tacticalFallback), {
+  const holdPlan = buildMiniPlanNextTurnHoldPlan(tacticalFallback);
+  assert.deepEqual(holdPlan, {
     empty: false,
     label: 'tenir repli de valeur',
     action: 'garder réserve courte',
     constraint: 'tempo',
     riskIfIgnored: 'tempo repris par le rival',
+  });
+  assert.deepEqual(buildMiniPlanHoldReleaseCue(holdPlan), {
+    empty: false,
+    state: 'cautious-release',
+    label: 'relâchement prudent possible',
+    constraint: 'menace voisine',
+    action: 'surveiller voisin',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -1096,6 +1128,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     action: null,
     constraint: null,
     riskIfIgnored: null,
+  });
+  assert.deepEqual(buildMiniPlanHoldReleaseCue(null), {
+    empty: true,
+    state: 'safe-release',
+    label: 'relâchement sûr',
+    constraint: null,
+    action: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -78,6 +78,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanFollowThroughOpportunityTradeoff\(/);
   assert.match(webAppSource, /buildMiniPlanSafestTacticalFallback\(/);
   assert.match(webAppSource, /buildMiniPlanNextTurnHoldPlan\(/);
+  assert.match(webAppSource, /buildMiniPlanHoldReleaseCue\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -125,6 +126,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanFollowThroughOpportunityTradeoff: buildMiniPlanFollowThroughOpportunityTradeoff\(/);
   assert.match(webAppSource, /miniPlanSafestTacticalFallback: buildMiniPlanSafestTacticalFallback\(/);
   assert.match(webAppSource, /miniPlanNextTurnHoldPlan: buildMiniPlanNextTurnHoldPlan\(/);
+  assert.match(webAppSource, /miniPlanHoldReleaseCue: buildMiniPlanHoldReleaseCue\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
@@ -138,6 +140,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /opportunité: aucun conflit/);
   assert.match(webAppSource, /repli tactique: inutile/);
   assert.match(webAppSource, /tour\+1: aucun maintien requis/);
+  assert.match(webAppSource, /relâche: sûr/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -158,6 +161,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__follow-through-opportunity/);
   assert.match(webAppSource, /atlas-military-fallback-order__safest-tactical-fallback/);
   assert.match(webAppSource, /atlas-military-fallback-order__next-turn-hold-plan/);
+  assert.match(webAppSource, /atlas-military-fallback-order__hold-release-cue/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -178,6 +182,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /opportunité: \$\{opportunityTradeoff\.label\} · \$\{opportunityTradeoff\.constraint\} · \$\{opportunityTradeoff\.action\}/);
   assert.match(webAppSource, /repli tactique: \$\{safestTacticalFallback\.label\} · \$\{safestTacticalFallback\.constraint\} · \$\{safestTacticalFallback\.action\}/);
   assert.match(webAppSource, /tour\+1: \$\{nextTurnHoldPlan\.action\} · risque \$\{nextTurnHoldPlan\.riskIfIgnored\}/);
+  assert.match(webAppSource, /relâche: \$\{holdReleaseCue\.label\} · \$\{holdReleaseCue\.constraint\}\$\{holdReleaseCue\.action \? ` · \$\{holdReleaseCue\.action\}` : ''\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -208,4 +213,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__follow-through-opportunity/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__safest-tactical-fallback/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__next-turn-hold-plan/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__hold-release-cue/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -16,6 +16,7 @@ import {
   buildMiniPlanFollowThroughOpportunityTradeoff,
   buildMiniPlanSafestTacticalFallback,
   buildMiniPlanNextTurnHoldPlan,
+  buildMiniPlanHoldReleaseCue,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -2036,6 +2037,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanNextTurnHoldPlan: buildMiniPlanNextTurnHoldPlan(
         buildMiniPlanSafestTacticalFallback(null),
       ),
+      miniPlanHoldReleaseCue: buildMiniPlanHoldReleaseCue(
+        buildMiniPlanNextTurnHoldPlan(null),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2102,6 +2106,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const miniPlanNextTurnHoldPlan = buildMiniPlanNextTurnHoldPlan(
     miniPlanSafestTacticalFallback,
   );
+  const miniPlanHoldReleaseCue = buildMiniPlanHoldReleaseCue(
+    miniPlanNextTurnHoldPlan,
+  );
 
   return {
     fallback: {
@@ -2133,6 +2140,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanFollowThroughOpportunityTradeoff,
       miniPlanSafestTacticalFallback,
       miniPlanNextTurnHoldPlan,
+      miniPlanHoldReleaseCue,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2159,7 +2167,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanFollowThroughOpportunityTradeoff,
     miniPlanSafestTacticalFallback,
     miniPlanNextTurnHoldPlan,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}; repli tactique: ${miniPlanSafestTacticalFallback.empty ? 'aucun' : miniPlanSafestTacticalFallback.state}; plan prochain tour: ${miniPlanNextTurnHoldPlan.empty ? 'aucun' : miniPlanNextTurnHoldPlan.action}).`,
+    miniPlanHoldReleaseCue,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}; repli tactique: ${miniPlanSafestTacticalFallback.empty ? 'aucun' : miniPlanSafestTacticalFallback.state}; plan prochain tour: ${miniPlanNextTurnHoldPlan.empty ? 'aucun' : miniPlanNextTurnHoldPlan.action}; relâche: ${miniPlanHoldReleaseCue.empty ? 'aucune' : miniPlanHoldReleaseCue.state}).`,
     empty: false,
   };
 }
@@ -2250,9 +2259,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const nextTurnHoldPlanLabel = nextTurnHoldPlan && !nextTurnHoldPlan.empty
     ? `tour+1: ${nextTurnHoldPlan.action} · risque ${nextTurnHoldPlan.riskIfIgnored}`
     : 'tour+1: aucun maintien requis';
+  const holdReleaseCue = fallback.miniPlanHoldReleaseCue;
+  const holdReleaseCueLabel = holdReleaseCue && !holdReleaseCue.empty
+    ? `relâche: ${holdReleaseCue.label} · ${holdReleaseCue.constraint}${holdReleaseCue.action ? ` · ${holdReleaseCue.action}` : ''}`
+    : 'relâche: sûr';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="32.4" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="33.6" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2280,6 +2293,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__follow-through-opportunity atlas-military-fallback-order__follow-through-opportunity--${opportunityTradeoff?.state ?? 'no-conflict'}" x="23.2" y="85.5">${opportunityTradeoffLabel}</text>
       <text class="atlas-military-fallback-order__safest-tactical-fallback atlas-military-fallback-order__safest-tactical-fallback--${safestTacticalFallback?.state ?? 'unneeded'}" x="23.2" y="86.6">${safestTacticalFallbackLabel}</text>
       <text class="atlas-military-fallback-order__next-turn-hold-plan" x="23.2" y="87.7">${nextTurnHoldPlanLabel}</text>
+      <text class="atlas-military-fallback-order__hold-release-cue atlas-military-fallback-order__hold-release-cue--${holdReleaseCue?.state ?? 'safe-release'}" x="23.2" y="88.8">${holdReleaseCueLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11194,6 +11194,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__safest-tactical-fallback--value-advised { fill: #fde68a; }
 .atlas-military-fallback-order__safest-tactical-fallback--urgent-save-opportunity { fill: #fecaca; }
 .atlas-military-fallback-order__next-turn-hold-plan { fill: #bfdbfe; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__hold-release-cue { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__hold-release-cue--cautious-release { fill: #fde68a; }
+.atlas-military-fallback-order__hold-release-cue--hold-required { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1129.

Summary:
- adds `miniPlanHoldReleaseCue` after the next-turn hold plan
- distinguishes hold-required, cautious-release, and safe-release states
- names the visible blocker and a compact micro-action when release is not safe
- renders a compact release cue in the war map fallback overlay without repeating A40/A41 labels

Tests:
- npm test

Zeta: ready for validation before merge.