### PR TITLE
Delta: add intrigue safe map mode

### DIFF
--- a/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
+++ b/test/ui/intrigue/webIntrigueFogAwareFocus.test.js
@@ -595,6 +595,25 @@ test('atlas intrigue filters prioritize stale uncertain recent and probable sign
   assert.match(stylesSource, /world-map-intrigue-filter-chip\.is-active/);
 });
 
+test('intrigue map adds safe mode, risk explanations, exposure warnings, and confidential fallback', () => {
+  assert.match(webAppSource, /intrigueSafeMapMode: true/);
+  assert.match(webAppSource, /function buildIntrigueRiskExplanations/);
+  assert.match(webAppSource, /function buildIntrigueObservationExposureWarnings/);
+  assert.match(webAppSource, /function renderIntrigueSafeMapModeControls/);
+  assert.match(webAppSource, /data-toggle-intrigue-safe-map-mode/);
+  assert.match(webAppSource, /state\.intrigueSafeMapMode = !state\.intrigueSafeMapMode/);
+  assert.match(webAppSource, /Mode carte sûr intrigue/);
+  assert.match(webAppSource, /Données intrigue absentes ou confidentielles/);
+  assert.match(webAppSource, /évite de déduire cellule, relais, cible ou cause cachée/);
+  assert.match(webAppSource, /Alertes observation élargie et coût d’exposition/);
+  assert.match(webAppSource, /Aucune donnée d’observation élargie lisible/);
+  assert.match(webAppSource, /intrigue-map-layer--safe-mode/);
+  assert.match(stylesSource, /\.intrigue-map-layer--safe-mode/);
+  assert.match(stylesSource, /\.intrigue-safe-map-mode/);
+  assert.match(stylesSource, /\.intrigue-risk-explanations/);
+  assert.match(stylesSource, /\.intrigue-observation-exposure-warnings/);
+});
+
 test('world map intrigue signals show presence risk shadows and probable sabotage safely', () => {
   assert.match(webAppSource, /function buildWorldMapIntrigueSignals/);
   assert.match(webAppSource, /function renderWorldMapIntrigueSignals/);

--- a/web/app.js
+++ b/web/app.js
@@ -454,6 +454,7 @@ const state = {
     alerts: true,
     sabotage: true,
   },
+  intrigueSafeMapMode: true,
   intrigueExposureOutcomeFilters: {
     lowered: false,
     unchanged: false,
@@ -14176,6 +14177,107 @@ function renderWorldMapIntrigueSignals(signals) {
   `;
 }
 
+function buildIntrigueRiskExplanations(intrigueView = null) {
+  const entries = intrigueView?.map?.entries ?? [];
+
+  if (entries.length === 0) {
+    return [{
+      key: 'fallback-confidential',
+      tone: 'shadow',
+      title: 'Données intrigue absentes ou confidentielles',
+      explanation: 'Mode sûr: la carte conserve seulement un repère neutre et évite de déduire cellule, relais, cible ou cause cachée.',
+    }];
+  }
+
+  return entries.slice(0, 4).map((entry) => {
+    const factors = [
+      entry.presenceLevel !== 'none' ? `présence ${entry.presenceLevel}` : 'présence non confirmée',
+      entry.sabotageRiskLevel !== 'none' ? `sabotage ${entry.sabotageRiskLevel}` : 'sabotage non confirmé',
+      entry.metrics.exposedCellCount > 0 ? 'exposition visible' : 'identifiants masqués',
+    ];
+
+    return {
+      key: entry.locationId,
+      tone: entry.sabotageRiskLevel === 'high' ? 'danger' : entry.sabotageRiskLevel === 'medium' || entry.presenceLevel === 'high' ? 'warning' : 'watch',
+      title: entry.locationName,
+      explanation: `${factors.join(' · ')}; lecture par indices uniquement, sans révéler les détails cachés.`,
+    };
+  });
+}
+
+function buildIntrigueObservationExposureWarnings(intrigueView = null) {
+  const entries = intrigueView?.map?.entries ?? [];
+  const warnings = entries.map((entry) => {
+    const tradeoff = entry.lowExposureSweepConfidencePreview?.thirdSweepRecommendation?.monitoringRationale?.observationBroadeningTradeoff ?? null;
+
+    if (!tradeoff) {
+      return null;
+    }
+
+    return {
+      locationId: entry.locationId,
+      locationName: entry.locationName,
+      tone: tradeoff.tradeoff === 'exposure-too-high' ? 'warning' : 'watch',
+      label: tradeoff.label,
+      message: `${entry.locationName}: ${tradeoff.message}`,
+      action: tradeoff.action,
+    };
+  }).filter(Boolean);
+
+  return warnings.length > 0 ? warnings : [{
+    locationId: null,
+    locationName: 'Carte intrigue',
+    tone: 'shadow',
+    label: 'Observation: fallback sûr.',
+    message: 'Aucune donnée d’observation élargie lisible: rester en mode discret et attendre un signal confirmé.',
+    action: 'safe-map-fallback',
+  }];
+}
+
+function renderIntrigueSafeMapModeControls() {
+  return `
+    <section class="intrigue-safe-map-mode" aria-label="Mode carte intrigue discret">
+      <div>
+        <strong>Mode carte sûr intrigue</strong>
+        <span>${state.intrigueSafeMapMode ? 'Intensité réduite, icônes compactes et détails secondaires masqués.' : 'Lecture complète de la couche intrigue active.'}</span>
+      </div>
+      <button type="button" class="intrigue-safe-map-mode__toggle ${state.intrigueSafeMapMode ? 'is-active' : ''}" data-toggle-intrigue-safe-map-mode aria-pressed="${state.intrigueSafeMapMode}">
+        ${state.intrigueSafeMapMode ? 'Mode sûr actif' : 'Activer mode sûr'}
+      </button>
+    </section>
+  `;
+}
+
+function renderIntrigueRiskExplanations(explanations) {
+  return `
+    <section class="intrigue-risk-explanations" aria-label="Explication fog-safe des risques intrigue sabotage">
+      <strong>Pourquoi ces risques apparaissent</strong>
+      <div class="intrigue-risk-explanations__grid">
+        ${explanations.map((item) => `
+          <article class="intrigue-risk-explanation intrigue-risk-explanation--${item.tone}">
+            <span>${item.title}</span>
+            <p>${item.explanation}</p>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
+function renderIntrigueObservationExposureWarnings(warnings) {
+  return `
+    <section class="intrigue-observation-exposure-warnings" aria-label="Alertes observation élargie et coût d’exposition">
+      <strong>Observation élargie</strong>
+      ${warnings.map((warning) => `
+        <article class="intrigue-observation-exposure-warning intrigue-observation-exposure-warning--${warning.tone}">
+          <span>${warning.label}</span>
+          <p>${warning.message}</p>
+        </article>
+      `).join('')}
+    </section>
+  `;
+}
+
 function renderWorldMapIntrigueSignalRollup(rollup) {
   if (rollup.totalCount === 0) {
     return '';
@@ -17133,6 +17235,7 @@ function renderIntrigueMapOverlay(intrigueView) {
     `;
   }
 
+  const safeMode = state.intrigueSafeMapMode;
   const heatmapMarkup = intrigueView.map.entries.map((entry) => `
     <g class="intrigue-heat-node intrigue-heat-node--${entry.sabotageRiskLevel} ${entry.isSelected ? 'is-selected' : ''}">
       <circle class="intrigue-heat-node__outer" cx="${entry.center.x}%" cy="${entry.center.y}%" r="${entry.heatRadius}" style="opacity:${Math.min(0.62, entry.heatIntensity)}"></circle>
@@ -17172,13 +17275,9 @@ function renderIntrigueMapOverlay(intrigueView) {
   `).join('');
 
   return `
-    <svg class="intrigue-map-layer" viewBox="0 0 100 100" aria-label="Overlay intrigue et heatmap de sabotage">
-      <g class="intrigue-heat-layer">
-        ${heatmapMarkup}
-      </g>
-      <g class="intrigue-network-layer">
-        ${linkMarkup}
-      </g>
+    <svg class="intrigue-map-layer ${safeMode ? 'intrigue-map-layer--safe-mode' : ''}" viewBox="0 0 100 100" aria-label="Overlay intrigue et heatmap de sabotage${safeMode ? ' en mode discret sûr' : ''}">
+      ${safeMode ? '' : `<g class="intrigue-heat-layer">${heatmapMarkup}</g>`}
+      ${safeMode ? '' : `<g class="intrigue-network-layer">${linkMarkup}</g>`}
       <g class="intrigue-threat-layer">
         ${threatGlyphMarkup}
       </g>
@@ -17199,6 +17298,8 @@ function renderIntrigueSidePanel(intrigueView) {
   const worldMapSignals = buildWorldMapIntrigueSignals(intrigueView, { ignoreFilters: true });
   const worldMapSignalRollup = buildWorldMapIntrigueSignalRollup(worldMapSignals);
   const counterintelligencePlan = buildAtlasCounterintelligenceSweepPlan(worldMapSignals);
+  const riskExplanations = buildIntrigueRiskExplanations(intrigueView);
+  const observationExposureWarnings = buildIntrigueObservationExposureWarnings(intrigueView);
 
   return `
     <section class="panel overlay-panel overlay-panel--intrigue">
@@ -17217,6 +17318,9 @@ function renderIntrigueSidePanel(intrigueView) {
         <button type="button" class="intrigue-filter-chip ${intrigueView.filters.alerts ? 'is-active' : ''}" data-intrigue-filter="alerts">Alertes</button>
         <button type="button" class="intrigue-filter-chip ${intrigueView.filters.sabotage ? 'is-active' : ''}" data-intrigue-filter="sabotage">Sabotage</button>
       </section>
+      ${renderIntrigueSafeMapModeControls()}
+      ${renderIntrigueRiskExplanations(riskExplanations)}
+      ${renderIntrigueObservationExposureWarnings(observationExposureWarnings)}
       ${renderWorldMapIntrigueSignalRollup(worldMapSignalRollup)}
       ${renderAtlasCounterintelligenceSweepPlan(counterintelligencePlan)}
       ${renderIntrigueExposureMarkerRollup(exposureMarkerRollup)}
@@ -19046,6 +19150,13 @@ function render() {
     element.addEventListener('click', () => {
       const key = element.dataset.intrigueFilter;
       state.intrigueFilters[key] = !state.intrigueFilters[key];
+      render();
+    });
+  });
+
+  document.querySelectorAll('[data-toggle-intrigue-safe-map-mode]').forEach((element) => {
+    element.addEventListener('click', () => {
+      state.intrigueSafeMapMode = !state.intrigueSafeMapMode;
       render();
     });
   });

--- a/web/styles.css
+++ b/web/styles.css
@@ -2928,6 +2928,22 @@ button { font: inherit; }
   filter: drop-shadow(0 10px 18px rgba(2, 6, 23, 0.22));
   pointer-events: none;
 }
+.intrigue-map-layer--safe-mode {
+  filter: drop-shadow(0 8px 14px rgba(2, 6, 23, 0.18));
+}
+.intrigue-map-layer--safe-mode .intrigue-hotspot__halo,
+.intrigue-map-layer--safe-mode .intrigue-threat-glyph__backplate,
+.intrigue-map-layer--safe-mode .world-map-intrigue-signal__aura {
+  opacity: 0.58;
+}
+.intrigue-map-layer--safe-mode .intrigue-hotspot__label,
+.intrigue-map-layer--safe-mode .intrigue-hotspot__meta,
+.intrigue-map-layer--safe-mode .world-map-intrigue-signal__copy {
+  display: none;
+}
+.intrigue-map-layer--safe-mode .intrigue-threat-glyph__tick {
+  opacity: 0.35;
+}
 .intrigue-critical-signal__pulse {
   fill: rgba(251, 113, 133, 0.14);
   stroke: rgba(251, 113, 133, 0.86);
@@ -3119,6 +3135,61 @@ button { font: inherit; }
 .world-map-intrigue-filter-chip b {
   color: #f8fafc;
 }
+.intrigue-safe-map-mode,
+.intrigue-risk-explanations,
+.intrigue-observation-exposure-warnings {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(15, 23, 42, 0.5);
+}
+.intrigue-safe-map-mode {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  border-color: rgba(45, 212, 191, 0.32);
+}
+.intrigue-safe-map-mode span,
+.intrigue-risk-explanation p,
+.intrigue-observation-exposure-warning p {
+  color: #cbd5e1;
+  margin: 0;
+}
+.intrigue-safe-map-mode__toggle {
+  border: 1px solid rgba(45, 212, 191, 0.34);
+  color: #ccfbf1;
+  background: rgba(20, 184, 166, 0.14);
+  border-radius: 999px;
+  padding: 7px 10px;
+  font-weight: 800;
+  cursor: pointer;
+}
+.intrigue-safe-map-mode__toggle.is-active {
+  background: rgba(20, 184, 166, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(153, 246, 228, 0.18);
+}
+.intrigue-risk-explanations__grid {
+  display: grid;
+  gap: 6px;
+}
+.intrigue-risk-explanation,
+.intrigue-observation-exposure-warning {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border-radius: 11px;
+  border-left: 3px solid rgba(148, 163, 184, 0.5);
+  background: rgba(2, 6, 23, 0.25);
+}
+.intrigue-risk-explanation--danger,
+.intrigue-observation-exposure-warning--danger { border-left-color: rgba(248, 113, 113, 0.86); }
+.intrigue-risk-explanation--warning,
+.intrigue-observation-exposure-warning--warning { border-left-color: rgba(251, 191, 36, 0.86); }
+.intrigue-risk-explanation--watch,
+.intrigue-observation-exposure-warning--watch { border-left-color: rgba(96, 165, 250, 0.76); }
+.intrigue-risk-explanation--shadow,
+.intrigue-observation-exposure-warning--shadow { border-left-color: rgba(148, 163, 184, 0.58); }
 .atlas-counterintelligence-plan {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: ## Summary
- Adds a safe intrigue map mode toggle that suppresses heavy heat/link layers and uses compact, lower-intensity markers.
- Adds fog-safe risk explanation cards and observation-broadening exposure warnings in the intrigue panel.
- Adds fallback copy for absent/confidential intrigue data so the map does not infer hidden cells, relays, targets, or causes.

Closes #1172.

## Tests
- npm test -- test/ui/intrigue/webIntrigueFogAwareFocus.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés web intrigue passés et tests complets passés avec `npm test` (646/646); j’attends ta validation avant tout merge.