### PR TITLE
Alpha: recommend recovery after front replay

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1866,6 +1866,128 @@ function buildFrontPressureTimelineReplay(renderedProvinces, options) {
   };
 }
 
+
+function buildRecoveryRecommendation({ actionCode, label, stance, reason, risk, safest = false, opportunistic = false }) {
+  return {
+    actionCode,
+    label,
+    stance,
+    reason,
+    risk,
+    safest,
+    opportunistic,
+  };
+}
+
+function buildFrontRecoveryRecommendations(frontPressureReplay) {
+  if (frontPressureReplay.empty) {
+    return {
+      empty: true,
+      fallbackMessage: 'Recommandations indisponibles sans historique de pression du front.',
+      safestActionCode: null,
+      opportunisticActionCode: null,
+      recommendations: [],
+    };
+  }
+
+  if (frontPressureReplay.incomplete) {
+    return {
+      empty: false,
+      fallbackMessage: 'Historique incomplet: attendre ou consolider avant une reprise risquée.',
+      safestActionCode: 'hold-and-observe',
+      opportunisticActionCode: null,
+      recommendations: [
+        buildRecoveryRecommendation({
+          actionCode: 'hold-and-observe',
+          label: 'Attendre et observer',
+          stance: 'sûre',
+          reason: 'un seul état de replay ne suffit pas pour distinguer gain, perte ou pression adjacente',
+          risk: 'faible, mais l’initiative reste limitée',
+          safest: true,
+        }),
+      ],
+    };
+  }
+
+  const activeFrame = frontPressureReplay.activeFrame;
+  const frames = frontPressureReplay.frames;
+  const hasBlocked = frames.some((frame) => frame.marker.type === 'blocked');
+  const hasGain = frames.some((frame) => frame.marker.type === 'gain');
+  const hasLoss = frames.some((frame) => frame.marker.type === 'loss');
+  const hasAdjacentPressure = frames.some((frame) => frame.adjacentPressure.length > 0);
+  const supportPressure = activeFrame?.adjacentPressure.some((adjacent) => ['high', 'critical'].includes(adjacent.pressure)) ?? false;
+  const recommendations = [];
+
+  if (hasBlocked || supportPressure) {
+    recommendations.push(buildRecoveryRecommendation({
+      actionCode: 'consolidate-support',
+      label: 'Consolider le soutien',
+      stance: 'sûre',
+      reason: hasBlocked
+        ? 'le replay montre un blocage qui empêche la pression de retomber'
+        : 'la pression adjacente reste haute autour de la province contestée',
+      risk: 'faible à moyen: stabilise le front mais retarde l’exploitation',
+      safest: true,
+    }));
+  }
+
+  if (hasLoss || activeFrame?.pressureDelta > 0) {
+    recommendations.push(buildRecoveryRecommendation({
+      actionCode: 'reinforce-front',
+      label: 'Renforcer le front',
+      stance: recommendations.length === 0 ? 'sûre' : 'défensive',
+      reason: 'le replay indique une perte de pression favorable ou une remontée adverse',
+      risk: 'moyen: consomme des ressources mais évite une rupture',
+      safest: recommendations.length === 0,
+    }));
+  }
+
+  if (hasGain && !supportPressure) {
+    recommendations.push(buildRecoveryRecommendation({
+      actionCode: 'exploit-breach',
+      label: 'Exploiter la brèche',
+      stance: 'opportuniste',
+      reason: 'un gain récent ouvre une fenêtre avant que la pression voisine ne remonte',
+      risk: 'élevé: peut exposer le front si le soutien manque',
+      opportunistic: true,
+    }));
+  }
+
+  if (hasGain && supportPressure) {
+    recommendations.push(buildRecoveryRecommendation({
+      actionCode: 'limited-probe',
+      label: 'Sonder prudemment la brèche',
+      stance: 'opportuniste',
+      reason: 'le replay montre un gain, mais la pression adjacente exige une reprise limitée',
+      risk: 'moyen à élevé: opportunité réelle mais soutien fragile',
+      opportunistic: true,
+    }));
+  }
+
+  if (recommendations.length < 2) {
+    recommendations.push(buildRecoveryRecommendation({
+      actionCode: 'hold-line',
+      label: 'Tenir la ligne',
+      stance: recommendations.length === 0 ? 'sûre' : 'attente',
+      reason: 'le replay ne montre pas de bascule assez nette pour forcer une action',
+      risk: 'faible: garde la lisibilité mais laisse l’adversaire respirer',
+      safest: recommendations.length === 0,
+    }));
+  }
+
+  const compactRecommendations = recommendations.slice(0, 3);
+  const safest = compactRecommendations.find((recommendation) => recommendation.safest) ?? compactRecommendations[0] ?? null;
+  const opportunistic = compactRecommendations.find((recommendation) => recommendation.opportunistic) ?? null;
+
+  return {
+    empty: compactRecommendations.length === 0,
+    fallbackMessage: null,
+    safestActionCode: safest?.actionCode ?? null,
+    opportunisticActionCode: opportunistic?.actionCode ?? null,
+    recommendations: compactRecommendations,
+  };
+}
+
 function buildKeyboardActionPlanner(renderedProvinces, options) {
   const activeProvince = renderedProvinces.find(
     (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
@@ -2098,6 +2220,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const keyboardActionPlanner = buildKeyboardActionPlanner(renderedProvinces, normalizedOptions);
   const afterActionMapRecap = buildAfterActionMapRecap(renderedProvinces, keyboardActionPlanner, normalizedOptions);
   const frontPressureReplay = buildFrontPressureTimelineReplay(renderedProvinces, normalizedOptions);
+  const frontRecoveryRecommendations = buildFrontRecoveryRecommendations(frontPressureReplay);
 
   return {
     title,
@@ -2107,6 +2230,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     keyboardActionPlanner,
     afterActionMapRecap,
     frontPressureReplay,
+    frontRecoveryRecommendations,
     stats: {
       provinceCount: stats.provinceCount,
       contestedCount: stats.contestedCount,

--- a/src/ui/war/buildStrategicMapPreviewHtml.js
+++ b/src/ui/war/buildStrategicMapPreviewHtml.js
@@ -289,6 +289,27 @@ function renderFrontPressureReplay(shell) {
   `;
 }
 
+
+function renderFrontRecoveryRecommendations(shell) {
+  const recovery = shell.frontRecoveryRecommendations;
+  const entries = recovery.recommendations.map((recommendation) => `
+    <li class="front-recovery-item ${recommendation.safest ? 'is-safest' : ''} ${recommendation.opportunistic ? 'is-opportunistic' : ''}">
+      <span>${escapeHtml(recommendation.label)} · ${escapeHtml(recommendation.stance)}</span>
+      <strong>${recommendation.safest ? 'option la plus sûre' : recommendation.opportunistic ? 'option opportuniste' : 'option de reprise'}</strong>
+      <small>${escapeHtml(recommendation.reason)}</small>
+      <em>Risque: ${escapeHtml(recommendation.risk)}</em>
+    </li>
+  `).join('');
+
+  return `
+    <section class="front-recovery" aria-label="Recommandations de récupération après replay de pression">
+      <h2>Reprise front</h2>
+      <p>${escapeHtml(recovery.fallbackMessage ?? 'Actions proposées depuis le replay de pression.')}</p>
+      ${recovery.empty ? '<small class="front-recovery-empty">Aucune recommandation disponible.</small>' : `<ol>${entries}</ol>`}
+    </section>
+  `;
+}
+
 function renderProvinceActionQueueValidation(shell) {
   const validation = shell.keyboardActionPlanner.actionQueueValidation;
   const entries = validation.entries.map((entry) => {
@@ -451,6 +472,16 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .front-pressure-frame strong { color:#f5d0fe; font-size:12px; }
     .front-pressure-frame small { color:#dbeafe; }
     .front-pressure-frame em { color:#bae6fd; font-size:11px; font-style:normal; }
+    .front-recovery { display:grid; gap:10px; }
+    .front-recovery p, .front-recovery-empty { margin:0; color:#cbd5e1; font-size:12px; }
+    .front-recovery ol { display:grid; gap:6px; margin:0; padding:0; }
+    .front-recovery-item { display:grid; gap:3px; border:1px solid rgba(148,163,184,0.18); border-radius:12px; padding:7px 9px; }
+    .front-recovery-item.is-safest { border-color:rgba(74,222,128,0.44); background:rgba(22,101,52,0.12); }
+    .front-recovery-item.is-opportunistic { border-color:rgba(251,191,36,0.48); background:rgba(120,53,15,0.12); }
+    .front-recovery-item strong { color:#bbf7d0; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
+    .front-recovery-item.is-opportunistic strong { color:#fde68a; }
+    .front-recovery-item small { color:#dbeafe; }
+    .front-recovery-item em { color:#bae6fd; font-size:11px; font-style:normal; }
     table { width:100%; border-collapse:collapse; font-size:13px; }
     th, td { padding:10px 8px; border-bottom:1px solid rgba(148, 163, 184, 0.14); text-align:left; }
     th { color:#93c5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
@@ -497,6 +528,7 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
         ${renderProvinceActionQueueValidation(shell)}
         ${renderAfterActionMapRecap(shell)}
         ${renderFrontPressureReplay(shell)}
+        ${renderFrontRecoveryRecommendations(shell)}
         <section>
           <h2>Lecture</h2>
           <ul>

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -215,6 +215,13 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     activeFrame: null,
     fallbackMessage: 'Aucun historique de pression disponible pour le replay.',
   });
+  assert.deepEqual(shell.frontRecoveryRecommendations, {
+    empty: true,
+    fallbackMessage: 'Recommandations indisponibles sans historique de pression du front.',
+    safestActionCode: null,
+    opportunisticActionCode: null,
+    recommendations: [],
+  });
   assert.deepEqual(shell.stats, {
     provinceCount: 2,
     contestedCount: 1,
@@ -605,6 +612,41 @@ test('StrategicMapShell builds a scrub-ready front pressure timeline replay', ()
     },
     fallbackMessage: null,
   });
+  assert.deepEqual(shell.frontRecoveryRecommendations, {
+    empty: false,
+    fallbackMessage: null,
+    safestActionCode: 'consolidate-support',
+    opportunisticActionCode: 'limited-probe',
+    recommendations: [
+      {
+        actionCode: 'consolidate-support',
+        label: 'Consolider le soutien',
+        stance: 'sûre',
+        reason: 'le replay montre un blocage qui empêche la pression de retomber',
+        risk: 'faible à moyen: stabilise le front mais retarde l’exploitation',
+        safest: true,
+        opportunistic: false,
+      },
+      {
+        actionCode: 'reinforce-front',
+        label: 'Renforcer le front',
+        stance: 'défensive',
+        reason: 'le replay indique une perte de pression favorable ou une remontée adverse',
+        risk: 'moyen: consomme des ressources mais évite une rupture',
+        safest: false,
+        opportunistic: false,
+      },
+      {
+        actionCode: 'limited-probe',
+        label: 'Sonder prudemment la brèche',
+        stance: 'opportuniste',
+        reason: 'le replay montre un gain, mais la pression adjacente exige une reprise limitée',
+        risk: 'moyen à élevé: opportunité réelle mais soutien fragile',
+        safest: false,
+        opportunistic: true,
+      },
+    ],
+  });
 });
 
 test('StrategicMapShell reports incomplete front pressure replay history', () => {
@@ -620,6 +662,23 @@ test('StrategicMapShell reports incomplete front pressure replay history', () =>
   assert.equal(shell.frontPressureReplay.empty, false);
   assert.equal(shell.frontPressureReplay.incomplete, true);
   assert.equal(shell.frontPressureReplay.fallbackMessage, 'Historique incomplet: un seul état disponible pour ce front.');
+  assert.deepEqual(shell.frontRecoveryRecommendations, {
+    empty: false,
+    fallbackMessage: 'Historique incomplet: attendre ou consolider avant une reprise risquée.',
+    safestActionCode: 'hold-and-observe',
+    opportunisticActionCode: null,
+    recommendations: [
+      {
+        actionCode: 'hold-and-observe',
+        label: 'Attendre et observer',
+        stance: 'sûre',
+        reason: 'un seul état de replay ne suffit pas pour distinguer gain, perte ou pression adjacente',
+        risk: 'faible, mais l’initiative reste limitée',
+        safest: true,
+        opportunistic: false,
+      },
+    ],
+  });
 });
 
 test('StrategicMapShell projects intrigue presence and sabotage risk into the map overlay slot', () => {

--- a/test/ui/war/buildStrategicMapPreviewHtml.test.js
+++ b/test/ui/war/buildStrategicMapPreviewHtml.test.js
@@ -38,6 +38,11 @@ test('buildStrategicMapPreviewHtml renders a screenshot-ready preview from the g
   assert.match(html, /Après résolution/);
   assert.match(html, /Ordre bloqué/);
   assert.match(html, /front-pressure-frame--loss is-active/);
+  assert.match(html, /Recommandations de récupération après replay de pression/);
+  assert.match(html, /Consolider le soutien/);
+  assert.match(html, /Sonder prudemment la brèche/);
+  assert.match(html, /option la plus sûre/);
+  assert.match(html, /option opportuniste/);
   assert.match(html, /class="province is-contested is-occupied is-selected is-queued is-recently-affected"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /Porte du Fleuve/);


### PR DESCRIPTION
Alpha: Implements #1229.

Summary:
- adds front recovery recommendations derived from the pressure replay
- proposes compact next actions for consolidation, reinforcement, cautious probing, exploitation, or waiting
- marks safest and opportunistic options with risks and reasons tied to gains, losses, blockers, and adjacent pressure
- renders a compact recovery panel with fallback guidance for missing or incomplete replay history

Tests:
- npm test
- git diff --check

Zeta: ready for validation before merge.
