### PR TITLE
Beta: show guarded corridor normalization checkpoint

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -663,6 +663,64 @@ function buildGuardedCorridorLoadRelief(rollbackGuardLoadMargin) {
   };
 }
 
+function describeNormalizationConstraint(guardedCorridorLoadRelief, rollbackGuardLoadMargin, monitoredCorridorRollbackGuard) {
+  if (guardedCorridorLoadRelief.status === 'no-relief-needed') {
+    return 'aucune contrainte visible';
+  }
+
+  if (monitoredCorridorRollbackGuard.status === 'rollback-ready-required') {
+    return 'risque de rollback';
+  }
+
+  const constraint = rollbackGuardLoadMargin.constraint ?? guardedCorridorLoadRelief.protectedMargin;
+  if (constraint === 'alternative' || constraint === 'alternative-plus-sure') {
+    return 'alternative fragile';
+  }
+
+  if (constraint === 'capacité tampon' || constraint === 'protection d’étape') {
+    return 'réserve logistique';
+  }
+
+  return 'pic de charge';
+}
+
+function buildGuardedCorridorNormalizationCheckpoint(
+  guardedCorridorLoadRelief,
+  rollbackGuardLoadMargin,
+  monitoredCorridorRollbackGuard,
+) {
+  const remainingConstraint = describeNormalizationConstraint(
+    guardedCorridorLoadRelief,
+    rollbackGuardLoadMargin,
+    monitoredCorridorRollbackGuard,
+  );
+
+  if (guardedCorridorLoadRelief.status === 'no-relief-needed') {
+    return {
+      status: 'corridor-normalized',
+      remainingConstraint,
+      action: 'normaliser sans promotion automatique',
+      summary: 'Corridor normalisé: garder la lecture active sans promotion automatique.',
+    };
+  }
+
+  if (guardedCorridorLoadRelief.status === 'relief-recommended') {
+    return {
+      status: 'monitored-normalization-possible',
+      remainingConstraint,
+      action: 'appliquer l’allègement puis surveiller un tour',
+      summary: `Normalisation surveillée possible: vérifier ${remainingConstraint} après allègement.`,
+    };
+  }
+
+  return {
+    status: 'guard-still-required',
+    remainingConstraint,
+    action: 'stabiliser avant de normaliser',
+    summary: `Garde toujours nécessaire: stabiliser ${remainingConstraint} avant normalisation.`,
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -882,6 +940,11 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
   const monitoredCorridorRollbackGuard = buildMonitoredCorridorRollbackGuard(monitoredCorridorPromotionRisk);
   const rollbackGuardLoadMargin = buildRollbackGuardLoadMargin(monitoredCorridorRollbackGuard);
   const guardedCorridorLoadRelief = buildGuardedCorridorLoadRelief(rollbackGuardLoadMargin);
+  const guardedCorridorNormalizationCheckpoint = buildGuardedCorridorNormalizationCheckpoint(
+    guardedCorridorLoadRelief,
+    rollbackGuardLoadMargin,
+    monitoredCorridorRollbackGuard,
+  );
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -903,6 +966,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     monitoredCorridorRollbackGuard,
     rollbackGuardLoadMargin,
     guardedCorridorLoadRelief,
+    guardedCorridorNormalizationCheckpoint,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -598,6 +598,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         nextGesture: 'absorber',
         summary: 'Aucun allègement utile: la marge absorbe le prochain pic visible.',
       },
+      guardedCorridorNormalizationCheckpoint: {
+        status: 'corridor-normalized',
+        remainingConstraint: 'aucune contrainte visible',
+        action: 'normaliser sans promotion automatique',
+        summary: 'Corridor normalisé: garder la lecture active sans promotion automatique.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -783,6 +789,12 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       nextGesture: 'absorber',
       summary: 'Aucun allègement utile: la marge absorbe le prochain pic visible.',
     },
+    guardedCorridorNormalizationCheckpoint: {
+      status: 'corridor-normalized',
+      remainingConstraint: 'aucune contrainte visible',
+      action: 'normaliser sans promotion automatique',
+      summary: 'Corridor normalisé: garder la lecture active sans promotion automatique.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -918,6 +930,12 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     nextGesture: 'revenir en secours',
     summary: 'Allègement urgent: alternative surcharge la route, garder une alternative active.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.guardedCorridorNormalizationCheckpoint, {
+    status: 'guard-still-required',
+    remainingConstraint: 'risque de rollback',
+    action: 'stabiliser avant de normaliser',
+    summary: 'Garde toujours nécessaire: stabiliser risque de rollback avant normalisation.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -1019,6 +1037,12 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     protectedMargin: 'alternative',
     nextGesture: 'plafonner le flux',
     summary: 'Allègement utile: déporter vers alternative de secours protège la marge sans promettre une sécurité totale.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.guardedCorridorNormalizationCheckpoint, {
+    status: 'monitored-normalization-possible',
+    remainingConstraint: 'alternative fragile',
+    action: 'appliquer l’allègement puis surveiller un tour',
+    summary: 'Normalisation surveillée possible: vérifier alternative fragile après allègement.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a compact normalization checkpoint after guarded corridor load relief so the map explains whether guard is still required, monitored normalization is possible, or the corridor is normalized.

## Changes

- Add `guardedCorridorNormalizationCheckpoint` derived from existing B39-B41 corridor signals.
- Distinguish guard still required, monitored normalization possible, and corridor normalized.
- Name the visible remaining constraint as rollback risk, fragile alternative, logistics reserve, load peak, or no visible constraint.
- Keep actions short and avoid automatic promotion.
- Extend economy overlay tests for normalized, monitored, and guard-required cases.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (640/640 pass)

Fixes loo469/historia#1130