### PR TITLE
Alpha: add front pressure replay

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1714,6 +1714,158 @@ function buildAfterActionMapRecap(renderedProvinces, keyboardActionPlanner, opti
   };
 }
 
+
+function normalizePressureLevel(value, fallback = 'stable') {
+  const level = String(value ?? fallback).trim() || fallback;
+  if (['low', 'stable', 'guarded', 'high', 'critical'].includes(level)) return level;
+  return fallback;
+}
+
+function pressureScore(level) {
+  return {
+    low: 0,
+    stable: 1,
+    guarded: 2,
+    high: 3,
+    critical: 4,
+  }[level] ?? 1;
+}
+
+function pressureChangeLabel(delta) {
+  if (delta > 0) return `+${delta} pression`;
+  if (delta < 0) return `${delta} pression`;
+  return 'pression stable';
+}
+
+function markerTone(marker) {
+  if (marker === 'gain') return 'positive';
+  if (marker === 'loss') return 'negative';
+  if (marker === 'blocked') return 'warning';
+  return 'neutral';
+}
+
+function markerLabel(marker) {
+  if (marker === 'gain') return 'gain';
+  if (marker === 'loss') return 'perte';
+  if (marker === 'blocked') return 'blocage';
+  return 'pression adjacente';
+}
+
+function inferMarker(previousPressure, pressure, result) {
+  if (result === 'blocked' || result === 'conflict') return 'blocked';
+  const delta = pressureScore(pressure) - pressureScore(previousPressure);
+  if (delta < 0) return 'gain';
+  if (delta > 0) return 'loss';
+  return 'adjacent-pressure';
+}
+
+function normalizeFrontPressureTimeline(value) {
+  if (value === undefined) return [];
+
+  if (!Array.isArray(value)) {
+    throw new TypeError('StrategicMapShell frontPressureTimeline must be an array.');
+  }
+
+  return value.map((entry, index) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new TypeError('StrategicMapShell frontPressureTimeline entries must be objects.');
+    }
+
+    const pressure = normalizePressureLevel(entry.pressure, 'stable');
+    const previousPressure = normalizePressureLevel(entry.previousPressure, pressure);
+    const result = String(entry.result ?? '').trim();
+    const marker = String(entry.marker ?? inferMarker(previousPressure, pressure, result)).trim() || 'adjacent-pressure';
+    const adjacentPressure = Array.isArray(entry.adjacentPressure) ? entry.adjacentPressure : [];
+
+    return {
+      frameId: String(entry.frameId ?? `front-frame-${index + 1}`).trim() || `front-frame-${index + 1}`,
+      provinceId: String(entry.provinceId ?? '').trim(),
+      turnLabel: String(entry.turnLabel ?? `État ${index + 1}`).trim() || `État ${index + 1}`,
+      pressure,
+      previousPressure,
+      result,
+      marker,
+      reason: String(entry.reason ?? '').trim(),
+      adjacentPressure: adjacentPressure.map((adjacent, adjacentIndex) => ({
+        provinceId: String(adjacent?.provinceId ?? `adjacent-${adjacentIndex + 1}`).trim() || `adjacent-${adjacentIndex + 1}`,
+        label: String(adjacent?.label ?? adjacent?.provinceId ?? `Voisin ${adjacentIndex + 1}`).trim() || `Voisin ${adjacentIndex + 1}`,
+        pressure: normalizePressureLevel(adjacent?.pressure, 'stable'),
+      })),
+    };
+  }).filter((entry) => entry.provinceId).slice(-4);
+}
+
+function buildFrontPressureTimelineReplay(renderedProvinces, options) {
+  const timeline = normalizeFrontPressureTimeline(options.frontPressureTimeline);
+  const provinceById = new Map(renderedProvinces.map((province) => [province.provinceId, province]));
+  const frames = timeline.map((entry, index) => {
+    const province = provinceById.get(entry.provinceId) ?? null;
+    const delta = pressureScore(entry.pressure) - pressureScore(entry.previousPressure);
+    const reason = entry.reason || (
+      entry.marker === 'blocked'
+        ? 'un blocage empêche le front de bouger'
+        : delta < 0
+          ? 'les ordres récents relâchent la pression locale'
+          : delta > 0
+            ? 'les pressions voisines renforcent le front adverse'
+            : 'aucun basculement net entre les deux états'
+    );
+
+    return {
+      frameId: entry.frameId,
+      frameIndex: index,
+      provinceId: entry.provinceId,
+      provinceLabel: province?.label ?? entry.provinceId,
+      turnLabel: entry.turnLabel,
+      previousPressure: entry.previousPressure,
+      pressure: entry.pressure,
+      pressureDelta: delta,
+      changeLabel: pressureChangeLabel(delta),
+      marker: {
+        type: entry.marker,
+        label: markerLabel(entry.marker),
+        tone: markerTone(entry.marker),
+      },
+      adjacentPressure: entry.adjacentPressure,
+      summary: `${pressureChangeLabel(delta)} — ${reason}`,
+      reason,
+    };
+  });
+
+  const requestedIndex = Number.isInteger(options.frontPressureReplayIndex) ? options.frontPressureReplayIndex : frames.length - 1;
+  const currentIndex = frames.length === 0 ? -1 : Math.min(Math.max(requestedIndex, 0), frames.length - 1);
+  const activeFrame = currentIndex === -1 ? null : frames[currentIndex];
+  const firstFrame = frames[0] ?? null;
+
+  return {
+    empty: frames.length === 0,
+    incomplete: frames.length > 0 && frames.length < 2,
+    frameCount: frames.length,
+    currentIndex,
+    controls: frames.length === 0 ? null : {
+      type: 'scrub',
+      min: 0,
+      max: frames.length - 1,
+      step: 1,
+      label: 'Rejouer la pression du front',
+    },
+    beforeAfter: activeFrame && firstFrame ? {
+      provinceId: activeFrame.provinceId,
+      provinceLabel: activeFrame.provinceLabel,
+      before: firstFrame.previousPressure,
+      after: activeFrame.pressure,
+      changeLabel: activeFrame.changeLabel,
+    } : null,
+    frames,
+    activeFrame,
+    fallbackMessage: frames.length === 0
+      ? 'Aucun historique de pression disponible pour le replay.'
+      : frames.length < 2
+        ? 'Historique incomplet: un seul état disponible pour ce front.'
+        : null,
+  };
+}
+
 function buildKeyboardActionPlanner(renderedProvinces, options) {
   const activeProvince = renderedProvinces.find(
     (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
@@ -1945,6 +2097,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
 
   const keyboardActionPlanner = buildKeyboardActionPlanner(renderedProvinces, normalizedOptions);
   const afterActionMapRecap = buildAfterActionMapRecap(renderedProvinces, keyboardActionPlanner, normalizedOptions);
+  const frontPressureReplay = buildFrontPressureTimelineReplay(renderedProvinces, normalizedOptions);
 
   return {
     title,
@@ -1953,6 +2106,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     mapLayers: buildProvinceMapLayers(renderedProvinces),
     keyboardActionPlanner,
     afterActionMapRecap,
+    frontPressureReplay,
     stats: {
       provinceCount: stats.provinceCount,
       contestedCount: stats.contestedCount,

--- a/src/ui/war/buildStrategicMapPreviewHtml.js
+++ b/src/ui/war/buildStrategicMapPreviewHtml.js
@@ -260,6 +260,35 @@ function renderAfterActionMapRecap(shell) {
   `;
 }
 
+
+function renderFrontPressureReplay(shell) {
+  const replay = shell.frontPressureReplay;
+  const frames = replay.frames.map((frame) => {
+    const adjacent = frame.adjacentPressure.length > 0
+      ? frame.adjacentPressure.map((item) => `${item.label}: ${item.pressure}`).join(', ')
+      : 'aucune pression adjacente';
+
+    return `
+    <li class="front-pressure-frame front-pressure-frame--${escapeHtml(frame.marker.type)} ${frame.frameIndex === replay.currentIndex ? 'is-active' : ''}">
+      <span>${escapeHtml(frame.turnLabel)} · ${escapeHtml(frame.provinceLabel)}</span>
+      <strong>${escapeHtml(frame.marker.label)} · ${escapeHtml(frame.changeLabel)}</strong>
+      <small>${escapeHtml(frame.summary)}</small>
+      <em>${escapeHtml(adjacent)}</em>
+    </li>
+  `;
+  }).join('');
+
+  return `
+    <section class="front-pressure-replay" aria-label="Replay timeline de pression du front">
+      <h2>Replay front</h2>
+      <p>${escapeHtml(replay.fallbackMessage ?? replay.activeFrame?.summary ?? 'Timeline prête.')}</p>
+      ${replay.controls ? `<label class="front-pressure-scrub"><span>${escapeHtml(replay.controls.label)}</span><input type="range" min="${replay.controls.min}" max="${replay.controls.max}" step="${replay.controls.step}" value="${replay.currentIndex}" aria-label="${escapeHtml(replay.controls.label)}"><small>${replay.currentIndex + 1}/${replay.frameCount}</small></label>` : ''}
+      ${replay.beforeAfter ? `<article class="front-pressure-before-after"><span>Avant</span><strong>${escapeHtml(replay.beforeAfter.before)}</strong><span>Après</span><strong>${escapeHtml(replay.beforeAfter.after)}</strong><small>${escapeHtml(replay.beforeAfter.changeLabel)}</small></article>` : ''}
+      ${replay.empty ? '<small class="front-pressure-empty">Aucun historique à rejouer pour cette province.</small>' : `<ol>${frames}</ol>`}
+    </section>
+  `;
+}
+
 function renderProvinceActionQueueValidation(shell) {
   const validation = shell.keyboardActionPlanner.actionQueueValidation;
   const entries = validation.entries.map((entry) => {
@@ -314,6 +343,12 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     resolvedProvinceOrders: normalizedOptions.resolvedProvinceOrders ?? [
       { resolutionId: 'preview-success', queueId: 'preview-main', provinceId: normalizedOptions.selectedProvinceId ?? 'river-gate', result: 'success', label: 'Ordre principal résolu' },
       { resolutionId: 'preview-deferred', queueId: 'preview-support', provinceId: normalizedOptions.focusedProvinceId ?? 'crown-heart', result: 'deferred', label: 'Appui reporté' },
+    ],
+    frontPressureReplayIndex: normalizedOptions.frontPressureReplayIndex ?? 1,
+    frontPressureTimeline: normalizedOptions.frontPressureTimeline ?? [
+      { frameId: 'preview-pressure-before', provinceId: normalizedOptions.selectedProvinceId ?? 'river-gate', turnLabel: 'Avant ordre', previousPressure: 'critical', pressure: 'high', marker: 'gain', reason: 'renforts stabilisent la province contestée', adjacentPressure: [{ provinceId: normalizedOptions.focusedProvinceId ?? 'crown-heart', label: 'Voisin ciblé', pressure: 'high' }] },
+      { frameId: 'preview-pressure-after', provinceId: normalizedOptions.selectedProvinceId ?? 'river-gate', turnLabel: 'Après résolution', previousPressure: 'high', pressure: 'critical', marker: 'loss', reason: 'la pression adjacente remonte après le report du soutien', adjacentPressure: [{ provinceId: normalizedOptions.focusedProvinceId ?? 'crown-heart', label: 'Voisin ciblé', pressure: 'critical' }] },
+      { frameId: 'preview-pressure-blocked', provinceId: normalizedOptions.selectedProvinceId ?? 'river-gate', turnLabel: 'Ordre bloqué', previousPressure: 'critical', pressure: 'critical', marker: 'blocked', result: 'blocked', reason: 'le ravitaillement empêche la bascule du front' },
     ],
   });
 
@@ -400,6 +435,22 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .after-action-item strong { color:#f0abfc; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
     .after-action-item small { color:#dbeafe; }
     .after-action-item em { color:#bae6fd; font-size:11px; font-style:normal; }
+    .front-pressure-replay { display:grid; gap:10px; }
+    .front-pressure-replay p, .front-pressure-empty { margin:0; color:#cbd5e1; font-size:12px; }
+    .front-pressure-scrub { display:grid; grid-template-columns:1fr auto; gap:6px 10px; align-items:center; color:#bfdbfe; font-size:12px; }
+    .front-pressure-scrub input { grid-column:1 / -1; width:100%; accent-color:#f0abfc; }
+    .front-pressure-before-after { display:grid; grid-template-columns:auto 1fr auto 1fr; gap:5px 8px; border:1px solid rgba(240,171,252,0.28); border-radius:12px; padding:8px; background:rgba(88,28,135,0.14); }
+    .front-pressure-before-after span, .front-pressure-before-after small { color:#c4b5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
+    .front-pressure-before-after small { grid-column:1 / -1; text-transform:none; letter-spacing:0; }
+    .front-pressure-replay ol { display:grid; gap:6px; margin:0; padding:0; }
+    .front-pressure-frame { display:grid; gap:3px; border:1px solid rgba(148,163,184,0.18); border-radius:12px; padding:7px 9px; }
+    .front-pressure-frame.is-active { border-color:rgba(240,171,252,0.58); box-shadow:0 0 0 1px rgba(240,171,252,0.16) inset; }
+    .front-pressure-frame--gain { border-color:rgba(74,222,128,0.36); }
+    .front-pressure-frame--loss { border-color:rgba(248,113,113,0.44); }
+    .front-pressure-frame--blocked { border-color:rgba(251,191,36,0.48); }
+    .front-pressure-frame strong { color:#f5d0fe; font-size:12px; }
+    .front-pressure-frame small { color:#dbeafe; }
+    .front-pressure-frame em { color:#bae6fd; font-size:11px; font-style:normal; }
     table { width:100%; border-collapse:collapse; font-size:13px; }
     th, td { padding:10px 8px; border-bottom:1px solid rgba(148, 163, 184, 0.14); text-align:left; }
     th { color:#93c5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
@@ -445,6 +496,7 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
         ${renderKeyboardActionPlanner(shell)}
         ${renderProvinceActionQueueValidation(shell)}
         ${renderAfterActionMapRecap(shell)}
+        ${renderFrontPressureReplay(shell)}
         <section>
           <h2>Lecture</h2>
           <ul>

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -204,6 +204,17 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     affectedFronts: [],
     summary: 'Aucune résolution récente à récapituler.',
   });
+  assert.deepEqual(shell.frontPressureReplay, {
+    empty: true,
+    incomplete: false,
+    frameCount: 0,
+    currentIndex: -1,
+    controls: null,
+    beforeAfter: null,
+    frames: [],
+    activeFrame: null,
+    fallbackMessage: 'Aucun historique de pression disponible pour le replay.',
+  });
   assert.deepEqual(shell.stats, {
     provinceCount: 2,
     contestedCount: 1,
@@ -464,6 +475,151 @@ test('StrategicMapShell summarizes recently resolved province orders for after-a
       highlight: { provinceId: 'reserve', frontIds: ['reserve'] },
     },
   ]);
+});
+
+
+test('StrategicMapShell builds a scrub-ready front pressure timeline replay', () => {
+  const shell = buildStrategicMapShell(
+    [
+      createProvince({ id: 'front', name: 'Front rouge', contested: true, neighborIds: ['support', 'reserve'] }),
+      createProvince({ id: 'support', name: 'Support rompu', supplyLevel: 'disrupted', neighborIds: ['front'] }),
+      createProvince({ id: 'reserve', name: 'Réserve nord', strategicValue: 1, neighborIds: ['front'] }),
+    ],
+    {
+      frontPressureReplayIndex: 1,
+      frontPressureTimeline: [
+        {
+          frameId: 't1',
+          provinceId: 'front',
+          turnLabel: 'Avant ordre',
+          previousPressure: 'critical',
+          pressure: 'high',
+          marker: 'gain',
+          reason: 'renfort arrivé sur la ligne contestée',
+          adjacentPressure: [{ provinceId: 'support', label: 'Support rompu', pressure: 'high' }],
+        },
+        {
+          frameId: 't2',
+          provinceId: 'front',
+          turnLabel: 'Après blocage voisin',
+          previousPressure: 'high',
+          pressure: 'critical',
+          marker: 'loss',
+          reason: 'support voisin désorganisé',
+          adjacentPressure: [{ provinceId: 'support', label: 'Support rompu', pressure: 'critical' }],
+        },
+        {
+          frameId: 't3',
+          provinceId: 'front',
+          turnLabel: 'Ordre reporté',
+          previousPressure: 'critical',
+          pressure: 'critical',
+          marker: 'blocked',
+          result: 'blocked',
+          reason: 'ordre bloqué par ravitaillement rompu',
+        },
+      ],
+    },
+  );
+
+  assert.deepEqual(shell.frontPressureReplay, {
+    empty: false,
+    incomplete: false,
+    frameCount: 3,
+    currentIndex: 1,
+    controls: {
+      type: 'scrub',
+      min: 0,
+      max: 2,
+      step: 1,
+      label: 'Rejouer la pression du front',
+    },
+    beforeAfter: {
+      provinceId: 'front',
+      provinceLabel: 'Front rouge',
+      before: 'critical',
+      after: 'critical',
+      changeLabel: '+1 pression',
+    },
+    frames: [
+      {
+        frameId: 't1',
+        frameIndex: 0,
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        turnLabel: 'Avant ordre',
+        previousPressure: 'critical',
+        pressure: 'high',
+        pressureDelta: -1,
+        changeLabel: '-1 pression',
+        marker: { type: 'gain', label: 'gain', tone: 'positive' },
+        adjacentPressure: [{ provinceId: 'support', label: 'Support rompu', pressure: 'high' }],
+        summary: '-1 pression — renfort arrivé sur la ligne contestée',
+        reason: 'renfort arrivé sur la ligne contestée',
+      },
+      {
+        frameId: 't2',
+        frameIndex: 1,
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        turnLabel: 'Après blocage voisin',
+        previousPressure: 'high',
+        pressure: 'critical',
+        pressureDelta: 1,
+        changeLabel: '+1 pression',
+        marker: { type: 'loss', label: 'perte', tone: 'negative' },
+        adjacentPressure: [{ provinceId: 'support', label: 'Support rompu', pressure: 'critical' }],
+        summary: '+1 pression — support voisin désorganisé',
+        reason: 'support voisin désorganisé',
+      },
+      {
+        frameId: 't3',
+        frameIndex: 2,
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        turnLabel: 'Ordre reporté',
+        previousPressure: 'critical',
+        pressure: 'critical',
+        pressureDelta: 0,
+        changeLabel: 'pression stable',
+        marker: { type: 'blocked', label: 'blocage', tone: 'warning' },
+        adjacentPressure: [],
+        summary: 'pression stable — ordre bloqué par ravitaillement rompu',
+        reason: 'ordre bloqué par ravitaillement rompu',
+      },
+    ],
+    activeFrame: {
+      frameId: 't2',
+      frameIndex: 1,
+      provinceId: 'front',
+      provinceLabel: 'Front rouge',
+      turnLabel: 'Après blocage voisin',
+      previousPressure: 'high',
+      pressure: 'critical',
+      pressureDelta: 1,
+      changeLabel: '+1 pression',
+      marker: { type: 'loss', label: 'perte', tone: 'negative' },
+      adjacentPressure: [{ provinceId: 'support', label: 'Support rompu', pressure: 'critical' }],
+      summary: '+1 pression — support voisin désorganisé',
+      reason: 'support voisin désorganisé',
+    },
+    fallbackMessage: null,
+  });
+});
+
+test('StrategicMapShell reports incomplete front pressure replay history', () => {
+  const shell = buildStrategicMapShell(
+    [createProvince({ id: 'front', name: 'Front rouge', contested: true })],
+    {
+      frontPressureTimeline: [
+        { frameId: 'only', provinceId: 'front', previousPressure: 'high', pressure: 'high' },
+      ],
+    },
+  );
+
+  assert.equal(shell.frontPressureReplay.empty, false);
+  assert.equal(shell.frontPressureReplay.incomplete, true);
+  assert.equal(shell.frontPressureReplay.fallbackMessage, 'Historique incomplet: un seul état disponible pour ce front.');
 });
 
 test('StrategicMapShell projects intrigue presence and sabotage risk into the map overlay slot', () => {

--- a/test/ui/war/buildStrategicMapPreviewHtml.test.js
+++ b/test/ui/war/buildStrategicMapPreviewHtml.test.js
@@ -32,6 +32,12 @@ test('buildStrategicMapPreviewHtml renders a screenshot-ready preview from the g
   assert.match(html, /Après-action/);
   assert.match(html, /Ordre principal résolu/);
   assert.match(html, /Appui reporté/);
+  assert.match(html, /Replay timeline de pression du front/);
+  assert.match(html, /Rejouer la pression du front/);
+  assert.match(html, /Avant ordre/);
+  assert.match(html, /Après résolution/);
+  assert.match(html, /Ordre bloqué/);
+  assert.match(html, /front-pressure-frame--loss is-active/);
   assert.match(html, /class="province is-contested is-occupied is-selected is-queued is-recently-affected"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /Porte du Fleuve/);


### PR DESCRIPTION
Alpha: Implements #1219.

Summary:
- adds a lightweight front pressure timeline replay model for contested province history
- supports scrub controls over the last relevant pressure states with before/after comparison
- marks gains, losses, blocked states, and adjacent pressure with concise change/why summaries
- renders the replay panel in the strategic map preview with fallback states for missing or incomplete history

Tests:
- npm test
- git diff --check

Zeta: ready for validation before merge.
