### PR TITLE
Epsilon: add climate alert mitigation previews

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1383,6 +1383,159 @@ function buildClimateUrgency(region, previewImpact, previewRiskLevel, previewAno
   };
 }
 
+
+function normalizeCollateralCost(value, fallback = 'medium') {
+  const cost = String(value ?? fallback).trim().toLowerCase();
+
+  if (['none', 'low', 'medium', 'high'].includes(cost)) {
+    return cost;
+  }
+
+  return fallback;
+}
+
+function normalizeRiskImpact(value, fallback) {
+  const impact = String(value ?? fallback).trim();
+
+  return impact || fallback;
+}
+
+function normalizeMitigationPreview(preview, index, alertContext) {
+  const mode = String(preview.mode ?? preview.kind ?? `custom-${index + 1}`).trim();
+  const label = String(preview.label ?? mode).trim();
+
+  return {
+    previewId: String(preview.previewId ?? `${alertContext.regionId}:mitigation:${mode}`).trim(),
+    mode,
+    label,
+    expectedTiming: String(preview.expectedTiming ?? preview.timing ?? alertContext.timeWindow).trim(),
+    riskImpact: normalizeRiskImpact(preview.riskImpact ?? preview.expectedRiskImpact, alertContext.defaultRiskImpact),
+    confidenceBand: normalizeConfidenceBand(preview.confidenceBand) ?? alertContext.confidenceBand,
+    urgencyRank: alertContext.urgencyRank,
+    collateralCost: normalizeCollateralCost(preview.collateralCost ?? preview.cost, alertContext.defaultCollateralCost),
+    playerImpact: String(preview.playerImpact ?? alertContext.playerImpact).trim(),
+  };
+}
+
+function buildDefaultMitigationPreviews(alertContext) {
+  if (alertContext.urgencyRank === 1) {
+    return [
+      {
+        previewId: `${alertContext.regionId}:mitigation:immediate`,
+        mode: 'immediate-mitigation',
+        label: 'mitiger maintenant',
+        expectedTiming: alertContext.timeWindow,
+        riskImpact: alertContext.previewRiskLevel === 'critical' ? 'réduit le risque critique vers tendu' : 'réduit le risque avant impact',
+        confidenceBand: alertContext.confidenceBand,
+        urgencyRank: alertContext.urgencyRank,
+        collateralCost: 'high',
+        playerImpact: alertContext.playerImpact,
+      },
+      {
+        previewId: `${alertContext.regionId}:mitigation:delayed`,
+        mode: 'delayed-mitigation',
+        label: 'préparer puis agir',
+        expectedTiming: 'prochain tour',
+        riskImpact: 'réduction partielle si la fenêtre reste ouverte',
+        confidenceBand: alertContext.confidenceBand === 'extreme' ? 'uncertain' : alertContext.confidenceBand,
+        urgencyRank: alertContext.urgencyRank + 1,
+        collateralCost: 'medium',
+        playerImpact: 'préserve des ressources mais laisse un risque intermédiaire',
+      },
+      {
+        previewId: `${alertContext.regionId}:mitigation:no-action`,
+        mode: 'no-action',
+        label: 'ne rien changer',
+        expectedTiming: alertContext.timeWindow,
+        riskImpact: 'aucune réduction: risque inchangé ou aggravé',
+        confidenceBand: alertContext.confidenceBand,
+        urgencyRank: 4,
+        collateralCost: 'none',
+        playerImpact: 'conserve le plan mais accepte le risque signalé',
+      },
+    ];
+  }
+
+  if (alertContext.urgencyRank === 2) {
+    return [
+      {
+        previewId: `${alertContext.regionId}:mitigation:reserve`,
+        mode: 'reserve-prep',
+        label: 'préparer réserve',
+        expectedTiming: alertContext.timeWindow,
+        riskImpact: 'réduit le risque attendu sans déplacer toute la priorité',
+        confidenceBand: alertContext.confidenceBand,
+        urgencyRank: alertContext.urgencyRank,
+        collateralCost: 'medium',
+        playerImpact: alertContext.playerImpact,
+      },
+      {
+        previewId: `${alertContext.regionId}:mitigation:no-action`,
+        mode: 'no-action',
+        label: 'surveiller sans dépense',
+        expectedTiming: alertContext.timeWindow,
+        riskImpact: 'aucune réduction avant confirmation',
+        confidenceBand: alertContext.confidenceBand,
+        urgencyRank: 4,
+        collateralCost: 'none',
+        playerImpact: 'garde les ressources mais expose le plan à la bascule',
+      },
+    ];
+  }
+
+  if (alertContext.urgencyRank === 3) {
+    return [
+      {
+        previewId: `${alertContext.regionId}:mitigation:confirm`,
+        mode: 'confirm-first',
+        label: 'attendre confirmation',
+        expectedTiming: alertContext.timeWindow,
+        riskImpact: 'évite une dépense inutile tant que le signal reste incertain',
+        confidenceBand: alertContext.confidenceBand,
+        urgencyRank: alertContext.urgencyRank,
+        collateralCost: 'low',
+        playerImpact: alertContext.playerImpact,
+      },
+    ];
+  }
+
+  return [
+    {
+      previewId: `${alertContext.regionId}:mitigation:keep-plan`,
+      mode: 'no-action',
+      label: 'conserver plan',
+      expectedTiming: alertContext.timeWindow,
+      riskImpact: 'aucune mitigation nécessaire pour l’instant',
+      confidenceBand: alertContext.confidenceBand,
+      urgencyRank: alertContext.urgencyRank,
+      collateralCost: 'none',
+      playerImpact: alertContext.playerImpact,
+    },
+  ];
+}
+
+function buildClimateMitigationPreviews(region, previewImpact, alertContext) {
+  const explicitPreviews = Array.isArray(previewImpact.mitigationPreviews)
+    ? previewImpact.mitigationPreviews
+    : Array.isArray(previewImpact.mitigations)
+      ? previewImpact.mitigations
+      : null;
+  const normalizedContext = {
+    ...alertContext,
+    regionId: region.regionId,
+    defaultRiskImpact: alertContext.previewRiskLevel === 'critical'
+      ? 'réduit le risque critique attendu'
+      : 'réduit le risque attendu',
+    defaultCollateralCost: alertContext.urgencyRank <= 1 ? 'high' : alertContext.urgencyRank === 2 ? 'medium' : 'low',
+  };
+
+  if (explicitPreviews?.length) {
+    return explicitPreviews.map((preview, index) => normalizeMitigationPreview(preview, index, normalizedContext));
+  }
+
+  return buildDefaultMitigationPreviews(normalizedContext);
+}
+
 function buildClimateAlert(region, previewImpact, previewRiskLevel, previewAnomaly, seasonPreview) {
   const riskDelta = getClimateRiskRank(previewRiskLevel) - getClimateRiskRank(region.strategicImpact);
   const anomalyChanged = region.anomaly !== previewAnomaly;
@@ -1399,7 +1552,7 @@ function buildClimateAlert(region, previewImpact, previewRiskLevel, previewAnoma
     anomalyChanged,
   );
 
-  return {
+  const alertContext = {
     regionId: region.regionId,
     currentRiskLevel: region.strategicImpact,
     previewRiskLevel,
@@ -1409,6 +1562,11 @@ function buildClimateAlert(region, previewImpact, previewRiskLevel, previewAnoma
     timeWindow,
     playerImpact,
     ...urgency,
+  };
+
+  return {
+    ...alertContext,
+    mitigationPreviews: buildClimateMitigationPreviews(region, previewImpact, alertContext),
   };
 }
 

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -1561,3 +1561,133 @@ test('buildClimateMapOverlay ranks climate alerts by urgency and keeps static fa
     'Fallback statique: aucune prévision exploitable pour classer les alertes.',
   );
 });
+
+test('buildClimateMapOverlay adds mitigation previews for urgent climate alerts', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'citadel', season: 'spring', temperatureC: 18, precipitationLevel: 40, droughtIndex: 20 },
+    { regionId: 'granary', season: 'spring', temperatureC: 20, precipitationLevel: 35, droughtIndex: 25 },
+    { regionId: 'watch', season: 'spring', temperatureC: 21, precipitationLevel: 30, droughtIndex: 30 },
+  ], {
+    seasonPreview: {
+      season: 'summer',
+      impactsByRegion: {
+        citadel: {
+          strategicImpact: 'critical',
+          anomaly: 'storm',
+          confidenceBand: 'extreme',
+          timeWindow: 'tour actuel',
+          playerImpact: 'priorité capitale et route fragile',
+        },
+        granary: {
+          strategicImpact: 'strained',
+          anomaly: null,
+          confidenceBand: 'probable',
+          timeWindow: '2 tours',
+          playerImpact: 'réserve de grains à préparer',
+        },
+        watch: {
+          strategicImpact: 'stable',
+          anomaly: 'frost',
+          confidenceBand: 'uncertain',
+          timeWindow: 'fin de saison',
+          playerImpact: 'signal à confirmer avant dépense',
+        },
+      },
+    },
+  });
+
+  const urgentAlert = overlay.climateTimeline.climateAlerts.find((alert) => alert.regionId === 'citadel');
+  assert.deepEqual(urgentAlert.mitigationPreviews.map((preview) => ({
+    mode: preview.mode,
+    expectedTiming: preview.expectedTiming,
+    riskImpact: preview.riskImpact,
+    confidenceBand: preview.confidenceBand,
+    urgencyRank: preview.urgencyRank,
+    collateralCost: preview.collateralCost,
+  })), [
+    {
+      mode: 'immediate-mitigation',
+      expectedTiming: 'tour actuel',
+      riskImpact: 'réduit le risque critique vers tendu',
+      confidenceBand: 'extreme',
+      urgencyRank: 1,
+      collateralCost: 'high',
+    },
+    {
+      mode: 'delayed-mitigation',
+      expectedTiming: 'prochain tour',
+      riskImpact: 'réduction partielle si la fenêtre reste ouverte',
+      confidenceBand: 'uncertain',
+      urgencyRank: 2,
+      collateralCost: 'medium',
+    },
+    {
+      mode: 'no-action',
+      expectedTiming: 'tour actuel',
+      riskImpact: 'aucune réduction: risque inchangé ou aggravé',
+      confidenceBand: 'extreme',
+      urgencyRank: 4,
+      collateralCost: 'none',
+    },
+  ]);
+
+  const delayedAlert = overlay.climateTimeline.climateAlerts.find((alert) => alert.regionId === 'granary');
+  assert.deepEqual(delayedAlert.mitigationPreviews.map((preview) => preview.mode), [
+    'reserve-prep',
+    'no-action',
+  ]);
+  assert.equal(delayedAlert.mitigationPreviews[0].riskImpact, 'réduit le risque attendu sans déplacer toute la priorité');
+
+  const monitorAlert = overlay.climateTimeline.climateAlerts.find((alert) => alert.regionId === 'watch');
+  assert.deepEqual(monitorAlert.mitigationPreviews.map((preview) => ({
+    mode: preview.mode,
+    collateralCost: preview.collateralCost,
+    confidenceBand: preview.confidenceBand,
+  })), [
+    { mode: 'confirm-first', collateralCost: 'low', confidenceBand: 'uncertain' },
+  ]);
+});
+
+test('buildClimateMapOverlay preserves explicit mitigation previews without merging confidence urgency and cost', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'delta', season: 'spring', temperatureC: 18, precipitationLevel: 40, droughtIndex: 20 },
+  ], {
+    seasonPreview: {
+      season: 'summer',
+      impactsByRegion: {
+        delta: {
+          strategicImpact: 'critical',
+          anomaly: 'flood',
+          confidenceBand: 'probable',
+          timeWindow: '2 tours',
+          playerImpact: 'route et récolte exposées',
+          mitigationPreviews: [
+            {
+              mode: 'raise-dikes',
+              label: 'renforcer digues',
+              expectedTiming: 'avant crue',
+              riskImpact: 'réduit inondation vers risque tendu',
+              confidenceBand: 'probable',
+              collateralCost: 'medium',
+              playerImpact: 'mobilise ouvriers mais protège la route',
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(overlay.climateTimeline.climateAlerts[0].mitigationPreviews, [
+    {
+      previewId: 'delta:mitigation:raise-dikes',
+      mode: 'raise-dikes',
+      label: 'renforcer digues',
+      expectedTiming: 'avant crue',
+      riskImpact: 'réduit inondation vers risque tendu',
+      confidenceBand: 'probable',
+      urgencyRank: 1,
+      collateralCost: 'medium',
+      playerImpact: 'mobilise ouvriers mais protège la route',
+    },
+  ]);
+});


### PR DESCRIPTION
Epsilon: Adds climate mitigation previews for urgent map alerts.

- exposes mitigationPreviews on climate timeline alerts
- distinguishes expected timing, risk impact, confidence band, urgency rank, and collateral cost
- includes immediate mitigation, delayed mitigation, and no-action/default outcomes
- preserves existing urgency ranking and supports explicit preview overrides

Tests:
- `npm test -- test/ui/climate/buildClimateMapOverlay.test.js`
- `npm test`
- `git diff --check`

Closes #1203