### PR TITLE
Delta: add map intrigue risk overlay

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -78,10 +78,90 @@ function normalizeCleanupInput(value, label) {
   return value.filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry));
 }
 
+function normalizeIntrigueMapEntries(value) {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new TypeError('StrategicMapShell intrigueMapOverlay must be an array.');
+  }
+
+  return value.map((entry) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new TypeError('StrategicMapShell intrigueMapOverlay entries must be objects.');
+    }
+
+    const locationId = String(entry.locationId ?? '').trim();
+
+    return {
+      locationId,
+      locationName: String(entry.locationName ?? locationId).trim() || locationId,
+      presenceLevel: String(entry.presenceLevel ?? 'none').trim() || 'none',
+      sabotageRiskLevel: String(entry.sabotageRiskLevel ?? 'none').trim() || 'none',
+      sabotageRiskScore: Number.isFinite(entry.sabotageRiskScore) ? Math.max(0, Math.min(100, Math.round(entry.sabotageRiskScore))) : 0,
+      celluleCount: Number.isFinite(entry.metrics?.celluleCount) ? Math.max(0, Math.round(entry.metrics.celluleCount)) : 0,
+      sabotageOperationCount: Number.isFinite(entry.metrics?.sabotageOperationCount)
+        ? Math.max(0, Math.round(entry.metrics.sabotageOperationCount))
+        : 0,
+    };
+  }).filter((entry) => entry.locationId);
+}
+
 function getRiskLocationId(riskKey) {
   const [, locationId = null] = String(riskKey ?? '').split(':');
 
   return locationId && locationId.trim() ? locationId.trim() : null;
+}
+
+export function buildIntriguePresenceSabotageOverlay(provinces, intrigueMapOverlay = []) {
+  const normalizedProvinces = requireProvinceList(provinces);
+  const provinceById = new Map(normalizedProvinces.map((province) => [province.id, province]));
+  const entries = normalizeIntrigueMapEntries(intrigueMapOverlay)
+    .filter((entry) => provinceById.has(entry.locationId))
+    .filter((entry) => entry.presenceLevel !== 'none' || entry.sabotageRiskLevel !== 'none' || entry.sabotageRiskScore > 0)
+    .map((entry) => {
+      const province = provinceById.get(entry.locationId);
+      const tone = entry.sabotageRiskLevel === 'high'
+        ? 'danger'
+        : entry.sabotageRiskLevel === 'medium' || entry.presenceLevel === 'high'
+          ? 'warning'
+          : 'watch';
+      const sortPriority = (entry.sabotageRiskScore * 10)
+        + (entry.presenceLevel === 'high' ? 3 : entry.presenceLevel === 'medium' ? 2 : entry.presenceLevel === 'low' ? 1 : 0);
+
+      return {
+        provinceId: province.id,
+        provinceName: province.name,
+        locationId: entry.locationId,
+        label: `${province.name}: présence ${entry.presenceLevel}, sabotage ${entry.sabotageRiskLevel} (${entry.sabotageRiskScore})`,
+        tone,
+        presence: {
+          level: entry.presenceLevel,
+          celluleCount: entry.celluleCount,
+        },
+        sabotageRisk: {
+          level: entry.sabotageRiskLevel,
+          score: entry.sabotageRiskScore,
+          operationCount: entry.sabotageOperationCount,
+        },
+        sortPriority,
+      };
+    })
+    .sort((left, right) => right.sortPriority - left.sortPriority || left.provinceId.localeCompare(right.provinceId))
+    .map(({ sortPriority, ...entry }) => entry);
+
+  return {
+    overlayId: 'intrigue-presence-sabotage',
+    slotId: 'intrigue-overlay',
+    label: 'Présence intrigue et risque sabotage',
+    markers: entries,
+    summary: {
+      markerCount: entries.length,
+      highRiskCount: entries.filter((entry) => entry.sabotageRisk.level === 'high').length,
+      activePresenceCount: entries.filter((entry) => entry.presence.level !== 'none').length,
+    },
+  };
 }
 
 export function buildFirstCleanupPayoff(cleanupOrders = [], residualRisks = []) {
@@ -1268,6 +1348,10 @@ export function buildStrategicMapShell(provinces, options = {}) {
     || 'Vue d’ensemble des provinces et lignes de front';
   const overlaySlots = normalizeOverlaySlots(normalizedOptions.overlaySlots);
   const provinceGeometryById = normalizeGeometryMap(normalizedOptions.provinceGeometryById);
+  const intriguePresenceSabotageOverlay = buildIntriguePresenceSabotageOverlay(
+    normalizedProvinces,
+    normalizedOptions.intrigueMapOverlay,
+  );
   const firstCleanupPayoff = buildFirstCleanupPayoff(normalizedOptions.cleanupOrders, normalizedOptions.residualRisks);
   const followUpCleanupChoices = buildFollowUpCleanupChoices(
     normalizedOptions.cleanupOrders,
@@ -1379,6 +1463,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
         label: slotId.replace(/-/g, ' '),
         enabled: true,
       })),
+      intrigue: intriguePresenceSabotageOverlay,
     },
     firstCleanupPayoff,
     followUpCleanupChoices,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { Province } from '../../../src/domain/war/Province.js';
 import {
   buildFirstCleanupPayoff,
+  buildIntriguePresenceSabotageOverlay,
   buildFollowUpCleanupChoices,
   buildFollowUpCleanupMiniPlan,
   buildMiniPlanConflictTradeoffs,
@@ -126,6 +127,94 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     'intrigue-overlay',
   ]);
   assert.equal(shell.activeProvince.provinceId, 'prov-a');
+});
+
+test('StrategicMapShell projects intrigue presence and sabotage risk into the map overlay slot', () => {
+  const provinces = [
+    createProvince({ id: 'ashlands', name: 'Ashlands' }),
+    createProvince({ id: 'riverlands', name: 'Riverlands' }),
+    createProvince({ id: 'quiet-plains', name: 'Quiet Plains' }),
+  ];
+  const intrigueMapOverlay = [
+    {
+      locationId: 'riverlands',
+      locationName: 'Riverlands',
+      presenceLevel: 'low',
+      sabotageRiskLevel: 'high',
+      sabotageRiskScore: 83.6,
+      metrics: { celluleCount: 1, sabotageOperationCount: 2 },
+    },
+    {
+      locationId: 'ashlands',
+      locationName: 'Ashlands',
+      presenceLevel: 'high',
+      sabotageRiskLevel: 'medium',
+      sabotageRiskScore: 48,
+      metrics: { celluleCount: 3, sabotageOperationCount: 1 },
+    },
+    {
+      locationId: 'off-map',
+      presenceLevel: 'high',
+      sabotageRiskLevel: 'high',
+      sabotageRiskScore: 100,
+      metrics: { celluleCount: 4, sabotageOperationCount: 4 },
+    },
+    {
+      locationId: 'quiet-plains',
+      presenceLevel: 'none',
+      sabotageRiskLevel: 'none',
+      sabotageRiskScore: 0,
+    },
+  ];
+
+  const shell = buildStrategicMapShell(provinces, { intrigueMapOverlay });
+
+  assert.deepEqual(shell.overlays.intrigue, {
+    overlayId: 'intrigue-presence-sabotage',
+    slotId: 'intrigue-overlay',
+    label: 'Présence intrigue et risque sabotage',
+    markers: [
+      {
+        provinceId: 'riverlands',
+        provinceName: 'Riverlands',
+        locationId: 'riverlands',
+        label: 'Riverlands: présence low, sabotage high (84)',
+        tone: 'danger',
+        presence: { level: 'low', celluleCount: 1 },
+        sabotageRisk: { level: 'high', score: 84, operationCount: 2 },
+      },
+      {
+        provinceId: 'ashlands',
+        provinceName: 'Ashlands',
+        locationId: 'ashlands',
+        label: 'Ashlands: présence high, sabotage medium (48)',
+        tone: 'warning',
+        presence: { level: 'high', celluleCount: 3 },
+        sabotageRisk: { level: 'medium', score: 48, operationCount: 1 },
+      },
+    ],
+    summary: {
+      markerCount: 2,
+      highRiskCount: 1,
+      activePresenceCount: 2,
+    },
+  });
+  assert.deepEqual(buildIntriguePresenceSabotageOverlay(provinces, undefined).summary, {
+    markerCount: 0,
+    highRiskCount: 0,
+    activePresenceCount: 0,
+  });
+});
+
+test('StrategicMapShell rejects invalid intrigue map overlay payloads', () => {
+  assert.throws(
+    () => buildStrategicMapShell([createProvince()], { intrigueMapOverlay: {} }),
+    /intrigueMapOverlay must be an array/,
+  );
+  assert.throws(
+    () => buildStrategicMapShell([createProvince()], { intrigueMapOverlay: [null] }),
+    /intrigueMapOverlay entries must be objects/,
+  );
 });
 
 test('StrategicMapShell exposes the first cleanup payoff from cleanup orders and residual risks', () => {


### PR DESCRIPTION
Delta: ## Summary
- Adds a strategic map intrigue overlay payload for clandestine presence + sabotage risk markers.
- Filters off-map/empty intrigue entries, ranks visible markers by sabotage pressure, and exposes summary counts for the intrigue slot.
- Covers invalid intrigue overlay payloads and direct helper behavior in StrategicMapShell tests.

Closes #1162.

## Tests
- npm test -- test/ui/war/StrategicMapShell.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés StrategicMapShell passés et tests complets passés avec `npm test` (646/646); j’attends ta validation avant tout merge.