### PR TITLE
Delta: add fog-safe confidence hints

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2154,6 +2154,75 @@ function buildSuspicionHeatDecayPlayback({ locationCellules, locationOperations,
   };
 }
 
+function buildFogSafeConfidenceState({ locationCellules, locationOperations, presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount }) {
+  const activeOperation = locationOperations.some((operation) => operation.phase === 'execution' || operation.heat >= 70);
+  const hasVisibleExposure = exposedCellCount > 0;
+  const hasProbableSignal = sabotageRiskScore > 0 || ['medium', 'high'].includes(presenceLevel) || locationOperations.length > 0;
+  const hasOldSignal = locationCellules.some((cellule) => cellule.exposure > 0 || cellule.status === 'dormant');
+  const state = hasVisibleExposure || riskLevel === 'high' || activeOperation
+    ? 'confirmed'
+    : hasProbableSignal
+      ? 'suspected'
+      : hasOldSignal
+        ? 'stale'
+        : 'masked';
+
+  const copyByState = {
+    confirmed: 'Confiance confirmée: pression visible, détails sensibles encore expurgés.',
+    suspected: 'Confiance suspecte: signal probable à vérifier, danger réel non confirmé.',
+    stale: 'Confiance ancienne: indice à revérifier, ne pas lire comme danger faible.',
+    masked: 'Confiance masquée: données absentes ou confidentielles, ne pas inférer un danger faible.',
+  };
+
+  return {
+    state,
+    label: state === 'confirmed'
+      ? 'Confirmé'
+      : state === 'suspected'
+        ? 'Suspect'
+        : state === 'stale'
+          ? 'Ancien'
+          : 'Masqué',
+    dangerInterpretation: state === 'masked' || state === 'stale'
+      ? 'incertitude élevée, pas danger faible'
+      : riskLevel === 'none'
+        ? 'danger non confirmé'
+        : `danger ${riskLevel}`,
+    safeCopy: copyByState[state],
+  };
+}
+
+function buildSafeVerificationHint({ confidenceState, safeMapMasking }) {
+  const hintByState = {
+    confirmed: {
+      action: 'observe-locally',
+      label: 'Observer localement',
+      reason: 'Confirmer la tendance visible sans nommer cellule, relais, cible ou cause.',
+    },
+    suspected: {
+      action: 'limit-coverage',
+      label: 'Limiter couverture',
+      reason: 'Réduire le rayon de vérification pour éviter une exposition inutile sur un signal probable.',
+    },
+    stale: {
+      action: 'wait',
+      label: 'Attendre un signal frais',
+      reason: 'Indice ancien: attendre ou revérifier avant toute action directe.',
+    },
+    masked: {
+      action: 'ignore',
+      label: 'Ignorer pour l’instant',
+      reason: 'Information masquée ou confidentielle: ne pas transformer l’absence de données en faux signal rassurant.',
+    },
+  };
+  const hint = hintByState[confidenceState.state] ?? hintByState.masked;
+
+  return {
+    ...hint,
+    safeMapLabel: `${hint.label}: ${safeMapMasking.redactedLabel.toLowerCase()}, ${confidenceState.dangerInterpretation}.`,
+  };
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2257,20 +2326,33 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         sleeperCellCount,
         sabotageRiskScore,
       });
+      const suspicionHeatDecayPlayback = buildSuspicionHeatDecayPlayback({
+        locationCellules,
+        locationOperations,
+        sabotageRiskScore,
+      });
+      const safeMapMasking = buildSafeMapMasking({
+        presenceLevel,
+        riskLevel,
+        sabotageRiskScore,
+        exposedCellCount,
+        locationOperations,
+      });
+      const confidenceState = buildFogSafeConfidenceState({
+        locationCellules,
+        locationOperations,
+        presenceLevel,
+        riskLevel,
+        sabotageRiskScore,
+        exposedCellCount,
+      });
+      const safeVerificationHint = buildSafeVerificationHint({ confidenceState, safeMapMasking });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
-          suspicionHeatDecayPlayback: buildSuspicionHeatDecayPlayback({
-            locationCellules,
-            locationOperations,
-            sabotageRiskScore,
-          }),
-          safeMapMasking: buildSafeMapMasking({
-            presenceLevel,
-            riskLevel,
-            sabotageRiskScore,
-            exposedCellCount,
-            locationOperations,
-          }),
+          suspicionHeatDecayPlayback,
+          safeMapMasking,
+          confidenceState,
+          safeVerificationHint,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -1756,3 +1756,76 @@ test('buildIntrigueMapOverlay exposes safe-map heat decay playback and redacted 
   assert.match(masked.safeMapMasking.safeLabel, /données absentes ou confidentielles/);
   assert.deepEqual(masked.safeMapMasking.maskedDetails, ['identité cellule', 'relais opérationnel', 'objectif précis', 'cause du signal']);
 });
+
+test('buildIntrigueMapOverlay exposes fog-safe confidence states and verification hints', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-confirmed',
+      factionId: 'shadow-league',
+      codename: 'Torch',
+      locationId: 'confirmed-zone',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 74,
+    }),
+    new Cellule({
+      id: 'cell-suspected',
+      factionId: 'shadow-league',
+      codename: 'Lantern',
+      locationId: 'suspected-zone',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+    new Cellule({
+      id: 'cell-stale',
+      factionId: 'shadow-league',
+      codename: 'Ash',
+      locationId: 'stale-zone',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      exposure: 18,
+    }),
+    new Cellule({
+      id: 'cell-masked-confidence',
+      factionId: 'shadow-league',
+      codename: 'Blank',
+      locationId: 'masked-zone',
+      memberIds: ['ag-4'],
+      assetIds: ['asset-4'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-suspected',
+      celluleId: 'cell-suspected',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe patrol timings',
+      theaterId: 'suspected-zone',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 80,
+      progress: 5,
+      heat: 10,
+      phase: 'planning',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry]));
+
+  assert.equal(byLocation.get('confirmed-zone').confidenceState.state, 'confirmed');
+  assert.equal(byLocation.get('confirmed-zone').safeVerificationHint.action, 'observe-locally');
+  assert.match(byLocation.get('confirmed-zone').safeVerificationHint.safeMapLabel, /danger non confirmé/);
+
+  assert.equal(byLocation.get('suspected-zone').confidenceState.state, 'suspected');
+  assert.equal(byLocation.get('suspected-zone').safeVerificationHint.action, 'limit-coverage');
+  assert.match(byLocation.get('suspected-zone').confidenceState.safeCopy, /danger réel non confirmé/);
+
+  assert.equal(byLocation.get('stale-zone').confidenceState.state, 'stale');
+  assert.equal(byLocation.get('stale-zone').safeVerificationHint.action, 'wait');
+  assert.equal(byLocation.get('stale-zone').confidenceState.dangerInterpretation, 'incertitude élevée, pas danger faible');
+
+  assert.equal(byLocation.get('masked-zone').confidenceState.state, 'masked');
+  assert.equal(byLocation.get('masked-zone').safeVerificationHint.action, 'ignore');
+  assert.match(byLocation.get('masked-zone').safeVerificationHint.reason, /ne pas transformer l’absence de données/);
+});


### PR DESCRIPTION
Delta: ## Summary
- Adds deterministic fog-safe `confidenceState` values for intrigue overlay entries: confirmed, suspected, stale, and masked.
- Adds `safeVerificationHint` actions that distinguish uncertainty from low danger: observe locally, limit coverage, wait, or ignore.
- Keeps safe-map labels redacted so cell, relay, target, and hidden cause details are not exposed.

Closes #1192.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés intrigue passés et tests complets passés avec `npm test` (659/659); j’attends ta validation avant tout merge.