### PR TITLE
Alpha: validate province action queues

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1485,7 +1485,91 @@ function buildProvincePlannedActionPreview(province) {
   };
 }
 
-function buildKeyboardActionPlanner(renderedProvinces) {
+function normalizeProvinceActionQueue(value) {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new TypeError('StrategicMapShell provinceActionQueue must be an array.');
+  }
+
+  return value.map((entry, index) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new TypeError('StrategicMapShell provinceActionQueue entries must be objects.');
+    }
+
+    return {
+      queueId: String(entry.queueId ?? `queue-${index + 1}`).trim() || `queue-${index + 1}`,
+      provinceId: String(entry.provinceId ?? '').trim(),
+      actionCode: String(entry.actionCode ?? '').trim(),
+      label: String(entry.label ?? '').trim(),
+      requiresSupport: Boolean(entry.requiresSupport),
+      invalidatedByPrevious: Boolean(entry.invalidatedByPrevious),
+    };
+  }).filter((entry) => entry.provinceId);
+}
+
+function getQueueConflictReason(entry, province, previousEntry, previousProvince) {
+  if (!province) return 'cible inconnue';
+  if (previousEntry && previousEntry.provinceId === entry.provinceId) return 'cible déjà engagée';
+  if (entry.requiresSupport && ['disrupted', 'collapsed'].includes(province.supplyLevel)) return 'support manquant';
+  if (province.neighborIds.includes(previousEntry?.provinceId) && previousProvince?.contested) return 'front voisin instable';
+  if (entry.invalidatedByPrevious) return 'action rendue caduque';
+  if (province.actionAffordance.state === 'blocked') return province.actionAffordance.reason;
+  return null;
+}
+
+function queueStatusForProvince(province) {
+  if (!province) return 'blocked';
+  if (province.actionAffordance.state === 'blocked') return 'blocked';
+  if (province.actionAffordance.state === 'discouraged') return 'risky';
+  return 'ready';
+}
+
+function buildProvinceActionQueueValidation(renderedProvinces, options) {
+  const queue = normalizeProvinceActionQueue(options.provinceActionQueue);
+  const provinceById = new Map(renderedProvinces.map((province) => [province.provinceId, province]));
+  const queueEntries = queue.map((entry, index) => {
+    const province = provinceById.get(entry.provinceId) ?? null;
+    const previousEntry = queue[index - 1] ?? null;
+    const previousProvince = previousEntry ? provinceById.get(previousEntry.provinceId) ?? null : null;
+    const conflictReason = getQueueConflictReason(entry, province, previousEntry, previousProvince);
+    const baseStatus = queueStatusForProvince(province);
+    const status = conflictReason ? (baseStatus === 'blocked' ? 'blocked' : 'conflict') : baseStatus;
+    const action = province?.tacticalHoverIntel.nextAction ?? null;
+
+    return {
+      queueId: entry.queueId,
+      provinceId: entry.provinceId,
+      provinceLabel: province?.label ?? entry.provinceId,
+      actionCode: entry.actionCode || action?.code || 'unknown-action',
+      actionLabel: entry.label || action?.label || 'Action inconnue',
+      status,
+      reason: conflictReason ?? (status === 'ready' ? 'ordre prêt' : 'ordre risqué'),
+      safeReplacement: status === 'ready' ? null : {
+        actionCode: action?.status === 'available' ? action.code : 'hold-reserve',
+        label: action?.status === 'available' ? action.label : 'Garder en réserve',
+        reason: action?.status === 'available' ? action.reason : 'attendre résolution du blocage',
+      },
+    };
+  });
+  const firstBlocked = queueEntries.find((entry) => entry.status === 'blocked' || entry.status === 'conflict') ?? null;
+
+  return {
+    empty: queueEntries.length === 0,
+    entries: queueEntries,
+    summary: {
+      readyCount: queueEntries.filter((entry) => entry.status === 'ready').length,
+      riskyCount: queueEntries.filter((entry) => entry.status === 'risky').length,
+      blockedCount: queueEntries.filter((entry) => entry.status === 'blocked').length,
+      conflictCount: queueEntries.filter((entry) => entry.status === 'conflict').length,
+    },
+    nextSafeAction: firstBlocked?.safeReplacement ?? null,
+  };
+}
+
+function buildKeyboardActionPlanner(renderedProvinces, options) {
   const activeProvince = renderedProvinces.find(
     (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
   ) ?? renderedProvinces[0] ?? null;
@@ -1503,6 +1587,7 @@ function buildKeyboardActionPlanner(renderedProvinces) {
     })),
     activeProvinceId: activeProvince?.provinceId ?? null,
     plannedActionPreview: buildProvincePlannedActionPreview(activeProvince),
+    actionQueueValidation: buildProvinceActionQueueValidation(renderedProvinces, options),
     emptyState: renderedProvinces.length === 0 ? 'Aucune province disponible pour le planificateur clavier.' : null,
   };
 }
@@ -1713,7 +1798,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     },
   );
 
-  const keyboardActionPlanner = buildKeyboardActionPlanner(renderedProvinces);
+  const keyboardActionPlanner = buildKeyboardActionPlanner(renderedProvinces, normalizedOptions);
 
   return {
     title,

--- a/src/ui/war/buildStrategicMapPreviewHtml.js
+++ b/src/ui/war/buildStrategicMapPreviewHtml.js
@@ -238,6 +238,25 @@ function renderKeyboardActionPlanner(shell) {
   `;
 }
 
+function renderProvinceActionQueueValidation(shell) {
+  const validation = shell.keyboardActionPlanner.actionQueueValidation;
+  const entries = validation.entries.map((entry) => `
+    <li class="queue-validation-item queue-validation-item--${escapeHtml(entry.status)}">
+      <span>${escapeHtml(entry.provinceLabel)} · ${escapeHtml(entry.actionLabel)}</span>
+      <small>${escapeHtml(entry.status)} — ${escapeHtml(entry.reason)}</small>
+    </li>
+  `).join('');
+
+  return `
+    <section class="queue-validation" aria-label="Validation de file d’actions province">
+      <h2>Validation file</h2>
+      <p>${validation.empty ? 'Aucun ordre en file.' : `${validation.summary.readyCount} prêt · ${validation.summary.riskyCount} risqué · ${validation.summary.blockedCount} bloqué · ${validation.summary.conflictCount} conflit`}</p>
+      ${validation.nextSafeAction ? `<article class="next-safe-action"><span>Prochaine action sûre</span><strong>${escapeHtml(validation.nextSafeAction.label)}</strong><small>${escapeHtml(validation.nextSafeAction.reason)}</small></article>` : ''}
+      <ol>${entries}</ol>
+    </section>
+  `;
+}
+
 export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
   const map = requireGeneratedMap(generatedMap);
   const normalizedOptions = requireOptions(options);
@@ -252,6 +271,10 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     selectedProvinceId: normalizedOptions.selectedProvinceId ?? 'river-gate',
     focusedProvinceId: normalizedOptions.focusedProvinceId ?? 'crown-heart',
     queuedProvinceId: normalizedOptions.queuedProvinceId ?? normalizedOptions.selectedProvinceId ?? 'river-gate',
+    provinceActionQueue: normalizedOptions.provinceActionQueue ?? [
+      { provinceId: normalizedOptions.selectedProvinceId ?? 'river-gate', label: 'Ordre principal' },
+      { provinceId: normalizedOptions.focusedProvinceId ?? 'crown-heart', label: 'Appui suivant', requiresSupport: true },
+    ],
   });
 
   return `<!doctype html>
@@ -310,6 +333,19 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .planner-focus-item.is-focused { border-color:rgba(103,232,249,0.48); }
     .planner-focus-item.is-selected { color:#fef3c7; }
     .planner-focus-item.is-queued { border-color:rgba(74,222,128,0.48); }
+    .queue-validation { display:grid; gap:10px; }
+    .queue-validation p { margin:0; color:#cbd5e1; font-size:12px; }
+    .queue-validation ol { display:grid; gap:6px; margin:0; padding:0; }
+    .queue-validation-item { display:grid; gap:2px; border:1px solid rgba(148,163,184,0.16); border-radius:12px; padding:7px 9px; }
+    .queue-validation-item--ready { border-color:rgba(74,222,128,0.34); }
+    .queue-validation-item--risky { border-color:rgba(251,191,36,0.44); }
+    .queue-validation-item--blocked,
+    .queue-validation-item--conflict { border-color:rgba(248,113,113,0.48); }
+    .queue-validation-item small,
+    .next-safe-action small { color:#cbd5e1; }
+    .next-safe-action { display:grid; gap:3px; border:1px solid rgba(74,222,128,0.34); border-radius:14px; padding:9px; background:rgba(22,101,52,0.14); }
+    .next-safe-action span { color:#93a4bb; font-size:11px; text-transform:uppercase; letter-spacing:0.09em; }
+    .next-safe-action strong { color:#bbf7d0; }
     table { width:100%; border-collapse:collapse; font-size:13px; }
     th, td { padding:10px 8px; border-bottom:1px solid rgba(148, 163, 184, 0.14); text-align:left; }
     th { color:#93c5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
@@ -353,6 +389,7 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
           <ul>${renderLegend(shell)}</ul>
         </section>
         ${renderKeyboardActionPlanner(shell)}
+        ${renderProvinceActionQueueValidation(shell)}
         <section>
           <h2>Lecture</h2>
           <ul>

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -184,6 +184,17 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
       expectedEffect: 'maintenir Avant-poste en réserve',
       tacticalReason: 'aucune urgence militaire locale',
     },
+    actionQueueValidation: {
+      empty: true,
+      entries: [],
+      summary: {
+        readyCount: 0,
+        riskyCount: 0,
+        blockedCount: 0,
+        conflictCount: 0,
+      },
+      nextSafeAction: null,
+    },
     emptyState: null,
   });
   assert.deepEqual(shell.stats, {
@@ -220,6 +231,98 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     'intrigue-overlay',
   ]);
   assert.equal(shell.activeProvince.provinceId, 'prov-a');
+});
+
+
+test('StrategicMapShell validates province action queues and suggests a safe replacement', () => {
+  const shell = buildStrategicMapShell(
+    [
+      createProvince({ id: 'front', name: 'Front rouge', contested: true, neighborIds: ['support'] }),
+      createProvince({
+        id: 'support',
+        name: 'Support rompu',
+        supplyLevel: 'disrupted',
+        neighborIds: ['front'],
+      }),
+      createProvince({ id: 'reserve', name: 'Réserve nord', strategicValue: 1, neighborIds: [] }),
+    ],
+    {
+      selectedProvinceId: 'front',
+      focusedProvinceId: 'front',
+      queuedProvinceId: 'support',
+      provinceActionQueue: [
+        { queueId: 'q1', provinceId: 'reserve', label: 'Tenir la réserve' },
+        { queueId: 'q2', provinceId: 'support', label: 'Pousser sans soutien', requiresSupport: true },
+        { queueId: 'q3', provinceId: 'front', label: 'Avancer après front instable' },
+        { queueId: 'q4', provinceId: 'front', label: 'Rejouer même cible' },
+      ],
+    },
+  );
+
+  assert.deepEqual(shell.keyboardActionPlanner.actionQueueValidation, {
+    empty: false,
+    entries: [
+      {
+        queueId: 'q1',
+        provinceId: 'reserve',
+        provinceLabel: 'Réserve nord',
+        actionCode: 'hold-reserve',
+        actionLabel: 'Tenir la réserve',
+        status: 'ready',
+        reason: 'ordre prêt',
+        safeReplacement: null,
+      },
+      {
+        queueId: 'q2',
+        provinceId: 'support',
+        provinceLabel: 'Support rompu',
+        actionCode: 'avoid-push',
+        actionLabel: 'Pousser sans soutien',
+        status: 'conflict',
+        reason: 'support manquant',
+        safeReplacement: {
+          actionCode: 'hold-reserve',
+          label: 'Garder en réserve',
+          reason: 'attendre résolution du blocage',
+        },
+      },
+      {
+        queueId: 'q3',
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        actionCode: 'reinforce-front',
+        actionLabel: 'Avancer après front instable',
+        status: 'ready',
+        reason: 'ordre prêt',
+        safeReplacement: null,
+      },
+      {
+        queueId: 'q4',
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        actionCode: 'reinforce-front',
+        actionLabel: 'Rejouer même cible',
+        status: 'conflict',
+        reason: 'cible déjà engagée',
+        safeReplacement: {
+          actionCode: 'reinforce-front',
+          label: 'Renforcer le front',
+          reason: 'front contesté et pression militaire visible',
+        },
+      },
+    ],
+    summary: {
+      readyCount: 2,
+      riskyCount: 0,
+      blockedCount: 0,
+      conflictCount: 2,
+    },
+    nextSafeAction: {
+      actionCode: 'hold-reserve',
+      label: 'Garder en réserve',
+      reason: 'attendre résolution du blocage',
+    },
+  });
 });
 
 test('StrategicMapShell projects intrigue presence and sabotage risk into the map overlay slot', () => {

--- a/test/ui/war/buildStrategicMapPreviewHtml.test.js
+++ b/test/ui/war/buildStrategicMapPreviewHtml.test.js
@@ -21,6 +21,9 @@ test('buildStrategicMapPreviewHtml renders a screenshot-ready preview from the g
   assert.match(html, /Planificateur clavier d’action province/);
   assert.match(html, /Première action recommandée/);
   assert.match(html, /Raison tactique/);
+  assert.match(html, /Validation de file d’actions province/);
+  assert.match(html, /Prochaine action sûre/);
+  assert.match(html, /queue-validation-item--conflict/);
   assert.match(html, /class="province is-contested is-occupied is-selected is-queued"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /Porte du Fleuve/);


### PR DESCRIPTION
Alpha: Implements #1189.

Summary:
- adds deterministic province action queue validation to `StrategicMapShell`
- distinguishes ready, risky, blocked, and conflict queue entries
- explains conflicts such as duplicate targets, missing support, unstable neighboring fronts, and obsolete actions
- exposes next safe replacement guidance and renders it in the strategic map preview HTML

Tests:
- npm test
- git diff --check

Zeta: ready for validation before merge.
