### PR TITLE
Gamma: show premature culture redeployment cost

### DIFF
--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1270,6 +1270,30 @@ export function buildResidualCultureSupportRedeploymentCue(residualCultureStabil
   };
 }
 
+export function buildResidualCulturePrematureRedeploymentRisk(residualCultureSupportRedeploymentCue) {
+  if (residualCultureSupportRedeploymentCue.status === 'safe-redeploy') {
+    return {
+      status: 'safe',
+      culturalCost: 'aucun coût culturel attendu: redéploiement acceptable',
+      alternative: 'redéployer si la stabilité reste confirmée',
+    };
+  }
+
+  if (residualCultureSupportRedeploymentCue.status === 'careful-reduction') {
+    return {
+      status: 'watch-before-redeploy',
+      culturalCost: `coût possible: ${residualCultureSupportRedeploymentCue.blockingFactor} peut réduire la stabilité culturelle`,
+      alternative: 'attendre le signal de stabilité avant redéploiement complet',
+    };
+  }
+
+  return {
+    status: 'premature',
+    culturalCost: `coût culturel probable: ${residualCultureSupportRedeploymentCue.blockingFactor} peut faire retomber la stabilité`,
+    alternative: 'attendre la stabilité avant de redéployer le soutien',
+  };
+}
+
 function buildStabilizationDebtSummary(status, regionId, dependencies, incompatibilities, mediationRegionIds, fragileRegionIds, postBundleCumulativeRisk) {
   const debts = [];
 
@@ -1336,6 +1360,7 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
   const residualCultureMinimalDelayedSupport = buildResidualCultureMinimalDelayedSupport(residualCultureReevaluationDelayCost);
   const residualCultureReliabilityUpgradeCondition = buildResidualCultureReliabilityUpgradeCondition(residualCultureMinimalDelayedSupport);
   const residualCultureStabilityWatchWindow = buildResidualCultureStabilityWatchWindow(residualCultureReliabilityUpgradeCondition);
+  const residualCultureSupportRedeploymentCue = buildResidualCultureSupportRedeploymentCue(residualCultureStabilityWatchWindow);
 
   return {
     status: uniqueDebts.length > 0 ? 'open' : 'neutral',
@@ -1358,7 +1383,8 @@ function buildStabilizationDebtSummary(status, regionId, dependencies, incompati
     residualCultureMinimalDelayedSupport,
     residualCultureReliabilityUpgradeCondition,
     residualCultureStabilityWatchWindow,
-    residualCultureSupportRedeploymentCue: buildResidualCultureSupportRedeploymentCue(residualCultureStabilityWatchWindow),
+    residualCultureSupportRedeploymentCue,
+    residualCulturePrematureRedeploymentRisk: buildResidualCulturePrematureRedeploymentRisk(residualCultureSupportRedeploymentCue),
   };
 }
 

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { Culture } from '../../../src/domain/culture/Culture.js';
 import { HistoricalEvent } from '../../../src/domain/culture/HistoricalEvent.js';
 import { ResearchState } from '../../../src/domain/culture/ResearchState.js';
-import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability, buildResidualCultureReevaluationTrigger, buildResidualCultureReevaluationDelayCost, buildResidualCultureMinimalDelayedSupport, buildResidualCultureReliabilityUpgradeCondition, buildResidualCultureStabilityWatchWindow, buildResidualCultureSupportRedeploymentCue } from '../../../src/ui/culture/buildCultureMapOverlay.js';
+import { buildCultureMapOverlay, buildResidualCultureActionPayoff, buildResidualCultureFollowUpWindow, buildResidualCultureWindowClosureThreat, buildResidualCultureSupportAllocationChoice, buildResidualCulturePostAllocationStability, buildResidualCultureReevaluationTrigger, buildResidualCultureReevaluationDelayCost, buildResidualCultureMinimalDelayedSupport, buildResidualCultureReliabilityUpgradeCondition, buildResidualCultureStabilityWatchWindow, buildResidualCultureSupportRedeploymentCue, buildResidualCulturePrematureRedeploymentRisk } from '../../../src/ui/culture/buildCultureMapOverlay.js';
 
 function withoutSupportRiskPreviews(value) {
   if (Array.isArray(value)) {
@@ -995,6 +995,11 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         redeploymentCue: 'réduction prudente possible après le prochain signal confirmé',
         microAction: 'revoir le support si fatigue de médiation remonte',
       },
+      residualCulturePrematureRedeploymentRisk: {
+        status: 'watch-before-redeploy',
+        culturalCost: 'coût possible: tension locale peut réduire la stabilité culturelle',
+        alternative: 'attendre le signal de stabilité avant redéploiement complet',
+      },
     },
     summary: 'amélioration partielle: isolement du support baisse, médiation à prévoir',
   });
@@ -1143,6 +1148,11 @@ test('buildCultureMapOverlay bundles compatible supports for fragile cultural re
         blockingFactor: 'soutien résiduel faible',
         redeploymentCue: 'redéploiement sûr: la stabilité tient sans soutien dédié',
         microAction: null,
+      },
+      residualCulturePrematureRedeploymentRisk: {
+        status: 'safe',
+        culturalCost: 'aucun coût culturel attendu: redéploiement acceptable',
+        alternative: 'redéployer si la stabilité reste confirmée',
       },
     },
     summary: 'stabilisation complète: aucun second soutien requis',
@@ -1857,6 +1867,50 @@ test('buildResidualCultureSupportRedeploymentCue covers maintain, reduce, and re
       blockingFactor: 'soutien résiduel faible',
       redeploymentCue: 'redéploiement sûr: la stabilité tient sans soutien dédié',
       microAction: null,
+    },
+  );
+});
+
+test('buildResidualCulturePrematureRedeploymentRisk covers premature and safe redeployment', () => {
+  assert.deepEqual(
+    buildResidualCulturePrematureRedeploymentRisk({
+      status: 'keep-support',
+      blockingFactor: 'fragilité sociale voisine',
+      redeploymentCue: 'soutien à maintenir: la stabilité retomberait sans consolidation',
+      microAction: 'sécuriser un support local avant tout suivi',
+    }),
+    {
+      status: 'premature',
+      culturalCost: 'coût culturel probable: fragilité sociale voisine peut faire retomber la stabilité',
+      alternative: 'attendre la stabilité avant de redéployer le soutien',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCulturePrematureRedeploymentRisk({
+      status: 'careful-reduction',
+      blockingFactor: 'tension locale',
+      redeploymentCue: 'réduction prudente possible après le prochain signal confirmé',
+      microAction: 'revoir le support si fatigue de médiation remonte',
+    }),
+    {
+      status: 'watch-before-redeploy',
+      culturalCost: 'coût possible: tension locale peut réduire la stabilité culturelle',
+      alternative: 'attendre le signal de stabilité avant redéploiement complet',
+    },
+  );
+
+  assert.deepEqual(
+    buildResidualCulturePrematureRedeploymentRisk({
+      status: 'safe-redeploy',
+      blockingFactor: 'soutien résiduel faible',
+      redeploymentCue: 'redéploiement sûr: la stabilité tient sans soutien dédié',
+      microAction: null,
+    }),
+    {
+      status: 'safe',
+      culturalCost: 'aucun coût culturel attendu: redéploiement acceptable',
+      alternative: 'redéployer si la stabilité reste confirmée',
     },
   );
 });


### PR DESCRIPTION
Gamma: ## Summary

Shows the cultural risk/cost when support is redeployed too early after the G43 support redeployment cue.

## Changes

- Adds `residualCulturePrematureRedeploymentRisk` alongside the redeployment cue.
- Distinguishes premature, watch-before-redeploy, and safe redéploiement states.
- Names a compact cultural cost for early withdrawal and gives a short alternative to wait for confirmed stability or redeploy when safe.
- Avoids duplicating the exact G43 cue wording.

## Testing

- `node --test test/ui/culture/buildCultureMapOverlay.test.js`
- `npm test`

Fixes loo469/historia#1151