### PR TITLE
Delta: show observation broadening tradeoff

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -1021,6 +1021,47 @@ function buildObservationBroadeningSignal({ firstSafeObservationTarget }) {
   };
 }
 
+
+function buildObservationBroadeningTradeoff({ observationBroadeningSignal }) {
+  if (observationBroadeningSignal.broadening === 'primary-coverage-safe') {
+    return {
+      tradeoff: 'coverage-justifies-broadening',
+      visibleFactor: observationBroadeningSignal.visibleConstraint,
+      action: 'broaden-main-coverage',
+      label: 'Compromis: couverture utile.',
+      message: 'La couverture principale vaut l’exposition ajoutée: élargir sans ouvrir de zone brouillée.',
+    };
+  }
+
+  if (observationBroadeningSignal.broadening === 'cautious-broadening-possible') {
+    return {
+      tradeoff: 'coverage-justifies-broadening',
+      visibleFactor: observationBroadeningSignal.visibleConstraint,
+      action: 'broaden-one-step',
+      label: 'Compromis: élargissement utile.',
+      message: 'Le gain de couverture justifie un cran d’observation, pas une extension complète.',
+    };
+  }
+
+  if (observationBroadeningSignal.visibleConstraint === 'Heat restant') {
+    return {
+      tradeoff: 'exposure-too-high',
+      visibleFactor: 'Heat restant',
+      action: 'stay-focused',
+      label: 'Compromis: exposition trop haute.',
+      message: 'Rester focalisé: le heat restant rend l’exposition d’un élargissement trop chère.',
+    };
+  }
+
+  return {
+    tradeoff: 'exposure-too-high',
+    visibleFactor: observationBroadeningSignal.visibleConstraint,
+    action: 'wait-for-clearer-coverage',
+    label: 'Compromis: attendre.',
+    message: 'Attendre: la zone brouillée ajouterait de l’exposition sans couverture fiable.',
+  };
+}
+
 function buildMonitoringRestartPlan({ state, monitoringPreferred, marginalExposureAdded, expectedConfidenceGain }) {
   const normalizedExposure = clampPercent(marginalExposureAdded);
   const normalizedGain = clampPercent(expectedConfidenceGain);
@@ -1787,6 +1828,83 @@ function withMonitoringRestartPlan(rationale, marginalExposureAdded, expectedCon
             }),
           }),
         }),
+      }),
+    }),
+    observationBroadeningTradeoff: buildObservationBroadeningTradeoff({
+      observationBroadeningSignal: buildObservationBroadeningSignal({
+      firstSafeObservationTarget: buildFirstSafeObservationTarget({
+        activeObservationResumeSignal: buildActiveObservationResumeSignal({
+          followUpCoolingWindow: buildFollowUpCoolingWindow({
+            followUpHeatDebt: buildFollowUpHeatDebt({
+              resumedConstrainedSweepResult: buildResumedConstrainedSweepResult({
+                monitoringMinimalResumeSignal: buildMonitoringMinimalResumeSignal({
+                  monitoringSafeCadence: buildMonitoringSafeCadence({
+                    monitoringMarginResponsePriority: buildMonitoringMarginResponsePriority({
+                      postRecoveryMarginDecay: buildPostRecoveryMarginDecay({
+                        postRecoverySafetyMargin: buildPostRecoverySafetyMargin({
+                          preventiveRecoveryState: buildPreventiveRecoveryState({
+                            preventiveAction: buildMonitoringPreventiveAction({
+                              state: rationale.state,
+                              driftForecast: buildMonitoringDriftForecast({
+                                state: rationale.state,
+                                marginalExposureAdded,
+                                expectedConfidenceGain,
+                              }),
+                            }),
+                          }),
+                          preventiveAction: buildMonitoringPreventiveAction({
+                            state: rationale.state,
+                            driftForecast: buildMonitoringDriftForecast({
+                              state: rationale.state,
+                              marginalExposureAdded,
+                              expectedConfidenceGain,
+                            }),
+                          }),
+                          driftForecast: buildMonitoringDriftForecast({
+                            state: rationale.state,
+                            marginalExposureAdded,
+                            expectedConfidenceGain,
+                          }),
+                        }),
+                        driftForecast: buildMonitoringDriftForecast({
+                          state: rationale.state,
+                          marginalExposureAdded,
+                          expectedConfidenceGain,
+                        }),
+                      }),
+                      postRecoverySafetyMargin: buildPostRecoverySafetyMargin({
+                        preventiveRecoveryState: buildPreventiveRecoveryState({
+                          preventiveAction: buildMonitoringPreventiveAction({
+                            state: rationale.state,
+                            driftForecast: buildMonitoringDriftForecast({
+                              state: rationale.state,
+                              marginalExposureAdded,
+                              expectedConfidenceGain,
+                            }),
+                          }),
+                        }),
+                        preventiveAction: buildMonitoringPreventiveAction({
+                          state: rationale.state,
+                          driftForecast: buildMonitoringDriftForecast({
+                            state: rationale.state,
+                            marginalExposureAdded,
+                            expectedConfidenceGain,
+                          }),
+                        }),
+                        driftForecast: buildMonitoringDriftForecast({
+                          state: rationale.state,
+                          marginalExposureAdded,
+                          expectedConfidenceGain,
+                        }),
+                      }),
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
       }),
     }),
   };

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -257,6 +257,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           label: 'Élargissement: rester limité.',
           reason: 'La zone brouillée rend l’extension trop large: rafraîchir le signal avant tout élargissement.',
         },
+        observationBroadeningTradeoff: {
+          tradeoff: 'exposure-too-high',
+          visibleFactor: 'Zone brouillée',
+          action: 'wait-for-clearer-coverage',
+          label: 'Compromis: attendre.',
+          message: 'Attendre: la zone brouillée ajouterait de l’exposition sans couverture fiable.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -353,6 +360,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               action: 'refresh-signal',
               label: 'Élargissement: rester limité.',
               reason: 'La zone brouillée rend l’extension trop large: rafraîchir le signal avant tout élargissement.',
+            },
+            observationBroadeningTradeoff: {
+              tradeoff: 'exposure-too-high',
+              visibleFactor: 'Zone brouillée',
+              action: 'wait-for-clearer-coverage',
+              label: 'Compromis: attendre.',
+              message: 'Attendre: la zone brouillée ajouterait de l’exposition sans couverture fiable.',
             },
         monitoringChecklist: [
           {
@@ -555,6 +569,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
           label: 'Élargissement: rester limité.',
           reason: 'La zone brouillée rend l’extension trop large: rafraîchir le signal avant tout élargissement.',
         },
+        observationBroadeningTradeoff: {
+          tradeoff: 'exposure-too-high',
+          visibleFactor: 'Zone brouillée',
+          action: 'wait-for-clearer-coverage',
+          label: 'Compromis: attendre.',
+          message: 'Attendre: la zone brouillée ajouterait de l’exposition sans couverture fiable.',
+        },
             monitoringChecklistFocus: {
               signal: null,
               state: 'stable-for-now',
@@ -651,6 +672,13 @@ test('buildIntrigueMapOverlay merges intrigue presence and active sabotage threa
               action: 'refresh-signal',
               label: 'Élargissement: rester limité.',
               reason: 'La zone brouillée rend l’extension trop large: rafraîchir le signal avant tout élargissement.',
+            },
+            observationBroadeningTradeoff: {
+              tradeoff: 'exposure-too-high',
+              visibleFactor: 'Zone brouillée',
+              action: 'wait-for-clearer-coverage',
+              label: 'Compromis: attendre.',
+              message: 'Attendre: la zone brouillée ajouterait de l’exposition sans couverture fiable.',
             },
         monitoringChecklist: [
           {
@@ -953,6 +981,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
           label: 'Élargissement: rester limité.',
           reason: 'La zone brouillée rend l’extension trop large: rafraîchir le signal avant tout élargissement.',
         },
+        observationBroadeningTradeoff: {
+          tradeoff: 'exposure-too-high',
+          visibleFactor: 'Zone brouillée',
+          action: 'wait-for-clearer-coverage',
+          label: 'Compromis: attendre.',
+          message: 'Attendre: la zone brouillée ajouterait de l’exposition sans couverture fiable.',
+        },
         monitoringChecklist: [
           {
             signal: 'Nouveau gap',
@@ -1128,6 +1163,13 @@ test('buildIntrigueMapOverlay exposes bounded low-exposure confidence deltas and
         action: 'broaden-one-step',
         label: 'Élargissement: prudent possible.',
         reason: 'La cible limitée absorbe la dette d’observation: élargir d’un cran seulement tant que la couverture partielle tient.',
+      },
+      observationBroadeningTradeoff: {
+        tradeoff: 'coverage-justifies-broadening',
+        visibleFactor: 'Dette d’observation',
+        action: 'broaden-one-step',
+        label: 'Compromis: élargissement utile.',
+        message: 'Le gain de couverture justifie un cran d’observation, pas une extension complète.',
       },
       monitoringChecklist: [
         {
@@ -1371,6 +1413,13 @@ test('buildIntrigueMapOverlay recommends preparing a third sweep only when resid
         label: 'Élargissement: couverture principale sûre.',
         reason: 'La première cible confirme une menace lisible: élargir vers la couverture principale sans ouvrir de zone brouillée.',
       },
+      observationBroadeningTradeoff: {
+        tradeoff: 'coverage-justifies-broadening',
+        visibleFactor: 'Menace confirmée',
+        action: 'broaden-main-coverage',
+        label: 'Compromis: couverture utile.',
+        message: 'La couverture principale vaut l’exposition ajoutée: élargir sans ouvrir de zone brouillée.',
+      },
       monitoringChecklist: [
         {
           signal: 'Fenêtre sûre',
@@ -1537,6 +1586,13 @@ test('buildIntrigueMapOverlay marks second sweep stop conditions for signal and 
       action: 'broaden-one-step',
       label: 'Élargissement: prudent possible.',
       reason: 'La cible limitée absorbe la dette d’observation: élargir d’un cran seulement tant que la couverture partielle tient.',
+    },
+    observationBroadeningTradeoff: {
+      tradeoff: 'coverage-justifies-broadening',
+      visibleFactor: 'Dette d’observation',
+      action: 'broaden-one-step',
+      label: 'Compromis: élargissement utile.',
+      message: 'Le gain de couverture justifie un cran d’observation, pas une extension complète.',
     },
     monitoringChecklist: [
       {


### PR DESCRIPTION
Delta: Implements #1152.

Summary:
- Adds `observationBroadeningTradeoff` after the D43 broadening signal.
- Warns when exposure remains too high and advises staying focused or waiting.
- Explains when gained coverage justifies a cautious/main broadening step in one concise message.

Tests:
- `node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js`
- `npm test` (644/644)

Zeta: PR ready for validation. Please review before any merge.