### PR TITLE
Epsilon: add climate map layers

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1057,6 +1057,168 @@ function buildRegionalRiskMode(regions) {
   }));
 }
 
+
+function normalizeRegionGeometryById(options) {
+  return requireObject(
+    options.regionGeometryById ?? options.provinceGeometryById ?? {},
+    'ClimateMapOverlay regionGeometryById',
+  );
+}
+
+function getRegionCenter(regionId, regionGeometryById) {
+  const geometry = regionGeometryById[regionId] ?? {};
+  const center = geometry.center ?? geometry.labelLayout ?? null;
+
+  if (!center || !Number.isFinite(center.x) || !Number.isFinite(center.y)) {
+    return null;
+  }
+
+  return { x: center.x, y: center.y };
+}
+
+function buildClimateMapLayers(regions, stateEntries, catastropheEntries, seasonPreview, regionGeometryById) {
+  const seasonEntriesByRegion = new Map(stateEntries
+    .filter((entry) => entry.kind === 'season')
+    .map((entry) => [entry.regionId, entry]));
+  const anomalyEntriesByRegion = new Map(stateEntries
+    .filter((entry) => entry.kind === 'anomaly')
+    .map((entry) => [entry.regionId, entry]));
+  const catastrophesByRegion = catastropheEntries.reduce((map, entry) => {
+    const bucket = map.get(entry.regionId) ?? [];
+    bucket.push(entry);
+    map.set(entry.regionId, bucket);
+    return map;
+  }, new Map());
+
+  const seasonSurfaces = regions.map((region) => {
+    const seasonEntry = seasonEntriesByRegion.get(region.regionId);
+    const center = getRegionCenter(region.regionId, regionGeometryById);
+
+    return {
+      regionId: region.regionId,
+      layerId: `${region.regionId}:climate-season-surface`,
+      kind: 'season-surface',
+      season: region.season,
+      label: region.seasonLabel,
+      tone: seasonEntry?.tone ?? 'info',
+      accent: seasonEntry?.badge?.accent ?? 'slate',
+      riskLevel: region.strategicImpact,
+      geometry: {
+        center,
+        shape: regionGeometryById[region.regionId]?.shape ?? null,
+        polygon: regionGeometryById[region.regionId]?.polygon ?? null,
+      },
+      style: {
+        fill: seasonEntry?.badge?.accent ?? 'slate',
+        opacity: region.strategicImpact === 'critical' ? 0.16 : region.strategicImpact === 'strained' ? 0.12 : 0.08,
+      },
+      ariaLabel: `${region.regionId}: saison ${region.seasonLabel}, risque ${region.strategicImpact}`,
+    };
+  });
+
+  const climateLabels = regions.map((region) => {
+    const seasonEntry = seasonEntriesByRegion.get(region.regionId);
+    const anomalyEntry = anomalyEntriesByRegion.get(region.regionId) ?? null;
+    const regionalCatastrophes = catastrophesByRegion.get(region.regionId) ?? [];
+    const center = getRegionCenter(region.regionId, regionGeometryById);
+    const alertBadges = [
+      anomalyEntry ? {
+        kind: 'anomaly',
+        label: anomalyEntry.label,
+        icon: anomalyEntry.marker.icon,
+        tone: anomalyEntry.tone,
+      } : null,
+      ...regionalCatastrophes.map((entry) => ({
+        kind: 'catastrophe',
+        label: entry.label,
+        icon: entry.style.icon,
+        tone: entry.severity === 'critical' ? 'danger' : 'warning',
+      })),
+    ].filter(Boolean);
+
+    return {
+      regionId: region.regionId,
+      layerId: `${region.regionId}:climate-label`,
+      text: region.seasonLabel,
+      meta: region.strategicSignals.summary,
+      x: center?.x ?? null,
+      y: center?.y ?? null,
+      tone: region.strategicImpact === 'critical' ? 'danger' : region.strategicImpact === 'strained' ? 'warning' : seasonEntry?.tone ?? 'calm',
+      badges: [
+        {
+          kind: 'season',
+          label: region.seasonLabel,
+          icon: seasonEntry?.badge?.icon ?? '◐',
+          tone: seasonEntry?.tone ?? 'info',
+        },
+        ...alertBadges,
+      ],
+      ariaLabel: `${region.regionId}: ${region.seasonLabel}; ${region.strategicSignals.summary}`,
+      placement: {
+        anchor: center ? 'region-center' : 'region-label-slot',
+        avoid: ['province-name', 'front-line', 'route-label'],
+        priority: region.strategicImpact === 'critical' ? 'primary' : 'secondary',
+      },
+    };
+  });
+
+  const anomalyMarkers = [...anomalyEntriesByRegion.values()].map((entry) => {
+    const center = getRegionCenter(entry.regionId, regionGeometryById);
+
+    return {
+      regionId: entry.regionId,
+      layerId: `${entry.regionId}:climate-anomaly-marker:${entry.label}`,
+      kind: 'anomaly-marker',
+      label: entry.label,
+      icon: entry.marker.icon,
+      tone: entry.tone,
+      accent: entry.marker.accent,
+      x: center?.x ?? null,
+      y: center?.y ?? null,
+      placement: 'edge-pinned',
+      ariaLabel: `${entry.regionId}: anomalie ${entry.label}`,
+    };
+  });
+
+  const disasterRings = catastropheEntries.map((entry) => ({
+    regionId: entry.regionId,
+    layerId: `${entry.regionId}:climate-disaster-ring:${entry.catastropheId}`,
+    kind: 'disaster-ring',
+    catastropheId: entry.catastropheId,
+    label: entry.label,
+    severity: entry.severity,
+    status: entry.status,
+    stroke: entry.style.stroke,
+    fill: entry.style.fill,
+    icon: entry.style.icon,
+    geometry: {
+      center: getRegionCenter(entry.regionId, regionGeometryById),
+      shape: regionGeometryById[entry.regionId]?.shape ?? null,
+      polygon: regionGeometryById[entry.regionId]?.polygon ?? null,
+    },
+    ariaLabel: `${entry.regionId}: catastrophe ${entry.label}`,
+  }));
+
+  return {
+    seasonSurfaces,
+    climateLabels,
+    anomalyMarkers,
+    disasterRings,
+    ...(seasonPreview?.active ? {
+      seasonPreviewLabels: regions
+        .filter((region) => region.season !== seasonPreview.season)
+        .map((region) => ({
+          regionId: region.regionId,
+          layerId: `${region.regionId}:climate-preview-label:${seasonPreview.season}`,
+          text: `${region.seasonLabel} → ${seasonPreview.label}`,
+          tone: seasonPreview.badge.tone,
+          icon: seasonPreview.badge.icon,
+          placement: 'edge-halo-label',
+        })),
+    } : {}),
+  };
+}
+
 function buildLegend(stateEntries, catastropheEntries, seasonLabels, seasonPreview) {
   const seasonLegend = [...new Set(stateEntries
     .filter((entry) => entry.kind === 'season')
@@ -1142,6 +1304,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     ...requireObject(normalizedOptions.anomalyStyleByType ?? {}, 'ClimateMapOverlay anomalyStyleByType'),
   };
   const progressionByRegion = requireObject(normalizedOptions.progressionByRegion ?? {}, 'ClimateMapOverlay progressionByRegion');
+  const regionGeometryById = normalizeRegionGeometryById(normalizedOptions);
   const tacticalHud = Boolean(normalizedOptions.tacticalHud);
   const visualEffects = Boolean(normalizedOptions.visualEffects);
   const readabilityProfile = buildReadabilityProfile(normalizedOptions);
@@ -1214,6 +1377,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     seasonalPanel: buildSeasonSummary(states, seasonLabels, seasonStyleByType),
     catastropheZones: buildCatastropheZones(catastropheEntries, readabilityProfile),
     regionalRiskMode: buildRegionalRiskMode(regions),
+    mapLayers: buildClimateMapLayers(regions, stateEntries, catastropheEntries, seasonPreview, regionGeometryById),
     selectedClimateImpactComparison,
     selectedClimateTimingRecommendation,
     selectedClimateMitigationChoices,

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -55,7 +55,44 @@ test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into 
     },
   });
 
-  assert.deepEqual(overlay, {
+  const { mapLayers, ...stableOverlay } = overlay;
+
+  assert.deepEqual(mapLayers.climateLabels.map((label) => ({
+    regionId: label.regionId,
+    text: label.text,
+    tone: label.tone,
+    badgeKinds: label.badges.map((badge) => badge.kind),
+  })), [
+    {
+      regionId: 'north-coast',
+      text: 'Printemps',
+      tone: 'danger',
+      badgeKinds: ['season', 'catastrophe'],
+    },
+    {
+      regionId: 'sunreach',
+      text: 'Été',
+      tone: 'danger',
+      badgeKinds: ['season', 'anomaly', 'catastrophe'],
+    },
+  ]);
+  assert.deepEqual(mapLayers.anomalyMarkers.map((marker) => marker.layerId), [
+    'sunreach:climate-anomaly-marker:heatwave',
+  ]);
+  assert.deepEqual(mapLayers.disasterRings.map((ring) => ring.layerId), [
+    'north-coast:climate-disaster-ring:storm-1',
+    'sunreach:climate-disaster-ring:storm-1',
+  ]);
+  assert.deepEqual(mapLayers.seasonSurfaces.map((surface) => ({
+    regionId: surface.regionId,
+    season: surface.season,
+    riskLevel: surface.riskLevel,
+  })), [
+    { regionId: 'north-coast', season: 'spring', riskLevel: 'critical' },
+    { regionId: 'sunreach', season: 'summer', riskLevel: 'critical' },
+  ]);
+
+  assert.deepEqual(stableOverlay, {
     title: 'Carte climat et catastrophes',
     summary: '2 régions, 2 catastrophes visibles, 1 anomalies',
     entries: [
@@ -543,6 +580,7 @@ test('buildClimateMapOverlay rejects invalid inputs', () => {
   assert.throws(() => buildClimateMapOverlay([], { seasonLabels: [] }), /seasonLabels must be an object/);
   assert.throws(() => buildClimateMapOverlay([], { seasonStyleByType: [] }), /seasonStyleByType must be an object/);
   assert.throws(() => buildClimateMapOverlay([], { anomalyStyleByType: [] }), /anomalyStyleByType must be an object/);
+  assert.throws(() => buildClimateMapOverlay([], { regionGeometryById: [] }), /regionGeometryById must be an object/);
   assert.throws(() => buildClimateMapOverlay([], { seasonPreview: [] }), /seasonPreview must be an object/);
   assert.throws(() => buildClimateMapOverlay([], { seasonPreview: {} }), /seasonPreview.season is required/);
 });
@@ -1236,4 +1274,46 @@ test('buildClimateMapOverlay keeps recovery forecast graceful for stable and mis
       summary: 'Attendre et surveiller: récupération ~7j, rechute low avant winter.',
     },
   ]);
+});
+
+test('buildClimateMapOverlay places climate map layers on province geometry', () => {
+  const overlay = buildClimateMapOverlay([
+    {
+      regionId: 'delta',
+      season: 'autumn',
+      temperatureC: 18,
+      precipitationLevel: 48,
+      droughtIndex: 29,
+      anomaly: 'storm',
+    },
+  ], {
+    provinceGeometryById: {
+      delta: {
+        center: { x: 42, y: 24 },
+        shape: 'polygon(40% 20%, 44% 20%, 44% 28%, 40% 28%)',
+        polygon: '40,20 44,20 44,28 40,28',
+      },
+    },
+    catastrophes: [
+      {
+        id: 'flood-1',
+        type: 'flood',
+        severity: 'critical',
+        status: 'active',
+        regionIds: ['delta'],
+        startedAt: '2026-04-19T00:00:00.000Z',
+        impact: { unrest: 2 },
+      },
+    ],
+  });
+
+  assert.deepEqual(overlay.mapLayers.seasonSurfaces[0].geometry, {
+    center: { x: 42, y: 24 },
+    shape: 'polygon(40% 20%, 44% 20%, 44% 28%, 40% 28%)',
+    polygon: '40,20 44,20 44,28 40,28',
+  });
+  assert.equal(overlay.mapLayers.climateLabels[0].x, 42);
+  assert.equal(overlay.mapLayers.climateLabels[0].placement.anchor, 'region-center');
+  assert.equal(overlay.mapLayers.anomalyMarkers[0].y, 24);
+  assert.deepEqual(overlay.mapLayers.disasterRings[0].geometry.center, { x: 42, y: 24 });
 });


### PR DESCRIPTION
Epsilon: Adds map-layer payloads to the climate overlay so seasons, anomalies, and disasters can render directly on province geometry without replacing the existing compact overlay data.

- adds season surfaces, climate labels, anomaly markers, disaster rings, and season preview labels
- accepts `regionGeometryById` / `provinceGeometryById` for placement
- covers geometry-backed climate labels and existing season/anomaly/disaster composition

Tests:
- `npm test -- test/ui/climate/buildClimateMapOverlay.test.js`
- `npm test` (646/646)

Closes #1163