### PR TITLE
Delta: add intelligence provenance panel

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2384,6 +2384,51 @@ function buildEvidenceTrailMarkers({ locationId, locationName, confidenceState, 
   }];
 }
 
+function buildIntelligenceProvenancePanel({ confidenceState, safeVerificationHint, verificationPathPreviews, incidentReplay, evidenceTrailMarkers, safeMapMasking, locationOperations, exposedCellCount }) {
+  const provenanceType = confidenceState.state === 'confirmed'
+    ? 'observed'
+    : confidenceState.state === 'suspected'
+      ? 'inferred'
+      : confidenceState.state === 'stale'
+        ? 'rumor'
+        : 'unknown';
+  const sourceLabelByType = {
+    observed: 'Observation directe expurgée',
+    inferred: 'Déduction par signaux visibles',
+    rumor: 'Rumeur ou indice ancien',
+    unknown: 'Source inconnue ou confidentielle',
+  };
+  const methodByType = {
+    observed: exposedCellCount > 0 ? 'exposition visible confirmée' : 'pression active confirmée',
+    inferred: locationOperations.length > 0 ? 'corrélation chaleur/progression visible' : 'corrélation de présence locale',
+    rumor: 'ancien signal à revérifier avant action',
+    unknown: 'aucune méthode affichable en mode sûr',
+  };
+  const recommendedPath = verificationPathPreviews.find((path) => path.recommended) ?? verificationPathPreviews[0] ?? null;
+  const evidenceStates = [...new Set(evidenceTrailMarkers.map((marker) => marker.state))];
+
+  return {
+    provenanceType,
+    sourceLabel: sourceLabelByType[provenanceType],
+    confirmationMethod: methodByType[provenanceType],
+    credibility: confidenceState.label,
+    credibilityReason: confidenceState.safeCopy,
+    evidenceStates,
+    nextVerificationStep: recommendedPath ? {
+      action: safeVerificationHint.action,
+      label: safeVerificationHint.label,
+      costCue: recommendedPath.costCue,
+      exposureCost: recommendedPath.exposureCost,
+      evidenceNeeded: recommendedPath.evidenceNeeded,
+    } : null,
+    safeMapSummary: safeMapMasking.state === 'masked-information'
+      ? 'Provenance généralisée: les détails non autorisés restent masqués.'
+      : `${safeMapMasking.redactedLabel}: provenance limitée aux signaux visibles.`,
+    hiddenDetailPolicy: 'Ne révèle jamais cellule, relais, cible, objectif précis ou cause cachée.',
+    incidentSummary: incidentReplay.summary,
+  };
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2528,6 +2573,16 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         locationOperations,
         relatedLocationIds,
       });
+      const intelligenceProvenancePanel = buildIntelligenceProvenancePanel({
+        confidenceState,
+        safeVerificationHint,
+        verificationPathPreviews,
+        incidentReplay,
+        evidenceTrailMarkers,
+        safeMapMasking,
+        locationOperations,
+        exposedCellCount,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -2537,6 +2592,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           verificationPathPreviews,
           incidentReplay,
           evidenceTrailMarkers,
+          intelligenceProvenancePanel,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2011,3 +2011,83 @@ test('buildIntrigueMapOverlay replays fog-safe incidents and evidence trail mark
     reason: 'Mode sûr: lien de preuve non affiché car les données sont absentes ou confidentielles.',
   }]);
 });
+
+test('buildIntrigueMapOverlay exposes fog-safe intelligence provenance panels', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-observed-prov',
+      factionId: 'shadow-league',
+      codename: 'Torch',
+      locationId: 'observed-prov',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 78,
+    }),
+    new Cellule({
+      id: 'cell-inferred-prov',
+      factionId: 'shadow-league',
+      codename: 'Lantern',
+      locationId: 'inferred-prov',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+    new Cellule({
+      id: 'cell-rumor-prov',
+      factionId: 'shadow-league',
+      codename: 'Ash',
+      locationId: 'rumor-prov',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      exposure: 18,
+    }),
+    new Cellule({
+      id: 'cell-unknown-prov',
+      factionId: 'shadow-league',
+      codename: 'Blank',
+      locationId: 'unknown-prov',
+      memberIds: ['ag-4'],
+      assetIds: ['asset-4'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-inferred-prov',
+      celluleId: 'cell-inferred-prov',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe road rumor',
+      theaterId: 'inferred-prov',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 80,
+      progress: 5,
+      heat: 10,
+      phase: 'planning',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.intelligenceProvenancePanel]));
+
+  assert.equal(byLocation.get('observed-prov').provenanceType, 'observed');
+  assert.equal(byLocation.get('observed-prov').sourceLabel, 'Observation directe expurgée');
+  assert.equal(byLocation.get('observed-prov').confirmationMethod, 'exposition visible confirmée');
+  assert.equal(byLocation.get('observed-prov').nextVerificationStep.action, 'observe-locally');
+  assert.match(byLocation.get('observed-prov').hiddenDetailPolicy, /Ne révèle jamais cellule, relais, cible/);
+
+  assert.equal(byLocation.get('inferred-prov').provenanceType, 'inferred');
+  assert.equal(byLocation.get('inferred-prov').sourceLabel, 'Déduction par signaux visibles');
+  assert.equal(byLocation.get('inferred-prov').confirmationMethod, 'corrélation chaleur/progression visible');
+  assert.equal(byLocation.get('inferred-prov').nextVerificationStep.action, 'limit-coverage');
+  assert.deepEqual(byLocation.get('inferred-prov').evidenceStates, ['suspected-evidence']);
+
+  assert.equal(byLocation.get('rumor-prov').provenanceType, 'rumor');
+  assert.equal(byLocation.get('rumor-prov').sourceLabel, 'Rumeur ou indice ancien');
+  assert.equal(byLocation.get('rumor-prov').nextVerificationStep.action, 'wait');
+  assert.match(byLocation.get('rumor-prov').credibilityReason, /indice à revérifier/);
+
+  assert.equal(byLocation.get('unknown-prov').provenanceType, 'unknown');
+  assert.equal(byLocation.get('unknown-prov').sourceLabel, 'Source inconnue ou confidentielle');
+  assert.equal(byLocation.get('unknown-prov').confirmationMethod, 'aucune méthode affichable en mode sûr');
+  assert.equal(byLocation.get('unknown-prov').nextVerificationStep.action, 'ignore');
+  assert.match(byLocation.get('unknown-prov').safeMapSummary, /Provenance généralisée/);
+});


### PR DESCRIPTION
Delta: ## Summary
- Adds fog-safe `intelligenceProvenancePanel` data for intrigue map markers.
- Separates observed, inferred, rumor, and unknown provenance with redacted source/method labels.
- Shows the least-risk next verification step and evidence states without revealing hidden cells, relays, targets, objectives, or causes.

Closes #1222.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés intrigue passés et tests complets passés avec `npm test` (670/670); j’attends ta validation avant tout merge.