### PR TITLE
Gamma: add cultural momentum layer

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -147,6 +147,96 @@ function buildInfluenceDiffs(selectedMarker, previousMarker, selectedCluster, re
   }];
 }
 
+function buildMomentumLevel(priority, influenceDiff, recapItem) {
+  const confidence = priority?.consequencePreview?.confidence ?? influenceDiff?.linkedPriority?.confidence ?? recapItem?.linkedPriority?.confidence ?? 'low';
+
+  if (confidence === 'low' || influenceDiff?.changeState === 'masked' || influenceDiff?.changeState === 'investigate') {
+    return 'fragile';
+  }
+
+  if (priority?.state === 'opportunity' || influenceDiff?.changeState === 'strengthened') {
+    return 'surging';
+  }
+
+  if (priority?.state === 'tension' || influenceDiff?.changeState === 'weakened') {
+    return 'volatile';
+  }
+
+  return 'observing';
+}
+
+function buildMomentumFilterState(priority, level) {
+  if (priority?.state === 'opportunity' || level === 'surging') {
+    return 'opportunity';
+  }
+
+  if (priority?.state === 'tension' || level === 'volatile' || level === 'fragile') {
+    return 'tension';
+  }
+
+  return 'watch';
+}
+
+function buildCulturalMomentumLayer({ regionId, selectedMarker, selectedCluster, timelineRecap, influenceDiffs, momentumFilter }) {
+  const priority = selectedMarker?.narrativePriority ?? selectedCluster?.narrativePriority ?? selectedCluster?.markerCollisionCluster?.narrativePriority ?? null;
+  const discoveryIds = (selectedMarker?.discoveries ?? [])
+    .slice(0, 3)
+    .sort();
+  const fallbackDiscovery = discoveryIds[0] ?? timelineRecap.find((item) => item.kind === 'discovery')?.title ?? priority?.source ?? 'signal culturel';
+  const baseDiffs = influenceDiffs.length > 0 ? influenceDiffs : [{
+    diffId: `${regionId}:momentum:unknown`,
+    regionId,
+    cultureName: selectedMarker?.cultureName ?? 'Culture locale',
+    changeState: priority?.consequencePreview?.confidence === 'low' ? 'investigate' : 'stable',
+    label: priority?.consequencePreview?.confidence === 'low' ? 'à investiguer' : 'stable',
+    reason: priority?.reason ?? 'momentum culturel stable',
+    linkedPriority: priority ? {
+      state: priority.state,
+      microAction: priority.microAction,
+      confidence: priority.consequencePreview?.confidence ?? 'medium',
+    } : null,
+  }];
+  const items = baseDiffs.map((diff, index) => {
+    const recapItem = timelineRecap[index] ?? timelineRecap[0] ?? null;
+    const level = buildMomentumLevel(priority, diff, recapItem);
+    const filterState = buildMomentumFilterState(priority, level);
+    const action = priority?.microAction ?? (level === 'fragile' ? 'observer' : 'attendre');
+    const risk = priority?.state === 'tension' || level === 'volatile' || level === 'fragile'
+      ? (priority?.consequencePreview?.tradeoff ?? diff.reason)
+      : null;
+
+    return {
+      momentumId: `${regionId}:momentum:${diff.changeState}:${index + 1}`,
+      regionId,
+      cultureName: diff.cultureName,
+      level,
+      filterState,
+      discoveryId: discoveryIds[index] ?? fallbackDiscovery,
+      influenceState: diff.changeState,
+      chain: `${discoveryIds[index] ?? fallbackDiscovery} → ${diff.label} → ${action}`,
+      suggestedAction: action,
+      opportunity: priority?.consequencePreview?.opportunity ?? recapItem?.summary ?? diff.reason,
+      risk,
+      confidence: priority?.consequencePreview?.confidence ?? diff.linkedPriority?.confidence ?? 'low',
+      markerIds: priority?.consequencePreview?.visibleMarkerIds ?? [],
+    };
+  });
+  const filteredItems = momentumFilter && momentumFilter !== 'all'
+    ? items.filter((item) => item.filterState === momentumFilter)
+    : items;
+
+  return {
+    layerId: `${regionId}:cultural-momentum`,
+    regionId,
+    activeFilter: momentumFilter ?? 'all',
+    availableFilters: ['all', 'opportunity', 'tension', 'watch'],
+    summary: filteredItems.length === 0
+      ? 'Aucun momentum culturel pour ce filtre.'
+      : `${filteredItems.length} chaîne${filteredItems.length > 1 ? 's' : ''} découverte → influence → décision.`,
+    items: filteredItems.slice(0, 3),
+  };
+}
+
 function dedupeAndSort(deltas) {
   return [...new Map(deltas.map((delta) => [
     `${delta.tone}:${delta.label}:${delta.value}:${delta.regionId}`,
@@ -167,10 +257,19 @@ export function buildCultureTurnReportDeltas({
   localTimeline = null,
   consequenceChips = [],
   previousMarker = null,
+  momentumFilter = 'all',
 } = {}) {
   const regionId = normalizeText(selectedRegionId ?? selectedMarker?.regionId ?? selectedCluster?.regionIds?.[0], 'province');
   const timelineRecap = buildDiscoveryTimelineRecap(localTimeline, selectedMarker, selectedCluster, regionId);
   const influenceDiffs = buildInfluenceDiffs(selectedMarker, previousMarker, selectedCluster, regionId);
+  const momentumLayer = buildCulturalMomentumLayer({
+    regionId,
+    selectedMarker,
+    selectedCluster,
+    timelineRecap,
+    influenceDiffs,
+    momentumFilter,
+  });
   const deltas = dedupeAndSort([
     ...buildTimelineDeltas(localTimeline, regionId),
     ...buildMarkerDeltas(selectedMarker, regionId),
@@ -186,6 +285,14 @@ export function buildCultureTurnReportDeltas({
       deltas: [],
       timelineRecap: [],
       influenceDiffs: [],
+      momentumLayer: {
+        layerId: `${regionId}:cultural-momentum`,
+        regionId,
+        activeFilter: momentumFilter,
+        availableFilters: ['all', 'opportunity', 'tension', 'watch'],
+        summary: 'Aucun momentum culturel pour ce filtre.',
+        items: [],
+      },
     };
   }
 
@@ -197,5 +304,6 @@ export function buildCultureTurnReportDeltas({
     deltas,
     timelineRecap,
     influenceDiffs,
+    momentumLayer,
   };
 }

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -22,6 +22,8 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
         consequencePreview: {
           confidence: 'high',
           summary: 'explorer: archives ouvertes; tradeoff: retarde apaisement.',
+          opportunity: 'Saisir les archives peut déclencher une décision culturelle immédiate.',
+          visibleMarkerIds: ['river-gate:culture-aurora:event:event-archive-opening'],
         },
       },
     },
@@ -98,6 +100,30 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       },
     },
   ]);
+  assert.deepEqual(report.momentumLayer, {
+    layerId: 'river-gate:cultural-momentum',
+    regionId: 'river-gate',
+    activeFilter: 'all',
+    availableFilters: ['all', 'opportunity', 'tension', 'watch'],
+    summary: '1 chaîne découverte → influence → décision.',
+    items: [
+      {
+        momentumId: 'river-gate:momentum:strengthened:1',
+        regionId: 'river-gate',
+        cultureName: 'Compact d’Aurora',
+        level: 'surging',
+        filterState: 'opportunity',
+        discoveryId: 'archive-routes',
+        influenceState: 'strengthened',
+        chain: 'archive-routes → influence renforcée → explorer',
+        suggestedAction: 'explorer',
+        opportunity: 'Saisir les archives peut déclencher une décision culturelle immédiate.',
+        risk: null,
+        confidence: 'high',
+        markerIds: ['river-gate:culture-aurora:event:event-archive-opening'],
+      },
+    ],
+  });
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -109,6 +135,14 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
     deltas: [],
     timelineRecap: [],
     influenceDiffs: [],
+    momentumLayer: {
+      layerId: 'quiet-field:cultural-momentum',
+      regionId: 'quiet-field',
+      activeFilter: 'all',
+      availableFilters: ['all', 'opportunity', 'tension', 'watch'],
+      summary: 'Aucun momentum culturel pour ce filtre.',
+      items: [],
+    },
   });
 });
 
@@ -148,4 +182,46 @@ test('buildCultureTurnReportDeltas classifies new, weakened, masked, and investi
     selectedMarker: baseMarker,
     previousMarker: { ...baseMarker, influenceScore: 42, discoveries: ['fog-index'] },
   }).influenceDiffs[0].changeState, 'investigate');
+});
+
+test('buildCultureTurnReportDeltas filters fragile cultural momentum for tension decisions', () => {
+  const report = buildCultureTurnReportDeltas({
+    selectedRegionId: 'mist-hills',
+    momentumFilter: 'tension',
+    selectedMarker: {
+      overlayId: 'mist-hills:culture-mist',
+      regionId: 'mist-hills',
+      cultureName: 'Mist Circle',
+      influenceTier: 'faint',
+      influenceScore: 42,
+      discoveries: ['fog-index'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'watch',
+        microAction: 'attendre',
+        reason: 'Aucun signal critique: attendre le prochain repère culturel.',
+        consequencePreview: {
+          confidence: 'low',
+          tradeoff: 'risque de laisser passer un signal faible',
+          summary: 'attendre: intel culturel incomplet.',
+          visibleMarkerIds: ['mist-hills:culture-mist'],
+        },
+      },
+    },
+    previousMarker: {
+      overlayId: 'mist-hills:culture-mist',
+      regionId: 'mist-hills',
+      cultureName: 'Mist Circle',
+      influenceTier: 'faint',
+      influenceScore: 42,
+      discoveries: ['fog-index'],
+    },
+  });
+
+  assert.equal(report.momentumLayer.activeFilter, 'tension');
+  assert.deepEqual(report.momentumLayer.items.map((item) => [item.level, item.filterState, item.discoveryId, item.suggestedAction, item.confidence]), [
+    ['fragile', 'tension', 'fog-index', 'attendre', 'low'],
+  ]);
+  assert.match(report.momentumLayer.items[0].risk, /signal faible/);
 });


### PR DESCRIPTION
Gamma: Implements #1221.

Summary:
- adds a cultural momentum layer to the turn report model
- groups discovery-driven signals into surging, volatile, fragile, and observing states
- exposes discovery → influence → suggested action/risk chains with opportunity/tension/watch filtering
- preserves existing cluster readability by enriching report data only

Validation:
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- npm test -- test/ui/culture/buildCultureTurnReportDeltas.test.js
- npm test

Zeta: ready for validation before merge.