### PR TITLE
Delta: add verification path previews

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2223,6 +2223,75 @@ function buildSafeVerificationHint({ confidenceState, safeMapMasking }) {
   };
 }
 
+function buildVerificationPathPreviews({ confidenceState, safeVerificationHint, suspicionHeatDecayPlayback, safeMapMasking }) {
+  const currentHeat = suspicionHeatDecayPlayback.currentHeat;
+  const nextCoolerFrame = suspicionHeatDecayPlayback.frames.find((frame) => frame.turnOffset > 0 && frame.projectedHeat < currentHeat) ?? null;
+  const heatDecayContext = currentHeat >= 70
+    ? 'Chaleur active: éviter les vérifications larges avant refroidissement.'
+    : nextCoolerFrame
+      ? `${nextCoolerFrame.label}: coût réduit si la vérification attend ce palier.`
+      : 'Aucune décroissance exploitable: rester sur une vérification minimale.';
+  const pathByState = {
+    confirmed: {
+      pathId: 'observe-local-confirmation',
+      label: 'Confirmer par observation locale',
+      exposureCost: currentHeat >= 70 ? 8 : 4,
+      confidenceAfter: 'confirmed-stable',
+      evidenceNeeded: 'un second indice visible sur la même province, sans nommer source ni cible',
+    },
+    suspected: {
+      pathId: 'limited-coverage-check',
+      label: 'Vérifier en couverture limitée',
+      exposureCost: currentHeat >= 45 ? 9 : 6,
+      confidenceAfter: 'suspected-or-confirmed',
+      evidenceNeeded: 'une convergence de niveau de risque ou de fraîcheur, pas une identité cachée',
+    },
+    stale: {
+      pathId: 'wait-fresh-signal',
+      label: 'Attendre un signal frais',
+      exposureCost: 1,
+      confidenceAfter: 'stale-or-suspected',
+      evidenceNeeded: 'fraîcheur visible renouvelée avant toute action directe',
+    },
+    masked: {
+      pathId: 'ignore-masked-signal',
+      label: 'Ignorer tant que masqué',
+      exposureCost: 0,
+      confidenceAfter: 'masked-safe',
+      evidenceNeeded: 'donnée visible non confidentielle; l’absence de signal ne prouve pas un danger faible',
+    },
+  };
+  const recommended = pathByState[confidenceState.state] ?? pathByState.masked;
+  const unsafeBroadening = currentHeat >= 70 || safeMapMasking.state === 'active-risk'
+    ? [{
+      pathId: 'broad-coverage-now',
+      label: 'Élargir la couverture maintenant',
+      recommended: false,
+      unsafe: true,
+      exposureCost: clampPercent(Math.max(14, currentHeat - 50)),
+      costCue: 'trop coûteux',
+      confidenceAfter: 'uncertain-with-exposure',
+      evidenceNeeded: 'non recommandé: coûterait de l’exposition sans preuve fog-safe supplémentaire',
+      heatDecayContext,
+      fogSafeCopy: 'Chemin bloqué: la carte ne révèle aucun relais, cellule ou cible pour justifier cet élargissement.',
+      saferFallbackAction: safeVerificationHint.action,
+    }]
+    : [];
+
+  return [
+    {
+      ...recommended,
+      recommended: true,
+      unsafe: false,
+      costCue: recommended.exposureCost >= 8 ? 'coût modéré' : recommended.exposureCost > 0 ? 'coût bas' : 'sans coût',
+      heatDecayContext,
+      fogSafeCopy: `${recommended.label}: ${confidenceState.safeCopy} Prochaine preuve requise: ${recommended.evidenceNeeded}.`,
+      saferFallbackAction: null,
+    },
+    ...unsafeBroadening,
+  ];
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2347,12 +2416,19 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         exposedCellCount,
       });
       const safeVerificationHint = buildSafeVerificationHint({ confidenceState, safeMapMasking });
+      const verificationPathPreviews = buildVerificationPathPreviews({
+        confidenceState,
+        safeVerificationHint,
+        suspicionHeatDecayPlayback,
+        safeMapMasking,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
           safeMapMasking,
           confidenceState,
           safeVerificationHint,
+          verificationPathPreviews,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -1829,3 +1829,86 @@ test('buildIntrigueMapOverlay exposes fog-safe confidence states and verificatio
   assert.equal(byLocation.get('masked-zone').safeVerificationHint.action, 'ignore');
   assert.match(byLocation.get('masked-zone').safeVerificationHint.reason, /ne pas transformer l’absence de données/);
 });
+
+test('buildIntrigueMapOverlay previews fog-safe verification paths with costs and unsafe fallback', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-confirmed-path',
+      factionId: 'shadow-league',
+      codename: 'Torch',
+      locationId: 'confirmed-path',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 76,
+    }),
+    new Cellule({
+      id: 'cell-uncertain-path',
+      factionId: 'shadow-league',
+      codename: 'Lantern',
+      locationId: 'uncertain-path',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+    new Cellule({
+      id: 'cell-masked-path',
+      factionId: 'shadow-league',
+      codename: 'Blank',
+      locationId: 'masked-path',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-confirmed-hot',
+      celluleId: 'cell-confirmed-path',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Stress gate watches',
+      theaterId: 'confirmed-path',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 12,
+      progress: 84,
+      heat: 86,
+      phase: 'execution',
+    }),
+    new OperationClandestine({
+      id: 'op-uncertain-probe',
+      celluleId: 'cell-uncertain-path',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe road rumor',
+      theaterId: 'uncertain-path',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 80,
+      progress: 5,
+      heat: 10,
+      phase: 'planning',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry]));
+  const confirmedPaths = byLocation.get('confirmed-path').verificationPathPreviews;
+  const uncertainPaths = byLocation.get('uncertain-path').verificationPathPreviews;
+  const maskedPaths = byLocation.get('masked-path').verificationPathPreviews;
+
+  assert.equal(confirmedPaths[0].pathId, 'observe-local-confirmation');
+  assert.equal(confirmedPaths[0].recommended, true);
+  assert.equal(confirmedPaths[0].costCue, 'coût modéré');
+  assert.match(confirmedPaths[0].heatDecayContext, /Chaleur active/);
+  assert.match(confirmedPaths[0].fogSafeCopy, /sans nommer source ni cible/);
+  assert.deepEqual(confirmedPaths.filter((path) => path.unsafe).map((path) => path.saferFallbackAction), ['observe-locally']);
+  assert.match(confirmedPaths.find((path) => path.unsafe).fogSafeCopy, /ne révèle aucun relais, cellule ou cible/);
+
+  assert.equal(uncertainPaths[0].pathId, 'limited-coverage-check');
+  assert.equal(uncertainPaths[0].unsafe, false);
+  assert.equal(uncertainPaths[0].costCue, 'coût bas');
+  assert.match(uncertainPaths[0].fogSafeCopy, /danger réel non confirmé/);
+  assert.match(uncertainPaths[0].evidenceNeeded, /pas une identité cachée/);
+
+  assert.equal(maskedPaths[0].pathId, 'ignore-masked-signal');
+  assert.equal(maskedPaths[0].exposureCost, 0);
+  assert.match(maskedPaths[0].fogSafeCopy, /l’absence de signal ne prouve pas un danger faible/);
+});


### PR DESCRIPTION
Delta: ## Summary
- Adds fog-safe `verificationPathPreviews` for intrigue overlay decisions.
- Shows recommended verification paths with exposure/cost cues, next evidence needed, and heat/decay context.
- Marks too-expensive broad coverage paths unsafe and provides safer fallbacks without revealing hidden cells, relays, targets, or causes.

Closes #1202.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés intrigue passés et tests complets passés avec `npm test` (661/661); j’attends ta validation avant tout merge.