### PR TITLE
Alpha: add province order after-action recap

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1616,6 +1616,104 @@ function buildProvinceActionQueueValidation(renderedProvinces, options) {
   };
 }
 
+
+function normalizeResolvedProvinceOrders(value) {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new TypeError('StrategicMapShell resolvedProvinceOrders must be an array.');
+  }
+
+  return value.map((entry, index) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new TypeError('StrategicMapShell resolvedProvinceOrders entries must be objects.');
+    }
+
+    const result = String(entry.result ?? entry.status ?? 'deferred').trim() || 'deferred';
+
+    return {
+      resolutionId: String(entry.resolutionId ?? entry.queueId ?? `resolved-${index + 1}`).trim() || `resolved-${index + 1}`,
+      queueId: entry.queueId === undefined ? null : String(entry.queueId).trim() || null,
+      provinceId: String(entry.provinceId ?? '').trim(),
+      actionCode: String(entry.actionCode ?? '').trim(),
+      label: String(entry.label ?? '').trim(),
+      result,
+      explanation: String(entry.explanation ?? '').trim(),
+      affectedFront: String(entry.affectedFront ?? '').trim(),
+    };
+  }).filter((entry) => entry.provinceId);
+}
+
+function fallbackResolutionExplanation(result, province, matchingValidation) {
+  if (matchingValidation?.conflictAwarePreview?.blockers?.length > 0) {
+    return matchingValidation.conflictAwarePreview.blockers.join(', ');
+  }
+
+  if (matchingValidation?.conflictAwarePreview?.frontEffect) {
+    return matchingValidation.conflictAwarePreview.frontEffect;
+  }
+
+  const provinceLabel = province?.label ?? 'la province ciblée';
+  if (result === 'success') return `${provinceLabel} applique l'ordre et met à jour le front local.`;
+  if (result === 'blocked') return `${provinceLabel} attend encore un prérequis avant résolution.`;
+  if (result === 'conflict') return `${provinceLabel} a été stoppée par un ordre incompatible.`;
+  if (result === 'cancelled') return `${provinceLabel} annule l'ordre sans effet de front.`;
+  return `${provinceLabel} reporte l'ordre au prochain créneau sûr.`;
+}
+
+function resultTone(result) {
+  if (result === 'success') return 'positive';
+  if (result === 'blocked' || result === 'conflict') return 'warning';
+  if (result === 'cancelled') return 'muted';
+  return 'neutral';
+}
+
+function buildAfterActionMapRecap(renderedProvinces, keyboardActionPlanner, options) {
+  const resolvedOrders = normalizeResolvedProvinceOrders(options.resolvedProvinceOrders);
+  const provinceById = new Map(renderedProvinces.map((province) => [province.provinceId, province]));
+  const validationByQueueId = new Map(
+    keyboardActionPlanner.actionQueueValidation.entries.map((entry) => [entry.queueId, entry]),
+  );
+
+  const entries = resolvedOrders.map((entry) => {
+    const province = provinceById.get(entry.provinceId) ?? null;
+    const matchingValidation = entry.queueId ? validationByQueueId.get(entry.queueId) ?? null : null;
+    const actionLabel = entry.label || matchingValidation?.actionLabel || province?.tacticalHoverIntel.nextAction.label || 'Ordre province';
+    const frontEffect = matchingValidation?.conflictAwarePreview?.frontEffect
+      ?? (province ? `met à jour ${province.tacticalHoverIntel.garrisonStatus} sur ${province.label}` : 'effet de front non projetable');
+
+    return {
+      resolutionId: entry.resolutionId,
+      queueId: entry.queueId,
+      provinceId: entry.provinceId,
+      provinceLabel: province?.label ?? entry.provinceId,
+      actionCode: entry.actionCode || matchingValidation?.actionCode || province?.tacticalHoverIntel.nextAction.code || 'unknown-action',
+      actionLabel,
+      result: entry.result,
+      tone: resultTone(entry.result),
+      explanation: entry.explanation || fallbackResolutionExplanation(entry.result, province, matchingValidation),
+      frontEffect,
+      affectedFront: entry.affectedFront || (province?.contested ? 'front local contesté' : province?.occupied ? 'zone occupée' : 'contrôle local'),
+      highlight: {
+        provinceId: entry.provinceId,
+        frontIds: [entry.affectedFront || province?.provinceId || entry.provinceId].filter(Boolean),
+      },
+    };
+  });
+
+  return {
+    empty: entries.length === 0,
+    entries,
+    affectedProvinceIds: [...new Set(entries.map((entry) => entry.provinceId))],
+    affectedFronts: [...new Set(entries.map((entry) => entry.affectedFront))],
+    summary: entries.length === 0
+      ? 'Aucune résolution récente à récapituler.'
+      : `${entries.length} ordre${entries.length > 1 ? 's' : ''} résolu${entries.length > 1 ? 's' : ''}: ${entries.filter((entry) => entry.result === 'success').length} succès · ${entries.filter((entry) => entry.result === 'blocked').length} blocage · ${entries.filter((entry) => entry.result === 'conflict').length} conflit · ${entries.filter((entry) => entry.result === 'cancelled').length} annulation · ${entries.filter((entry) => entry.result === 'deferred').length} report`,
+  };
+}
+
 function buildKeyboardActionPlanner(renderedProvinces, options) {
   const activeProvince = renderedProvinces.find(
     (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
@@ -1846,6 +1944,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
   );
 
   const keyboardActionPlanner = buildKeyboardActionPlanner(renderedProvinces, normalizedOptions);
+  const afterActionMapRecap = buildAfterActionMapRecap(renderedProvinces, keyboardActionPlanner, normalizedOptions);
 
   return {
     title,
@@ -1853,6 +1952,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     provinces: renderedProvinces,
     mapLayers: buildProvinceMapLayers(renderedProvinces),
     keyboardActionPlanner,
+    afterActionMapRecap,
     stats: {
       provinceCount: stats.provinceCount,
       contestedCount: stats.contestedCount,

--- a/src/ui/war/buildStrategicMapPreviewHtml.js
+++ b/src/ui/war/buildStrategicMapPreviewHtml.js
@@ -184,6 +184,7 @@ function renderProvinceShapes(shell) {
       province.selectionState.selected ? 'is-selected' : '',
       province.selectionState.focused ? 'is-focused' : '',
       province.selectionState.queued ? 'is-queued' : '',
+      shell.afterActionMapRecap.affectedProvinceIds.includes(province.provinceId) ? 'is-recently-affected' : '',
     ].filter(Boolean).join(' ');
 
     return `
@@ -238,6 +239,27 @@ function renderKeyboardActionPlanner(shell) {
   `;
 }
 
+
+function renderAfterActionMapRecap(shell) {
+  const recap = shell.afterActionMapRecap;
+  const entries = recap.entries.map((entry) => `
+    <li class="after-action-item after-action-item--${escapeHtml(entry.result)}">
+      <span>${escapeHtml(entry.provinceLabel)} · ${escapeHtml(entry.actionLabel)}</span>
+      <strong>${escapeHtml(entry.result)}</strong>
+      <small>${escapeHtml(entry.explanation)}</small>
+      <em>${escapeHtml(entry.frontEffect)} · ${escapeHtml(entry.affectedFront)}</em>
+    </li>
+  `).join('');
+
+  return `
+    <section class="after-action-recap" aria-label="Récapitulatif des ordres de province résolus">
+      <h2>Après-action</h2>
+      <p>${escapeHtml(recap.summary)}</p>
+      ${recap.empty ? '<small class="after-action-empty">Aucun changement récent à surligner sur la carte.</small>' : `<ol>${entries}</ol>`}
+    </section>
+  `;
+}
+
 function renderProvinceActionQueueValidation(shell) {
   const validation = shell.keyboardActionPlanner.actionQueueValidation;
   const entries = validation.entries.map((entry) => {
@@ -286,8 +308,12 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     focusedProvinceId: normalizedOptions.focusedProvinceId ?? 'crown-heart',
     queuedProvinceId: normalizedOptions.queuedProvinceId ?? normalizedOptions.selectedProvinceId ?? 'river-gate',
     provinceActionQueue: normalizedOptions.provinceActionQueue ?? [
-      { provinceId: normalizedOptions.selectedProvinceId ?? 'river-gate', label: 'Ordre principal' },
-      { provinceId: normalizedOptions.focusedProvinceId ?? 'crown-heart', label: 'Appui suivant', requiresSupport: true },
+      { queueId: 'preview-main', provinceId: normalizedOptions.selectedProvinceId ?? 'river-gate', label: 'Ordre principal' },
+      { queueId: 'preview-support', provinceId: normalizedOptions.focusedProvinceId ?? 'crown-heart', label: 'Appui suivant', requiresSupport: true },
+    ],
+    resolvedProvinceOrders: normalizedOptions.resolvedProvinceOrders ?? [
+      { resolutionId: 'preview-success', queueId: 'preview-main', provinceId: normalizedOptions.selectedProvinceId ?? 'river-gate', result: 'success', label: 'Ordre principal résolu' },
+      { resolutionId: 'preview-deferred', queueId: 'preview-support', provinceId: normalizedOptions.focusedProvinceId ?? 'crown-heart', result: 'deferred', label: 'Appui reporté' },
     ],
   });
 
@@ -321,6 +347,7 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .province.is-focused .province-shape { filter:drop-shadow(0 0 2px rgba(103,232,249,0.78)); }
     .province.is-selected .province-shape { stroke:#67e8f9; stroke-width:1.72; }
     .province.is-queued .province-shape { stroke:#22c55e; stroke-width:1.62; }
+    .province.is-recently-affected .province-shape { stroke:#f0abfc; stroke-width:2.05; filter:drop-shadow(0 0 5px rgba(240,171,252,0.6)); }
     .province-label-leader { fill:none; stroke:rgba(226, 232, 240, 0.36); stroke-width:0.28; stroke-dasharray:0.7 0.85; }
     .province-label-plate { fill:rgba(5,10,20,0.74); stroke:rgba(226,232,240,0.18); stroke-width:0.22; }
     .province-label { fill:#f8fafc; font-size:2.75px; font-weight:900; paint-order:stroke; stroke:#020617; stroke-width:0.7; stroke-linejoin:round; letter-spacing:0.04em; }
@@ -363,6 +390,16 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .next-safe-action { display:grid; gap:3px; border:1px solid rgba(74,222,128,0.34); border-radius:14px; padding:9px; background:rgba(22,101,52,0.14); }
     .next-safe-action span { color:#93a4bb; font-size:11px; text-transform:uppercase; letter-spacing:0.09em; }
     .next-safe-action strong { color:#bbf7d0; }
+    .after-action-recap { display:grid; gap:10px; }
+    .after-action-recap p, .after-action-empty { margin:0; color:#cbd5e1; font-size:12px; }
+    .after-action-recap ol { display:grid; gap:6px; margin:0; padding:0; }
+    .after-action-item { display:grid; gap:3px; align-items:start; border:1px solid rgba(148,163,184,0.18); border-radius:12px; padding:7px 9px; }
+    .after-action-item--success { border-color:rgba(74,222,128,0.4); }
+    .after-action-item--blocked, .after-action-item--conflict { border-color:rgba(251,191,36,0.48); }
+    .after-action-item--cancelled { border-color:rgba(148,163,184,0.28); opacity:0.86; }
+    .after-action-item strong { color:#f0abfc; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
+    .after-action-item small { color:#dbeafe; }
+    .after-action-item em { color:#bae6fd; font-size:11px; font-style:normal; }
     table { width:100%; border-collapse:collapse; font-size:13px; }
     th, td { padding:10px 8px; border-bottom:1px solid rgba(148, 163, 184, 0.14); text-align:left; }
     th { color:#93c5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
@@ -407,6 +444,7 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
         </section>
         ${renderKeyboardActionPlanner(shell)}
         ${renderProvinceActionQueueValidation(shell)}
+        ${renderAfterActionMapRecap(shell)}
         <section>
           <h2>Lecture</h2>
           <ul>

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -197,6 +197,13 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     },
     emptyState: null,
   });
+  assert.deepEqual(shell.afterActionMapRecap, {
+    empty: true,
+    entries: [],
+    affectedProvinceIds: [],
+    affectedFronts: [],
+    summary: 'Aucune résolution récente à récapituler.',
+  });
   assert.deepEqual(shell.stats, {
     provinceCount: 2,
     contestedCount: 1,
@@ -367,6 +374,96 @@ test('StrategicMapShell validates province action queues and suggests a safe rep
       reason: 'attendre résolution du blocage',
     },
   });
+});
+
+
+test('StrategicMapShell summarizes recently resolved province orders for after-action map recap', () => {
+  const shell = buildStrategicMapShell(
+    [
+      createProvince({ id: 'front', name: 'Front rouge', contested: true, neighborIds: ['support'] }),
+      createProvince({ id: 'support', name: 'Support rompu', supplyLevel: 'disrupted', neighborIds: ['front'] }),
+      createProvince({ id: 'reserve', name: 'Réserve nord', strategicValue: 1, neighborIds: [] }),
+    ],
+    {
+      provinceActionQueue: [
+        { queueId: 'q1', provinceId: 'reserve', label: 'Tenir la réserve' },
+        { queueId: 'q2', provinceId: 'support', label: 'Pousser sans soutien', requiresSupport: true },
+        { queueId: 'q3', provinceId: 'front', label: 'Avancer après front instable' },
+      ],
+      resolvedProvinceOrders: [
+        { resolutionId: 'r1', queueId: 'q1', provinceId: 'reserve', result: 'success', label: 'Tenir la réserve', explanation: 'Réserve consolidée sans ouvrir de nouveau front.' },
+        { resolutionId: 'r2', queueId: 'q2', provinceId: 'support', result: 'blocked', label: 'Pousser sans soutien' },
+        { resolutionId: 'r3', queueId: 'q3', provinceId: 'front', result: 'conflict', label: 'Avancer après front instable', affectedFront: 'front rouge' },
+        { resolutionId: 'r4', provinceId: 'front', result: 'cancelled', label: 'Annuler la poussée', explanation: 'Ordre annulé avant résolution.' },
+        { resolutionId: 'r5', provinceId: 'reserve', result: 'deferred', label: 'Reporter le relais' },
+      ],
+    },
+  );
+
+  assert.deepEqual(shell.afterActionMapRecap.summary, '5 ordres résolus: 1 succès · 1 blocage · 1 conflit · 1 annulation · 1 report');
+  assert.deepEqual(shell.afterActionMapRecap.affectedProvinceIds, ['reserve', 'support', 'front']);
+  assert.deepEqual(shell.afterActionMapRecap.affectedFronts, ['contrôle local', 'front rouge', 'front local contesté']);
+  assert.deepEqual(shell.afterActionMapRecap.entries.map((entry) => ({
+    resolutionId: entry.resolutionId,
+    provinceLabel: entry.provinceLabel,
+    result: entry.result,
+    tone: entry.tone,
+    explanation: entry.explanation,
+    frontEffect: entry.frontEffect,
+    affectedFront: entry.affectedFront,
+    highlight: entry.highlight,
+  })), [
+    {
+      resolutionId: 'r1',
+      provinceLabel: 'Réserve nord',
+      result: 'success',
+      tone: 'positive',
+      explanation: 'Réserve consolidée sans ouvrir de nouveau front.',
+      frontEffect: 'maintient Réserve nord sans bascule de front',
+      affectedFront: 'contrôle local',
+      highlight: { provinceId: 'reserve', frontIds: ['reserve'] },
+    },
+    {
+      resolutionId: 'r2',
+      provinceLabel: 'Support rompu',
+      result: 'blocked',
+      tone: 'warning',
+      explanation: 'support manquant',
+      frontEffect: 'évite une poussée fragile sur Support rompu',
+      affectedFront: 'contrôle local',
+      highlight: { provinceId: 'support', frontIds: ['support'] },
+    },
+    {
+      resolutionId: 'r3',
+      provinceLabel: 'Front rouge',
+      result: 'conflict',
+      tone: 'warning',
+      explanation: 'stabilise front actif sur Front rouge',
+      frontEffect: 'stabilise front actif sur Front rouge',
+      affectedFront: 'front rouge',
+      highlight: { provinceId: 'front', frontIds: ['front rouge'] },
+    },
+    {
+      resolutionId: 'r4',
+      provinceLabel: 'Front rouge',
+      result: 'cancelled',
+      tone: 'muted',
+      explanation: 'Ordre annulé avant résolution.',
+      frontEffect: 'met à jour front actif sur Front rouge',
+      affectedFront: 'front local contesté',
+      highlight: { provinceId: 'front', frontIds: ['front'] },
+    },
+    {
+      resolutionId: 'r5',
+      provinceLabel: 'Réserve nord',
+      result: 'deferred',
+      tone: 'neutral',
+      explanation: "Réserve nord reporte l'ordre au prochain créneau sûr.",
+      frontEffect: 'met à jour garnison stable sur Réserve nord',
+      affectedFront: 'contrôle local',
+      highlight: { provinceId: 'reserve', frontIds: ['reserve'] },
+    },
+  ]);
 });
 
 test('StrategicMapShell projects intrigue presence and sabotage risk into the map overlay slot', () => {

--- a/test/ui/war/buildStrategicMapPreviewHtml.test.js
+++ b/test/ui/war/buildStrategicMapPreviewHtml.test.js
@@ -28,7 +28,11 @@ test('buildStrategicMapPreviewHtml renders a screenshot-ready preview from the g
   assert.match(html, /Blocage:/);
   assert.match(html, /Exclusif avec/);
   assert.match(html, /corriger avant confirmation/);
-  assert.match(html, /class="province is-contested is-occupied is-selected is-queued"/);
+  assert.match(html, /Récapitulatif des ordres de province résolus/);
+  assert.match(html, /Après-action/);
+  assert.match(html, /Ordre principal résolu/);
+  assert.match(html, /Appui reporté/);
+  assert.match(html, /class="province is-contested is-occupied is-selected is-queued is-recently-affected"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /Porte du Fleuve/);
   assert.match(html, /historia-alpha-strategic-map-v1/);


### PR DESCRIPTION
Alpha: Implements #1209.

Summary:
- adds an after-action map recap model for recently resolved province orders
- surfaces success, blocked, conflict, cancelled, and deferred outcomes with short explanations
- reuses queue validation/conflict preview data where available for front effects and blockers
- highlights recently affected provinces in the screenshot-ready strategic map preview and renders the recap with an empty state

Tests:
- npm test
- git diff --check

Zeta: ready for validation before merge.
