### PR TITLE
Epsilon: show climate consolidation duration

### DIFF
--- a/test/ui/climate/webAtlasMinimalClimateConsolidationProtectionDuration.test.js
+++ b/test/ui/climate/webAtlasMinimalClimateConsolidationProtectionDuration.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+
+test('atlas shows how long minimal climate consolidation protects the next window', () => {
+  assert.match(webAppSource, /function buildMinimalClimateConsolidationProtectionDuration/);
+  assert.match(webAppSource, /minimalClimateConsolidationProtectionDuration: null/);
+  assert.match(webAppSource, /minimalClimateConsolidationProtectionDuration,/);
+
+  for (const stableKey of [
+    'state',
+    'shorteningConstraint',
+    'microAction',
+    'expiresBeforeCriticalWindow',
+    'sourceWindowPrevention',
+    'sourceConsolidation',
+    'summary',
+  ]) {
+    assert.match(webAppSource, new RegExp(`${stableKey}[:,]`));
+  }
+
+  assert.match(webAppSource, /protection courte/);
+  assert.match(webAppSource, /protection jusqu’à la prochaine fenêtre/);
+  assert.match(webAppSource, /protection durable/);
+  assert.match(webAppSource, /réserve basse/);
+  assert.match(webAppSource, /anomalie voisine/);
+  assert.match(webAppSource, /dette secondaire/);
+  assert.match(webAppSource, /pression de saison/);
+  assert.match(webAppSource, /rafraîchir la consolidation avant \$\{shorteningConstraint\}/);
+  assert.match(webAppSource, /aucune micro-action immédiate/);
+  assert.match(webAppSource, /Durée protection consolidation/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -10097,6 +10097,43 @@ function buildMinimalConsolidationNextClimateWindowPrevention(minimalConsolidati
   };
 }
 
+function buildMinimalClimateConsolidationProtectionDuration(minimalConsolidationNextClimateWindowPrevention, minimalConsolidationAfterFragileClimateReservePayment, residualReserveRiskAfterSecondaryClimateDebtPayment) {
+  if (!minimalConsolidationNextClimateWindowPrevention) {
+    return null;
+  }
+
+  const constraintText = `${minimalConsolidationNextClimateWindowPrevention.visibleConstraint ?? ''} ${minimalConsolidationAfterFragileClimateReservePayment?.visibleConstraint ?? ''} ${residualReserveRiskAfterSecondaryClimateDebtPayment?.visibleConstraint ?? ''} ${minimalConsolidationNextClimateWindowPrevention.summary ?? ''}`.toLowerCase();
+  const shorteningConstraint = constraintText.includes('cascade') || constraintText.includes('voisine')
+    ? 'anomalie voisine'
+    : constraintText.includes('dette')
+      ? 'dette secondaire'
+      : constraintText.includes('saison') || constraintText.includes('deadline') || constraintText.includes('pression régionale')
+        ? 'pression de saison'
+        : 'réserve basse';
+  const state = minimalConsolidationNextClimateWindowPrevention.state === 'fenêtre proche empêchée'
+    ? 'protection durable'
+    : minimalConsolidationNextClimateWindowPrevention.state === 'fenêtre contenue'
+      ? 'protection jusqu’à la prochaine fenêtre'
+      : 'protection courte';
+  const expiresBeforeCriticalWindow = state === 'protection courte';
+  const microAction = expiresBeforeCriticalWindow
+    ? `rafraîchir la consolidation avant ${shorteningConstraint}`
+    : 'aucune micro-action immédiate';
+  const summary = expiresBeforeCriticalWindow
+    ? `${state}: raccourcie par ${shorteningConstraint}; micro-action: ${microAction}.`
+    : `${state}: ${shorteningConstraint} ne raccourcit pas le prochain jalon critique.`;
+
+  return {
+    state,
+    shorteningConstraint,
+    microAction,
+    expiresBeforeCriticalWindow,
+    sourceWindowPrevention: minimalConsolidationNextClimateWindowPrevention.state,
+    sourceConsolidation: minimalConsolidationAfterFragileClimateReservePayment?.state ?? null,
+    summary,
+  };
+}
+
 function buildNextClimateCommitmentAfterResidualPressure(cheapestSafeCommitment, remainingDeadlinePressure) {
   if (!cheapestSafeCommitment || !remainingDeadlinePressure || !remainingDeadlinePressure.deadlineStillThreatened) {
     return null;
@@ -10157,6 +10194,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
       residualReserveRiskAfterSecondaryClimateDebtPayment: null,
       minimalConsolidationAfterFragileClimateReservePayment: null,
       minimalConsolidationNextClimateWindowPrevention: null,
+      minimalClimateConsolidationProtectionDuration: null,
       summary: 'Aucun engagement climat minimal sûr: aucun plan recovery actif à démarrer.',
     };
   }
@@ -10269,6 +10307,11 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     residualReserveRiskAfterSecondaryClimateDebtPayment,
     decisionWindow,
   );
+  const minimalClimateConsolidationProtectionDuration = buildMinimalClimateConsolidationProtectionDuration(
+    minimalConsolidationNextClimateWindowPrevention,
+    minimalConsolidationAfterFragileClimateReservePayment,
+    residualReserveRiskAfterSecondaryClimateDebtPayment,
+  );
 
   return {
     state: projection.firstPressureRelieved === 'aucun relief sûr' ? 'safe-but-risky' : 'recommended',
@@ -10292,6 +10335,7 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
     residualReserveRiskAfterSecondaryClimateDebtPayment,
     minimalConsolidationAfterFragileClimateReservePayment,
     minimalConsolidationNextClimateWindowPrevention,
+    minimalClimateConsolidationProtectionDuration,
     summary: `${projection.provinceLabel}: engagement sûr le moins coûteux — ${selected.cost}, couvre ${projection.deadline} et réduit ${projection.firstPressureRelieved}.`,
   };
 }
@@ -10336,6 +10380,7 @@ function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
       ${view.residualReserveRiskAfterSecondaryClimateDebtPayment ? `<small><b>Risque réserve résiduel</b> · ${view.residualReserveRiskAfterSecondaryClimateDebtPayment.summary}</small>` : ''}
       ${view.minimalConsolidationAfterFragileClimateReservePayment ? `<small><b>Consolidation minimale</b> · ${view.minimalConsolidationAfterFragileClimateReservePayment.summary}</small>` : ''}
       ${view.minimalConsolidationNextClimateWindowPrevention ? `<small><b>Fenêtre après consolidation</b> · ${view.minimalConsolidationNextClimateWindowPrevention.summary}</small>` : ''}
+      ${view.minimalClimateConsolidationProtectionDuration ? `<small><b>Durée protection consolidation</b> · ${view.minimalClimateConsolidationProtectionDuration.summary}</small>` : ''}
       <small><b>Pourquoi sûr</b> · ${commitment.safeBecause}</small>
       <small><b>Reste actif</b> · ${commitment.doesNotSolve}</small>
     </aside>


### PR DESCRIPTION
Epsilon: Closes #1133.

## Résumé
- ajoute la durée de protection de la consolidation climat minimale
- distingue protection courte, jusqu’à la prochaine fenêtre, ou durable
- nomme la contrainte qui raccourcit la protection et propose une micro-action si elle expire trop tôt

## Tests
- `npm test`
