### PR TITLE
Epsilon: rank climate alert urgency

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1309,6 +1309,109 @@ function getClimateRiskRank(riskLevel) {
   return { stable: 0, strained: 1, critical: 2 }[riskLevel] ?? 0;
 }
 
+
+function normalizeForecastWindow(previewImpact, seasonPreview) {
+  return String(
+    previewImpact.window
+      ?? previewImpact.timeWindow
+      ?? previewImpact.forecastWindow
+      ?? (seasonPreview?.active ? `maintenant → ${seasonPreview.label}` : 'tour actuel'),
+  ).trim();
+}
+
+function normalizeForecastPlayerImpact(region, previewImpact, previewRiskLevel, previewAnomaly) {
+  const explicitImpact = previewImpact.playerImpact ?? previewImpact.impact ?? previewImpact.decisionImpact;
+
+  if (explicitImpact !== undefined) {
+    return String(explicitImpact).trim();
+  }
+
+  if (previewRiskLevel === 'critical') {
+    return 'décision de carte sensible: prioriser mitigation ou détour';
+  }
+
+  if (previewRiskLevel === 'strained' || previewAnomaly) {
+    return 'préparer réserve ou vérifier routes/récoltes avant engagement';
+  }
+
+  if (region.strategicImpact === 'critical' && previewRiskLevel !== 'critical') {
+    return 'amélioration prévue: conserver le plan si le timing le permet';
+  }
+
+  return 'aucun changement majeur: conserver le plan actuel';
+}
+
+function buildClimateUrgency(region, previewImpact, previewRiskLevel, previewAnomaly, confidenceBand, riskDelta, anomalyChanged) {
+  const window = normalizeForecastWindow(previewImpact, previewImpact.seasonPreview ?? null);
+  const immediateWindow = /maintenant|now|tour actuel|1\s*tour|imm[eé]diat/i.test(window);
+  const highImpact = /priorit|mitigation|d[ée]tour|route|r[ée]colte|r[ée]serve|co[uû]t|fragile|sensible/i.test(
+    normalizeForecastPlayerImpact(region, previewImpact, previewRiskLevel, previewAnomaly),
+  );
+
+  if (confidenceBand === 'extreme' || (previewRiskLevel === 'critical' && (immediateWindow || highImpact))) {
+    return {
+      urgencyRank: 1,
+      urgency: 'act-now',
+      urgencyLabel: 'agir maintenant',
+      microAction: 'déplacer priorité',
+    };
+  }
+
+  if (confidenceBand === 'probable' && (riskDelta > 0 || previewRiskLevel === 'strained' || highImpact)) {
+    return {
+      urgencyRank: 2,
+      urgency: 'prepare',
+      urgencyLabel: 'préparer',
+      microAction: 'préparer réserve',
+    };
+  }
+
+  if (anomalyChanged || riskDelta !== 0 || confidenceBand === 'uncertain') {
+    return {
+      urgencyRank: 3,
+      urgency: 'monitor',
+      urgencyLabel: 'surveiller',
+      microAction: 'attendre confirmation',
+    };
+  }
+
+  return {
+    urgencyRank: 4,
+    urgency: 'ignore-now',
+    urgencyLabel: 'ignorer pour l’instant',
+    microAction: 'conserver plan',
+  };
+}
+
+function buildClimateAlert(region, previewImpact, previewRiskLevel, previewAnomaly, seasonPreview) {
+  const riskDelta = getClimateRiskRank(previewRiskLevel) - getClimateRiskRank(region.strategicImpact);
+  const anomalyChanged = region.anomaly !== previewAnomaly;
+  const confidenceBand = inferConfidenceBand(region, previewImpact, previewRiskLevel, previewAnomaly);
+  const timeWindow = normalizeForecastWindow(previewImpact, seasonPreview);
+  const playerImpact = normalizeForecastPlayerImpact(region, previewImpact, previewRiskLevel, previewAnomaly);
+  const urgency = buildClimateUrgency(
+    region,
+    { ...previewImpact, seasonPreview },
+    previewRiskLevel,
+    previewAnomaly,
+    confidenceBand,
+    riskDelta,
+    anomalyChanged,
+  );
+
+  return {
+    regionId: region.regionId,
+    currentRiskLevel: region.strategicImpact,
+    previewRiskLevel,
+    currentAnomaly: region.anomaly,
+    previewAnomaly,
+    confidenceBand,
+    timeWindow,
+    playerImpact,
+    ...urgency,
+  };
+}
+
 function buildClimateTimeline(regions, seasonPreview, normalizedOptions, seasonLabels) {
   const previewImpacts = seasonPreview?.active ? normalizePreviewImpacts(normalizedOptions, seasonPreview) : {};
   const frames = [
@@ -1334,26 +1437,24 @@ function buildClimateTimeline(regions, seasonPreview, normalizedOptions, seasonL
     });
   }
 
-  const decisionChangingRegions = seasonPreview?.active
+  const climateAlerts = seasonPreview?.active
     ? regions.map((region) => {
       const previewImpact = previewImpacts[region.regionId] ?? {};
       const previewRiskLevel = String(previewImpact.riskLevel ?? previewImpact.strategicImpact ?? region.strategicImpact).trim()
         || region.strategicImpact;
       const previewAnomaly = previewImpact.anomaly === undefined ? region.anomaly : previewImpact.anomaly;
-      const riskDelta = getClimateRiskRank(previewRiskLevel) - getClimateRiskRank(region.strategicImpact);
-      const anomalyChanged = region.anomaly !== previewAnomaly;
 
-      if (riskDelta === 0 && !anomalyChanged) {
-        return null;
-      }
+      return buildClimateAlert(region, previewImpact, previewRiskLevel, previewAnomaly, seasonPreview);
+    }).sort((left, right) => left.urgencyRank - right.urgencyRank || left.regionId.localeCompare(right.regionId))
+    : [];
+
+  const decisionChangingRegions = climateAlerts
+    .filter((alert) => alert.currentRiskLevel !== alert.previewRiskLevel || alert.currentAnomaly !== alert.previewAnomaly)
+    .map((alert) => {
+      const riskDelta = getClimateRiskRank(alert.previewRiskLevel) - getClimateRiskRank(alert.currentRiskLevel);
 
       return {
-        regionId: region.regionId,
-        currentRiskLevel: region.strategicImpact,
-        previewRiskLevel,
-        currentAnomaly: region.anomaly,
-        previewAnomaly,
-        confidenceBand: inferConfidenceBand(region, previewImpact, previewRiskLevel, previewAnomaly),
+        ...alert,
         changeType: riskDelta > 0 ? 'risk-increases' : riskDelta < 0 ? 'risk-decreases' : 'anomaly-changes',
         decisionHint: riskDelta > 0
           ? 'agir avant la bascule si la province porte une action sensible'
@@ -1362,8 +1463,7 @@ function buildClimateTimeline(regions, seasonPreview, normalizedOptions, seasonL
             : 'vérifier l’anomalie avant d’engager récoltes ou routes',
         tone: riskDelta > 0 ? 'warning' : riskDelta < 0 ? 'positive' : 'info',
       };
-    }).filter(Boolean)
-    : [];
+    });
 
   return {
     mode: seasonPreview?.active ? 'now-next-scrubber' : 'static-current-climate',
@@ -1381,6 +1481,16 @@ function buildClimateTimeline(regions, seasonPreview, normalizedOptions, seasonL
     },
     frames,
     decisionChangingRegions,
+    climateAlerts,
+    alertSummary: {
+      fallback: seasonPreview?.active ? null : 'Fallback statique: aucune prévision exploitable pour classer les alertes.',
+      buckets: [
+        { urgencyRank: 1, urgency: 'act-now', label: 'agir maintenant', microAction: 'déplacer priorité' },
+        { urgencyRank: 2, urgency: 'prepare', label: 'préparer', microAction: 'préparer réserve' },
+        { urgencyRank: 3, urgency: 'monitor', label: 'surveiller', microAction: 'attendre confirmation' },
+        { urgencyRank: 4, urgency: 'ignore-now', label: 'ignorer pour l’instant', microAction: 'conserver plan' },
+      ],
+    },
     clarity: {
       anomalyLevels: [
         { level: 'none', label: 'aucune anomalie', decisionWeight: 'normal' },

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -1360,27 +1360,31 @@ test('buildClimateMapOverlay exposes timeline scrubber decision-changing forecas
     ],
     fallback: null,
   });
-  assert.deepEqual(overlay.climateTimeline.decisionChangingRegions, [
+  assert.deepEqual(overlay.climateTimeline.decisionChangingRegions.map((region) => ({
+    regionId: region.regionId,
+    confidenceBand: region.confidenceBand,
+    urgencyRank: region.urgencyRank,
+    microAction: region.microAction,
+    timeWindow: region.timeWindow,
+    changeType: region.changeType,
+    tone: region.tone,
+  })), [
     {
       regionId: 'delta',
-      currentRiskLevel: 'stable',
-      previewRiskLevel: 'critical',
-      currentAnomaly: null,
-      previewAnomaly: 'storm',
       confidenceBand: 'extreme',
+      urgencyRank: 1,
+      microAction: 'déplacer priorité',
+      timeWindow: 'maintenant → Automne',
       changeType: 'risk-increases',
-      decisionHint: 'agir avant la bascule si la province porte une action sensible',
       tone: 'warning',
     },
     {
       regionId: 'sunreach',
-      currentRiskLevel: 'critical',
-      previewRiskLevel: 'strained',
-      currentAnomaly: 'heatwave',
-      previewAnomaly: null,
       confidenceBand: 'uncertain',
+      urgencyRank: 3,
+      microAction: 'attendre confirmation',
+      timeWindow: 'maintenant → Automne',
       changeType: 'risk-decreases',
-      decisionHint: 'attendre la fenêtre prévue peut réduire le coût',
       tone: 'positive',
     },
   ]);
@@ -1440,9 +1444,9 @@ test('buildClimateMapOverlay exposes deterministic confidence bands and anomaly 
     regionId: region.regionId,
     confidenceBand: region.confidenceBand,
   })), [
-    { regionId: 'basin', confidenceBand: 'uncertain' },
     { regionId: 'coast', confidenceBand: 'extreme' },
     { regionId: 'ridge', confidenceBand: 'probable' },
+    { regionId: 'basin', confidenceBand: 'uncertain' },
   ]);
   assert.deepEqual(overlay.mapLayers.anomalyMarkers.find((marker) => marker.regionId === 'ridge').tooltip, {
     title: 'Anomalie: storm',
@@ -1454,5 +1458,106 @@ test('buildClimateMapOverlay exposes deterministic confidence bands and anomaly 
   assert.equal(
     overlay.mapLayers.anomalyMarkers.find((marker) => marker.regionId === 'basin').tooltip.playerImpact,
     'réserves et récoltes sous pression, attendre ou irriguer avant dépense',
+  );
+});
+
+test('buildClimateMapOverlay ranks climate alerts by urgency and keeps static fallback', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'citadel', season: 'spring', temperatureC: 18, precipitationLevel: 40, droughtIndex: 20 },
+    { regionId: 'granary', season: 'spring', temperatureC: 20, precipitationLevel: 35, droughtIndex: 25 },
+    { regionId: 'watch', season: 'spring', temperatureC: 21, precipitationLevel: 30, droughtIndex: 30 },
+    { regionId: 'quiet', season: 'spring', temperatureC: 19, precipitationLevel: 32, droughtIndex: 22 },
+  ], {
+    seasonPreview: {
+      season: 'summer',
+      impactsByRegion: {
+        citadel: {
+          strategicImpact: 'critical',
+          anomaly: 'storm',
+          confidenceBand: 'extreme',
+          timeWindow: 'tour actuel',
+          playerImpact: 'priorité capitale et route fragile',
+        },
+        granary: {
+          strategicImpact: 'strained',
+          anomaly: null,
+          confidenceBand: 'probable',
+          timeWindow: '2 tours',
+          playerImpact: 'réserve de grains à préparer',
+        },
+        watch: {
+          strategicImpact: 'stable',
+          anomaly: 'frost',
+          confidenceBand: 'uncertain',
+          timeWindow: 'fin de saison',
+          playerImpact: 'signal à confirmer avant dépense',
+        },
+        quiet: {
+          strategicImpact: 'stable',
+          anomaly: null,
+          confidenceBand: 'probable',
+          timeWindow: 'fin de saison',
+          playerImpact: 'aucun changement majeur',
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(overlay.climateTimeline.climateAlerts.map((alert) => ({
+    regionId: alert.regionId,
+    urgencyRank: alert.urgencyRank,
+    microAction: alert.microAction,
+    confidenceBand: alert.confidenceBand,
+    timeWindow: alert.timeWindow,
+    playerImpact: alert.playerImpact,
+  })), [
+    {
+      regionId: 'citadel',
+      urgencyRank: 1,
+      microAction: 'déplacer priorité',
+      confidenceBand: 'extreme',
+      timeWindow: 'tour actuel',
+      playerImpact: 'priorité capitale et route fragile',
+    },
+    {
+      regionId: 'granary',
+      urgencyRank: 2,
+      microAction: 'préparer réserve',
+      confidenceBand: 'probable',
+      timeWindow: '2 tours',
+      playerImpact: 'réserve de grains à préparer',
+    },
+    {
+      regionId: 'watch',
+      urgencyRank: 3,
+      microAction: 'attendre confirmation',
+      confidenceBand: 'uncertain',
+      timeWindow: 'fin de saison',
+      playerImpact: 'signal à confirmer avant dépense',
+    },
+    {
+      regionId: 'quiet',
+      urgencyRank: 4,
+      microAction: 'conserver plan',
+      confidenceBand: 'probable',
+      timeWindow: 'fin de saison',
+      playerImpact: 'aucun changement majeur',
+    },
+  ]);
+  assert.deepEqual(overlay.climateTimeline.alertSummary.buckets.map((bucket) => bucket.microAction), [
+    'déplacer priorité',
+    'préparer réserve',
+    'attendre confirmation',
+    'conserver plan',
+  ]);
+
+  const staticOverlay = buildClimateMapOverlay([
+    { regionId: 'quiet', season: 'spring', temperatureC: 19, precipitationLevel: 32, droughtIndex: 22 },
+  ]);
+
+  assert.deepEqual(staticOverlay.climateTimeline.climateAlerts, []);
+  assert.equal(
+    staticOverlay.climateTimeline.alertSummary.fallback,
+    'Fallback statique: aucune prévision exploitable pour classer les alertes.',
   );
 });


### PR DESCRIPTION
Epsilon: Adds compact deterministic climate alert ranking for #1193.

- ranks forecast alerts into agir maintenant / préparer / surveiller / ignorer pour l’instant
- exposes urgencyRank, timeWindow, playerImpact, and microAction from confidence/window/impact signals
- keeps a static fallback when no forecast is exploitable
- preserves existing climate timeline, confidence bands, and anomaly tooltip payloads

Tests:
- `npm test -- test/ui/climate/buildClimateMapOverlay.test.js`
- `npm test` (646/646)
- `git diff --check`

Closes #1193