### PR TITLE
Gamma: add discoveries and cultural map markers

### DIFF
--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -55,6 +55,11 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /is-focused/);
   assert.match(webAppSource, /is-related/);
   assert.match(webAppSource, /atlas-discovery-site__link/);
+  assert.match(webAppSource, /const discoveryClusters =/);
+  assert.match(webAppSource, /data-atlas-discovery-cluster="\$\{cluster\.regionId\}"/);
+  assert.match(webAppSource, /D×\$\{cluster\.discoveryCount\}/);
+  assert.match(webAppSource, /Cluster découvertes/);
+  assert.match(webAppSource, /discoveryClusters,/);
   assert.match(webAppSource, /linkedToFocus/);
   assert.match(webAppSource, /summary\.drift\.causes\.join/);
   assert.match(webAppSource, /mainDriver === 'migration'/);
@@ -154,6 +159,8 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-culture-summary/);
   assert.match(stylesSource, /\.atlas-discovery-site\.is-focused path/);
   assert.match(stylesSource, /\.atlas-discovery-site__link/);
+  assert.match(stylesSource, /\.atlas-discovery-cluster rect/);
+  assert.match(stylesSource, /\.atlas-discovery-cluster\.is-selected rect/);
   assert.match(stylesSource, /\.atlas-culture-summary__drift/);
   assert.match(stylesSource, /\.atlas-culture-drift--migre/);
   assert.match(stylesSource, /\.atlas-culture-drift\.is-linked-focus path/);

--- a/web/app.js
+++ b/web/app.js
@@ -2556,6 +2556,30 @@ function buildAtlasCultureFeatures(cultureView) {
     related: Boolean(selectedDiscoveryId) && link.discoveryId === selectedDiscoveryId && entry.regionId !== selectedRegionId,
   })));
 
+  const discoveryClusters = [...new Set(entries.map((entry) => entry.regionId))]
+    .sort()
+    .map((regionId) => {
+      const regionEntries = entries.filter((entry) => entry.regionId === regionId);
+      const discoveries = [...new Set(regionEntries.flatMap((entry) => entry.regionalDiscoveryLinks.map((link) => link.discoveryId)))]
+        .sort();
+      const cultures = [...new Set(regionEntries.map((entry) => entry.cultureName))].sort();
+
+      return {
+        clusterId: `atlas-culture-discovery-cluster:${regionId}`,
+        regionId,
+        center: getProvinceCenter(regionId),
+        discoveryCount: discoveries.length,
+        discoveries: discoveries.slice(0, 3),
+        cultureCount: cultures.length,
+        cultures: cultures.slice(0, 2),
+        selected: regionId === selectedRegionId,
+        tone: getCultureTone(dominantByRegion.get(regionId) ?? regionEntries[0]),
+        label: `${discoveries.length} découverte${discoveries.length > 1 ? 's' : ''} · ${cultures.length} culture${cultures.length > 1 ? 's' : ''}`,
+      };
+    })
+    .filter((cluster) => cluster.discoveryCount > 0)
+    .slice(0, 6);
+
   const regionSummaries = influenceZones.map((zone) => {
     const regionEntries = entries.filter((entry) => entry.regionId === zone.regionId);
     const discoveryCount = new Set(regionEntries.flatMap((entry) => entry.regionalDiscoveryLinks.map((link) => link.discoveryId))).size;
@@ -2638,6 +2662,7 @@ function buildAtlasCultureFeatures(cultureView) {
     influenceZones,
     cultureMarkers: influenceZones.filter((zone) => zone.influenceTier === 'dominant' || zone.influenceTier === 'strong'),
     discoverySites,
+    discoveryClusters,
     focusedDiscovery: discoverySites.find((site) => site.focused) ?? null,
     regionSummaries,
     driftPreviews,
@@ -3271,6 +3296,13 @@ function renderAtlasCultureLayer(cultureView) {
         <g class="atlas-culture-marker atlas-culture-marker--${marker.tone}" data-atlas-culture-region="${marker.regionId}">
           <circle cx="${marker.center.x}%" cy="${marker.center.y}%" r="${marker.influenceTier === 'dominant' ? 2.35 : 1.85}"></circle>
           <text x="${marker.center.x}%" y="${marker.center.y + 0.82}%" text-anchor="middle">C</text>
+        </g>
+      `).join('')}
+      ${features.discoveryClusters.map((cluster, index) => `
+        <g class="atlas-discovery-cluster atlas-discovery-cluster--${cluster.tone} ${cluster.selected ? 'is-selected' : ''}" data-atlas-discovery-cluster="${cluster.regionId}" aria-label="Cluster découvertes ${cluster.regionId}: ${cluster.label}, cultures ${cluster.cultures.join(', ')}, découvertes ${cluster.discoveries.join(', ')}">
+          <rect x="${Math.min(88, cluster.center.x + 3.4)}" y="${Math.max(6, cluster.center.y - 1.8 + (index % 2) * 2.2)}" width="9.4" height="4.6" rx="1.2"></rect>
+          <text x="${Math.min(89, cluster.center.x + 4.1)}%" y="${Math.max(8.9, cluster.center.y + 1.2 + (index % 2) * 2.2)}%">D×${cluster.discoveryCount}</text>
+          <title>${cluster.label} · ${cluster.discoveries.join(' · ')}</title>
         </g>
       `).join('')}
       ${features.discoverySites.map((site) => {

--- a/web/styles.css
+++ b/web/styles.css
@@ -10688,6 +10688,26 @@ button { font: inherit; }
 .atlas-discovery-site--amber path { fill: #fde68a; }
 .atlas-discovery-site--rose path { fill: #fecdd3; }
 .atlas-discovery-site--cyan path { fill: #a5f3fc; }
+.atlas-discovery-cluster rect {
+  fill: rgba(15, 23, 42, 0.78);
+  stroke: rgba(224, 242, 254, 0.42);
+  stroke-width: 0.28;
+}
+.atlas-discovery-cluster text {
+  fill: #e0f2fe;
+  font-size: 1.55px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.82);
+  stroke-width: 0.34;
+}
+.atlas-discovery-cluster--amber rect { stroke: rgba(253, 230, 138, 0.72); }
+.atlas-discovery-cluster--rose rect { stroke: rgba(254, 205, 211, 0.72); }
+.atlas-discovery-cluster--cyan rect { stroke: rgba(165, 243, 252, 0.72); }
+.atlas-discovery-cluster.is-selected rect {
+  fill: rgba(20, 184, 166, 0.28);
+  stroke-width: 0.46;
+}
 
 .atlas-military-layer {
   pointer-events: none;


### PR DESCRIPTION
Gamma: Implements #1161.

## Summary
- add region-level discovery cluster badges to the culture atlas overlay
- surface discovery counts alongside existing cultural influence markers without adding a new source of truth
- style selected and tone-matched discovery clusters for map readability

## Tests
- `node --check web/app.js`
- `npm test`

Gamma: Ready for Zeta review; please validate before any merge.
