### PR TITLE
Alpha: build strategic map province layers

### DIFF
--- a/src/ui/war/ProvinceRenderer.js
+++ b/src/ui/war/ProvinceRenderer.js
@@ -35,6 +35,18 @@ function getFactionPalette(paletteByFaction, factionId) {
   };
 }
 
+function buildProvinceStatusLabel(province) {
+  if (province.contested) {
+    return 'Front contesté';
+  }
+
+  if (province.isOccupied) {
+    return 'Occupation';
+  }
+
+  return 'Contrôle stable';
+}
+
 export function renderProvince(province, options = {}) {
   const normalizedProvince = requireProvince(province);
   const normalizedOptions = requireOptions(options);
@@ -53,6 +65,10 @@ export function renderProvince(province, options = {}) {
   const ownerPalette = getFactionPalette(paletteByFaction, normalizedProvince.ownerFactionId);
   const controllerPalette = getFactionPalette(paletteByFaction, normalizedProvince.controllingFactionId);
 
+  const statusLabel = buildProvinceStatusLabel(normalizedProvince);
+  const supplyTone = String(supplyToneByLevel[normalizedProvince.supplyLevel] ?? normalizedProvince.supplyLevel).trim()
+    || normalizedProvince.supplyLevel;
+
   return {
     provinceId: normalizedProvince.id,
     label: normalizedProvince.name,
@@ -61,8 +77,9 @@ export function renderProvince(province, options = {}) {
     occupied: normalizedProvince.isOccupied,
     contested: normalizedProvince.contested,
     supplyLevel: normalizedProvince.supplyLevel,
-    supplyTone: String(supplyToneByLevel[normalizedProvince.supplyLevel] ?? normalizedProvince.supplyLevel).trim()
-      || normalizedProvince.supplyLevel,
+    supplyTone,
+    statusLabel,
+    ariaLabel: `${normalizedProvince.name} — ${statusLabel}, ravitaillement ${normalizedProvince.supplyLevel}, loyauté ${normalizedProvince.loyalty}%, valeur ${normalizedProvince.strategicValue}`,
     loyalty: normalizedProvince.loyalty,
     strategicValue: normalizedProvince.strategicValue,
     neighborIds: [...normalizedProvince.neighborIds],

--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1260,6 +1260,71 @@ function enhanceProvince(renderedProvince, options, provinceGeometryById) {
   };
 }
 
+function buildProvinceCssClasses(province) {
+  return [
+    'province-node',
+    province.contested ? 'province-node--contested' : null,
+    province.occupied ? 'province-node--occupied' : null,
+    `province-node--supply-${province.supplyLevel}`,
+    province.selectionState.selected ? 'is-selected' : null,
+    province.selectionState.focused ? 'is-focused' : null,
+    province.selectionState.hovered ? 'is-hovered' : null,
+  ].filter(Boolean);
+}
+
+function buildProvinceLabelNode(province) {
+  const center = province.geometry.center;
+  const labelLayout = province.geometry.labelLayout ?? center;
+
+  if (!center || !labelLayout) {
+    return null;
+  }
+
+  const align = String(labelLayout.align ?? 'middle').trim() || 'middle';
+  const x = Number.isFinite(labelLayout.x) ? labelLayout.x : center.x;
+  const y = Number.isFinite(labelLayout.y) ? labelLayout.y : center.y;
+  const leaderLine = Math.abs(x - center.x) > 4 || Math.abs(y - center.y) > 4
+    ? { from: { ...center }, to: { x, y } }
+    : null;
+
+  return {
+    provinceId: province.provinceId,
+    text: province.label,
+    meta: province.statusLabel,
+    x,
+    y,
+    align,
+    tone: String(labelLayout.tone ?? province.supplyTone ?? 'standard').trim() || 'standard',
+    leaderLine,
+  };
+}
+
+function buildProvinceMapLayers(renderedProvinces) {
+  return {
+    provinceSurfaces: renderedProvinces.map((province) => ({
+      provinceId: province.provinceId,
+      label: province.label,
+      ariaLabel: province.ariaLabel,
+      cssClasses: buildProvinceCssClasses(province),
+      data: {
+        provinceId: province.provinceId,
+        ownerFactionId: province.ownerFactionId,
+        controllingFactionId: province.controllingFactionId,
+        supplyLevel: province.supplyLevel,
+        supplyTone: province.supplyTone,
+        status: province.contested ? 'contested' : province.occupied ? 'occupied' : 'stable',
+      },
+      geometry: {
+        polygon: province.geometry.polygon,
+        shape: province.geometry.shape,
+        center: province.geometry.center,
+      },
+      style: { ...province.style },
+    })),
+    provinceLabels: renderedProvinces.map(buildProvinceLabelNode).filter(Boolean),
+  };
+}
+
 export function buildStrategicMapShell(provinces, options = {}) {
   const normalizedProvinces = requireProvinceList(provinces);
   const normalizedOptions = requireOptions(options);
@@ -1366,6 +1431,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     title,
     subtitle,
     provinces: renderedProvinces,
+    mapLayers: buildProvinceMapLayers(renderedProvinces),
     stats: {
       provinceCount: stats.provinceCount,
       contestedCount: stats.contestedCount,

--- a/test/ui/war/ProvinceRenderer.test.js
+++ b/test/ui/war/ProvinceRenderer.test.js
@@ -38,6 +38,8 @@ test('ProvinceRenderer builds deterministic UI data for a stable province', () =
     contested: false,
     supplyLevel: 'stable',
     supplyTone: 'ready',
+    statusLabel: 'Contrôle stable',
+    ariaLabel: 'Marches du Nord — Contrôle stable, ravitaillement stable, loyauté 68%, valeur 4',
     loyalty: 68,
     strategicValue: 4,
     neighborIds: ['prov-b', 'prov-c'],
@@ -80,6 +82,8 @@ test('ProvinceRenderer highlights contested occupation states and supports suppl
   });
   assert.deepEqual(rendered.badges, ['contested', 'occupied', 'supply:disrupted', 'value:4']);
   assert.equal(rendered.supplyTone, 'breaking');
+  assert.equal(rendered.statusLabel, 'Front contesté');
+  assert.equal(rendered.ariaLabel, 'Marches du Nord — Front contesté, ravitaillement disrupted, loyauté 31%, valeur 4');
 });
 
 test('ProvinceRenderer rejects invalid inputs', () => {

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -92,6 +92,37 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
   assert.deepEqual(shell.provinces[0].geometry.layout, { x: 10, y: 12, w: 20, h: 18 });
   assert.equal(shell.provinces[0].geometry.shape, 'polygon(10% 12%, 30% 12%, 30% 30%, 10% 30%)');
   assert.equal(shell.provinces[1].geometry.layout, null);
+  assert.deepEqual(shell.mapLayers.provinceSurfaces.map((surface) => ({
+    provinceId: surface.provinceId,
+    cssClasses: surface.cssClasses,
+    status: surface.data.status,
+    ariaLabel: surface.ariaLabel,
+  })), [
+    {
+      provinceId: 'prov-a',
+      cssClasses: ['province-node', 'province-node--supply-stable', 'is-focused', 'is-hovered'],
+      status: 'stable',
+      ariaLabel: 'Avant-poste — Contrôle stable, ravitaillement stable, loyauté 82%, valeur 2',
+    },
+    {
+      provinceId: 'prov-c',
+      cssClasses: ['province-node', 'province-node--contested', 'province-node--occupied', 'province-node--supply-strained', 'is-selected'],
+      status: 'contested',
+      ariaLabel: 'Colline rouge — Front contesté, ravitaillement strained, loyauté 40%, valeur 4',
+    },
+  ]);
+  assert.deepEqual(shell.mapLayers.provinceLabels, [
+    {
+      provinceId: 'prov-a',
+      text: 'Avant-poste',
+      meta: 'Contrôle stable',
+      x: 20,
+      y: 18,
+      align: 'middle',
+      tone: 'capital',
+      leaderLine: null,
+    },
+  ]);
   assert.deepEqual(shell.stats, {
     provinceCount: 2,
     contestedCount: 1,


### PR DESCRIPTION
Alpha: Implements #1159.

Summary:
- adds accessible province status labels and ARIA text to `ProvinceRenderer`
- exposes strategic map `mapLayers` with province surfaces, state/supply CSS classes, geometry, styles, and labels
- keeps the existing shell stats/legend/overlay contract while making the map shell easier to render as an interactive province layer

Tests:
- npm test

Zeta: ready for validation before merge.
