### PR TITLE
Alpha: add tactical province hover intel

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1317,11 +1317,138 @@ function buildLegend(renderedProvinces, options) {
   };
 }
 
+function getProvinceMilitaryPressure(province) {
+  let score = 0;
+
+  if (province.contested) score += 72;
+  if (province.occupied) score += 48;
+  if (province.supplyLevel === 'collapsed') score += 20;
+  if (province.supplyLevel === 'disrupted') score += 14;
+  if (province.supplyLevel === 'strained') score += 8;
+  if (province.loyalty < 45) score += 10;
+  score += Math.min(18, Math.max(0, province.strategicValue) * 2);
+
+  const normalizedScore = Math.max(0, Math.min(100, score));
+
+  return {
+    score: normalizedScore,
+    level: normalizedScore >= 75 ? 'critical' : normalizedScore >= 50 ? 'high' : normalizedScore >= 28 ? 'watch' : 'low',
+    label: normalizedScore >= 75 ? 'pression critique' : normalizedScore >= 50 ? 'pression élevée' : normalizedScore >= 28 ? 'à surveiller' : 'pression basse',
+  };
+}
+
+function buildDefaultProvinceAction(province, pressure) {
+  if (province.contested) {
+    return {
+      code: 'reinforce-front',
+      label: 'Renforcer le front',
+      status: 'available',
+      reason: 'front contesté et pression militaire visible',
+    };
+  }
+
+  if (province.supplyLevel === 'collapsed' || province.supplyLevel === 'disrupted') {
+    return {
+      code: 'avoid-push',
+      label: 'Reporter l’offensive',
+      status: 'discouraged',
+      reason: 'ravitaillement insuffisant pour une action sûre',
+    };
+  }
+
+  if (province.occupied) {
+    return {
+      code: 'secure-occupation',
+      label: 'Stabiliser l’occupation',
+      status: 'available',
+      reason: 'contrôle différent du propriétaire',
+    };
+  }
+
+  if (pressure.level === 'low') {
+    return {
+      code: 'hold-reserve',
+      label: 'Garder en réserve',
+      status: 'idle',
+      reason: 'aucune urgence militaire locale',
+    };
+  }
+
+  return {
+    code: 'probe-neighbor-fronts',
+    label: 'Tester les fronts voisins',
+    status: 'available',
+    reason: 'pression locale exploitable',
+  };
+}
+
+function normalizeProvinceAction(action, province, pressure) {
+  const fallback = buildDefaultProvinceAction(province, pressure);
+
+  if (action === undefined) {
+    return fallback;
+  }
+
+  if (action === null || typeof action !== 'object' || Array.isArray(action)) {
+    throw new TypeError('StrategicMapShell tacticalActionByProvinceId entries must be objects.');
+  }
+
+  const status = String(action.status ?? fallback.status).trim() || fallback.status;
+
+  return {
+    code: String(action.code ?? fallback.code).trim() || fallback.code,
+    label: String(action.label ?? fallback.label).trim() || fallback.label,
+    status: ['available', 'discouraged', 'idle', 'blocked'].includes(status) ? status : fallback.status,
+    reason: String(action.reason ?? fallback.reason).trim() || fallback.reason,
+  };
+}
+
+function buildProvinceTacticalHoverIntel(province, options) {
+  const pressure = getProvinceMilitaryPressure(province);
+  const tacticalActionByProvinceId = normalizeTextMap(
+    options.tacticalActionByProvinceId,
+    'StrategicMapShell tacticalActionByProvinceId',
+  );
+  const nextAction = normalizeProvinceAction(tacticalActionByProvinceId[province.provinceId], province, pressure);
+
+  return {
+    empty: false,
+    title: province.label,
+    control: {
+      ownerFactionId: province.ownerFactionId,
+      controllingFactionId: province.controllingFactionId,
+      status: province.statusLabel,
+    },
+    militaryPressure: pressure,
+    garrisonStatus: province.contested ? 'front actif' : province.occupied ? 'garnison d’occupation' : 'garnison stable',
+    nextAction,
+    summary: `${province.statusLabel} · ${pressure.label} · ${nextAction.label}`,
+  };
+}
+
+function buildProvinceActionAffordance(tacticalHoverIntel) {
+  const action = tacticalHoverIntel.nextAction;
+
+  return {
+    state: action.status,
+    label: action.status === 'available'
+      ? 'action disponible'
+      : action.status === 'discouraged'
+        ? 'action déconseillée'
+        : action.status === 'blocked'
+          ? 'action bloquée'
+          : 'aucune action urgente',
+    cssClass: `province-node--action-${action.status}`,
+    reason: action.reason,
+  };
+}
+
 function enhanceProvince(renderedProvince, options, provinceGeometryById) {
   const selectedProvinceId = String(options.selectedProvinceId ?? '').trim();
   const focusedProvinceId = String(options.focusedProvinceId ?? '').trim();
   const hoveredProvinceId = String(options.hoveredProvinceId ?? '').trim();
   const geometry = provinceGeometryById[renderedProvince.provinceId] ?? {};
+  const tacticalHoverIntel = buildProvinceTacticalHoverIntel(renderedProvince, options);
 
   return {
     ...renderedProvince,
@@ -1337,6 +1464,8 @@ function enhanceProvince(renderedProvince, options, provinceGeometryById) {
       focused: renderedProvince.provinceId === focusedProvinceId,
       hovered: renderedProvince.provinceId === hoveredProvinceId,
     },
+    tacticalHoverIntel,
+    actionAffordance: buildProvinceActionAffordance(tacticalHoverIntel),
   };
 }
 
@@ -1346,6 +1475,7 @@ function buildProvinceCssClasses(province) {
     province.contested ? 'province-node--contested' : null,
     province.occupied ? 'province-node--occupied' : null,
     `province-node--supply-${province.supplyLevel}`,
+    province.actionAffordance.cssClass,
     province.selectionState.selected ? 'is-selected' : null,
     province.selectionState.focused ? 'is-focused' : null,
     province.selectionState.hovered ? 'is-hovered' : null,
@@ -1393,7 +1523,10 @@ function buildProvinceMapLayers(renderedProvinces) {
         supplyLevel: province.supplyLevel,
         supplyTone: province.supplyTone,
         status: province.contested ? 'contested' : province.occupied ? 'occupied' : 'stable',
+        actionState: province.actionAffordance.state,
       },
+      tacticalHoverIntel: province.tacticalHoverIntel,
+      actionAffordance: province.actionAffordance,
       geometry: {
         polygon: province.geometry.polygon,
         shape: province.geometry.shape,

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -101,15 +101,40 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
   })), [
     {
       provinceId: 'prov-a',
-      cssClasses: ['province-node', 'province-node--supply-stable', 'is-focused', 'is-hovered'],
+      cssClasses: ['province-node', 'province-node--supply-stable', 'province-node--action-idle', 'is-focused', 'is-hovered'],
       status: 'stable',
       ariaLabel: 'Avant-poste — Contrôle stable, ravitaillement stable, loyauté 82%, valeur 2',
     },
     {
       provinceId: 'prov-c',
-      cssClasses: ['province-node', 'province-node--contested', 'province-node--occupied', 'province-node--supply-strained', 'is-selected'],
+      cssClasses: ['province-node', 'province-node--contested', 'province-node--occupied', 'province-node--supply-strained', 'province-node--action-available', 'is-selected'],
       status: 'contested',
       ariaLabel: 'Colline rouge — Front contesté, ravitaillement strained, loyauté 40%, valeur 4',
+    },
+  ]);
+  assert.deepEqual(shell.mapLayers.provinceSurfaces.map((surface) => ({
+    provinceId: surface.provinceId,
+    actionState: surface.data.actionState,
+    affordanceLabel: surface.actionAffordance.label,
+    pressure: surface.tacticalHoverIntel.militaryPressure.label,
+    nextAction: surface.tacticalHoverIntel.nextAction.label,
+    garrisonStatus: surface.tacticalHoverIntel.garrisonStatus,
+  })), [
+    {
+      provinceId: 'prov-a',
+      actionState: 'idle',
+      affordanceLabel: 'aucune action urgente',
+      pressure: 'pression basse',
+      nextAction: 'Garder en réserve',
+      garrisonStatus: 'garnison stable',
+    },
+    {
+      provinceId: 'prov-c',
+      actionState: 'available',
+      affordanceLabel: 'action disponible',
+      pressure: 'pression critique',
+      nextAction: 'Renforcer le front',
+      garrisonStatus: 'front actif',
     },
   ]);
   assert.deepEqual(shell.mapLayers.provinceLabels, [

--- a/test/ui/war/webProvinceTacticalHoverIntel.test.js
+++ b/test/ui/war/webProvinceTacticalHoverIntel.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('province nodes expose tactical hover intel and action affordances', () => {
+  assert.match(webAppSource, /province-node__tactical-tooltip/);
+  assert.match(webAppSource, /data-tactical-action/);
+  assert.match(webAppSource, /data-action-affordance/);
+  assert.match(webAppSource, /province-node__action-affordance/);
+});
+
+test('province tactical hover affordances have readable hover styles', () => {
+  assert.match(stylesSource, /\.province-node__tactical-tooltip/);
+  assert.match(stylesSource, /\.province-node--action-available::before/);
+  assert.match(stylesSource, /\.province-node__action-affordance--discouraged/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -5511,6 +5511,15 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
   const climateCascadeGroupMarker = selectedClimateCascadeGroup?.markers.find((marker) => marker.provinceId === province.provinceId) ?? null;
   const worldClimateEntry = worldClimateLayer?.entries.find((entry) => entry.provinceId === province.provinceId) ?? null;
   const warOverlayOverflow = buildProvinceWarOverlayOverflowSummary(province, { readinessTone, militaryOutcomeMarker, logisticsOutcomeMarker });
+  const tacticalIntel = province.tacticalHoverIntel ?? {
+    empty: true,
+    summary: 'Données guerre indisponibles',
+    control: { status: tacticalState },
+    militaryPressure: { label: 'pression inconnue', score: 0 },
+    garrisonStatus: 'garnison inconnue',
+    nextAction: { label: 'Aucune action fiable', status: 'idle', reason: 'données guerre manquantes' },
+  };
+  const actionAffordance = province.actionAffordance ?? { state: 'idle', label: 'aucune action urgente', cssClass: 'province-node--action-idle', reason: tacticalIntel.nextAction.reason };
   const isReadinessHighlight = Boolean(readinessTone);
   const isMilitaryOutcomeHighlight = Boolean(militaryOutcomeMarker);
   const isLogisticsOutcomeHighlight = Boolean(logisticsOutcomeMarker);
@@ -5546,6 +5555,7 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
     isMuted ? 'is-muted' : '',
     province.contested ? 'is-contested' : '',
     province.occupied ? 'is-occupied' : '',
+    actionAffordance.cssClass,
   ].filter(Boolean).join(' ');
 
   return `
@@ -5554,6 +5564,8 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
       type="button"
       data-province-id="${province.provinceId}"
       data-tactical-state="${readinessLabel ?? tacticalState}"
+      data-tactical-action="${tacticalIntel.nextAction.label}"
+      data-action-affordance="${actionAffordance.state}"
       data-readiness-highlight="${readinessTone ?? ''}"
       data-economy-blocker="${economyBlockerLabel ?? ''}"
       data-military-outcome="${militaryOutcomeMarker?.label ?? ''}"
@@ -5570,6 +5582,13 @@ function renderProvinceCard(province, focusContext, postCommitClimateMarkers = [
       <span class="province-node__signal">${selectionSignal}</span>
       <span class="province-node__name">${province.label}</span>
       <span class="province-node__meta">${province.supplyTone} · loyauté ${province.loyalty}</span>
+      <span class="province-node__tactical-tooltip province-node__tactical-tooltip--${actionAffordance.state}" role="tooltip">
+        <b>${tacticalIntel.summary}</b>
+        <small>Contrôle: ${tacticalIntel.control.status} · Menace: ${tacticalIntel.militaryPressure.label} (${tacticalIntel.militaryPressure.score})</small>
+        <small>Garnison/front: ${tacticalIntel.garrisonStatus}</small>
+        <em>${actionAffordance.label}: ${tacticalIntel.nextAction.label}</em>
+      </span>
+      <span class="province-node__action-affordance province-node__action-affordance--${actionAffordance.state}" aria-label="${actionAffordance.label}: ${actionAffordance.reason}">${actionAffordance.label}</span>
       ${economyBlocker ? `<span class="province-node__economy-blocker"><b>${economyBlocker.blocker}</b>${economyBlocker.summary}<small>${economyBlocker.effect}</small></span>` : ''}
       ${renderProvinceLogisticsOutcomeMarker(logisticsOutcomeMarker)}
       ${climateMarker ? `<span class="province-node__climate-marker"><b>${climateMarker.label}</b>${climateMarker.summary}<small>${climateMarker.detail}</small></span>` : ''}

--- a/web/styles.css
+++ b/web/styles.css
@@ -12299,3 +12299,82 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+
+.province-node--action-available::before {
+  border-color: rgba(74, 222, 128, 0.48);
+  box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.12);
+}
+.province-node--action-discouraged::before,
+.province-node--action-blocked::before {
+  border-color: rgba(251, 191, 36, 0.52);
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.09), transparent 40%, rgba(248, 113, 113, 0.07));
+}
+.province-node--action-idle::before {
+  border-color: rgba(148, 163, 184, 0.18);
+}
+.province-node__tactical-tooltip {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 3;
+  display: grid;
+  gap: 3px;
+  padding: 9px 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  background: rgba(5, 10, 20, 0.82);
+  color: rgba(226, 232, 240, 0.94);
+  box-shadow: 0 16px 34px rgba(2, 6, 23, 0.42);
+  opacity: 0;
+  transform: translateY(8px);
+  pointer-events: none;
+  transition: opacity 160ms ease, transform 160ms ease, border-color 160ms ease;
+}
+.province-node:hover .province-node__tactical-tooltip,
+.province-node.is-hovered .province-node__tactical-tooltip,
+.province-node.is-focused .province-node__tactical-tooltip,
+.province-node.is-selected .province-node__tactical-tooltip {
+  opacity: 1;
+  transform: translateY(0);
+}
+.province-node__tactical-tooltip b {
+  color: #f8fafc;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.province-node__tactical-tooltip small,
+.province-node__tactical-tooltip em {
+  color: rgba(203, 213, 225, 0.88);
+  font-size: 10px;
+  font-style: normal;
+  line-height: 1.25;
+}
+.province-node__tactical-tooltip--available { border-color: rgba(74, 222, 128, 0.42); }
+.province-node__tactical-tooltip--discouraged,
+.province-node__tactical-tooltip--blocked { border-color: rgba(251, 191, 36, 0.48); }
+.province-node__action-affordance {
+  position: relative;
+  z-index: 2;
+  align-self: flex-start;
+  display: none;
+  margin-top: 6px;
+  padding: 3px 7px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(5, 10, 20, 0.58);
+  color: rgba(226, 232, 240, 0.84);
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.province-node.is-hovered .province-node__action-affordance,
+.province-node.is-focused .province-node__action-affordance,
+.province-node.is-selected .province-node__action-affordance {
+  display: inline-flex;
+}
+.province-node__action-affordance--available { border-color: rgba(74, 222, 128, 0.42); color: #bbf7d0; }
+.province-node__action-affordance--discouraged,
+.province-node__action-affordance--blocked { border-color: rgba(251, 191, 36, 0.48); color: #fde68a; }


### PR DESCRIPTION
Alpha: Implements #1169.

Summary:
- adds tactical hover intel to strategic map province surfaces (control, pressure, garrison/front, next action)
- derives action affordances for available, discouraged, blocked, and idle military actions
- renders compact hover/focus tooltip and map affordance styles without adding a new subsystem
- keeps fallback copy for missing tactical data

Tests:
- npm test
- git diff --check

Zeta: ready for validation before merge.
