### PR TITLE
Delta: add suspicion heat decay playback

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2110,6 +2110,83 @@ function buildLowExposureSweepConfidencePreview({ celluleCount, exposedCellCount
   };
 }
 
+function buildSuspicionHeatDecayPlayback({ locationCellules, locationOperations, sabotageRiskScore }) {
+  const currentHeat = clampPercent(Math.max(
+    sabotageRiskScore,
+    ...locationOperations.map((operation) => operation.heat),
+    ...locationCellules.map((cellule) => cellule.exposure),
+    0,
+  ));
+  const decayStep = locationOperations.length > 0 ? 12 : locationCellules.some((cellule) => cellule.isExposed) ? 9 : 7;
+  const floor = locationOperations.some((operation) => operation.phase === 'execution') ? 25 : 0;
+  const frames = [0, 1, 2, 3].map((turnOffset) => {
+    const projectedHeat = clampPercent(Math.max(floor, currentHeat - (decayStep * turnOffset)));
+    const state = currentHeat === 0
+      ? 'masked'
+      : turnOffset === 0 && projectedHeat >= 70
+        ? 'active-risk'
+        : projectedHeat > floor && projectedHeat > 0
+          ? 'decaying-risk'
+          : projectedHeat === 0
+            ? 'masked'
+            : 'decaying-risk';
+
+    return {
+      turnOffset,
+      projectedHeat,
+      state,
+      label: state === 'active-risk'
+        ? `T+${turnOffset}: risque actif`
+        : state === 'decaying-risk'
+          ? `T+${turnOffset}: chaleur en décroissance`
+          : `T+${turnOffset}: information masquée`,
+    };
+  });
+
+  return {
+    state: frames[0].state,
+    currentHeat,
+    decayStep,
+    frames,
+    summary: currentHeat > 0
+      ? `Chaleur ${currentHeat}, décroissance sûre estimée -${decayStep}/tour sans révéler la source.`
+      : 'Aucune chaleur confirmée: information gardée masquée en mode sûr.',
+  };
+}
+
+function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
+  const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
+  const decayingRisk = !activeRisk && sabotageRiskScore > 0;
+  const state = activeRisk
+    ? 'active-risk'
+    : decayingRisk
+      ? 'decaying-risk'
+      : 'masked-information';
+
+  return {
+    state,
+    redactedLabel: state === 'active-risk'
+      ? 'Risque actif visible'
+      : state === 'decaying-risk'
+        ? 'Risque en décroissance'
+        : 'Information masquée',
+    safeLabel: state === 'masked-information'
+      ? 'Indice intrigue masqué: données absentes ou confidentielles.'
+      : `Indice intrigue ${presenceLevel}, risque ${riskLevel}: détails sensibles expurgés.`,
+    maskedDetails: [
+      exposedCellCount === 0 ? 'identité cellule' : null,
+      'relais opérationnel',
+      'objectif précis',
+      state === 'masked-information' ? 'cause du signal' : null,
+    ].filter(Boolean),
+    reason: state === 'active-risk'
+      ? 'La carte montre seulement le niveau de pression actif, pas la source.'
+      : state === 'decaying-risk'
+        ? 'La pression baisse; le mode sûr masque encore les routes et relais.'
+        : 'Aucun signal confirmé ne justifie de révéler une route ou cible.',
+  };
+}
+
 function normalizeStyle(styleMap, key, defaults) {
   const style = styleMap[key] ?? styleMap.default ?? defaults[key] ?? defaults.none;
   const fallback = defaults[key] ?? defaults.none;
@@ -2180,6 +2257,22 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         sleeperCellCount,
         sabotageRiskScore,
       });
+      const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
+        ? {
+          suspicionHeatDecayPlayback: buildSuspicionHeatDecayPlayback({
+            locationCellules,
+            locationOperations,
+            sabotageRiskScore,
+          }),
+          safeMapMasking: buildSafeMapMasking({
+            presenceLevel,
+            riskLevel,
+            sabotageRiskScore,
+            exposedCellCount,
+            locationOperations,
+          }),
+        }
+        : {};
 
       return {
         overlayId: `intrigue:${locationId}`,
@@ -2198,6 +2291,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           sabotageOperationCount: locationOperations.length,
         },
         lowExposureSweepConfidencePreview,
+        ...safeMapSignals,
         style: {
           presence: normalizeStyle(styleByPresence, presenceLevel, DEFAULT_STYLE_BY_PRESENCE),
           risk: normalizeStyle(styleByRisk, riskLevel, DEFAULT_STYLE_BY_RISK),

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -1689,3 +1689,70 @@ test('buildIntrigueMapOverlay rejects invalid inputs', () => {
   assert.throws(() => buildIntrigueMapOverlay([], [], { styleByRisk: [] }), /styleByRisk must be an object/);
   assert.throws(() => buildIntrigueMapOverlay([], [], { locationNames: [] }), /locationNames must be an object/);
 });
+
+test('buildIntrigueMapOverlay exposes safe-map heat decay playback and redacted labels', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-active',
+      factionId: 'shadow-league',
+      codename: 'Ember',
+      locationId: 'ashlands',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 42,
+    }),
+    new Cellule({
+      id: 'cell-masked',
+      factionId: 'shadow-league',
+      codename: 'Still',
+      locationId: 'quiet-plains',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-active',
+      celluleId: 'cell-active',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Disrupt road watches',
+      theaterId: 'ashlands',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 15,
+      progress: 80,
+      heat: 82,
+      phase: 'execution',
+    }),
+  ], {
+    safeMapMode: true,
+    locationNames: { ashlands: 'Ashlands', 'quiet-plains': 'Quiet Plains' },
+  });
+
+  const active = overlay.find((entry) => entry.locationId === 'ashlands');
+  const masked = overlay.find((entry) => entry.locationId === 'quiet-plains');
+
+  assert.equal(active.suspicionHeatDecayPlayback.state, 'active-risk');
+  assert.deepEqual(active.suspicionHeatDecayPlayback.frames.map((frame) => frame.state), [
+    'active-risk',
+    'decaying-risk',
+    'decaying-risk',
+    'decaying-risk',
+  ]);
+  assert.deepEqual(active.suspicionHeatDecayPlayback.frames.map((frame) => frame.projectedHeat), [82, 70, 58, 46]);
+  assert.equal(active.safeMapMasking.redactedLabel, 'Risque actif visible');
+  assert.equal(active.safeMapMasking.safeLabel, 'Indice intrigue low, risque high: détails sensibles expurgés.');
+  assert.deepEqual(active.safeMapMasking.maskedDetails, ['identité cellule', 'relais opérationnel', 'objectif précis']);
+
+  assert.equal(masked.suspicionHeatDecayPlayback.state, 'masked');
+  assert.deepEqual(masked.suspicionHeatDecayPlayback.frames.map((frame) => frame.label), [
+    'T+0: information masquée',
+    'T+1: information masquée',
+    'T+2: information masquée',
+    'T+3: information masquée',
+  ]);
+  assert.equal(masked.safeMapMasking.redactedLabel, 'Information masquée');
+  assert.match(masked.safeMapMasking.safeLabel, /données absentes ou confidentielles/);
+  assert.deepEqual(masked.safeMapMasking.maskedDetails, ['identité cellule', 'relais opérationnel', 'objectif précis', 'cause du signal']);
+});


### PR DESCRIPTION
Delta: ## Summary
- Adds optional safe-map suspicion heat decay playback to intrigue overlay entries.
- Adds redacted safe-map labels that distinguish active risk, decaying risk, and masked information without leaking cell/relay/objective details.
- Covers active and masked safe-map states in buildIntrigueMapOverlay tests.

Closes #1182.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés intrigue passés et tests complets passés avec `npm test` (653/653); j’attends ta validation avant tout merge.