### PR TITLE
Beta: add city resource logistics map overlay

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -1183,6 +1183,99 @@ function normalizeRouteStyle(route, styleByTransportMode) {
   };
 }
 
+function buildResourceLayer(cityOverlays) {
+  const resourceFeatures = cityOverlays.flatMap((city) => city.resources.entries.map((resource) => ({
+    featureId: `resource:${resource.resourceId}:${city.cityId}`,
+    cityId: city.cityId,
+    cityName: city.cityName,
+    resourceId: resource.resourceId,
+    quantity: resource.quantity,
+    position: city.marker.position,
+    intensity: resource.quantity === 0
+      ? 'empty'
+      : resource.quantity >= city.population / 5
+        ? 'abundant'
+        : 'available',
+    label: `${resource.resourceId}: ${resource.quantity}`,
+  })));
+  const totalsByResource = Object.values(resourceFeatures.reduce((totals, feature) => {
+    totals[feature.resourceId] ??= {
+      resourceId: feature.resourceId,
+      totalQuantity: 0,
+      cityCount: 0,
+    };
+    totals[feature.resourceId].totalQuantity += feature.quantity;
+    totals[feature.resourceId].cityCount += 1;
+
+    return totals;
+  }, {})).sort((left, right) => left.resourceId.localeCompare(right.resourceId));
+
+  return {
+    id: 'resources',
+    title: 'Ressources stockées',
+    visibleByDefault: true,
+    features: resourceFeatures.sort((left, right) => left.resourceId.localeCompare(right.resourceId)
+      || left.cityId.localeCompare(right.cityId)),
+    totalsByResource,
+    legend: [
+      { key: 'abundant', label: 'Stock abondant', tone: 'positive' },
+      { key: 'available', label: 'Stock disponible', tone: 'neutral' },
+      { key: 'empty', label: 'Stock nul', tone: 'muted' },
+    ],
+  };
+}
+
+function buildEconomyMapLayers(cityOverlays, routeOverlays) {
+  return {
+    cities: {
+      id: 'cities',
+      title: 'Villes',
+      visibleByDefault: true,
+      features: cityOverlays.map((city) => ({
+        featureId: city.overlayId,
+        cityId: city.cityId,
+        label: city.label,
+        regionId: city.regionId,
+        position: city.marker.position,
+        marker: { ...city.marker },
+        capital: city.capital,
+        prosperity: city.prosperity,
+        stability: city.stability,
+      })),
+      legend: [
+        { key: 'positive', label: 'Prospérité élevée', tone: 'positive' },
+        { key: 'warning', label: 'Stabilité fragile', tone: 'warning' },
+        { key: 'neutral', label: 'Ville stable', tone: 'neutral' },
+      ],
+    },
+    resources: buildResourceLayer(cityOverlays),
+    logistics: {
+      id: 'logistics',
+      title: 'Routes logistiques',
+      visibleByDefault: true,
+      features: routeOverlays.map((route) => ({
+        featureId: route.overlayId,
+        routeId: route.routeId,
+        label: route.label,
+        cityIds: [...route.cityIds],
+        active: route.active,
+        transportMode: route.transportMode,
+        riskLevel: route.riskLevel,
+        totalCapacity: route.totalCapacity,
+        capacityRemaining: route.capacitySpendPreview.capacityRemaining,
+        state: route.capacitySpendPreview.state,
+        bottleneckResourceId: route.capacitySpendPreview.nextBottleneck?.resourceId ?? null,
+        style: { ...route.style },
+      })),
+      legend: [
+        { key: 'remaining-margin', label: 'Marge de capacité restante', tone: 'positive' },
+        { key: 'fully-spent', label: 'Capacité mobilisée', tone: 'warning' },
+        { key: 'no-spend', label: 'Aucune dépense prévue', tone: 'neutral' },
+      ],
+    },
+  };
+}
+
 export function buildEconomyMapOverlay(cities, routes, options = {}) {
   const normalizedCities = requireArray(cities, 'EconomyMapOverlay cities').map(normalizeCity);
   const normalizedRoutes = requireArray(routes, 'EconomyMapOverlay routes').map(normalizeRoute);
@@ -1252,6 +1345,7 @@ export function buildEconomyMapOverlay(cities, routes, options = {}) {
     summary: `${cityOverlays.length} villes, ${routeOverlays.length} routes logistiques`,
     cities: cityOverlays,
     routes: routeOverlays,
+    layers: buildEconomyMapLayers(cityOverlays, routeOverlays),
     metrics: {
       cityCount: cityOverlays.length,
       capitalCount: cityOverlays.filter((city) => city.capital).length,

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1111,3 +1111,106 @@ test('buildEconomyMapOverlay rejects invalid inputs', () => {
   assert.throws(() => buildEconomyMapOverlay([], [], { cityPositionById: [] }), /cityPositionById must be an object/);
   assert.throws(() => buildEconomyMapOverlay([], [], { styleByTransportMode: [] }), /styleByTransportMode must be an object/);
 });
+
+test('buildEconomyMapOverlay exposes city resource and logistics map layers', () => {
+  const overlay = buildEconomyMapOverlay([
+    {
+      id: 'city-harbor',
+      name: 'Harbor',
+      regionId: 'coast',
+      population: 100,
+      prosperity: 72,
+      stability: 65,
+      stockByResource: { fish: 24, timber: 3 },
+      tradeRouteIds: ['route-coast'],
+      capital: true,
+    },
+    {
+      id: 'city-mill',
+      name: 'Mill',
+      regionId: 'riverlands',
+      population: 50,
+      prosperity: 44,
+      stability: 31,
+      stockByResource: { fish: 0, grain: 8 },
+      tradeRouteIds: ['route-coast'],
+    },
+  ], [
+    {
+      id: 'route-coast',
+      name: 'Coast Road',
+      stopCityIds: ['city-harbor', 'city-mill'],
+      distance: 6,
+      capacityByResource: { grain: 4, timber: 2 },
+      transportMode: 'land',
+      riskLevel: 47,
+    },
+  ], {
+    cityPositionById: {
+      'city-harbor': { x: 2, y: 3 },
+      'city-mill': { x: 7, y: 5 },
+    },
+    recommendedUnlockByRouteId: {
+      'route-coast': {
+        mobilizedByResource: { grain: 4, timber: 1 },
+      },
+    },
+  });
+
+  assert.deepEqual(Object.keys(overlay.layers), ['cities', 'resources', 'logistics']);
+  assert.deepEqual(overlay.layers.cities.features.map((feature) => ({
+    featureId: feature.featureId,
+    label: feature.label,
+    position: feature.position,
+    capital: feature.capital,
+  })), [
+    {
+      featureId: 'city:city-harbor',
+      label: 'Harbor ★',
+      position: { x: 2, y: 3 },
+      capital: true,
+    },
+    {
+      featureId: 'city:city-mill',
+      label: 'Mill',
+      position: { x: 7, y: 5 },
+      capital: false,
+    },
+  ]);
+  assert.deepEqual(overlay.layers.resources.totalsByResource, [
+    { resourceId: 'fish', totalQuantity: 24, cityCount: 2 },
+    { resourceId: 'grain', totalQuantity: 8, cityCount: 1 },
+    { resourceId: 'timber', totalQuantity: 3, cityCount: 1 },
+  ]);
+  assert.deepEqual(overlay.layers.resources.features.map((feature) => ({
+    featureId: feature.featureId,
+    intensity: feature.intensity,
+    label: feature.label,
+  })), [
+    { featureId: 'resource:fish:city-harbor', intensity: 'abundant', label: 'fish: 24' },
+    { featureId: 'resource:fish:city-mill', intensity: 'empty', label: 'fish: 0' },
+    { featureId: 'resource:grain:city-mill', intensity: 'available', label: 'grain: 8' },
+    { featureId: 'resource:timber:city-harbor', intensity: 'available', label: 'timber: 3' },
+  ]);
+  assert.deepEqual(overlay.layers.logistics.features, [
+    {
+      featureId: 'route:route-coast',
+      routeId: 'route-coast',
+      label: 'Coast Road (land)',
+      cityIds: ['city-harbor', 'city-mill'],
+      active: true,
+      transportMode: 'land',
+      riskLevel: 47,
+      totalCapacity: 6,
+      capacityRemaining: 1,
+      state: 'remaining-margin',
+      bottleneckResourceId: 'grain',
+      style: {
+        stroke: 'ochre',
+        width: 2,
+        pattern: 'solid',
+        opacity: 0.85,
+      },
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- Adds explicit economy map layers for cities, resources, and logistics routes.
- Surfaces resource layer features with per-resource totals and stock intensity.
- Adds logistics layer features with capacity state and bottleneck resource cues.

## Tests
- `npm test -- test/ui/economy/buildEconomyMapOverlay.test.js`
- `npm test` (645/645)

Closes #1160