### PR TITLE
Beta: show surplus stabilize or expand decision

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -751,6 +751,36 @@ function buildPostNormalizationSurplusUse(guardedCorridorNormalizationCheckpoint
   };
 }
 
+function buildSurplusStabilizationDecision(postNormalizationSurplusUse) {
+  if (postNormalizationSurplusUse.status === 'invest-next-corridor') {
+    return {
+      status: 'fund-expansion',
+      recommendation: 'financer l’expansion',
+      corridorState: 'stable',
+      decidingConstraint: postNormalizationSurplusUse.guidingConstraint,
+      summary: 'Surplus libre: financer l’expansion après stabilité du corridor.',
+    };
+  }
+
+  if (postNormalizationSurplusUse.status === 'reinforce-fragile-alternative') {
+    return {
+      status: 'stabilize-routes',
+      recommendation: 'stabiliser les routes',
+      corridorState: 'fragile',
+      decidingConstraint: postNormalizationSurplusUse.guidingConstraint,
+      summary: 'Surplus à stabiliser: sécuriser les routes avant expansion.',
+    };
+  }
+
+  return {
+    status: 'stabilize-routes',
+    recommendation: 'stabiliser les routes',
+    corridorState: 'chargé',
+    decidingConstraint: postNormalizationSurplusUse.guidingConstraint,
+    summary: 'Surplus à retenir: stabiliser le corridor chargé avant expansion.',
+  };
+}
+
 function buildPostSalvageDecisionAlert(salvageAction) {
   if (salvageAction === null) {
     return {
@@ -976,6 +1006,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     monitoredCorridorRollbackGuard,
   );
   const postNormalizationSurplusUse = buildPostNormalizationSurplusUse(guardedCorridorNormalizationCheckpoint);
+  const surplusStabilizationDecision = buildSurplusStabilizationDecision(postNormalizationSurplusUse);
 
   return {
     id: `timing-sensitivity:${opportunityCostComparison.recommendedOptionId}`,
@@ -999,6 +1030,7 @@ function buildTimingSensitivity(opportunityCostComparison, preparationBreakEven,
     guardedCorridorLoadRelief,
     guardedCorridorNormalizationCheckpoint,
     postNormalizationSurplusUse,
+    surplusStabilizationDecision,
   };
 }
 

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -611,6 +611,13 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
         microAction: 'attendre stabilité confirmée puis investir',
         summary: 'Surplus disponible: viser le prochain corridor utile après stabilité confirmée.',
       },
+      surplusStabilizationDecision: {
+        status: 'fund-expansion',
+        recommendation: 'financer l’expansion',
+        corridorState: 'stable',
+        decidingConstraint: 'charge voisine',
+        summary: 'Surplus libre: financer l’expansion après stabilité du corridor.',
+      },
     },
   });
   assert.deepEqual(overlay.routes[0].capacitySpendPreview.preparationSequence, [
@@ -809,6 +816,13 @@ test('buildEconomyMapOverlay compares deterministic bottleneck preparation optio
       microAction: 'attendre stabilité confirmée puis investir',
       summary: 'Surplus disponible: viser le prochain corridor utile après stabilité confirmée.',
     },
+    surplusStabilizationDecision: {
+      status: 'fund-expansion',
+      recommendation: 'financer l’expansion',
+      corridorState: 'stable',
+      decidingConstraint: 'charge voisine',
+      summary: 'Surplus libre: financer l’expansion après stabilité du corridor.',
+    },
   });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.nextBottleneck.bestValuePreparation,
@@ -957,6 +971,13 @@ test('buildEconomyMapOverlay warns when timing sensitivity flips to the fallback
     microAction: 'conserver jusqu’à stabilité visible',
     summary: 'Surplus en réserve: attendre que le risque de rechute baisse avant dépense.',
   });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.surplusStabilizationDecision, {
+    status: 'stabilize-routes',
+    recommendation: 'stabiliser les routes',
+    corridorState: 'chargé',
+    decidingConstraint: 'risque de rechute',
+    summary: 'Surplus à retenir: stabiliser le corridor chargé avant expansion.',
+  });
   assert.deepEqual(
     overlay.routes[0].capacitySpendPreview.timingSensitivity.scenarios.map((scenario) => [
       scenario.id,
@@ -1071,6 +1092,13 @@ test('buildEconomyMapOverlay flags partially restored salvage as durable inversi
     guidingConstraint: 'alternative critique',
     microAction: 'renforcer avant de consommer le surplus',
     summary: 'Surplus prudent: renforcer l’alternative critique avant nouvel investissement.',
+  });
+  assert.deepEqual(overlay.routes[0].capacitySpendPreview.timingSensitivity.surplusStabilizationDecision, {
+    status: 'stabilize-routes',
+    recommendation: 'stabiliser les routes',
+    corridorState: 'fragile',
+    decidingConstraint: 'alternative critique',
+    summary: 'Surplus à stabiliser: sécuriser les routes avant expansion.',
   });
 });
 


### PR DESCRIPTION
## Summary

Beta: Adds a compact decision readout for whether surplus should stabilize existing routes or fund the next expansion.

## Changes

- Add `surplusStabilizationDecision` derived from the post-normalization surplus signal.
- Prefer route stabilization for fragile or loaded corridors.
- Recommend funding expansion only once the corridor is stable.
- Keep labels distinct from B43 by framing the choice as stabilize routes vs fund expansion.
- Extend economy overlay tests for stable, fragile, and loaded corridor outcomes.

## Testing

- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (642/642 pass)

Fixes loo469/historia#1150