### PR TITLE
Epsilon: add climate aftermath resilience markers

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1159,7 +1159,7 @@ function inferConfidenceBand(region, previewImpact, previewRiskLevel, previewAno
   return 'uncertain';
 }
 
-function buildClimateMapLayers(regions, stateEntries, catastropheEntries, seasonPreview, regionGeometryById, anomalyTooltipByRegion) {
+function buildClimateMapLayers(regions, stateEntries, catastropheEntries, seasonPreview, regionGeometryById, anomalyTooltipByRegion, resilienceMarkers = []) {
   const seasonEntriesByRegion = new Map(stateEntries
     .filter((entry) => entry.kind === 'season')
     .map((entry) => [entry.regionId, entry]));
@@ -1289,6 +1289,19 @@ function buildClimateMapLayers(regions, stateEntries, catastropheEntries, season
     climateLabels,
     anomalyMarkers,
     disasterRings,
+    resilienceMarkers: resilienceMarkers.map((marker) => {
+      const center = getRegionCenter(marker.regionId, regionGeometryById);
+
+      return {
+        ...marker,
+        layerId: `${marker.regionId}:climate-resilience:${marker.markerId}`,
+        kind: 'resilience-marker',
+        x: center?.x ?? null,
+        y: center?.y ?? null,
+        placement: 'edge-recovery-badge',
+        ariaLabel: `${marker.regionId}: résilience ${marker.resilienceState}, ${marker.label}`,
+      };
+    }),
     ...(seasonPreview?.active ? {
       seasonPreviewLabels: regions
         .filter((region) => region.season !== seasonPreview.season)
@@ -1307,6 +1320,124 @@ function buildClimateMapLayers(regions, stateEntries, catastropheEntries, season
 
 function getClimateRiskRank(riskLevel) {
   return { stable: 0, strained: 1, critical: 2 }[riskLevel] ?? 0;
+}
+
+
+function normalizeAftermathSeverity(value, fallback = 'moderate') {
+  const severity = String(value ?? fallback).trim().toLowerCase();
+
+  if (['minor', 'moderate', 'major', 'critical'].includes(severity)) {
+    return severity;
+  }
+
+  return fallback;
+}
+
+function normalizeResilienceState(value, fallback = 'recovering') {
+  const state = String(value ?? fallback).trim().toLowerCase();
+
+  if (['recovering', 'resilient', 'strained', 'regressing'].includes(state)) {
+    return state;
+  }
+
+  return fallback;
+}
+
+function buildDefaultAftermathFromAlert(alert) {
+  const appliedMitigation = alert.mitigationPreviews.find((preview) => preview.mode !== 'no-action') ?? null;
+  const missingMitigation = alert.mitigationPreviews.find((preview) => preview.mode === 'no-action') ?? null;
+  const resilienceState = alert.urgencyRank <= 1
+    ? appliedMitigation ? 'recovering' : 'strained'
+    : alert.urgencyRank === 2 ? 'resilient' : alert.urgencyRank === 3 ? 'strained' : 'recovering';
+
+  return {
+    eventId: `${alert.regionId}:forecast-aftermath`,
+    regionIds: [alert.regionId],
+    observedImpact: alert.playerImpact,
+    severity: alert.previewRiskLevel === 'critical' ? 'major' : alert.previewRiskLevel === 'strained' ? 'moderate' : 'minor',
+    appliedMitigation: appliedMitigation?.label ?? null,
+    missingMitigation: missingMitigation ? missingMitigation.label : alert.urgencyRank <= 2 ? 'aucune mitigation renseignée' : null,
+    confidenceBand: alert.confidenceBand,
+    sourceAlertId: alert.regionId,
+    resilienceState,
+  };
+}
+
+function normalizeAftermathEvent(event, index, alertsByRegion) {
+  const regionIds = requireArray(event.regionIds ?? event.affectedRegionIds ?? [event.regionId], 'ClimateMapOverlay aftermath regionIds')
+    .map((regionId) => String(regionId).trim())
+    .filter(Boolean);
+  const firstRegionId = regionIds[0] ?? `region-${index + 1}`;
+  const linkedAlert = alertsByRegion.get(firstRegionId) ?? null;
+  const severity = normalizeAftermathSeverity(event.severity, linkedAlert?.previewRiskLevel === 'critical' ? 'major' : 'moderate');
+  const resilienceState = normalizeResilienceState(
+    event.resilienceState ?? event.recoveryState,
+    event.mitigationApplied ?? event.appliedMitigation ? 'recovering' : severity === 'major' || severity === 'critical' ? 'strained' : 'resilient',
+  );
+
+  return {
+    eventId: String(event.eventId ?? event.id ?? `${firstRegionId}:aftermath:${index + 1}`).trim(),
+    observedImpact: String(event.observedImpact ?? event.impact ?? linkedAlert?.playerImpact ?? 'impact climatique observé').trim(),
+    severity,
+    affectedRegionIds: regionIds,
+    appliedMitigation: event.appliedMitigation ?? event.mitigationApplied ?? null,
+    missingMitigation: event.missingMitigation ?? event.mitigationMissing ?? null,
+    confidenceBand: normalizeConfidenceBand(event.confidenceBand) ?? linkedAlert?.confidenceBand ?? 'uncertain',
+    sourceAlertId: event.sourceAlertId ?? linkedAlert?.regionId ?? null,
+    resilienceState,
+  };
+}
+
+function buildClimateAftermathRecap(regions, climateAlerts, normalizedOptions) {
+  const alertsByRegion = new Map(climateAlerts.map((alert) => [alert.regionId, alert]));
+  const explicitEvents = Array.isArray(normalizedOptions.climateAftermathEvents)
+    ? normalizedOptions.climateAftermathEvents
+    : Array.isArray(normalizedOptions.aftermathEvents)
+      ? normalizedOptions.aftermathEvents
+      : null;
+  const events = explicitEvents?.length
+    ? explicitEvents.map((event, index) => normalizeAftermathEvent(event, index, alertsByRegion))
+    : climateAlerts
+      .filter((alert) => alert.urgencyRank <= 2 || alert.previewRiskLevel !== alert.currentRiskLevel || alert.previewAnomaly !== alert.currentAnomaly)
+      .map(buildDefaultAftermathFromAlert)
+      .map((event, index) => normalizeAftermathEvent(event, index, alertsByRegion));
+  const regionIds = new Set(regions.map((region) => region.regionId));
+  const resilienceMarkers = events.flatMap((event) => event.affectedRegionIds
+    .filter((regionId) => regionIds.has(regionId))
+    .map((regionId) => ({
+      markerId: `${event.eventId}:${regionId}`,
+      eventId: event.eventId,
+      regionId,
+      resilienceState: event.resilienceState,
+      label: event.resilienceState === 'recovering'
+        ? 'récupération en cours'
+        : event.resilienceState === 'resilient'
+          ? 'résilience renforcée'
+          : event.resilienceState === 'regressing'
+            ? 'résilience en recul'
+            : 'résilience sous pression',
+      severity: event.severity,
+      confidenceBand: event.confidenceBand,
+      tooltip: {
+        observedImpact: event.observedImpact,
+        mitigation: event.appliedMitigation
+          ? `mitigation appliquée: ${event.appliedMitigation}`
+          : event.missingMitigation
+            ? `mitigation manquante: ${event.missingMitigation}`
+            : 'mitigation non renseignée',
+        confidenceBand: event.confidenceBand,
+      },
+    })));
+
+  return {
+    title: 'Récap climat après événement',
+    fallback: events.length > 0 ? null : 'Aucun événement climatique récent à récapituler.',
+    events,
+    resilienceMarkers,
+    summary: events.length > 0
+      ? `${events.length} conséquence(s) climatique(s), ${resilienceMarkers.length} marqueur(s) de résilience.`
+      : 'Aucune conséquence récente exploitable.',
+  };
 }
 
 
@@ -1811,6 +1942,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     });
 
   const climateTimeline = buildClimateTimeline(regions, seasonPreview, normalizedOptions, seasonLabels);
+  const climateAftermathRecap = buildClimateAftermathRecap(regions, climateTimeline.climateAlerts, normalizedOptions);
   const selectedClimateImpactComparison = buildSelectedClimateImpactComparison(regions, normalizedOptions, seasonPreview);
   const selectedClimateTimingRecommendation = buildSelectedClimateTimingRecommendation(selectedClimateImpactComparison);
   const selectedClimateMitigationChoices = buildSelectedClimateMitigationChoices(
@@ -1834,8 +1966,17 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     seasonalPanel: buildSeasonSummary(states, seasonLabels, seasonStyleByType),
     catastropheZones: buildCatastropheZones(catastropheEntries, readabilityProfile),
     regionalRiskMode: buildRegionalRiskMode(regions),
-    mapLayers: buildClimateMapLayers(regions, stateEntries, catastropheEntries, seasonPreview, regionGeometryById, anomalyTooltipByRegion),
+    mapLayers: buildClimateMapLayers(
+      regions,
+      stateEntries,
+      catastropheEntries,
+      seasonPreview,
+      regionGeometryById,
+      anomalyTooltipByRegion,
+      climateAftermathRecap.resilienceMarkers,
+    ),
     climateTimeline,
+    ...(climateAftermathRecap.events.length > 0 ? { climateAftermathRecap } : {}),
     selectedClimateImpactComparison,
     selectedClimateTimingRecommendation,
     selectedClimateMitigationChoices,

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -1691,3 +1691,118 @@ test('buildClimateMapOverlay preserves explicit mitigation previews without merg
     },
   ]);
 });
+
+test('buildClimateMapOverlay exposes climate aftermath recap and resilience markers', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'delta', season: 'spring', temperatureC: 18, precipitationLevel: 70, droughtIndex: 12 },
+    { regionId: 'ridge', season: 'spring', temperatureC: 29, precipitationLevel: 18, droughtIndex: 68, anomaly: 'drought' },
+  ], {
+    regionGeometryById: {
+      delta: { center: { x: 24, y: 12 } },
+      ridge: { center: { x: 44, y: 18 } },
+    },
+    seasonPreview: {
+      season: 'summer',
+      impactsByRegion: {
+        delta: {
+          strategicImpact: 'critical',
+          anomaly: 'flood',
+          confidenceBand: 'extreme',
+          timeWindow: 'tour actuel',
+          playerImpact: 'route fluviale et récolte touchées',
+        },
+      },
+    },
+    climateAftermathEvents: [
+      {
+        eventId: 'flood-aftermath',
+        affectedRegionIds: ['delta', 'ridge'],
+        observedImpact: 'récoltes basses et route coupée',
+        severity: 'major',
+        appliedMitigation: 'digues renforcées',
+        confidenceBand: 'probable',
+        resilienceState: 'recovering',
+      },
+    ],
+  });
+
+  assert.deepEqual(overlay.climateAftermathRecap.events, [
+    {
+      eventId: 'flood-aftermath',
+      observedImpact: 'récoltes basses et route coupée',
+      severity: 'major',
+      affectedRegionIds: ['delta', 'ridge'],
+      appliedMitigation: 'digues renforcées',
+      missingMitigation: null,
+      confidenceBand: 'probable',
+      sourceAlertId: 'delta',
+      resilienceState: 'recovering',
+    },
+  ]);
+  assert.deepEqual(overlay.mapLayers.resilienceMarkers.map((marker) => ({
+    regionId: marker.regionId,
+    resilienceState: marker.resilienceState,
+    severity: marker.severity,
+    confidenceBand: marker.confidenceBand,
+    x: marker.x,
+    y: marker.y,
+    tooltip: marker.tooltip,
+  })), [
+    {
+      regionId: 'delta',
+      resilienceState: 'recovering',
+      severity: 'major',
+      confidenceBand: 'probable',
+      x: 24,
+      y: 12,
+      tooltip: {
+        observedImpact: 'récoltes basses et route coupée',
+        mitigation: 'mitigation appliquée: digues renforcées',
+        confidenceBand: 'probable',
+      },
+    },
+    {
+      regionId: 'ridge',
+      resilienceState: 'recovering',
+      severity: 'major',
+      confidenceBand: 'probable',
+      x: 44,
+      y: 18,
+      tooltip: {
+        observedImpact: 'récoltes basses et route coupée',
+        mitigation: 'mitigation appliquée: digues renforcées',
+        confidenceBand: 'probable',
+      },
+    },
+  ]);
+});
+
+test('buildClimateMapOverlay links urgent alerts to default aftermath when no explicit recap exists', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'citadel', season: 'spring', temperatureC: 18, precipitationLevel: 40, droughtIndex: 20 },
+  ], {
+    seasonPreview: {
+      season: 'summer',
+      impactsByRegion: {
+        citadel: {
+          strategicImpact: 'critical',
+          anomaly: 'storm',
+          confidenceBand: 'extreme',
+          timeWindow: 'tour actuel',
+          playerImpact: 'priorité capitale et route fragile',
+        },
+      },
+    },
+  });
+
+  assert.equal(overlay.climateAftermathRecap.events[0].sourceAlertId, 'citadel');
+  assert.equal(overlay.climateAftermathRecap.events[0].appliedMitigation, 'mitiger maintenant');
+  assert.equal(overlay.climateAftermathRecap.events[0].missingMitigation, 'ne rien changer');
+  assert.deepEqual(overlay.mapLayers.resilienceMarkers.map((marker) => ({
+    regionId: marker.regionId,
+    resilienceState: marker.resilienceState,
+    label: marker.label,
+  })), [
+    { regionId: 'citadel', resilienceState: 'recovering', label: 'récupération en cours' },
+  ]);
+});


### PR DESCRIPTION
Epsilon: Adds climate event aftermath recaps and resilience markers for #1213.

- exposes compact climateAftermathRecap entries with observed impact, severity, affected zones, mitigation applied/missing, confidence, and source alert link
- adds mapLayers.resilienceMarkers for recovering/resilient/strained/regressing regions with short tooltips
- links urgent alert previews to default aftermath when no explicit recap is provided
- keeps existing alert, tooltip, confidence, and mitigation preview structures intact

Tests:
- `npm test -- test/ui/climate/buildClimateMapOverlay.test.js`
- `npm test`
- `git diff --check`

Closes #1213