### PR TITLE
Gamma: add cultural consequence previews

### DIFF
--- a/src/ui/culture/buildCultureLayerPanel.js
+++ b/src/ui/culture/buildCultureLayerPanel.js
@@ -52,6 +52,10 @@ function normalizeEntries(entries) {
       markerCollisionCluster: normalizedEntry.markerCollisionCluster ?? null,
       narrativeSummary: String(normalizedEntry.narrativeSummary ?? '').trim(),
       narrativePriority: normalizedEntry.narrativePriority ?? normalizedEntry.markerCollisionCluster?.narrativePriority ?? null,
+      consequencePreview: normalizedEntry.consequencePreview
+        ?? normalizedEntry.narrativePriority?.consequencePreview
+        ?? normalizedEntry.markerCollisionCluster?.narrativePriority?.consequencePreview
+        ?? null,
     };
   });
 }
@@ -209,6 +213,7 @@ function buildNarrativePriorityRows(entries) {
       source: entry.narrativePriority.source,
       reason: entry.narrativePriority.reason,
       priorityScore: entry.narrativePriority.priorityScore,
+      consequencePreview: entry.consequencePreview,
     }])).values()]
     .sort((left, right) => right.priorityScore - left.priorityScore || left.regionId.localeCompare(right.regionId));
 }

--- a/src/ui/culture/buildCultureLocalTimeline.js
+++ b/src/ui/culture/buildCultureLocalTimeline.js
@@ -93,9 +93,10 @@ export function buildCultureLocalTimeline({ selectedRegionId, selectedMarker = n
     regionId,
     heading: 'Chronologie locale',
     summary: narrativePriority
-      ? `${narrativePriority.label}: ${narrativePriority.microAction} · ${narrativePriority.reason}`
+      ? `${narrativePriority.label}: ${narrativePriority.microAction} · ${narrativePriority.consequencePreview?.confidenceLabel ?? narrativePriority.reason}`
       : `${items.length} signal${items.length > 1 ? 's' : ''} culturel${items.length > 1 ? 's' : ''} lié${items.length > 1 ? 's' : ''} à la province sélectionnée.`,
     narrativePriority,
+    consequencePreview: narrativePriority?.consequencePreview ?? null,
     items,
   };
 }

--- a/src/ui/culture/buildCultureMapOverlay.js
+++ b/src/ui/culture/buildCultureMapOverlay.js
@@ -1516,6 +1516,58 @@ function buildNarrativeEventCandidates(regionId, regionPresence, cultureSignalsB
     }));
 }
 
+function buildCultureConsequencePreview(regionId, priority, regionPresence) {
+  const confidence = priority.eventCount > 0 && priority.discoveryCount > 0
+    ? 'high'
+    : priority.eventCount === 0 && priority.discoveryCount === 0
+      ? 'low'
+      : 'medium';
+  const visibleMarkerIds = priority.eventMarkers.length > 0
+    ? priority.eventMarkers.map((event) => event.eventMarkerId)
+    : regionPresence.slice(0, 3).map((entry) => `${regionId}:${entry.cultureId}`);
+  const opportunityByState = {
+    opportunity: `Saisir ${priority.source} peut transformer le signal culturel en avantage narratif immédiat.`,
+    tension: `Apaiser ${priority.source} peut rendre les influences superposées lisibles avant décision.`,
+    completed: `Consolider ${priority.source} sécurise le gain culturel déjà visible.`,
+    watch: priority.microAction === 'soutenir'
+      ? `Soutenir ${priority.source} garde la recherche locale exploitable.`
+      : `Attendre ${priority.source} évite de surinterpréter un signal incomplet.`,
+  };
+  const tradeoffByAction = {
+    explorer: 'retarde l’apaisement des influences secondaires du cluster',
+    apaiser: 'sacrifie une exploitation immédiate de la découverte prioritaire',
+    consolider: 'retarde l’ouverture de nouveaux fils de recherche',
+    soutenir: 'consomme l’attention qui pourrait explorer un événement plus fort ailleurs',
+    attendre: 'risque de laisser passer une opportunité faible si de nouveaux marqueurs confirment le signal',
+  };
+  const confidenceLabel = confidence === 'high'
+    ? 'confiance élevée: événement et découverte visibles'
+    : confidence === 'medium'
+      ? 'confiance moyenne: signal partiel mais lisible'
+      : 'confiance basse: intel culturel incomplet';
+
+  return {
+    previewId: `${regionId}:priority:${priority.state}:consequence`,
+    regionId,
+    state: priority.state,
+    microAction: priority.microAction,
+    confidence,
+    confidenceLabel,
+    opportunity: opportunityByState[priority.state] ?? opportunityByState.watch,
+    tradeoff: tradeoffByAction[priority.microAction] ?? 'arbitrage culturel à confirmer',
+    delayedOrSacrificed: tradeoffByAction[priority.microAction] ?? 'aucun sacrifice connu',
+    visibleMarkerIds,
+    summary: `${priority.microAction}: ${opportunityByState[priority.state] ?? opportunityByState.watch} Tradeoff: ${tradeoffByAction[priority.microAction] ?? 'arbitrage culturel à confirmer'}.`,
+  };
+}
+
+function withCultureConsequencePreview(regionId, priority, regionPresence) {
+  return {
+    ...priority,
+    consequencePreview: buildCultureConsequencePreview(regionId, priority, regionPresence),
+  };
+}
+
 export function buildCultureNarrativePriority(regionId, regionPresence, cultureSignalsById) {
   const eventCandidates = buildNarrativeEventCandidates(regionId, regionPresence, cultureSignalsById);
   const discoveryIds = [...new Set(regionPresence.flatMap((entry) => (
@@ -1528,7 +1580,7 @@ export function buildCultureNarrativePriority(regionId, regionPresence, cultureS
   const hasCollision = regionPresence.length > 1 || eventCandidates.length > 1;
 
   if (topEvent && topEvent.importance >= 4) {
-    return {
+    return withCultureConsequencePreview(regionId, {
       state: 'opportunity',
       label: 'opportunité',
       microAction: 'explorer',
@@ -1538,13 +1590,13 @@ export function buildCultureNarrativePriority(regionId, regionPresence, cultureS
       eventCount: eventCandidates.length,
       discoveryCount: discoveryIds.length,
       eventMarkers: eventCandidates.slice(0, 3),
-    };
+    }, regionPresence);
   }
 
   if (hasCollision && (eventCandidates.length > 0 || discoveryIds.length > 1)) {
     const source = topEvent?.title ?? discoveryIds[0] ?? regionPresence[0]?.cultureName ?? regionId;
 
-    return {
+    return withCultureConsequencePreview(regionId, {
       state: 'tension',
       label: 'tension',
       microAction: 'apaiser',
@@ -1556,11 +1608,11 @@ export function buildCultureNarrativePriority(regionId, regionPresence, cultureS
       eventCount: eventCandidates.length,
       discoveryCount: discoveryIds.length,
       eventMarkers: eventCandidates.slice(0, 3),
-    };
+    }, regionPresence);
   }
 
   if (discoveryIds.length > 0 && activeResearchCount === 0 && eventCandidates.length === 0) {
-    return {
+    return withCultureConsequencePreview(regionId, {
       state: 'completed',
       label: 'suivi terminé',
       microAction: 'consolider',
@@ -1570,10 +1622,10 @@ export function buildCultureNarrativePriority(regionId, regionPresence, cultureS
       eventCount: 0,
       discoveryCount: discoveryIds.length,
       eventMarkers: [],
-    };
+    }, regionPresence);
   }
 
-  return {
+  return withCultureConsequencePreview(regionId, {
     state: 'watch',
     label: 'à surveiller',
     microAction: activeResearchCount > 0 ? 'soutenir' : 'attendre',
@@ -1585,7 +1637,7 @@ export function buildCultureNarrativePriority(regionId, regionPresence, cultureS
     eventCount: eventCandidates.length,
     discoveryCount: discoveryIds.length,
     eventMarkers: eventCandidates.slice(0, 3),
-  };
+  }, regionPresence);
 }
 
 export function buildCultureMarkerCollisionCluster(regionId, regionPresence, cultureSignalsById) {

--- a/test/ui/culture/buildCultureLayerPanel.test.js
+++ b/test/ui/culture/buildCultureLayerPanel.test.js
@@ -291,6 +291,10 @@ test('buildCultureLayerPanel exposes atlas story layer controls and collision st
           source: 'Harbor Forum',
           reason: 'Harbor Forum ouvre une action culturelle prioritaire.',
           priorityScore: 85,
+          consequencePreview: {
+            previewId: 'shared-bay:priority:opportunity:consequence',
+            confidence: 'high',
+          },
         },
         stack: [],
       },
@@ -327,6 +331,10 @@ test('buildCultureLayerPanel exposes atlas story layer controls and collision st
       source: 'Harbor Forum',
       reason: 'Harbor Forum ouvre une action culturelle prioritaire.',
       priorityScore: 85,
+      consequencePreview: {
+        previewId: 'shared-bay:priority:opportunity:consequence',
+        confidence: 'high',
+      },
     },
   ]);
 });

--- a/test/ui/culture/buildCultureMapOverlay.test.js
+++ b/test/ui/culture/buildCultureMapOverlay.test.js
@@ -1383,6 +1383,19 @@ test('buildCultureMapOverlay exposes atlas story layers and deterministic marker
           eventMarkerId: 'shared-bay:culture-harbor:event:event-harbor-forum',
         },
       ],
+      consequencePreview: {
+        previewId: 'shared-bay:priority:opportunity:consequence',
+        regionId: 'shared-bay',
+        state: 'opportunity',
+        microAction: 'explorer',
+        confidence: 'high',
+        confidenceLabel: 'confiance élevée: événement et découverte visibles',
+        opportunity: 'Saisir Harbor Forum peut transformer le signal culturel en avantage narratif immédiat.',
+        tradeoff: 'retarde l’apaisement des influences secondaires du cluster',
+        delayedOrSacrificed: 'retarde l’apaisement des influences secondaires du cluster',
+        visibleMarkerIds: ['shared-bay:culture-harbor:event:event-harbor-forum'],
+        summary: 'explorer: Saisir Harbor Forum peut transformer le signal culturel en avantage narratif immédiat. Tradeoff: retarde l’apaisement des influences secondaires du cluster.',
+      },
     },
     stack: [
       {
@@ -1483,6 +1496,8 @@ test('buildCultureMapOverlay assigns tension and completed narrative priority st
 
   assert.equal(tensionOverlay[0].narrativePriority.state, 'tension');
   assert.equal(tensionOverlay[0].narrativePriority.microAction, 'apaiser');
+  assert.equal(tensionOverlay[0].narrativePriority.consequencePreview.confidence, 'medium');
+  assert.match(tensionOverlay[0].narrativePriority.consequencePreview.tradeoff, /sacrifie/);
   assert.match(tensionOverlay[0].narrativeSummary, /tension/);
 
   const completedOverlay = buildCultureMapOverlay(
@@ -1522,6 +1537,34 @@ test('buildCultureMapOverlay assigns tension and completed narrative priority st
   assert.equal(completedOverlay[0].narrativePriority.state, 'completed');
   assert.equal(completedOverlay[0].narrativePriority.label, 'suivi terminé');
   assert.equal(completedOverlay[0].narrativePriority.microAction, 'consolider');
+
+  const lowConfidenceOverlay = buildCultureMapOverlay(
+    {
+      cultures: [
+        {
+          id: 'culture-mist',
+          name: 'Mist Circle',
+          archetype: 'oral',
+          primaryLanguage: 'mist-sign',
+          valueIds: ['silence'],
+          traditionIds: ['watchfires'],
+          openness: 45,
+          cohesion: 52,
+          researchDrive: 40,
+        },
+      ],
+      researchStates: [],
+      historicalEvents: [],
+    },
+    {
+      atlasStoryLayers: true,
+      regionIdsByCulture: { 'culture-mist': ['mist-hills'] },
+    },
+  );
+
+  assert.equal(lowConfidenceOverlay[0].narrativePriority.state, 'watch');
+  assert.equal(lowConfidenceOverlay[0].narrativePriority.consequencePreview.confidence, 'low');
+  assert.match(lowConfidenceOverlay[0].narrativePriority.consequencePreview.confidenceLabel, /incomplet/);
 });
 
 test('buildResidualCultureActionPayoff covers complete, partial, and insufficient outcomes', () => {


### PR DESCRIPTION
Gamma: Implements #1201.

Summary:
- adds consequence previews to cultural atlas narrative priority choices
- calls out opportunity, tradeoff/delayed consequence, confidence level, and visible marker ties
- propagates previews through the culture layer panel and local timeline summaries

Validation:
- node --check src/ui/culture/buildCultureMapOverlay.js
- node --check src/ui/culture/buildCultureLayerPanel.js
- node --check src/ui/culture/buildCultureLocalTimeline.js
- npm test -- test/ui/culture/buildCultureMapOverlay.test.js test/ui/culture/buildCultureLayerPanel.test.js test/ui/culture/buildCultureLocalTimeline.test.js
- npm test

Zeta: ready for validation before merge.