### PR TITLE
Alpha: preview province action conflicts

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1527,6 +1527,41 @@ function queueStatusForProvince(province) {
   return 'ready';
 }
 
+function buildQueueActionConflictPreview({ entry, province, status, reason, action, previousEntry, previousProvince, safeReplacement }) {
+  const blockers = status === 'blocked' || status === 'conflict'
+    ? [reason]
+    : status === 'risky'
+      ? [province?.actionAffordance.reason ?? 'risque tactique à confirmer']
+      : [];
+  const mutuallyExclusiveWith = previousEntry && (
+    previousEntry.provinceId === entry.provinceId
+    || province?.neighborIds.includes(previousEntry.provinceId)
+    || previousProvince?.neighborIds.includes(entry.provinceId)
+  ) ? {
+      queueId: previousEntry.queueId,
+      provinceId: previousEntry.provinceId,
+      reason: previousEntry.provinceId === entry.provinceId ? 'même cible' : 'fronts voisins liés',
+    } : null;
+
+  return {
+    frontEffect: province
+      ? action?.status === 'available'
+        ? `stabilise ${province.tacticalHoverIntel.garrisonStatus} sur ${province.label}`
+        : action?.status === 'discouraged'
+          ? `évite une poussée fragile sur ${province.label}`
+          : `maintient ${province.label} sans bascule de front`
+      : 'aucun effet projetable sans cible valide',
+    blockers,
+    mutuallyExclusiveWith,
+    safestAlternative: safeReplacement,
+    confirmationHint: status === 'ready'
+      ? 'confirmable maintenant'
+      : status === 'risky'
+        ? 'confirmation possible après lecture du risque'
+        : 'corriger avant confirmation',
+  };
+}
+
 function buildProvinceActionQueueValidation(renderedProvinces, options) {
   const queue = normalizeProvinceActionQueue(options.provinceActionQueue);
   const provinceById = new Map(renderedProvinces.map((province) => [province.provinceId, province]));
@@ -1538,6 +1573,12 @@ function buildProvinceActionQueueValidation(renderedProvinces, options) {
     const baseStatus = queueStatusForProvince(province);
     const status = conflictReason ? (baseStatus === 'blocked' ? 'blocked' : 'conflict') : baseStatus;
     const action = province?.tacticalHoverIntel.nextAction ?? null;
+    const reason = conflictReason ?? (status === 'ready' ? 'ordre prêt' : 'ordre risqué');
+    const safeReplacement = status === 'ready' ? null : {
+      actionCode: action?.status === 'available' ? action.code : 'hold-reserve',
+      label: action?.status === 'available' ? action.label : 'Garder en réserve',
+      reason: action?.status === 'available' ? action.reason : 'attendre résolution du blocage',
+    };
 
     return {
       queueId: entry.queueId,
@@ -1546,12 +1587,18 @@ function buildProvinceActionQueueValidation(renderedProvinces, options) {
       actionCode: entry.actionCode || action?.code || 'unknown-action',
       actionLabel: entry.label || action?.label || 'Action inconnue',
       status,
-      reason: conflictReason ?? (status === 'ready' ? 'ordre prêt' : 'ordre risqué'),
-      safeReplacement: status === 'ready' ? null : {
-        actionCode: action?.status === 'available' ? action.code : 'hold-reserve',
-        label: action?.status === 'available' ? action.label : 'Garder en réserve',
-        reason: action?.status === 'available' ? action.reason : 'attendre résolution du blocage',
-      },
+      reason,
+      safeReplacement,
+      conflictAwarePreview: buildQueueActionConflictPreview({
+        entry,
+        province,
+        status,
+        reason,
+        action,
+        previousEntry,
+        previousProvince,
+        safeReplacement,
+      }),
     };
   });
   const firstBlocked = queueEntries.find((entry) => entry.status === 'blocked' || entry.status === 'conflict') ?? null;

--- a/src/ui/war/buildStrategicMapPreviewHtml.js
+++ b/src/ui/war/buildStrategicMapPreviewHtml.js
@@ -240,12 +240,26 @@ function renderKeyboardActionPlanner(shell) {
 
 function renderProvinceActionQueueValidation(shell) {
   const validation = shell.keyboardActionPlanner.actionQueueValidation;
-  const entries = validation.entries.map((entry) => `
+  const entries = validation.entries.map((entry) => {
+    const preview = entry.conflictAwarePreview;
+    const blockers = preview.blockers.length > 0 ? preview.blockers.join(', ') : 'aucun blocage';
+    const exclusive = preview.mutuallyExclusiveWith
+      ? `Exclusif avec ${preview.mutuallyExclusiveWith.queueId}: ${preview.mutuallyExclusiveWith.reason}`
+      : 'pas d’exclusion';
+
+    return `
     <li class="queue-validation-item queue-validation-item--${escapeHtml(entry.status)}">
       <span>${escapeHtml(entry.provinceLabel)} · ${escapeHtml(entry.actionLabel)}</span>
       <small>${escapeHtml(entry.status)} — ${escapeHtml(entry.reason)}</small>
+      <div class="conflict-aware-preview">
+        <b>${escapeHtml(preview.frontEffect)}</b>
+        <small>Blocage: ${escapeHtml(blockers)}</small>
+        <small>${escapeHtml(exclusive)}</small>
+        <em>${escapeHtml(preview.confirmationHint)}</em>
+      </div>
     </li>
-  `).join('');
+  `;
+  }).join('');
 
   return `
     <section class="queue-validation" aria-label="Validation de file d’actions province">
@@ -343,6 +357,9 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .queue-validation-item--conflict { border-color:rgba(248,113,113,0.48); }
     .queue-validation-item small,
     .next-safe-action small { color:#cbd5e1; }
+    .conflict-aware-preview { display:grid; gap:2px; margin-top:5px; padding-top:5px; border-top:1px solid rgba(148,163,184,0.12); }
+    .conflict-aware-preview b { color:#e0f2fe; font-size:12px; }
+    .conflict-aware-preview em { color:#fde68a; font-size:11px; font-style:normal; }
     .next-safe-action { display:grid; gap:3px; border:1px solid rgba(74,222,128,0.34); border-radius:14px; padding:9px; background:rgba(22,101,52,0.14); }
     .next-safe-action span { color:#93a4bb; font-size:11px; text-transform:uppercase; letter-spacing:0.09em; }
     .next-safe-action strong { color:#bbf7d0; }

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -271,6 +271,13 @@ test('StrategicMapShell validates province action queues and suggests a safe rep
         status: 'ready',
         reason: 'ordre prêt',
         safeReplacement: null,
+        conflictAwarePreview: {
+          frontEffect: 'maintient Réserve nord sans bascule de front',
+          blockers: [],
+          mutuallyExclusiveWith: null,
+          safestAlternative: null,
+          confirmationHint: 'confirmable maintenant',
+        },
       },
       {
         queueId: 'q2',
@@ -285,6 +292,17 @@ test('StrategicMapShell validates province action queues and suggests a safe rep
           label: 'Garder en réserve',
           reason: 'attendre résolution du blocage',
         },
+        conflictAwarePreview: {
+          frontEffect: 'évite une poussée fragile sur Support rompu',
+          blockers: ['support manquant'],
+          mutuallyExclusiveWith: null,
+          safestAlternative: {
+            actionCode: 'hold-reserve',
+            label: 'Garder en réserve',
+            reason: 'attendre résolution du blocage',
+          },
+          confirmationHint: 'corriger avant confirmation',
+        },
       },
       {
         queueId: 'q3',
@@ -295,6 +313,17 @@ test('StrategicMapShell validates province action queues and suggests a safe rep
         status: 'ready',
         reason: 'ordre prêt',
         safeReplacement: null,
+        conflictAwarePreview: {
+          frontEffect: 'stabilise front actif sur Front rouge',
+          blockers: [],
+          mutuallyExclusiveWith: {
+            queueId: 'q2',
+            provinceId: 'support',
+            reason: 'fronts voisins liés',
+          },
+          safestAlternative: null,
+          confirmationHint: 'confirmable maintenant',
+        },
       },
       {
         queueId: 'q4',
@@ -308,6 +337,21 @@ test('StrategicMapShell validates province action queues and suggests a safe rep
           actionCode: 'reinforce-front',
           label: 'Renforcer le front',
           reason: 'front contesté et pression militaire visible',
+        },
+        conflictAwarePreview: {
+          frontEffect: 'stabilise front actif sur Front rouge',
+          blockers: ['cible déjà engagée'],
+          mutuallyExclusiveWith: {
+            queueId: 'q3',
+            provinceId: 'front',
+            reason: 'même cible',
+          },
+          safestAlternative: {
+            actionCode: 'reinforce-front',
+            label: 'Renforcer le front',
+            reason: 'front contesté et pression militaire visible',
+          },
+          confirmationHint: 'corriger avant confirmation',
         },
       },
     ],

--- a/test/ui/war/buildStrategicMapPreviewHtml.test.js
+++ b/test/ui/war/buildStrategicMapPreviewHtml.test.js
@@ -24,6 +24,10 @@ test('buildStrategicMapPreviewHtml renders a screenshot-ready preview from the g
   assert.match(html, /Validation de file d’actions province/);
   assert.match(html, /Prochaine action sûre/);
   assert.match(html, /queue-validation-item--conflict/);
+  assert.match(html, /conflict-aware-preview/);
+  assert.match(html, /Blocage:/);
+  assert.match(html, /Exclusif avec/);
+  assert.match(html, /corriger avant confirmation/);
   assert.match(html, /class="province is-contested is-occupied is-selected is-queued"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /Porte du Fleuve/);


### PR DESCRIPTION
Alpha: Implements #1199.

Summary:
- adds conflict-aware action previews to province order queue validation
- shows expected front/province effect, blockers, mutually exclusive queued orders, and confirmation guidance
- keeps safest alternative guidance for blocked/conflicting previews
- renders the conflict preview details in the strategic map preview HTML

Tests:
- npm test
- git diff --check

Zeta: ready for validation before merge.
