### PR TITLE
Delta: show first safe observation target

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -939,6 +939,47 @@ function buildActiveObservationResumeSignal({ followUpCoolingWindow }) {
   };
 }
 
+
+function buildFirstSafeObservationTarget({ activeObservationResumeSignal }) {
+  if (activeObservationResumeSignal.timing === 'resume-now') {
+    return {
+      target: 'primary-safe',
+      visibleFactor: 'Couverture partielle',
+      action: 'observe-primary',
+      label: 'Cible observation: principale sûre.',
+      reason: 'La reprise active peut viser la cible principale sans élargir le sweep au-delà de la couverture lisible.',
+    };
+  }
+
+  if (activeObservationResumeSignal.timing === 'wait-before-resume' && activeObservationResumeSignal.visibleFactor === 'Heat') {
+    return {
+      target: 'no-safe-target',
+      visibleFactor: 'Heat restant',
+      action: 'reduce-heat',
+      label: 'Cible observation: aucune sûre.',
+      reason: 'Le heat restant rend toute cible trop risquée: réduire la pression avant de choisir où reprendre.',
+    };
+  }
+
+  if (activeObservationResumeSignal.timing === 'wait-before-resume') {
+    return {
+      target: 'limited-recommended',
+      visibleFactor: 'Couverture partielle',
+      action: 'observe-limited',
+      label: 'Cible observation: limitée recommandée.',
+      reason: 'Commencer par une cible limitée évite de rouvrir trop large pendant la stabilisation visible.',
+    };
+  }
+
+  return {
+    target: 'no-safe-target',
+    visibleFactor: 'Zone brouillée',
+    action: 'refresh-signal',
+    label: 'Cible observation: aucune sûre.',
+    reason: 'La zone reste brouillée: rafraîchir le signal avant de choisir une première cible active.',
+  };
+}
+
 function buildMonitoringRestartPlan({ state, monitoringPreferred, marginalExposureAdded, expectedConfidenceGain }) {
   const normalizedExposure = clampPercent(marginalExposureAdded);
   const normalizedGain = clampPercent(expectedConfidenceGain);
@@ -1550,6 +1591,79 @@ function withMonitoringRestartPlan(rationale, marginalExposureAdded, expectedCon
                       state: rationale.state,
                       marginalExposureAdded,
                       expectedConfidenceGain,
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+    firstSafeObservationTarget: buildFirstSafeObservationTarget({
+      activeObservationResumeSignal: buildActiveObservationResumeSignal({
+        followUpCoolingWindow: buildFollowUpCoolingWindow({
+          followUpHeatDebt: buildFollowUpHeatDebt({
+            resumedConstrainedSweepResult: buildResumedConstrainedSweepResult({
+              monitoringMinimalResumeSignal: buildMonitoringMinimalResumeSignal({
+                monitoringSafeCadence: buildMonitoringSafeCadence({
+                  monitoringMarginResponsePriority: buildMonitoringMarginResponsePriority({
+                    postRecoveryMarginDecay: buildPostRecoveryMarginDecay({
+                      postRecoverySafetyMargin: buildPostRecoverySafetyMargin({
+                        preventiveRecoveryState: buildPreventiveRecoveryState({
+                          preventiveAction: buildMonitoringPreventiveAction({
+                            state: rationale.state,
+                            driftForecast: buildMonitoringDriftForecast({
+                              state: rationale.state,
+                              marginalExposureAdded,
+                              expectedConfidenceGain,
+                            }),
+                          }),
+                        }),
+                        preventiveAction: buildMonitoringPreventiveAction({
+                          state: rationale.state,
+                          driftForecast: buildMonitoringDriftForecast({
+                            state: rationale.state,
+                            marginalExposureAdded,
+                            expectedConfidenceGain,
+                          }),
+                        }),
+                        driftForecast: buildMonitoringDriftForecast({
+                          state: rationale.state,
+                          marginalExposureAdded,
+                          expectedConfidenceGain,
+                        }),
+                      }),
+                      driftForecast: buildMonitoringDriftForecast({
+                        state: rationale.state,
+                        marginalExposureAdded,
+                        expectedConfidenceGain,
+                      }),
+                    }),
+                    postRecoverySafetyMargin: buildPostRecoverySafetyMargin({
+                      preventiveRecoveryState: buildPreventiveRecoveryState({
+                        preventiveAction: buildMonitoringPreventiveAction({
+                          state: rationale.state,
+                          driftForecast: buildMonitoringDriftForecast({
+                            state: rationale.state,
+                            marginalExposureAdded,
+                            expectedConfidenceGain,
+                          }),
+                        }),
+                      }),
+                      preventiveAction: buildMonitoringPreventiveAction({
+                        state: rationale.state,
+                        driftForecast: buildMonitoringDriftForecast({
+                          state: rationale.state,
+                          marginalExposureAdded,
+                          expectedConfidenceGain,
+                        }),
+                      }),
+                      driftForecast: buildMonitoringDriftForecast({
+                        state: rationale.state,
+                        marginalExposureAdded,
+                        expectedConfidenceGain,
+                      }),
                     }),
                   }),
                 }),

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -243,6 +243,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           label: 'Observation: reprendre plus tard.',
           reason: 'Attendre protège la fenêtre, mais le signal peut perdre en fraîcheur: rafraîchir avant reprise.',
         },
+        firstSafeObservationTarget: {
+          target: 'no-safe-target',
+          visibleFactor: 'Zone brouillée',
+          action: 'refresh-signal',
+          label: 'Cible observation: aucune sûre.',
+          reason: 'La zone reste brouillée: rafraîchir le signal avant de choisir une première cible active.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -325,6 +332,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               action: 'refresh-signal',
               label: 'Observation: reprendre plus tard.',
               reason: 'Attendre protège la fenêtre, mais le signal peut perdre en fraîcheur: rafraîchir avant reprise.',
+            },
+            firstSafeObservationTarget: {
+              target: 'no-safe-target',
+              visibleFactor: 'Zone brouillée',
+              action: 'refresh-signal',
+              label: 'Cible observation: aucune sûre.',
+              reason: 'La zone reste brouillée: rafraîchir le signal avant de choisir une première cible active.',
             },
         monitoringChecklist: [
           {
@@ -513,6 +527,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           label: 'Observation: reprendre plus tard.',
           reason: 'Attendre protège la fenêtre, mais le signal peut perdre en fraîcheur: rafraîchir avant reprise.',
         },
+        firstSafeObservationTarget: {
+          target: 'no-safe-target',
+          visibleFactor: 'Zone brouillée',
+          action: 'refresh-signal',
+          label: 'Cible observation: aucune sûre.',
+          reason: 'La zone reste brouillée: rafraîchir le signal avant de choisir une première cible active.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -595,6 +616,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               action: 'refresh-signal',
               label: 'Observation: reprendre plus tard.',
               reason: 'Attendre protège la fenêtre, mais le signal peut perdre en fraîcheur: rafraîchir avant reprise.',
+            },
+            firstSafeObservationTarget: {
+              target: 'no-safe-target',
+              visibleFactor: 'Zone brouillée',
+              action: 'refresh-signal',
+              label: 'Cible observation: aucune sûre.',
+              reason: 'La zone reste brouillée: rafraîchir le signal avant de choisir une première cible active.',
             },
         monitoringChecklist: [
           {
@@ -883,6 +911,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
           label: 'Observation: reprendre plus tard.',
           reason: 'Attendre protège la fenêtre, mais le signal peut perdre en fraîcheur: rafraîchir avant reprise.',
         },
+        firstSafeObservationTarget: {
+          target: 'no-safe-target',
+          visibleFactor: 'Zone brouillée',
+          action: 'refresh-signal',
+          label: 'Cible observation: aucune sûre.',
+          reason: 'La zone reste brouillée: rafraîchir le signal avant de choisir une première cible active.',
+        },
         monitoringChecklist: [
           {
             signal: 'Nouveau gap',
@@ -1044,6 +1079,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
         action: 'wait-one-turn',
         label: 'Observation: attendre un tour.',
         reason: 'La pause courte stabilise le signal visible avant de rouvrir l’observation active.',
+      },
+      firstSafeObservationTarget: {
+        target: 'limited-recommended',
+        visibleFactor: 'Couverture partielle',
+        action: 'observe-limited',
+        label: 'Cible observation: limitée recommandée.',
+        reason: 'Commencer par une cible limitée évite de rouvrir trop large pendant la stabilisation visible.',
       },
       monitoringChecklist: [
         {
@@ -1273,6 +1315,13 @@ test('buildIntrigueMapOverlay recommends preparing a third sweep only when resid
         label: 'Observation: reprendre maintenant.',
         reason: 'La fenêtre visible reste ouverte: reprendre l’observation active sans attendre un refroidissement caché.',
       },
+      firstSafeObservationTarget: {
+        target: 'primary-safe',
+        visibleFactor: 'Couverture partielle',
+        action: 'observe-primary',
+        label: 'Cible observation: principale sûre.',
+        reason: 'La reprise active peut viser la cible principale sans élargir le sweep au-delà de la couverture lisible.',
+      },
       monitoringChecklist: [
         {
           signal: 'Fenêtre sûre',
@@ -1425,6 +1474,13 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
       action: 'wait-one-turn',
       label: 'Observation: attendre un tour.',
       reason: 'La pause courte stabilise le signal visible avant de rouvrir l’observation active.',
+    },
+    firstSafeObservationTarget: {
+      target: 'limited-recommended',
+      visibleFactor: 'Couverture partielle',
+      action: 'observe-limited',
+      label: 'Cible observation: limitée recommandée.',
+      reason: 'Commencer par une cible limitée évite de rouvrir trop large pendant la stabilisation visible.',
     },
     monitoringChecklist: [
       {


### PR DESCRIPTION
Delta: Implements #1132.

Summary:
- Adds `firstSafeObservationTarget` after active observation resume timing.
- Distinguishes no safe target, limited recommended target, and primary safe target.
- Names visible risk/safety factors and returns narrow fog-safe actions so observation does not reopen too broadly.

Tests:
- `node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js`
- `npm test` (638/638)

Zeta: PR ready for validation. Please review before any merge.