### PR TITLE
Alpha: show safe reengagement cue

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1132,6 +1132,48 @@ export function buildMiniPlanHoldReleaseCue(miniPlanNextTurnHoldPlan = null) {
   };
 }
 
+function reengagementConstraintForRelease(holdReleaseCue) {
+  if (holdReleaseCue.constraint === 'front exposé') return 'front voisin instable';
+  if (holdReleaseCue.constraint === 'support absent') return 'support incomplet';
+  if (holdReleaseCue.constraint === 'opportunité encore fragile') return 'opportunité trop fragile';
+  return 'menace non résolue';
+}
+
+export function buildMiniPlanFirstSafeReengagement(miniPlanHoldReleaseCue = null) {
+  if (!miniPlanHoldReleaseCue || miniPlanHoldReleaseCue.empty) {
+    return {
+      empty: true,
+      state: 'main-safe',
+      label: 'réengagement principal sûr',
+      constraint: null,
+      action: null,
+    };
+  }
+
+  const state = miniPlanHoldReleaseCue.state === 'hold-required'
+    ? 'defensive-stance'
+    : miniPlanHoldReleaseCue.state === 'cautious-release'
+      ? 'limited-reengagement'
+      : 'main-safe';
+  const constraint = reengagementConstraintForRelease(miniPlanHoldReleaseCue);
+
+  return {
+    empty: false,
+    state,
+    label: state === 'defensive-stance'
+      ? 'rester en posture défensive'
+      : state === 'limited-reengagement'
+        ? 'réengagement limité possible'
+        : 'réengagement principal sûr',
+    constraint,
+    action: state === 'defensive-stance'
+      ? 'garder écran'
+      : state === 'limited-reengagement'
+        ? 'tester avancée'
+        : null,
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -1250,6 +1292,9 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const miniPlanHoldReleaseCue = buildMiniPlanHoldReleaseCue(
     miniPlanNextTurnHoldPlan,
   );
+  const miniPlanFirstSafeReengagement = buildMiniPlanFirstSafeReengagement(
+    miniPlanHoldReleaseCue,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -1310,6 +1355,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanSafestTacticalFallback,
     miniPlanNextTurnHoldPlan,
     miniPlanHoldReleaseCue,
+    miniPlanFirstSafeReengagement,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -16,6 +16,7 @@ import {
   buildMiniPlanSafestTacticalFallback,
   buildMiniPlanNextTurnHoldPlan,
   buildMiniPlanHoldReleaseCue,
+  buildMiniPlanFirstSafeReengagement,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -412,6 +413,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     empty: true,
     state: 'safe-release',
     label: 'relâchement sûr',
+    constraint: null,
+    action: null,
+  });
+  assert.deepEqual(shell.miniPlanFirstSafeReengagement, {
+    empty: true,
+    state: 'main-safe',
+    label: 'réengagement principal sûr',
     constraint: null,
     action: null,
   });
@@ -827,12 +835,20 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     constraint: 'position',
     riskIfIgnored: 'position se rouvre',
   });
-  assert.deepEqual(buildMiniPlanHoldReleaseCue(holdPlan), {
+  const releaseCue = buildMiniPlanHoldReleaseCue(holdPlan);
+  assert.deepEqual(releaseCue, {
     empty: false,
     state: 'hold-required',
     label: 'maintien encore requis',
     constraint: 'front exposé',
     action: 'tenir écran',
+  });
+  assert.deepEqual(buildMiniPlanFirstSafeReengagement(releaseCue), {
+    empty: false,
+    state: 'defensive-stance',
+    label: 'rester en posture défensive',
+    constraint: 'front voisin instable',
+    action: 'garder écran',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -947,11 +963,19 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     constraint: 'fenêtre d’opportunité',
     riskIfIgnored: 'fenêtre d’opportunité se referme',
   });
-  assert.deepEqual(buildMiniPlanHoldReleaseCue(holdPlan), {
+  const releaseCue = buildMiniPlanHoldReleaseCue(holdPlan);
+  assert.deepEqual(releaseCue, {
     empty: false,
     state: 'safe-release',
     label: 'relâchement sûr',
     constraint: 'opportunité encore fragile',
+    action: null,
+  });
+  assert.deepEqual(buildMiniPlanFirstSafeReengagement(releaseCue), {
+    empty: false,
+    state: 'main-safe',
+    label: 'réengagement principal sûr',
+    constraint: 'opportunité trop fragile',
     action: null,
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
@@ -1058,12 +1082,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     constraint: 'tempo',
     riskIfIgnored: 'tempo repris par le rival',
   });
-  assert.deepEqual(buildMiniPlanHoldReleaseCue(holdPlan), {
+  const releaseCue = buildMiniPlanHoldReleaseCue(holdPlan);
+  assert.deepEqual(releaseCue, {
     empty: false,
     state: 'cautious-release',
     label: 'relâchement prudent possible',
     constraint: 'menace voisine',
     action: 'surveiller voisin',
+  });
+  assert.deepEqual(buildMiniPlanFirstSafeReengagement(releaseCue), {
+    empty: false,
+    state: 'limited-reengagement',
+    label: 'réengagement limité possible',
+    constraint: 'menace non résolue',
+    action: 'tester avancée',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -1133,6 +1165,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     empty: true,
     state: 'safe-release',
     label: 'relâchement sûr',
+    constraint: null,
+    action: null,
+  });
+  assert.deepEqual(buildMiniPlanFirstSafeReengagement(null), {
+    empty: true,
+    state: 'main-safe',
+    label: 'réengagement principal sûr',
     constraint: null,
     action: null,
   });

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -79,6 +79,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanSafestTacticalFallback\(/);
   assert.match(webAppSource, /buildMiniPlanNextTurnHoldPlan\(/);
   assert.match(webAppSource, /buildMiniPlanHoldReleaseCue\(/);
+  assert.match(webAppSource, /buildMiniPlanFirstSafeReengagement\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -127,6 +128,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanSafestTacticalFallback: buildMiniPlanSafestTacticalFallback\(/);
   assert.match(webAppSource, /miniPlanNextTurnHoldPlan: buildMiniPlanNextTurnHoldPlan\(/);
   assert.match(webAppSource, /miniPlanHoldReleaseCue: buildMiniPlanHoldReleaseCue\(/);
+  assert.match(webAppSource, /miniPlanFirstSafeReengagement: buildMiniPlanFirstSafeReengagement\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
@@ -141,6 +143,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /repli tactique: inutile/);
   assert.match(webAppSource, /tour\+1: aucun maintien requis/);
   assert.match(webAppSource, /relâche: sûr/);
+  assert.match(webAppSource, /réengage: principal sûr/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -162,6 +165,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__safest-tactical-fallback/);
   assert.match(webAppSource, /atlas-military-fallback-order__next-turn-hold-plan/);
   assert.match(webAppSource, /atlas-military-fallback-order__hold-release-cue/);
+  assert.match(webAppSource, /atlas-military-fallback-order__first-safe-reengagement/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -183,6 +187,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /repli tactique: \$\{safestTacticalFallback\.label\} · \$\{safestTacticalFallback\.constraint\} · \$\{safestTacticalFallback\.action\}/);
   assert.match(webAppSource, /tour\+1: \$\{nextTurnHoldPlan\.action\} · risque \$\{nextTurnHoldPlan\.riskIfIgnored\}/);
   assert.match(webAppSource, /relâche: \$\{holdReleaseCue\.label\} · \$\{holdReleaseCue\.constraint\}\$\{holdReleaseCue\.action \? ` · \$\{holdReleaseCue\.action\}` : ''\}/);
+  assert.match(webAppSource, /réengage: \$\{firstSafeReengagement\.label\} · \$\{firstSafeReengagement\.constraint\}\$\{firstSafeReengagement\.action \? ` · \$\{firstSafeReengagement\.action\}` : ''\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -214,4 +219,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__safest-tactical-fallback/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__next-turn-hold-plan/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__hold-release-cue/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__first-safe-reengagement/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -17,6 +17,7 @@ import {
   buildMiniPlanSafestTacticalFallback,
   buildMiniPlanNextTurnHoldPlan,
   buildMiniPlanHoldReleaseCue,
+  buildMiniPlanFirstSafeReengagement,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -2040,6 +2041,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanHoldReleaseCue: buildMiniPlanHoldReleaseCue(
         buildMiniPlanNextTurnHoldPlan(null),
       ),
+      miniPlanFirstSafeReengagement: buildMiniPlanFirstSafeReengagement(
+        buildMiniPlanHoldReleaseCue(null),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2109,6 +2113,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const miniPlanHoldReleaseCue = buildMiniPlanHoldReleaseCue(
     miniPlanNextTurnHoldPlan,
   );
+  const miniPlanFirstSafeReengagement = buildMiniPlanFirstSafeReengagement(
+    miniPlanHoldReleaseCue,
+  );
 
   return {
     fallback: {
@@ -2141,6 +2148,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanSafestTacticalFallback,
       miniPlanNextTurnHoldPlan,
       miniPlanHoldReleaseCue,
+      miniPlanFirstSafeReengagement,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2168,7 +2176,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanSafestTacticalFallback,
     miniPlanNextTurnHoldPlan,
     miniPlanHoldReleaseCue,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}; repli tactique: ${miniPlanSafestTacticalFallback.empty ? 'aucun' : miniPlanSafestTacticalFallback.state}; plan prochain tour: ${miniPlanNextTurnHoldPlan.empty ? 'aucun' : miniPlanNextTurnHoldPlan.action}; relâche: ${miniPlanHoldReleaseCue.empty ? 'aucune' : miniPlanHoldReleaseCue.state}).`,
+    miniPlanFirstSafeReengagement,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}; repli tactique: ${miniPlanSafestTacticalFallback.empty ? 'aucun' : miniPlanSafestTacticalFallback.state}; plan prochain tour: ${miniPlanNextTurnHoldPlan.empty ? 'aucun' : miniPlanNextTurnHoldPlan.action}; relâche: ${miniPlanHoldReleaseCue.empty ? 'aucune' : miniPlanHoldReleaseCue.state}; réengagement: ${miniPlanFirstSafeReengagement.empty ? 'aucun' : miniPlanFirstSafeReengagement.state}).`,
     empty: false,
   };
 }
@@ -2263,9 +2272,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const holdReleaseCueLabel = holdReleaseCue && !holdReleaseCue.empty
     ? `relâche: ${holdReleaseCue.label} · ${holdReleaseCue.constraint}${holdReleaseCue.action ? ` · ${holdReleaseCue.action}` : ''}`
     : 'relâche: sûr';
+  const firstSafeReengagement = fallback.miniPlanFirstSafeReengagement;
+  const firstSafeReengagementLabel = firstSafeReengagement && !firstSafeReengagement.empty
+    ? `réengage: ${firstSafeReengagement.label} · ${firstSafeReengagement.constraint}${firstSafeReengagement.action ? ` · ${firstSafeReengagement.action}` : ''}`
+    : 'réengage: principal sûr';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="33.6" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="34.8" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2294,6 +2307,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__safest-tactical-fallback atlas-military-fallback-order__safest-tactical-fallback--${safestTacticalFallback?.state ?? 'unneeded'}" x="23.2" y="86.6">${safestTacticalFallbackLabel}</text>
       <text class="atlas-military-fallback-order__next-turn-hold-plan" x="23.2" y="87.7">${nextTurnHoldPlanLabel}</text>
       <text class="atlas-military-fallback-order__hold-release-cue atlas-military-fallback-order__hold-release-cue--${holdReleaseCue?.state ?? 'safe-release'}" x="23.2" y="88.8">${holdReleaseCueLabel}</text>
+      <text class="atlas-military-fallback-order__first-safe-reengagement atlas-military-fallback-order__first-safe-reengagement--${firstSafeReengagement?.state ?? 'main-safe'}" x="23.2" y="89.9">${firstSafeReengagementLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11197,6 +11197,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__hold-release-cue { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
 .atlas-military-fallback-order__hold-release-cue--cautious-release { fill: #fde68a; }
 .atlas-military-fallback-order__hold-release-cue--hold-required { fill: #fecaca; }
+.atlas-military-fallback-order__first-safe-reengagement { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__first-safe-reengagement--limited-reengagement { fill: #fde68a; }
+.atlas-military-fallback-order__first-safe-reengagement--defensive-stance { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1139.

Summary:
- adds `miniPlanFirstSafeReengagement` after the hold release cue
- distinguishes defensive posture, limited re-engagement, and main-safe re-engagement
- names the visible limiting constraint and compact micro-action when gradual re-engagement is needed
- renders a compact re-engagement cue in the war map fallback overlay without repeating A41/A42 labels

Tests:
- npm test

Zeta: ready for validation before merge.