### PR TITLE
Gamma: add cultural atlas story layers

### DIFF
--- a/src/ui/culture/buildCultureLayerPanel.js
+++ b/src/ui/culture/buildCultureLayerPanel.js
@@ -48,6 +48,9 @@ function normalizeEntries(entries) {
         normalizedEntry.cultureMetrics ?? {},
         `CultureLayerPanel entries[${index}].cultureMetrics`,
       ),
+      atlasStoryLayers: Array.isArray(normalizedEntry.atlasStoryLayers) ? normalizedEntry.atlasStoryLayers : [],
+      markerCollisionCluster: normalizedEntry.markerCollisionCluster ?? null,
+      narrativeSummary: String(normalizedEntry.narrativeSummary ?? '').trim(),
     };
   });
 }
@@ -155,6 +158,43 @@ function buildFocus(entries, normalizedOptions) {
   };
 }
 
+function buildAtlasLayerControls(entries) {
+  const layersByKind = new Map();
+
+  for (const entry of entries) {
+    for (const layer of entry.atlasStoryLayers) {
+      const current = layersByKind.get(layer.kind) ?? {
+        kind: layer.kind,
+        label: layer.label,
+        enabled: false,
+        markerCount: 0,
+        regionIds: new Set(),
+      };
+      current.enabled = current.enabled || layer.enabled;
+      current.markerCount += layer.markerCount ?? 0;
+      current.regionIds.add(entry.regionId);
+      layersByKind.set(layer.kind, current);
+    }
+  }
+
+  return [...layersByKind.values()]
+    .sort((left, right) => left.kind.localeCompare(right.kind))
+    .map((layer) => ({
+      kind: layer.kind,
+      label: layer.label,
+      enabled: layer.enabled,
+      markerCount: layer.markerCount,
+      regionIds: [...layer.regionIds].sort(),
+    }));
+}
+
+function buildCollisionControls(entries) {
+  return [...new Map(entries
+    .filter((entry) => entry.markerCollisionCluster)
+    .map((entry) => [entry.regionId, entry.markerCollisionCluster])).values()]
+    .sort((left, right) => right.markerCount - left.markerCount || left.regionId.localeCompare(right.regionId));
+}
+
 export function buildCultureLayerPanel(entries, options = {}) {
   const normalizedEntries = normalizeEntries(entries);
   const normalizedOptions = requireObject(options, 'CultureLayerPanel options');
@@ -189,6 +229,8 @@ export function buildCultureLayerPanel(entries, options = {}) {
       summary: `${comparison.length} cultures visibles comparées`,
       rows: comparison,
     },
+    atlasLayers: buildAtlasLayerControls(normalizedEntries),
+    collisionControls: buildCollisionControls(normalizedEntries),
     metrics: {
       markerCount: normalizedEntries.length,
       regionCount: regionRows.length,

--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1471,6 +1471,122 @@ function buildCultureStabilizationSummary(regionId, recommendedFirstBundle, next
   };
 }
 
+function buildLayerMarkerId(regionId, cultureId, layerKind) {
+  return `${regionId}:${cultureId}:${layerKind}`;
+}
+
+function buildAtlasStoryReason(entry, signals, rank) {
+  if (signals.eventCount > 0) {
+    const eventTitle = signals.orderedHistoricalEvents[0]?.title ?? 'événement local';
+
+    return `${entry.cultureName} compte maintenant: ${eventTitle} donne un repère d'action immédiat.`;
+  }
+
+  if (signals.highlightedDiscoveries.length > 0) {
+    return `${entry.cultureName} compte maintenant: ${signals.highlightedDiscoveries[0]} relie découverte et influence locale.`;
+  }
+
+  if (rank === 0) {
+    return `${entry.cultureName} porte l'influence principale de cette région.`;
+  }
+
+  return `${entry.cultureName} reste visible comme couche secondaire à surveiller.`;
+}
+
+export function buildCultureMarkerCollisionCluster(regionId, regionPresence, cultureSignalsById) {
+  const stack = regionPresence
+    .map((entry, index) => {
+      const cultureState = cultureSignalsById.get(entry.cultureId);
+      const signals = cultureState?.signals ?? {
+        highlightedDiscoveries: [],
+        eventCount: 0,
+        activeResearchCount: 0,
+        orderedHistoricalEvents: [],
+      };
+      const priorityScore = clampScore(
+        (entry.influenceScore * 0.7)
+        + (signals.eventCount * 8)
+        + (signals.highlightedDiscoveries.length * 4)
+        + (signals.activeResearchCount * 3)
+        + (index === 0 ? 5 : 0),
+      );
+
+      return {
+        markerId: `${regionId}:${entry.cultureId}`,
+        cultureId: entry.cultureId,
+        cultureName: entry.cultureName,
+        priorityScore,
+        priorityReason: signals.eventCount > 0
+          ? `${signals.eventCount} événement${signals.eventCount > 1 ? 's' : ''}`
+          : signals.highlightedDiscoveries.length > 0
+            ? `${signals.highlightedDiscoveries.length} découverte${signals.highlightedDiscoveries.length > 1 ? 's' : ''}`
+            : `influence ${entry.influenceScore}`,
+        layerKinds: [
+          'influence',
+          ...(signals.highlightedDiscoveries.length > 0 ? ['discoveries'] : []),
+          ...(signals.eventCount > 0 ? ['timeline'] : []),
+        ],
+      };
+    })
+    .sort((left, right) => right.priorityScore - left.priorityScore || left.cultureId.localeCompare(right.cultureId));
+  const priorityMarker = stack[0] ?? null;
+
+  return {
+    clusterId: `${regionId}:marker-collision`,
+    regionId,
+    markerCount: stack.length,
+    overflowCount: Math.max(0, stack.length - 1),
+    strategy: stack.length > 1 ? 'stack-by-priority' : 'single-marker',
+    priorityMarkerId: priorityMarker?.markerId ?? null,
+    priorityCultureId: priorityMarker?.cultureId ?? null,
+    priorityReason: priorityMarker?.priorityReason ?? 'aucun marqueur',
+    stack,
+  };
+}
+
+export function buildCultureAtlasStoryLayers(regionId, regionPresence, cultureSignalsById) {
+  const orderedEntries = regionPresence
+    .slice()
+    .sort((left, right) => right.influenceScore - left.influenceScore || left.cultureId.localeCompare(right.cultureId));
+  const layerDefinitions = [
+    ['influence', 'Influences', (signals) => true],
+    ['discoveries', 'Découvertes', (signals) => signals.highlightedDiscoveries.length > 0],
+    ['timeline', 'Chronologie locale', (signals) => signals.eventCount > 0],
+  ];
+
+  return layerDefinitions.map(([kind, label, predicate]) => {
+    const markers = orderedEntries
+      .filter((entry) => predicate(cultureSignalsById.get(entry.cultureId)?.signals ?? { highlightedDiscoveries: [], eventCount: 0 }))
+      .map((entry, index) => {
+        const signals = cultureSignalsById.get(entry.cultureId)?.signals ?? {
+          highlightedDiscoveries: [],
+          eventCount: 0,
+          activeResearchCount: 0,
+          orderedHistoricalEvents: [],
+        };
+
+        return {
+          markerId: buildLayerMarkerId(regionId, entry.cultureId, kind),
+          regionId,
+          cultureId: entry.cultureId,
+          cultureName: entry.cultureName,
+          rank: index,
+          enabled: true,
+          reason: buildAtlasStoryReason(entry, signals, index),
+        };
+      });
+
+    return {
+      layerId: `${regionId}:atlas-layer:${kind}`,
+      kind,
+      label,
+      enabled: markers.length > 0,
+      markerCount: markers.length,
+      markers,
+    };
+  });
+}
+
 function buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById) {
   const cultureIds = regionPresence.map((entry) => entry.cultureId).sort();
   const cultureNames = regionPresence.map((entry) => entry.cultureName).sort();
@@ -1563,6 +1679,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
   );
   const regionPresenceMap = buildRegionPresenceMap(cultures, regionIdsByCulture, cultureSignalsById);
   const includeClusterSummaries = normalizedOptions.clusterSummaries === true;
+  const includeAtlasStoryLayers = normalizedOptions.atlasStoryLayers === true;
 
   return cultures
     .flatMap((culture) => {
@@ -1579,6 +1696,18 @@ export function buildCultureMapOverlay(payload, options = {}) {
         const zoneBand = buildZoneBand(zoneRank, overlapCount);
         const clusterSummary = includeClusterSummaries && overlapCount > 1
           ? buildRegionClusterSummary(regionId, regionPresence, cultureSignalsById)
+          : null;
+        const markerCollisionCluster = includeAtlasStoryLayers
+          ? buildCultureMarkerCollisionCluster(regionId, regionPresence, cultureSignalsById)
+          : null;
+        const atlasStoryLayers = includeAtlasStoryLayers
+          ? buildCultureAtlasStoryLayers(regionId, regionPresence, cultureSignalsById)
+          : null;
+        const narrativeSummary = includeAtlasStoryLayers
+          ? (atlasStoryLayers.find((layer) => layer.kind === 'timeline')?.markers[0]?.reason
+            ?? atlasStoryLayers.find((layer) => layer.kind === 'discoveries')?.markers[0]?.reason
+            ?? atlasStoryLayers[0]?.markers[0]?.reason
+            ?? `${culture.name} reste lisible dans ${regionId}.`)
           : null;
         const supportBundles = buildCultureSupportBundles(culture, regionId, regionPresence, cultureState);
         const riskChangePreview = buildCultureSupportRiskChangePreview(culture, supportBundles[0] ?? null, regionPresence, cultureState);
@@ -1657,6 +1786,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           cultureStabilizationSummary,
           ...(supportBundles.length > 0 ? { supportBundles, recommendedFirstBundle } : {}),
           ...(clusterSummary ? { clusterSummary } : {}),
+          ...(includeAtlasStoryLayers ? { markerCollisionCluster, atlasStoryLayers, narrativeSummary } : {}),
           zoneContour: buildZoneContour(cultureState.influenceTier, overlapCount, zoneRank),
           style,
           zoneStyle: buildZoneStyle(markerType, cultureState.influenceTier, style, zoneBand),

--- a/test/ui/culture/buildCultureLayerPanel.test.js
+++ b/test/ui/culture/buildCultureLayerPanel.test.js
@@ -251,3 +251,61 @@ test('buildCultureLayerPanel falls back to the first marker and validates inputs
   assert.throws(() => buildCultureLayerPanel([], { activeFilter: [] }), /activeFilter is required/);
   assert.throws(() => buildCultureLayerPanel([{ overlayId: 'x', regionId: 'r', cultureId: 'c', cultureName: 'n', label: 'l', cultureMetrics: [] }]), /cultureMetrics must be an object/);
 });
+test('buildCultureLayerPanel exposes atlas story layer controls and collision stacks', () => {
+  const panel = buildCultureLayerPanel([
+    {
+      overlayId: 'shared-bay:culture-harbor',
+      regionId: 'shared-bay',
+      cultureId: 'culture-harbor',
+      cultureName: 'Harbor Compact',
+      label: 'Harbor Compact (1 découvertes)',
+      summary: '1 recherches actives, 1 événements, 2 repères culturels',
+      influenceScore: 76,
+      influenceTier: 'strong',
+      discoveries: ['tidal-ledgers'],
+      unlockedResearchIds: ['harbor-ledgers'],
+      eventIds: ['event-harbor-forum'],
+      eventTitles: ['Harbor Forum'],
+      identityTags: ['forums'],
+      highlights: ['tidal-ledgers'],
+      markerType: 'innovation',
+      primaryLanguage: 'harbor-cant',
+      cultureMetrics: { openness: 80, cohesion: 58, researchDrive: 74 },
+      atlasStoryLayers: [
+        { layerId: 'shared-bay:atlas-layer:influence', kind: 'influence', label: 'Influences', enabled: true, markerCount: 2, markers: [] },
+        { layerId: 'shared-bay:atlas-layer:timeline', kind: 'timeline', label: 'Chronologie locale', enabled: true, markerCount: 1, markers: [] },
+      ],
+      markerCollisionCluster: {
+        clusterId: 'shared-bay:marker-collision',
+        regionId: 'shared-bay',
+        markerCount: 2,
+        overflowCount: 1,
+        strategy: 'stack-by-priority',
+        priorityMarkerId: 'shared-bay:culture-harbor',
+        priorityCultureId: 'culture-harbor',
+        priorityReason: '1 événement',
+        stack: [],
+      },
+      narrativeSummary: "Harbor Compact compte maintenant: Harbor Forum donne un repère d'action immédiat.",
+    },
+  ]);
+
+  assert.deepEqual(panel.atlasLayers, [
+    {
+      kind: 'influence',
+      label: 'Influences',
+      enabled: true,
+      markerCount: 2,
+      regionIds: ['shared-bay'],
+    },
+    {
+      kind: 'timeline',
+      label: 'Chronologie locale',
+      enabled: true,
+      markerCount: 1,
+      regionIds: ['shared-bay'],
+    },
+  ]);
+  assert.equal(panel.collisionControls[0].strategy, 'stack-by-priority');
+  assert.equal(panel.collisionControls[0].priorityCultureId, 'culture-harbor');
+});

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -1279,6 +1279,126 @@ test('buildCultureMapOverlay can summarize overlapping culture clusters with dis
   });
 });
 
+test('buildCultureMapOverlay exposes atlas story layers and deterministic marker collisions', () => {
+  const overlay = buildCultureMapOverlay(
+    {
+      cultures: [
+        {
+          id: 'culture-harbor',
+          name: 'Harbor Compact',
+          archetype: 'maritime',
+          primaryLanguage: 'harbor-cant',
+          valueIds: ['pilots'],
+          traditionIds: ['forums'],
+          openness: 80,
+          cohesion: 58,
+          researchDrive: 74,
+        },
+        {
+          id: 'culture-delta',
+          name: 'Delta Scribes',
+          archetype: 'riverine',
+          primaryLanguage: 'delta-script',
+          valueIds: ['archives'],
+          traditionIds: ['flood-oaths'],
+          openness: 52,
+          cohesion: 62,
+          researchDrive: 64,
+        },
+      ],
+      researchStates: [
+        {
+          id: 'research-harbor-ledgers',
+          cultureId: 'culture-harbor',
+          topicId: 'harbor-ledgers',
+          status: 'active',
+          progress: 50,
+          discoveredConceptIds: ['tidal-ledgers'],
+        },
+        {
+          id: 'research-delta-archives',
+          cultureId: 'culture-delta',
+          topicId: 'delta-archives',
+          status: 'completed',
+          progress: 100,
+          completedAt: '2026-04-20T00:00:00.000Z',
+          discoveredConceptIds: ['flood-archives'],
+        },
+      ],
+      historicalEvents: [
+        {
+          id: 'event-harbor-forum',
+          title: 'Harbor Forum',
+          category: 'knowledge',
+          summary: 'Pilots compare archive routes.',
+          era: 'map-play',
+          importance: 4,
+          triggeredAt: '2026-04-20T00:00:00.000Z',
+          affectedCultureIds: ['culture-harbor'],
+          discoveryIds: ['tidal-ledgers'],
+        },
+      ],
+    },
+    {
+      atlasStoryLayers: true,
+      regionIdsByCulture: {
+        'culture-harbor': ['shared-bay'],
+        'culture-delta': ['shared-bay'],
+      },
+    },
+  );
+
+  assert.deepEqual(overlay.map((entry) => entry.markerCollisionCluster.priorityCultureId), [
+    'culture-harbor',
+    'culture-harbor',
+  ]);
+  assert.deepEqual(overlay[0].markerCollisionCluster, {
+    clusterId: 'shared-bay:marker-collision',
+    regionId: 'shared-bay',
+    markerCount: 2,
+    overflowCount: 1,
+    strategy: 'stack-by-priority',
+    priorityMarkerId: 'shared-bay:culture-harbor',
+    priorityCultureId: 'culture-harbor',
+    priorityReason: '1 événement',
+    stack: [
+      {
+        markerId: 'shared-bay:culture-harbor',
+        cultureId: 'culture-harbor',
+        cultureName: 'Harbor Compact',
+        priorityScore: 67,
+        priorityReason: '1 événement',
+        layerKinds: ['influence', 'discoveries', 'timeline'],
+      },
+      {
+        markerId: 'shared-bay:culture-delta',
+        cultureId: 'culture-delta',
+        cultureName: 'Delta Scribes',
+        priorityScore: 42,
+        priorityReason: '1 découverte',
+        layerKinds: ['influence', 'discoveries'],
+      },
+    ],
+  });
+  assert.deepEqual(overlay[0].atlasStoryLayers.map((layer) => [layer.kind, layer.markerCount, layer.enabled]), [
+    ['influence', 2, true],
+    ['discoveries', 2, true],
+    ['timeline', 1, true],
+  ]);
+  assert.match(overlay[0].narrativeSummary, /Harbor Forum/);
+  assert.deepEqual(overlay[0].atlasStoryLayers[2].markers, [
+    {
+      markerId: 'shared-bay:culture-harbor:timeline',
+      regionId: 'shared-bay',
+      cultureId: 'culture-harbor',
+      cultureName: 'Harbor Compact',
+      rank: 0,
+      enabled: true,
+      reason: "Harbor Compact compte maintenant: Harbor Forum donne un repère d'action immédiat.",
+    },
+  ]);
+});
+
 test('buildResidualCultureActionPayoff covers complete, partial, and insufficient outcomes', () => {
   assert.deepEqual(
     buildResidualCultureActionPayoff(


### PR DESCRIPTION
Gamma: Implements #1181.

Summary:
- adds opt-in cultural atlas story layers for influence, discoveries, and local timeline events
- exposes deterministic marker collision stacks with priority marker, overflow count, and reasons
- surfaces atlas layer controls and collision controls in the culture layer panel

Validation:
- node --check src/ui/culture/buildCultureMapOverlay.js
- node --check src/ui/culture/buildCultureLayerPanel.js
- npm test -- test/ui/culture/buildCultureMapOverlay.test.js test/ui/culture/buildCultureLayerPanel.test.js
- npm test

Zeta: ready for validation before merge.