### PR TITLE
Gamma: add cultural narrative priority states

### DIFF
--- a/src/ui/culture/buildCultureLayerPanel.js
+++ b/src/ui/culture/buildCultureLayerPanel.js
@@ -51,6 +51,7 @@ function normalizeEntries(entries) {
       atlasStoryLayers: Array.isArray(normalizedEntry.atlasStoryLayers) ? normalizedEntry.atlasStoryLayers : [],
       markerCollisionCluster: normalizedEntry.markerCollisionCluster ?? null,
       narrativeSummary: String(normalizedEntry.narrativeSummary ?? '').trim(),
+      narrativePriority: normalizedEntry.narrativePriority ?? normalizedEntry.markerCollisionCluster?.narrativePriority ?? null,
     };
   });
 }
@@ -195,6 +196,23 @@ function buildCollisionControls(entries) {
     .sort((left, right) => right.markerCount - left.markerCount || left.regionId.localeCompare(right.regionId));
 }
 
+function buildNarrativePriorityRows(entries) {
+  return [...new Map(entries
+    .filter((entry) => entry.narrativePriority)
+    .map((entry) => [entry.regionId, {
+      regionId: entry.regionId,
+      cultureId: entry.narrativePriority.priorityCultureId ?? entry.cultureId,
+      cultureName: entry.narrativePriority.priorityCultureName ?? entry.cultureName,
+      state: entry.narrativePriority.state,
+      label: entry.narrativePriority.label,
+      microAction: entry.narrativePriority.microAction,
+      source: entry.narrativePriority.source,
+      reason: entry.narrativePriority.reason,
+      priorityScore: entry.narrativePriority.priorityScore,
+    }])).values()]
+    .sort((left, right) => right.priorityScore - left.priorityScore || left.regionId.localeCompare(right.regionId));
+}
+
 export function buildCultureLayerPanel(entries, options = {}) {
   const normalizedEntries = normalizeEntries(entries);
   const normalizedOptions = requireObject(options, 'CultureLayerPanel options');
@@ -231,6 +249,7 @@ export function buildCultureLayerPanel(entries, options = {}) {
     },
     atlasLayers: buildAtlasLayerControls(normalizedEntries),
     collisionControls: buildCollisionControls(normalizedEntries),
+    narrativePriorities: buildNarrativePriorityRows(normalizedEntries),
     metrics: {
       markerCount: normalizedEntries.length,
       regionCount: regionRows.length,

--- a/src/ui/culture/buildCultureLocalTimeline.js
+++ b/src/ui/culture/buildCultureLocalTimeline.js
@@ -86,11 +86,16 @@ export function buildCultureLocalTimeline({ selectedRegionId, selectedMarker = n
     };
   }
 
+  const narrativePriority = selectedCluster?.narrativePriority ?? selectedMarker?.narrativePriority ?? null;
+
   return {
     state: 'active',
     regionId,
     heading: 'Chronologie locale',
-    summary: `${items.length} signal${items.length > 1 ? 's' : ''} culturel${items.length > 1 ? 's' : ''} lié${items.length > 1 ? 's' : ''} à la province sélectionnée.`,
+    summary: narrativePriority
+      ? `${narrativePriority.label}: ${narrativePriority.microAction} · ${narrativePriority.reason}`
+      : `${items.length} signal${items.length > 1 ? 's' : ''} culturel${items.length > 1 ? 's' : ''} lié${items.length > 1 ? 's' : ''} à la province sélectionnée.`,
+    narrativePriority,
     items,
   };
 }

--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1493,6 +1493,101 @@ function buildAtlasStoryReason(entry, signals, rank) {
   return `${entry.cultureName} reste visible comme couche secondaire à surveiller.`;
 }
 
+function buildNarrativeEventCandidates(regionId, regionPresence, cultureSignalsById) {
+  return regionPresence
+    .flatMap((entry) => (cultureSignalsById.get(entry.cultureId)?.signals.orderedHistoricalEvents ?? [])
+      .map((event) => ({
+        eventId: event.id,
+        title: event.title,
+        cultureId: entry.cultureId,
+        cultureName: entry.cultureName,
+        importance: event.importance,
+        discoveryIds: [...event.discoveryIds],
+        triggeredAt: event.triggeredAt.toISOString(),
+      })))
+    .sort((left, right) => right.importance - left.importance
+      || left.triggeredAt.localeCompare(right.triggeredAt)
+      || left.title.localeCompare(right.title)
+      || left.cultureId.localeCompare(right.cultureId))
+    .map((event, index) => ({
+      ...event,
+      priorityRank: index,
+      eventMarkerId: `${regionId}:${event.cultureId}:event:${event.eventId}`,
+    }));
+}
+
+export function buildCultureNarrativePriority(regionId, regionPresence, cultureSignalsById) {
+  const eventCandidates = buildNarrativeEventCandidates(regionId, regionPresence, cultureSignalsById);
+  const discoveryIds = [...new Set(regionPresence.flatMap((entry) => (
+    cultureSignalsById.get(entry.cultureId)?.signals.highlightedDiscoveries ?? []
+  )))].sort();
+  const activeResearchCount = regionPresence.reduce((count, entry) => (
+    count + (cultureSignalsById.get(entry.cultureId)?.signals.activeResearchCount ?? 0)
+  ), 0);
+  const topEvent = eventCandidates[0] ?? null;
+  const hasCollision = regionPresence.length > 1 || eventCandidates.length > 1;
+
+  if (topEvent && topEvent.importance >= 4) {
+    return {
+      state: 'opportunity',
+      label: 'opportunité',
+      microAction: 'explorer',
+      source: topEvent.title,
+      reason: `${topEvent.title} ouvre une action culturelle prioritaire.`,
+      priorityScore: clampScore(80 + topEvent.importance + eventCandidates.length),
+      eventCount: eventCandidates.length,
+      discoveryCount: discoveryIds.length,
+      eventMarkers: eventCandidates.slice(0, 3),
+    };
+  }
+
+  if (hasCollision && (eventCandidates.length > 0 || discoveryIds.length > 1)) {
+    const source = topEvent?.title ?? discoveryIds[0] ?? regionPresence[0]?.cultureName ?? regionId;
+
+    return {
+      state: 'tension',
+      label: 'tension',
+      microAction: 'apaiser',
+      source,
+      reason: eventCandidates.length > 1
+        ? `${eventCandidates.length} événements se superposent: apaiser avant d'empiler une action.`
+        : `${regionPresence.length} influences partagent ${regionId}: apaiser la lecture du cluster.`,
+      priorityScore: clampScore(60 + (eventCandidates.length * 5) + discoveryIds.length),
+      eventCount: eventCandidates.length,
+      discoveryCount: discoveryIds.length,
+      eventMarkers: eventCandidates.slice(0, 3),
+    };
+  }
+
+  if (discoveryIds.length > 0 && activeResearchCount === 0 && eventCandidates.length === 0) {
+    return {
+      state: 'completed',
+      label: 'suivi terminé',
+      microAction: 'consolider',
+      source: discoveryIds[0],
+      reason: `${discoveryIds[0]} est documentée: consolider le repère sans ouvrir de journal complet.`,
+      priorityScore: clampScore(40 + discoveryIds.length),
+      eventCount: 0,
+      discoveryCount: discoveryIds.length,
+      eventMarkers: [],
+    };
+  }
+
+  return {
+    state: 'watch',
+    label: 'à surveiller',
+    microAction: activeResearchCount > 0 ? 'soutenir' : 'attendre',
+    source: topEvent?.title ?? discoveryIds[0] ?? regionPresence[0]?.cultureName ?? regionId,
+    reason: activeResearchCount > 0
+      ? `${activeResearchCount} recherche${activeResearchCount > 1 ? 's' : ''} active${activeResearchCount > 1 ? 's' : ''}: soutenir sans priorité critique.`
+      : 'Aucun signal critique: attendre le prochain repère culturel.',
+    priorityScore: clampScore(20 + activeResearchCount + discoveryIds.length),
+    eventCount: eventCandidates.length,
+    discoveryCount: discoveryIds.length,
+    eventMarkers: eventCandidates.slice(0, 3),
+  };
+}
+
 export function buildCultureMarkerCollisionCluster(regionId, regionPresence, cultureSignalsById) {
   const stack = regionPresence
     .map((entry, index) => {
@@ -1530,6 +1625,7 @@ export function buildCultureMarkerCollisionCluster(regionId, regionPresence, cul
     })
     .sort((left, right) => right.priorityScore - left.priorityScore || left.cultureId.localeCompare(right.cultureId));
   const priorityMarker = stack[0] ?? null;
+  const narrativePriority = buildCultureNarrativePriority(regionId, regionPresence, cultureSignalsById);
 
   return {
     clusterId: `${regionId}:marker-collision`,
@@ -1540,6 +1636,7 @@ export function buildCultureMarkerCollisionCluster(regionId, regionPresence, cul
     priorityMarkerId: priorityMarker?.markerId ?? null,
     priorityCultureId: priorityMarker?.cultureId ?? null,
     priorityReason: priorityMarker?.priorityReason ?? 'aucun marqueur',
+    narrativePriority,
     stack,
   };
 }
@@ -1703,11 +1800,11 @@ export function buildCultureMapOverlay(payload, options = {}) {
         const atlasStoryLayers = includeAtlasStoryLayers
           ? buildCultureAtlasStoryLayers(regionId, regionPresence, cultureSignalsById)
           : null;
+        const narrativePriority = includeAtlasStoryLayers
+          ? buildCultureNarrativePriority(regionId, regionPresence, cultureSignalsById)
+          : null;
         const narrativeSummary = includeAtlasStoryLayers
-          ? (atlasStoryLayers.find((layer) => layer.kind === 'timeline')?.markers[0]?.reason
-            ?? atlasStoryLayers.find((layer) => layer.kind === 'discoveries')?.markers[0]?.reason
-            ?? atlasStoryLayers[0]?.markers[0]?.reason
-            ?? `${culture.name} reste lisible dans ${regionId}.`)
+          ? `${narrativePriority.label}: ${narrativePriority.reason}`
           : null;
         const supportBundles = buildCultureSupportBundles(culture, regionId, regionPresence, cultureState);
         const riskChangePreview = buildCultureSupportRiskChangePreview(culture, supportBundles[0] ?? null, regionPresence, cultureState);
@@ -1786,7 +1883,7 @@ export function buildCultureMapOverlay(payload, options = {}) {
           cultureStabilizationSummary,
           ...(supportBundles.length > 0 ? { supportBundles, recommendedFirstBundle } : {}),
           ...(clusterSummary ? { clusterSummary } : {}),
-          ...(includeAtlasStoryLayers ? { markerCollisionCluster, atlasStoryLayers, narrativeSummary } : {}),
+          ...(includeAtlasStoryLayers ? { markerCollisionCluster, atlasStoryLayers, narrativeSummary, narrativePriority } : {}),
           zoneContour: buildZoneContour(cultureState.influenceTier, overlapCount, zoneRank),
           style,
           zoneStyle: buildZoneStyle(markerType, cultureState.influenceTier, style, zoneBand),

--- a/test/ui/culture/buildCultureLayerPanel.test.js
+++ b/test/ui/culture/buildCultureLayerPanel.test.js
@@ -284,9 +284,17 @@ test('buildCultureLayerPanel exposes atlas story layer controls and collision st
         priorityMarkerId: 'shared-bay:culture-harbor',
         priorityCultureId: 'culture-harbor',
         priorityReason: '1 événement',
+        narrativePriority: {
+          state: 'opportunity',
+          label: 'opportunité',
+          microAction: 'explorer',
+          source: 'Harbor Forum',
+          reason: 'Harbor Forum ouvre une action culturelle prioritaire.',
+          priorityScore: 85,
+        },
         stack: [],
       },
-      narrativeSummary: "Harbor Compact compte maintenant: Harbor Forum donne un repère d'action immédiat.",
+      narrativeSummary: "opportunité: Harbor Forum ouvre une action culturelle prioritaire.",
     },
   ]);
 
@@ -308,4 +316,17 @@ test('buildCultureLayerPanel exposes atlas story layer controls and collision st
   ]);
   assert.equal(panel.collisionControls[0].strategy, 'stack-by-priority');
   assert.equal(panel.collisionControls[0].priorityCultureId, 'culture-harbor');
+  assert.deepEqual(panel.narrativePriorities, [
+    {
+      regionId: 'shared-bay',
+      cultureId: 'culture-harbor',
+      cultureName: 'Harbor Compact',
+      state: 'opportunity',
+      label: 'opportunité',
+      microAction: 'explorer',
+      source: 'Harbor Forum',
+      reason: 'Harbor Forum ouvre une action culturelle prioritaire.',
+      priorityScore: 85,
+    },
+  ]);
 });

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -1361,6 +1361,29 @@ test('buildCultureMapOverlay exposes atlas story layers and deterministic marker
     priorityMarkerId: 'shared-bay:culture-harbor',
     priorityCultureId: 'culture-harbor',
     priorityReason: '1 événement',
+    narrativePriority: {
+      state: 'opportunity',
+      label: 'opportunité',
+      microAction: 'explorer',
+      source: 'Harbor Forum',
+      reason: 'Harbor Forum ouvre une action culturelle prioritaire.',
+      priorityScore: 85,
+      eventCount: 1,
+      discoveryCount: 2,
+      eventMarkers: [
+        {
+          eventId: 'event-harbor-forum',
+          title: 'Harbor Forum',
+          cultureId: 'culture-harbor',
+          cultureName: 'Harbor Compact',
+          importance: 4,
+          discoveryIds: ['tidal-ledgers'],
+          triggeredAt: '2026-04-20T00:00:00.000Z',
+          priorityRank: 0,
+          eventMarkerId: 'shared-bay:culture-harbor:event:event-harbor-forum',
+        },
+      ],
+    },
     stack: [
       {
         markerId: 'shared-bay:culture-harbor',
@@ -1385,7 +1408,8 @@ test('buildCultureMapOverlay exposes atlas story layers and deterministic marker
     ['discoveries', 2, true],
     ['timeline', 1, true],
   ]);
-  assert.match(overlay[0].narrativeSummary, /Harbor Forum/);
+  assert.equal(overlay[0].narrativePriority.microAction, 'explorer');
+  assert.match(overlay[0].narrativeSummary, /opportunité: Harbor Forum/);
   assert.deepEqual(overlay[0].atlasStoryLayers[2].markers, [
     {
       markerId: 'shared-bay:culture-harbor:timeline',
@@ -1397,6 +1421,107 @@ test('buildCultureMapOverlay exposes atlas story layers and deterministic marker
       reason: "Harbor Compact compte maintenant: Harbor Forum donne un repère d'action immédiat.",
     },
   ]);
+});
+
+test('buildCultureMapOverlay assigns tension and completed narrative priority states', () => {
+  const tensionOverlay = buildCultureMapOverlay(
+    {
+      cultures: [
+        {
+          id: 'culture-east',
+          name: 'East Chorus',
+          archetype: 'urban',
+          primaryLanguage: 'east-song',
+          valueIds: ['markets'],
+          traditionIds: ['choirs'],
+          openness: 55,
+          cohesion: 55,
+          researchDrive: 55,
+        },
+        {
+          id: 'culture-west',
+          name: 'West Loom',
+          archetype: 'guild',
+          primaryLanguage: 'west-thread',
+          valueIds: ['craft'],
+          traditionIds: ['looms'],
+          openness: 54,
+          cohesion: 56,
+          researchDrive: 55,
+        },
+      ],
+      researchStates: [
+        {
+          id: 'research-east-song',
+          cultureId: 'culture-east',
+          topicId: 'east-song',
+          status: 'completed',
+          progress: 100,
+          completedAt: '2026-04-20T00:00:00.000Z',
+          discoveredConceptIds: ['market-rhythm'],
+        },
+        {
+          id: 'research-west-loom',
+          cultureId: 'culture-west',
+          topicId: 'west-loom',
+          status: 'completed',
+          progress: 100,
+          completedAt: '2026-04-20T00:00:00.000Z',
+          discoveredConceptIds: ['loom-code'],
+        },
+      ],
+      historicalEvents: [],
+    },
+    {
+      atlasStoryLayers: true,
+      regionIdsByCulture: {
+        'culture-east': ['shared-market'],
+        'culture-west': ['shared-market'],
+      },
+    },
+  );
+
+  assert.equal(tensionOverlay[0].narrativePriority.state, 'tension');
+  assert.equal(tensionOverlay[0].narrativePriority.microAction, 'apaiser');
+  assert.match(tensionOverlay[0].narrativeSummary, /tension/);
+
+  const completedOverlay = buildCultureMapOverlay(
+    {
+      cultures: [
+        {
+          id: 'culture-archive',
+          name: 'Archive Circle',
+          archetype: 'scholarly',
+          primaryLanguage: 'archive-hand',
+          valueIds: ['memory'],
+          traditionIds: ['catalogues'],
+          openness: 50,
+          cohesion: 70,
+          researchDrive: 45,
+        },
+      ],
+      researchStates: [
+        {
+          id: 'research-catalogue',
+          cultureId: 'culture-archive',
+          topicId: 'catalogue',
+          status: 'completed',
+          progress: 100,
+          completedAt: '2026-04-20T00:00:00.000Z',
+          discoveredConceptIds: ['sealed-index'],
+        },
+      ],
+      historicalEvents: [],
+    },
+    {
+      atlasStoryLayers: true,
+      regionIdsByCulture: { 'culture-archive': ['quiet-stacks'] },
+    },
+  );
+
+  assert.equal(completedOverlay[0].narrativePriority.state, 'completed');
+  assert.equal(completedOverlay[0].narrativePriority.label, 'suivi terminé');
+  assert.equal(completedOverlay[0].narrativePriority.microAction, 'consolider');
 });
 
 test('buildResidualCultureActionPayoff covers complete, partial, and insufficient outcomes', () => {


### PR DESCRIPTION
Gamma: Implements #1191.

Summary:
- adds deterministic narrative priority states for atlas clusters: à surveiller, opportunité, tension, suivi terminé
- attaches short micro-actions (attendre/soutenir/explorer/apaiser/consolider) to cluster priorities
- exposes priority rows in the culture layer panel and priority summaries in local timelines

Validation:
- node --check src/ui/culture/buildCultureMapOverlay.js
- node --check src/ui/culture/buildCultureLayerPanel.js
- node --check src/ui/culture/buildCultureLocalTimeline.js
- npm test -- test/ui/culture/buildCultureMapOverlay.test.js test/ui/culture/buildCultureLayerPanel.test.js test/ui/culture/buildCultureLocalTimeline.test.js
- npm test

Zeta: ready for validation before merge.