### PR TITLE
Alpha: show premature reengagement risk

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1174,6 +1174,49 @@ export function buildMiniPlanFirstSafeReengagement(miniPlanHoldReleaseCue = null
   };
 }
 
+function prematureReengagementRiskForConstraint(constraint) {
+  if (constraint === 'front voisin instable') return 'front repris à revers';
+  if (constraint === 'support incomplet') return 'avance sans appui';
+  if (constraint === 'menace non résolue') return 'menace convertie en blocage';
+  return 'fenêtre cassée par précipitation';
+}
+
+export function buildMiniPlanPrematureReengagementRisk(miniPlanFirstSafeReengagement = null) {
+  if (!miniPlanFirstSafeReengagement || miniPlanFirstSafeReengagement.empty) {
+    return {
+      empty: true,
+      state: 'ready',
+      label: 'fenêtre prête',
+      risk: null,
+      nextSafe: null,
+    };
+  }
+
+  const state = miniPlanFirstSafeReengagement.state === 'main-safe'
+    ? 'ready'
+    : miniPlanFirstSafeReengagement.state === 'limited-reengagement'
+      ? 'partial-window'
+      : 'too-early';
+
+  return {
+    empty: false,
+    state,
+    label: state === 'ready'
+      ? 'fenêtre prête'
+      : state === 'partial-window'
+        ? 'risque si poussée totale'
+        : 'réengagement prématuré',
+    risk: state === 'ready'
+      ? 'risque contenu'
+      : prematureReengagementRiskForConstraint(miniPlanFirstSafeReengagement.constraint),
+    nextSafe: state === 'too-early'
+      ? 'attendre test limité'
+      : state === 'partial-window'
+        ? 'attendre fenêtre principale'
+        : 'pousser maintenant',
+  };
+}
+
 function buildLegend(renderedProvinces, options) {
   const factionMetaById = normalizeTextMap(options.factionMetaById, 'StrategicMapShell factionMetaById');
   const paletteByFaction = normalizeTextMap(options.paletteByFaction, 'StrategicMapShell paletteByFaction');
@@ -1295,6 +1338,9 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const miniPlanFirstSafeReengagement = buildMiniPlanFirstSafeReengagement(
     miniPlanHoldReleaseCue,
   );
+  const miniPlanPrematureReengagementRisk = buildMiniPlanPrematureReengagementRisk(
+    miniPlanFirstSafeReengagement,
+  );
 
   const renderedProvinces = normalizedProvinces
     .slice()
@@ -1356,6 +1402,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     miniPlanNextTurnHoldPlan,
     miniPlanHoldReleaseCue,
     miniPlanFirstSafeReengagement,
+    miniPlanPrematureReengagementRisk,
     activeProvince: renderedProvinces.find(
       (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
     ) ?? null,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -17,6 +17,7 @@ import {
   buildMiniPlanNextTurnHoldPlan,
   buildMiniPlanHoldReleaseCue,
   buildMiniPlanFirstSafeReengagement,
+  buildMiniPlanPrematureReengagementRisk,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -422,6 +423,13 @@ test('StrategicMapShell ranks follow-up cleanup choices after the first payoff',
     label: 'réengagement principal sûr',
     constraint: null,
     action: null,
+  });
+  assert.deepEqual(shell.miniPlanPrematureReengagementRisk, {
+    empty: true,
+    state: 'ready',
+    label: 'fenêtre prête',
+    risk: null,
+    nextSafe: null,
   });
 });
 
@@ -843,12 +851,20 @@ test('StrategicMapShell shows safest fallback when rival response invalidates th
     constraint: 'front exposé',
     action: 'tenir écran',
   });
-  assert.deepEqual(buildMiniPlanFirstSafeReengagement(releaseCue), {
+  const reengagement = buildMiniPlanFirstSafeReengagement(releaseCue);
+  assert.deepEqual(reengagement, {
     empty: false,
     state: 'defensive-stance',
     label: 'rester en posture défensive',
     constraint: 'front voisin instable',
     action: 'garder écran',
+  });
+  assert.deepEqual(buildMiniPlanPrematureReengagementRisk(reengagement), {
+    empty: false,
+    state: 'too-early',
+    label: 'réengagement prématuré',
+    risk: 'front repris à revers',
+    nextSafe: 'attendre test limité',
   });
   assert.deepEqual(buildMiniPlanRivalResponseFallback({
     empty: false,
@@ -971,12 +987,20 @@ test('StrategicMapShell distinguishes keeping fallback from returning to origina
     constraint: 'opportunité encore fragile',
     action: null,
   });
-  assert.deepEqual(buildMiniPlanFirstSafeReengagement(releaseCue), {
+  const reengagement = buildMiniPlanFirstSafeReengagement(releaseCue);
+  assert.deepEqual(reengagement, {
     empty: false,
     state: 'main-safe',
     label: 'réengagement principal sûr',
     constraint: 'opportunité trop fragile',
     action: null,
+  });
+  assert.deepEqual(buildMiniPlanPrematureReengagementRisk(reengagement), {
+    empty: false,
+    state: 'ready',
+    label: 'fenêtre prête',
+    risk: 'risque contenu',
+    nextSafe: 'pousser maintenant',
   });
   assert.deepEqual(buildMiniPlanFallbackReturnCue(null, comparison), {
     empty: true,
@@ -1090,12 +1114,20 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     constraint: 'menace voisine',
     action: 'surveiller voisin',
   });
-  assert.deepEqual(buildMiniPlanFirstSafeReengagement(releaseCue), {
+  const reengagement = buildMiniPlanFirstSafeReengagement(releaseCue);
+  assert.deepEqual(reengagement, {
     empty: false,
     state: 'limited-reengagement',
     label: 'réengagement limité possible',
     constraint: 'menace non résolue',
     action: 'tester avancée',
+  });
+  assert.deepEqual(buildMiniPlanPrematureReengagementRisk(reengagement), {
+    empty: false,
+    state: 'partial-window',
+    label: 'risque si poussée totale',
+    risk: 'menace convertie en blocage',
+    nextSafe: 'attendre fenêtre principale',
   });
   assert.deepEqual(buildMiniPlanReturnProtectionStatus(null, fallback, comparison), {
     empty: true,
@@ -1174,6 +1206,13 @@ test('StrategicMapShell reports whether returning keeps rival-response protectio
     label: 'réengagement principal sûr',
     constraint: null,
     action: null,
+  });
+  assert.deepEqual(buildMiniPlanPrematureReengagementRisk(null), {
+    empty: true,
+    state: 'ready',
+    label: 'fenêtre prête',
+    risk: null,
+    nextSafe: null,
   });
 });
 

--- a/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
+++ b/test/ui/war/webAtlasMilitaryFallbackOrderHint.test.js
@@ -80,6 +80,7 @@ test('atlas military fallback order hint handles resource route overcommitment a
   assert.match(webAppSource, /buildMiniPlanNextTurnHoldPlan\(/);
   assert.match(webAppSource, /buildMiniPlanHoldReleaseCue\(/);
   assert.match(webAppSource, /buildMiniPlanFirstSafeReengagement\(/);
+  assert.match(webAppSource, /buildMiniPlanPrematureReengagementRisk\(/);
   assert.match(webAppSource, /firstCleanupPayoff/);
   assert.match(webAppSource, /followUpCleanupChoices/);
   assert.match(webAppSource, /topFollowUpReadiness/);
@@ -129,6 +130,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /miniPlanNextTurnHoldPlan: buildMiniPlanNextTurnHoldPlan\(/);
   assert.match(webAppSource, /miniPlanHoldReleaseCue: buildMiniPlanHoldReleaseCue\(/);
   assert.match(webAppSource, /miniPlanFirstSafeReengagement: buildMiniPlanFirstSafeReengagement\(/);
+  assert.match(webAppSource, /miniPlanPrematureReengagementRisk: buildMiniPlanPrematureReengagementRisk\(/);
   assert.match(webAppSource, /Risque si: aucun rival lisible/);
   assert.match(webAppSource, /branches: aucune comparaison/);
   assert.match(webAppSource, /fallback: aucun repli requis/);
@@ -144,6 +146,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /tour\+1: aucun maintien requis/);
   assert.match(webAppSource, /relâche: sûr/);
   assert.match(webAppSource, /réengage: principal sûr/);
+  assert.match(webAppSource, /trop tôt: fenêtre prête/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-payoff/);
   assert.match(webAppSource, /atlas-military-fallback-order__cleanup-followups/);
   assert.match(webAppSource, /atlas-military-fallback-order__followup-readiness/);
@@ -166,6 +169,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /atlas-military-fallback-order__next-turn-hold-plan/);
   assert.match(webAppSource, /atlas-military-fallback-order__hold-release-cue/);
   assert.match(webAppSource, /atlas-military-fallback-order__first-safe-reengagement/);
+  assert.match(webAppSource, /atlas-military-fallback-order__premature-reengagement-risk/);
   assert.match(webAppSource, /payoff: \$\{fallback\.firstCleanupPayoff\.riskReduced\} ↓ · reste \$\{fallback\.firstCleanupPayoff\.remainingRiskCount\}/);
   assert.match(webAppSource, /suivi: \$\{fallback\.followUpCleanupChoices\.map\(\(choice\) => `\$\{choice\.rank\}\. \$\{choice\.cleanupOrderLabel\} \(\$\{choice\.riskCovered\}\)`\)\.join\(' · '\)\}/);
   assert.match(webAppSource, /readiness: \$\{fallback\.topFollowUpReadiness\.label\} · \$\{fallback\.topFollowUpReadiness\.blocker\}/);
@@ -188,6 +192,7 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(webAppSource, /tour\+1: \$\{nextTurnHoldPlan\.action\} · risque \$\{nextTurnHoldPlan\.riskIfIgnored\}/);
   assert.match(webAppSource, /relâche: \$\{holdReleaseCue\.label\} · \$\{holdReleaseCue\.constraint\}\$\{holdReleaseCue\.action \? ` · \$\{holdReleaseCue\.action\}` : ''\}/);
   assert.match(webAppSource, /réengage: \$\{firstSafeReengagement\.label\} · \$\{firstSafeReengagement\.constraint\}\$\{firstSafeReengagement\.action \? ` · \$\{firstSafeReengagement\.action\}` : ''\}/);
+  assert.match(webAppSource, /trop tôt: \$\{prematureReengagementRisk\.label\} · \$\{prematureReengagementRisk\.risk\} › \$\{prematureReengagementRisk\.nextSafe\}/);
   assert.match(webAppSource, /crossDomainBlocker \? `; \$\{crossDomainBlocker\.label\}` : ''/);
   assert.match(webAppSource, /selectionPreview \? `; \$\{selectionPreview\.label\}` : ''/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__panel/);
@@ -220,4 +225,5 @@ test('atlas military fallback order hint stays secondary and hides no-safe fallb
   assert.match(stylesSource, /\.atlas-military-fallback-order__next-turn-hold-plan/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__hold-release-cue/);
   assert.match(stylesSource, /\.atlas-military-fallback-order__first-safe-reengagement/);
+  assert.match(stylesSource, /\.atlas-military-fallback-order__premature-reengagement-risk/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -18,6 +18,7 @@ import {
   buildMiniPlanNextTurnHoldPlan,
   buildMiniPlanHoldReleaseCue,
   buildMiniPlanFirstSafeReengagement,
+  buildMiniPlanPrematureReengagementRisk,
   buildMiniPlanDependencyConflicts,
   buildMiniPlanRivalResponseComparison,
   buildMiniPlanRivalResponseFallback,
@@ -2044,6 +2045,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanFirstSafeReengagement: buildMiniPlanFirstSafeReengagement(
         buildMiniPlanHoldReleaseCue(null),
       ),
+      miniPlanPrematureReengagementRisk: buildMiniPlanPrematureReengagementRisk(
+        buildMiniPlanFirstSafeReengagement(null),
+      ),
       summary: 'Aucun fallback sûr: ordre principal non bloqué ou alternative trop risquée.',
       empty: true,
     };
@@ -2116,6 +2120,9 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
   const miniPlanFirstSafeReengagement = buildMiniPlanFirstSafeReengagement(
     miniPlanHoldReleaseCue,
   );
+  const miniPlanPrematureReengagementRisk = buildMiniPlanPrematureReengagementRisk(
+    miniPlanFirstSafeReengagement,
+  );
 
   return {
     fallback: {
@@ -2149,6 +2156,7 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
       miniPlanNextTurnHoldPlan,
       miniPlanHoldReleaseCue,
       miniPlanFirstSafeReengagement,
+      miniPlanPrematureReengagementRisk,
     },
     safetyReason,
     crossDomainBlocker,
@@ -2177,7 +2185,8 @@ function buildAtlasMilitaryFallbackOrderHint(priorityStack, orderHint, reliefPre
     miniPlanNextTurnHoldPlan,
     miniPlanHoldReleaseCue,
     miniPlanFirstSafeReengagement,
-    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}; repli tactique: ${miniPlanSafestTacticalFallback.empty ? 'aucun' : miniPlanSafestTacticalFallback.state}; plan prochain tour: ${miniPlanNextTurnHoldPlan.empty ? 'aucun' : miniPlanNextTurnHoldPlan.action}; relâche: ${miniPlanHoldReleaseCue.empty ? 'aucune' : miniPlanHoldReleaseCue.state}; réengagement: ${miniPlanFirstSafeReengagement.empty ? 'aucun' : miniPlanFirstSafeReengagement.state}).`,
+    miniPlanPrematureReengagementRisk,
+    summary: `${fallback.order}: ${fallback.detail} (${fallback.why}; ${safetyReason.label}${crossDomainBlocker ? `; ${crossDomainBlocker.label}` : ''}${selectionPreview ? `; ${selectionPreview.label}` : ''}${residualRisks.length ? `; risques restants: ${residualRisks.map((risk) => risk.label).join(', ')}` : '; risques restants: aucun visible'}${cleanupOrders.length ? `; nettoyage: ${cleanupOrders[0].label}` : '; nettoyage: aucun requis'}${firstCleanupPayoff ? `; payoff: ${firstCleanupPayoff.riskReduced} réduit, ${firstCleanupPayoff.remainingRiskCount} reste` : '; payoff: aucun'}${followUpCleanupChoices.length ? `; suivi: ${followUpCleanupChoices.map((choice) => `${choice.rank}. ${choice.cleanupOrderLabel}`).join(', ')}` : '; suivi: aucun'}; readiness suivi: ${topFollowUpReadiness.label}; mini-plan: ${followUpCleanupMiniPlan.steps.length} étapes; conflits plan: ${miniPlanDependencyConflicts.length}; arbitrages: ${miniPlanConflictTradeoffs.length}; action: ${miniPlanTradeoffActionPreview.empty ? 'aucune' : miniPlanTradeoffActionPreview.action}; risque rival: ${miniPlanRivalResponseRisk.label}; branches: ${miniPlanRivalResponseComparison.branches.length}; fallback: ${miniPlanRivalResponseFallback.empty ? 'aucun' : miniPlanRivalResponseFallback.action}; retour: ${miniPlanFallbackReturnCue.empty ? 'aucun' : miniPlanFallbackReturnCue.decision}; protection retour: ${miniPlanReturnProtectionStatus.empty ? 'aucune' : miniPlanReturnProtectionStatus.state}; confiance: ${miniPlanConfidenceSignalCue.empty ? 'aucune' : miniPlanConfidenceSignalCue.decision}; réversibilité: ${miniPlanDecisionReversibilityCue.empty ? 'aucune' : miniPlanDecisionReversibilityCue.state}; dernier sûr: ${miniPlanLastSafeCorrectionCue.empty ? 'aucun' : miniPlanLastSafeCorrectionCue.state}; coût sortie: ${miniPlanLateCorrectionExitCost.empty ? 'aucun' : miniPlanLateCorrectionExitCost.severity}; suivi minimal: ${miniPlanMinimalFollowThrough.empty ? 'aucun' : miniPlanMinimalFollowThrough.level}; arbitrage opportunité: ${miniPlanFollowThroughOpportunityTradeoff.empty ? 'aucun' : miniPlanFollowThroughOpportunityTradeoff.state}; repli tactique: ${miniPlanSafestTacticalFallback.empty ? 'aucun' : miniPlanSafestTacticalFallback.state}; plan prochain tour: ${miniPlanNextTurnHoldPlan.empty ? 'aucun' : miniPlanNextTurnHoldPlan.action}; relâche: ${miniPlanHoldReleaseCue.empty ? 'aucune' : miniPlanHoldReleaseCue.state}; réengagement: ${miniPlanFirstSafeReengagement.empty ? 'aucun' : miniPlanFirstSafeReengagement.state}; risque précoce: ${miniPlanPrematureReengagementRisk.empty ? 'aucun' : miniPlanPrematureReengagementRisk.state}).`,
     empty: false,
   };
 }
@@ -2276,9 +2285,13 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
   const firstSafeReengagementLabel = firstSafeReengagement && !firstSafeReengagement.empty
     ? `réengage: ${firstSafeReengagement.label} · ${firstSafeReengagement.constraint}${firstSafeReengagement.action ? ` · ${firstSafeReengagement.action}` : ''}`
     : 'réengage: principal sûr';
+  const prematureReengagementRisk = fallback.miniPlanPrematureReengagementRisk;
+  const prematureReengagementRiskLabel = prematureReengagementRisk && !prematureReengagementRisk.empty
+    ? `trop tôt: ${prematureReengagementRisk.label} · ${prematureReengagementRisk.risk} › ${prematureReengagementRisk.nextSafe}`
+    : 'trop tôt: fenêtre prête';
   return `
     <g class="atlas-military-fallback-order atlas-military-fallback-order--${fallback.type}" data-atlas-fallback-order="${fallback.fallbackId}" aria-label="Ordre de repli: ${fallbackHint.summary}">
-      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="34.8" rx="1.2"></rect>
+      <rect class="atlas-military-fallback-order__panel" x="22" y="58" width="16" height="36" rx="1.2"></rect>
       <text class="atlas-military-fallback-order__label" x="23.2" y="59.1">repli: ${fallback.order}</text>
       <text class="atlas-military-fallback-order__detail" x="23.2" y="60.2">${fallback.detail}</text>
       <text class="atlas-military-fallback-order__safety" x="23.2" y="61.3">${fallback.safetyReason.label}</text>
@@ -2308,6 +2321,7 @@ function renderAtlasMilitaryFallbackOrderHint(fallbackHint) {
       <text class="atlas-military-fallback-order__next-turn-hold-plan" x="23.2" y="87.7">${nextTurnHoldPlanLabel}</text>
       <text class="atlas-military-fallback-order__hold-release-cue atlas-military-fallback-order__hold-release-cue--${holdReleaseCue?.state ?? 'safe-release'}" x="23.2" y="88.8">${holdReleaseCueLabel}</text>
       <text class="atlas-military-fallback-order__first-safe-reengagement atlas-military-fallback-order__first-safe-reengagement--${firstSafeReengagement?.state ?? 'main-safe'}" x="23.2" y="89.9">${firstSafeReengagementLabel}</text>
+      <text class="atlas-military-fallback-order__premature-reengagement-risk atlas-military-fallback-order__premature-reengagement-risk--${prematureReengagementRisk?.state ?? 'ready'}" x="23.2" y="91">${prematureReengagementRiskLabel}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -11200,6 +11200,9 @@ button { font: inherit; }
 .atlas-military-fallback-order__first-safe-reengagement { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
 .atlas-military-fallback-order__first-safe-reengagement--limited-reengagement { fill: #fde68a; }
 .atlas-military-fallback-order__first-safe-reengagement--defensive-stance { fill: #fecaca; }
+.atlas-military-fallback-order__premature-reengagement-risk { fill: #bbf7d0; font-size: 0.39px; font-weight: 900; }
+.atlas-military-fallback-order__premature-reengagement-risk--partial-window { fill: #fde68a; }
+.atlas-military-fallback-order__premature-reengagement-risk--too-early { fill: #fecaca; }
 .atlas-military-commitment-conflicts__panel {
   fill: rgba(69, 10, 10, 0.76);
   stroke: rgba(248, 113, 113, 0.36);


### PR DESCRIPTION
Alpha: Implements #1149.

Summary:
- adds `miniPlanPrematureReengagementRisk` after the first safe re-engagement cue
- flags too-early and partial-window re-engagement with the premature risk
- keeps the ready state positive without repeating A43 labels
- renders a compact risk-vs-next-safe comparison in the war map fallback overlay

Tests:
- npm test

Zeta: ready for validation before merge.