### PR TITLE
Gamma: add culture atlas timeline diffs

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -2,7 +2,7 @@ function normalizeText(value, fallback = '') {
   return String(value ?? fallback).trim();
 }
 
-function buildDelta({ deltaId, tone, label, value, reason, regionId, cultureName }) {
+function buildDelta({ deltaId, tone, label, value, reason, regionId, cultureName, changeState = null, linkedPriority = null }) {
   return {
     deltaId,
     tone,
@@ -11,6 +11,8 @@ function buildDelta({ deltaId, tone, label, value, reason, regionId, cultureName
     reason,
     regionId,
     cultureName,
+    ...(changeState ? { changeState } : {}),
+    ...(linkedPriority ? { linkedPriority } : {}),
   };
 }
 
@@ -70,6 +72,81 @@ function buildConsequenceDeltas(consequenceChips, regionId) {
     }));
 }
 
+function buildDiscoveryTimelineRecap(localTimeline, selectedMarker, selectedCluster, regionId) {
+  const priority = selectedMarker?.narrativePriority ?? selectedCluster?.narrativePriority ?? selectedCluster?.markerCollisionCluster?.narrativePriority ?? null;
+  const items = (localTimeline?.items ?? [])
+    .filter((item) => item.kind === 'event' || item.kind === 'discovery')
+    .map((item, index) => ({
+      recapId: `${regionId}:recap:${item.timelineId}`,
+      order: item.date ? item.date : `turn-order-${index + 1}`,
+      kind: item.kind,
+      title: item.title,
+      changeState: item.kind === 'discovery' ? 'new' : 'investigate',
+      summary: priority?.consequencePreview?.summary ?? item.summary,
+      linkedPriority: priority ? {
+        state: priority.state,
+        microAction: priority.microAction,
+        confidence: priority.consequencePreview?.confidence ?? 'medium',
+      } : null,
+    }))
+    .sort((left, right) => left.order.localeCompare(right.order) || left.title.localeCompare(right.title))
+    .slice(0, 3);
+
+  return items;
+}
+
+function buildInfluenceDiffs(selectedMarker, previousMarker, selectedCluster, regionId) {
+  if (!selectedMarker) {
+    return [];
+  }
+
+  const priority = selectedMarker.narrativePriority ?? selectedCluster?.narrativePriority ?? selectedCluster?.markerCollisionCluster?.narrativePriority ?? null;
+  const previousScore = Number.isFinite(previousMarker?.influenceScore) ? previousMarker.influenceScore : null;
+  const currentScore = Number.isFinite(selectedMarker.influenceScore) ? selectedMarker.influenceScore : 0;
+  const previousDiscoveries = new Set(previousMarker?.discoveries ?? []);
+  const hasNewDiscovery = (selectedMarker.discoveries ?? []).some((discoveryId) => !previousDiscoveries.has(discoveryId));
+  const confidence = priority?.consequencePreview?.confidence ?? 'medium';
+  const changeState = selectedMarker.visible === false || selectedMarker.masked === true
+    ? 'masked'
+    : previousScore === null
+      ? 'new'
+      : currentScore > previousScore
+        ? 'strengthened'
+        : currentScore < previousScore
+          ? 'weakened'
+          : confidence === 'low'
+            ? 'investigate'
+            : hasNewDiscovery
+              ? 'new'
+              : 'stable';
+
+  return [{
+    diffId: `${regionId}:influence-diff:${selectedMarker.overlayId}`,
+    regionId,
+    cultureName: selectedMarker.cultureName,
+    previousScore,
+    currentScore,
+    changeState,
+    label: changeState === 'new'
+      ? 'nouveau repère'
+      : changeState === 'strengthened'
+        ? 'influence renforcée'
+        : changeState === 'weakened'
+          ? 'influence affaiblie'
+          : changeState === 'masked'
+            ? 'repère masqué'
+            : changeState === 'investigate'
+              ? 'à investiguer'
+              : 'stable',
+    reason: priority?.consequencePreview?.summary ?? `${selectedMarker.influenceTier} · ${currentScore}`,
+    linkedPriority: priority ? {
+      state: priority.state,
+      microAction: priority.microAction,
+      confidence,
+    } : null,
+  }];
+}
+
 function dedupeAndSort(deltas) {
   return [...new Map(deltas.map((delta) => [
     `${delta.tone}:${delta.label}:${delta.value}:${delta.regionId}`,
@@ -89,21 +166,26 @@ export function buildCultureTurnReportDeltas({
   selectedCluster = null,
   localTimeline = null,
   consequenceChips = [],
+  previousMarker = null,
 } = {}) {
   const regionId = normalizeText(selectedRegionId ?? selectedMarker?.regionId ?? selectedCluster?.regionIds?.[0], 'province');
+  const timelineRecap = buildDiscoveryTimelineRecap(localTimeline, selectedMarker, selectedCluster, regionId);
+  const influenceDiffs = buildInfluenceDiffs(selectedMarker, previousMarker, selectedCluster, regionId);
   const deltas = dedupeAndSort([
     ...buildTimelineDeltas(localTimeline, regionId),
     ...buildMarkerDeltas(selectedMarker, regionId),
     ...buildConsequenceDeltas(consequenceChips, regionId),
   ]);
 
-  if (deltas.length === 0) {
+  if (deltas.length === 0 && timelineRecap.length === 0 && influenceDiffs.length === 0) {
     return {
       state: 'quiet',
       turn,
       regionId,
       summary: 'Aucun delta culture/découverte visible ce tour.',
       deltas: [],
+      timelineRecap: [],
+      influenceDiffs: [],
     };
   }
 
@@ -111,7 +193,9 @@ export function buildCultureTurnReportDeltas({
     state: 'active',
     turn,
     regionId,
-    summary: `Tour ${turn}: ${deltas.length} delta${deltas.length > 1 ? 's' : ''} culture/découverte à vérifier.`,
+    summary: `Tour ${turn}: ${deltas.length} delta${deltas.length > 1 ? 's' : ''} culture/découverte à vérifier, ${influenceDiffs.length} diff${influenceDiffs.length > 1 ? 's' : ''} d’influence.`,
     deltas,
+    timelineRecap,
+    influenceDiffs,
   };
 }

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -16,6 +16,22 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       discoveries: ['archive-routes', 'tidal-ledgers'],
       activeResearchCount: 1,
       unlockedResearchIds: ['tidal-ledgers'],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'explorer',
+        consequencePreview: {
+          confidence: 'high',
+          summary: 'explorer: archives ouvertes; tradeoff: retarde apaisement.',
+        },
+      },
+    },
+    previousMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'emerging',
+      influenceScore: 70,
+      discoveries: ['archive-routes'],
     },
     localTimeline: {
       items: [
@@ -43,12 +59,44 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
   });
 
   assert.equal(report.state, 'active');
-  assert.equal(report.summary, 'Tour 4: 4 deltas culture/découverte à vérifier.');
+  assert.equal(report.summary, 'Tour 4: 4 deltas culture/découverte à vérifier, 1 diff d’influence.');
   assert.deepEqual(report.deltas.map((delta) => [delta.tone, delta.label, delta.value]), [
     ['risk', 'Tension culturelle', 'Tension mémorielle'],
     ['opportunity', 'Événement déclenché', 'Ouverture des archives'],
     ['opportunity', 'Influence culturelle', 'Compact d’Aurora · 82'],
     ['research', 'Recherche culturelle', '1 active'],
+  ]);
+  assert.deepEqual(report.timelineRecap, [
+    {
+      recapId: 'river-gate:recap:river-gate:event:event-archive-opening',
+      order: 'turn-order-1',
+      kind: 'event',
+      title: 'Ouverture des archives',
+      changeState: 'investigate',
+      summary: 'explorer: archives ouvertes; tradeoff: retarde apaisement.',
+      linkedPriority: {
+        state: 'opportunity',
+        microAction: 'explorer',
+        confidence: 'high',
+      },
+    },
+  ]);
+  assert.deepEqual(report.influenceDiffs, [
+    {
+      diffId: 'river-gate:influence-diff:river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      previousScore: 70,
+      currentScore: 82,
+      changeState: 'strengthened',
+      label: 'influence renforcée',
+      reason: 'explorer: archives ouvertes; tradeoff: retarde apaisement.',
+      linkedPriority: {
+        state: 'opportunity',
+        microAction: 'explorer',
+        confidence: 'high',
+      },
+    },
   ]);
 });
 
@@ -59,5 +107,45 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
     regionId: 'quiet-field',
     summary: 'Aucun delta culture/découverte visible ce tour.',
     deltas: [],
+    timelineRecap: [],
+    influenceDiffs: [],
   });
+});
+
+test('buildCultureTurnReportDeltas classifies new, weakened, masked, and investigate influence diffs', () => {
+  const baseMarker = {
+    overlayId: 'mist-hills:culture-mist',
+    regionId: 'mist-hills',
+    cultureName: 'Mist Circle',
+    influenceTier: 'faint',
+    influenceScore: 42,
+    discoveries: ['fog-index'],
+    activeResearchCount: 0,
+    unlockedResearchIds: [],
+    narrativePriority: {
+      state: 'watch',
+      microAction: 'attendre',
+      consequencePreview: {
+        confidence: 'low',
+        summary: 'attendre: intel culturel incomplet.',
+      },
+    },
+  };
+
+  assert.equal(buildCultureTurnReportDeltas({ selectedRegionId: 'mist-hills', selectedMarker: baseMarker }).influenceDiffs[0].changeState, 'new');
+  assert.equal(buildCultureTurnReportDeltas({
+    selectedRegionId: 'mist-hills',
+    selectedMarker: { ...baseMarker, influenceScore: 30, discoveries: ['fog-index'] },
+    previousMarker: { ...baseMarker, influenceScore: 48, discoveries: ['fog-index'] },
+  }).influenceDiffs[0].changeState, 'weakened');
+  assert.equal(buildCultureTurnReportDeltas({
+    selectedRegionId: 'mist-hills',
+    selectedMarker: { ...baseMarker, masked: true },
+    previousMarker: { ...baseMarker, influenceScore: 42, discoveries: ['fog-index'] },
+  }).influenceDiffs[0].changeState, 'masked');
+  assert.equal(buildCultureTurnReportDeltas({
+    selectedRegionId: 'mist-hills',
+    selectedMarker: baseMarker,
+    previousMarker: { ...baseMarker, influenceScore: 42, discoveries: ['fog-index'] },
+  }).influenceDiffs[0].changeState, 'investigate');
 });


### PR DESCRIPTION
Gamma: Implements #1211.

Summary:
- adds short discovery/event timeline recaps linked to atlas narrative priorities
- adds cultural influence diffs for new, strengthened, weakened, masked, and investigate states
- keeps existing collision/priority readability intact by enriching the turn report delta model only

Validation:
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- npm test -- test/ui/culture/buildCultureTurnReportDeltas.test.js
- npm test

Zeta: ready for validation before merge.