### PR TITLE
Delta: add intrigue incident replay markers

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2292,6 +2292,98 @@ function buildVerificationPathPreviews({ confidenceState, safeVerificationHint, 
   ];
 }
 
+function buildIntrigueIncidentReplay({ confidenceState, suspicionHeatDecayPlayback, safeMapMasking }) {
+  const frameByState = {
+    confirmed: {
+      incidentType: 'confirmed-trail',
+      label: 'Piste confirmée',
+      confidenceTrend: 'up',
+      reason: 'La pression visible confirme la piste sans révéler cellule, relais ou cible.',
+    },
+    suspected: {
+      incidentType: 'suspected-sabotage',
+      label: 'Sabotage suspecté',
+      confidenceTrend: 'up',
+      reason: 'Un signal probable augmente la vigilance, mais la preuve reste non nominative.',
+    },
+    stale: {
+      incidentType: 'verification-in-progress',
+      label: 'Vérification en cours',
+      confidenceTrend: 'down',
+      reason: 'Le signal vieillit; la confiance baisse jusqu’à une nouvelle preuve visible.',
+    },
+    masked: {
+      incidentType: 'false-alert-or-masked',
+      label: 'Fausse alerte possible',
+      confidenceTrend: 'masked',
+      reason: 'Le mode sûr masque ou généralise l’incident faute de donnée autorisée.',
+    },
+  };
+  const current = frameByState[confidenceState.state] ?? frameByState.masked;
+  const heatFrame = suspicionHeatDecayPlayback.frames[1] ?? suspicionHeatDecayPlayback.frames[0];
+
+  return {
+    state: current.incidentType,
+    summary: `${current.label}: ${current.reason}`,
+    frames: [
+      {
+        turnOffset: -2,
+        incidentType: safeMapMasking.state === 'masked-information' ? 'false-alert-or-masked' : 'verification-in-progress',
+        label: safeMapMasking.state === 'masked-information' ? 'Signal généralisé' : 'Vérification en cours',
+        confidenceTrend: 'masked',
+        safeCopy: 'Historique expurgé: aucune source, cible ou cause cachée affichée.',
+      },
+      {
+        turnOffset: -1,
+        incidentType: heatFrame.state === 'decaying-risk' ? 'verification-in-progress' : current.incidentType,
+        label: heatFrame.state === 'decaying-risk' ? 'Chaleur en baisse' : current.label,
+        confidenceTrend: heatFrame.state === 'decaying-risk' ? 'down' : current.confidenceTrend,
+        safeCopy: `${heatFrame.label}; la confiance suit seulement les signaux visibles.`,
+      },
+      {
+        turnOffset: 0,
+        incidentType: current.incidentType,
+        label: current.label,
+        confidenceTrend: current.confidenceTrend,
+        safeCopy: current.reason,
+      },
+    ],
+  };
+}
+
+function buildEvidenceTrailMarkers({ locationId, locationName, confidenceState, safeMapMasking, locationOperations, relatedLocationIds }) {
+  if (safeMapMasking.state === 'masked-information' || confidenceState.state === 'masked') {
+    return [{
+      markerId: `evidence:${locationId}:masked`,
+      state: 'masked',
+      fromLocationId: locationId,
+      toLocationId: null,
+      label: `${locationName}: piste masquée`,
+      reason: 'Mode sûr: lien de preuve non affiché car les données sont absentes ou confidentielles.',
+    }];
+  }
+
+  const targetLocationId = relatedLocationIds.find((candidate) => candidate !== locationId) ?? null;
+  const markerState = confidenceState.state === 'confirmed'
+    ? 'confirmed-evidence'
+    : confidenceState.state === 'suspected'
+      ? 'suspected-evidence'
+      : 'stale-evidence';
+
+  return [{
+    markerId: `evidence:${locationId}:${targetLocationId ?? 'local'}`,
+    state: markerState,
+    fromLocationId: locationId,
+    toLocationId: targetLocationId,
+    label: targetLocationId === null
+      ? `${locationName}: preuve locale ${confidenceState.label.toLowerCase()}`
+      : `${locationName}: piste ${confidenceState.label.toLowerCase()} reliée à une zone autorisée`,
+    reason: locationOperations.length > 0
+      ? 'Lien autorisé par signaux visibles seulement; relais, cellule et objectif restent masqués.'
+      : 'Piste locale sans détail sensible; le marqueur indique la confiance, pas la vérité cachée.',
+  }];
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2388,6 +2480,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
       const exposedCellCount = locationCellules.filter((cellule) => cellule.isExposed).length;
       const sleeperCellCount = locationCellules.filter((cellule) => cellule.sleeper).length;
       const locationName = String(locationNames[locationId] ?? locationId).trim() || locationId;
+      const relatedLocationIds = [...locationIds].sort((left, right) => left.localeCompare(right));
 
       const lowExposureSweepConfidencePreview = buildLowExposureSweepConfidencePreview({
         celluleCount: locationCellules.length,
@@ -2422,6 +2515,19 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         suspicionHeatDecayPlayback,
         safeMapMasking,
       });
+      const incidentReplay = buildIntrigueIncidentReplay({
+        confidenceState,
+        suspicionHeatDecayPlayback,
+        safeMapMasking,
+      });
+      const evidenceTrailMarkers = buildEvidenceTrailMarkers({
+        locationId,
+        locationName,
+        confidenceState,
+        safeMapMasking,
+        locationOperations,
+        relatedLocationIds,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -2429,6 +2535,8 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           confidenceState,
           safeVerificationHint,
           verificationPathPreviews,
+          incidentReplay,
+          evidenceTrailMarkers,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -1912,3 +1912,102 @@ test('buildIntrigueMapOverlay previews fog-safe verification paths with costs an
   assert.equal(maskedPaths[0].exposureCost, 0);
   assert.match(maskedPaths[0].fogSafeCopy, /l’absence de signal ne prouve pas un danger faible/);
 });
+
+test('buildIntrigueMapOverlay replays fog-safe incidents and evidence trail markers', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-confirmed-replay',
+      factionId: 'shadow-league',
+      codename: 'Torch',
+      locationId: 'confirmed-replay',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 76,
+    }),
+    new Cellule({
+      id: 'cell-suspected-replay',
+      factionId: 'shadow-league',
+      codename: 'Lantern',
+      locationId: 'suspected-replay',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+    new Cellule({
+      id: 'cell-masked-replay',
+      factionId: 'shadow-league',
+      codename: 'Blank',
+      locationId: 'masked-replay',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-confirmed-replay',
+      celluleId: 'cell-confirmed-replay',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Stress gate watches',
+      theaterId: 'confirmed-replay',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 12,
+      progress: 84,
+      heat: 86,
+      phase: 'execution',
+    }),
+    new OperationClandestine({
+      id: 'op-suspected-replay',
+      celluleId: 'cell-suspected-replay',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe road rumor',
+      theaterId: 'suspected-replay',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 80,
+      progress: 5,
+      heat: 10,
+      phase: 'planning',
+    }),
+  ], {
+    safeMapMode: true,
+    locationNames: {
+      'confirmed-replay': 'Confirmed Replay',
+      'suspected-replay': 'Suspected Replay',
+      'masked-replay': 'Masked Replay',
+    },
+  });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry]));
+  const confirmed = byLocation.get('confirmed-replay');
+  const suspected = byLocation.get('suspected-replay');
+  const masked = byLocation.get('masked-replay');
+
+  assert.equal(confirmed.incidentReplay.state, 'confirmed-trail');
+  assert.deepEqual(confirmed.incidentReplay.frames.map((frame) => frame.incidentType), [
+    'verification-in-progress',
+    'verification-in-progress',
+    'confirmed-trail',
+  ]);
+  assert.match(confirmed.incidentReplay.frames[0].safeCopy, /aucune source, cible ou cause cachée/);
+  assert.equal(confirmed.evidenceTrailMarkers[0].state, 'confirmed-evidence');
+  assert.equal(confirmed.evidenceTrailMarkers[0].toLocationId, 'masked-replay');
+  assert.match(confirmed.evidenceTrailMarkers[0].reason, /relais, cellule et objectif restent masqués/);
+
+  assert.equal(suspected.incidentReplay.state, 'suspected-sabotage');
+  assert.equal(suspected.incidentReplay.frames.at(-1).confidenceTrend, 'up');
+  assert.equal(suspected.evidenceTrailMarkers[0].state, 'suspected-evidence');
+  assert.match(suspected.evidenceTrailMarkers[0].label, /piste suspect/);
+
+  assert.equal(masked.incidentReplay.state, 'false-alert-or-masked');
+  assert.equal(masked.incidentReplay.frames.at(-1).confidenceTrend, 'masked');
+  assert.deepEqual(masked.evidenceTrailMarkers, [{
+    markerId: 'evidence:masked-replay:masked',
+    state: 'masked',
+    fromLocationId: 'masked-replay',
+    toLocationId: null,
+    label: 'Masked Replay: piste masquée',
+    reason: 'Mode sûr: lien de preuve non affiché car les données sont absentes ou confidentielles.',
+  }]);
+});


### PR DESCRIPTION
Delta: ## Summary
- Adds fog-safe `incidentReplay` frames for recent intrigue incidents: suspected sabotage, confirmed trails, possible false alerts/masked data, and verification-in-progress states.
- Adds `evidenceTrailMarkers` that link only authorized/generic zones and mask trails when data is confidential.
- Explains confidence changes using visible heat/decay context without revealing hidden cells, relays, targets, or causes.

Closes #1212.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés intrigue passés et tests complets passés avec `npm test` (665/665); j’attends ta validation avant tout merge.