### PR TITLE
Gamma: show culture support redeployment cue

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1243,6 +1243,33 @@ export function buildResidualCultureStabilityWatchWindow(residualCultureReliabil
   };
 }
 
+export function buildResidualCultureSupportRedeploymentCue(residualCultureStabilityWatchWindow) {
+  if (residualCultureStabilityWatchWindow.status === 'durable-now') {
+    return {
+      status: 'safe-redeploy',
+      blockingFactor: 'soutien résiduel faible',
+      redeploymentCue: 'redéploiement sûr: la stabilité tient sans soutien dédié',
+      microAction: null,
+    };
+  }
+
+  if (residualCultureStabilityWatchWindow.status === 'short-watch') {
+    return {
+      status: 'careful-reduction',
+      blockingFactor: 'tension locale',
+      redeploymentCue: 'réduction prudente possible après le prochain signal confirmé',
+      microAction: residualCultureStabilityWatchWindow.followUpAction,
+    };
+  }
+
+  return {
+    status: 'keep-support',
+    blockingFactor: 'fragilité sociale voisine',
+    redeploymentCue: 'soutien à maintenir: la stabilité retomberait sans consolidation',
+    microAction: residualCultureStabilityWatchWindow.followUpAction,
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -1308,6 +1335,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const residualCultureReevaluationDelayCost = buildResidualCultureReevaluationDelayCost(residualCultureReevaluationTrigger);
   const residualCultureMinimalDelayedSupport = buildResidualCultureMinimalDelayedSupport(residualCultureReevaluationDelayCost);
   const residualCultureReliabilityUpgradeCondition = buildResidualCultureReliabilityUpgradeCondition(residualCultureMinimalDelayedSupport);
+  const residualCultureStabilityWatchWindow = buildResidualCultureStabilityWatchWindow(residualCultureReliabilityUpgradeCondition);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -1329,7 +1357,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     residualCultureReevaluationDelayCost,
     residualCultureMinimalDelayedSupport,
     residualCultureReliabilityUpgradeCondition,
-    residualCultureStabilityWatchWindow: buildResidualCultureStabilityWatchWindow(residualCultureReliabilityUpgradeCondition),
+    residualCultureStabilityWatchWindow,
+    residualCultureSupportRedeploymentCue: buildResidualCultureSupportRedeploymentCue(residualCultureStabilityWatchWindow),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { Culture } from '../../../src/domain/culture/Culture.js';
 import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
-import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability, buildResidualCultureReevaluationTrigger, buildResidualCultureReevaluationDelayCost, buildResidualCultureMinimalDelayedSupport, buildResidualCultureReliabilityUpgradeCondition, buildResidualCultureStabilityWatchWindow } from '../../../src/ui/culture/buildCultureMapOverlay.js';
+import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability, buildResidualCultureReevaluationTrigger, buildResidualCultureReevaluationDelayCost, buildResidualCultureMinimalDelayedSupport, buildResidualCultureReliabilityUpgradeCondition, buildResidualCultureStabilityWatchWindow, buildResidualCultureSupportRedeploymentCue } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
 function withoutSupportRiskPreviews(value) {
   if (Array.isArray(value)) {
@@ -989,6 +989,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         watchWindow: 'surveillance courte recommandée: confirmer le prochain signal culturel',
         followUpAction: 'revoir le support si fatigue de médiation remonte',
       },
+      residualCultureSupportRedeploymentCue: {
+        status: 'careful-reduction',
+        blockingFactor: 'tension locale',
+        redeploymentCue: 'réduction prudente possible après le prochain signal confirmé',
+        microAction: 'revoir le support si fatigue de médiation remonte',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -1131,6 +1137,12 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         watchFactor: 'soutien restant',
         watchWindow: 'stabilité déjà durable: surveillance passive suffisante',
         followUpAction: null,
+      },
+      residualCultureSupportRedeploymentCue: {
+        status: 'safe-redeploy',
+        blockingFactor: 'soutien résiduel faible',
+        redeploymentCue: 'redéploiement sûr: la stabilité tient sans soutien dédié',
+        microAction: null,
       },
     },
     summary: 'stabilisation complète: aucun second soutien requis',
@@ -1798,6 +1810,53 @@ test('buildResidualCultureStabilityWatchWindow covers durable, short, and extend
       watchFactor: 'fragilité sociale résiduelle',
       watchWindow: 'surveillance prolongée requise: la stabilité reste conditionnelle',
       followUpAction: 'sécuriser un support local avant tout suivi',
+    },
+  );
+});
+
+test('buildResidualCultureSupportRedeploymentCue covers maintain, reduce, and redeploy states', () => {
+  assert.deepEqual(
+    buildResidualCultureSupportRedeploymentCue({
+      status: 'extended-watch',
+      watchFactor: 'fragilité sociale résiduelle',
+      watchWindow: 'surveillance prolongée requise: la stabilité reste conditionnelle',
+      followUpAction: 'sécuriser un support local avant tout suivi',
+    }),
+    {
+      status: 'keep-support',
+      blockingFactor: 'fragilité sociale voisine',
+      redeploymentCue: 'soutien à maintenir: la stabilité retomberait sans consolidation',
+      microAction: 'sécuriser un support local avant tout suivi',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureSupportRedeploymentCue({
+      status: 'short-watch',
+      watchFactor: 'tension locale',
+      watchWindow: 'surveillance courte recommandée: confirmer le prochain signal culturel',
+      followUpAction: 'revoir le support si fatigue de médiation remonte',
+    }),
+    {
+      status: 'careful-reduction',
+      blockingFactor: 'tension locale',
+      redeploymentCue: 'réduction prudente possible après le prochain signal confirmé',
+      microAction: 'revoir le support si fatigue de médiation remonte',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCultureSupportRedeploymentCue({
+      status: 'durable-now',
+      watchFactor: 'soutien restant',
+      watchWindow: 'stabilité déjà durable: surveillance passive suffisante',
+      followUpAction: null,
+    }),
+    {
+      status: 'safe-redeploy',
+      blockingFactor: 'soutien résiduel faible',
+      redeploymentCue: 'redéploiement sûr: la stabilité tient sans soutien dédié',
+      microAction: null,
     },
   );
 });


### PR DESCRIPTION
Gamma: ## Summary

Shows when cultural support can be maintained, reduced, or safely redeployed after the stability watch window.

## Changes

- Adds `residualCultureSupportRedeploymentCue` near the stability watch summary.
- Distinguishes keep support, careful reduction, and safe redeployment.
- Names the visible factor blocking release and includes a compact micro-action only when consolidation is still needed.
- Complements G42 without recalculating watch duration or revealing hidden details.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1141