### PR TITLE
Gamma: add cultural stabilization recommendations

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -237,6 +237,71 @@ function buildCulturalMomentumLayer({ regionId, selectedMarker, selectedCluster,
   };
 }
 
+function buildStabilizationAction(momentumItem) {
+  if (momentumItem.level === 'surging') {
+    return momentumItem.suggestedAction === 'soutenir' ? 'soutenir' : 'amplifier';
+  }
+
+  if (momentumItem.level === 'volatile') {
+    return 'apaiser';
+  }
+
+  if (momentumItem.level === 'fragile') {
+    return momentumItem.confidence === 'low' ? 'enquêter' : 'attendre';
+  }
+
+  return 'attendre';
+}
+
+function buildStabilizationTone(momentumItem, action) {
+  if (momentumItem.filterState === 'opportunity' || action === 'amplifier' || action === 'soutenir') {
+    return 'opportunity';
+  }
+
+  if (momentumItem.filterState === 'tension' || action === 'apaiser') {
+    return 'tension';
+  }
+
+  return 'watch';
+}
+
+function buildCultureStabilizationRecommendations(momentumLayer) {
+  const recommendations = (momentumLayer?.items ?? []).map((item, index) => {
+    const action = buildStabilizationAction(item);
+    const tone = buildStabilizationTone(item, action);
+    const reason = `${item.discoveryId} → ${item.level} → ${action}`;
+    const expectedEffect = tone === 'opportunity'
+      ? `opportunité à saisir: ${item.opportunity}`
+      : tone === 'tension'
+        ? `tension à calmer: ${item.risk ?? item.opportunity}`
+        : 'signal trop fragile pour agir sans observation';
+
+    return {
+      recommendationId: `${item.momentumId}:stabilization`,
+      regionId: item.regionId,
+      cultureName: item.cultureName,
+      action,
+      tone,
+      level: item.level,
+      discoveryId: item.discoveryId,
+      chain: `${item.chain} → ${action}`,
+      reason,
+      expectedEffect,
+      confidence: item.confidence,
+      markerIds: item.markerIds,
+      rank: index + 1,
+    };
+  });
+
+  return {
+    activeFilter: momentumLayer?.activeFilter ?? 'all',
+    summary: recommendations.length === 0
+      ? 'Aucune recommandation culturelle pour ce filtre.'
+      : `${recommendations.length} recommandation${recommendations.length > 1 ? 's' : ''} de stabilisation culturelle.`,
+    recommendations,
+  };
+}
+
 function dedupeAndSort(deltas) {
   return [...new Map(deltas.map((delta) => [
     `${delta.tone}:${delta.label}:${delta.value}:${delta.regionId}`,
@@ -270,6 +335,7 @@ export function buildCultureTurnReportDeltas({
     influenceDiffs,
     momentumFilter,
   });
+  const stabilizationRecommendations = buildCultureStabilizationRecommendations(momentumLayer);
   const deltas = dedupeAndSort([
     ...buildTimelineDeltas(localTimeline, regionId),
     ...buildMarkerDeltas(selectedMarker, regionId),
@@ -293,6 +359,11 @@ export function buildCultureTurnReportDeltas({
         summary: 'Aucun momentum culturel pour ce filtre.',
         items: [],
       },
+      stabilizationRecommendations: {
+        activeFilter: momentumFilter,
+        summary: 'Aucune recommandation culturelle pour ce filtre.',
+        recommendations: [],
+      },
     };
   }
 
@@ -305,5 +376,6 @@ export function buildCultureTurnReportDeltas({
     timelineRecap,
     influenceDiffs,
     momentumLayer,
+    stabilizationRecommendations,
   };
 }

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -124,6 +124,27 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       },
     ],
   });
+  assert.deepEqual(report.stabilizationRecommendations, {
+    activeFilter: 'all',
+    summary: '1 recommandation de stabilisation culturelle.',
+    recommendations: [
+      {
+        recommendationId: 'river-gate:momentum:strengthened:1:stabilization',
+        regionId: 'river-gate',
+        cultureName: 'Compact d’Aurora',
+        action: 'amplifier',
+        tone: 'opportunity',
+        level: 'surging',
+        discoveryId: 'archive-routes',
+        chain: 'archive-routes → influence renforcée → explorer → amplifier',
+        reason: 'archive-routes → surging → amplifier',
+        expectedEffect: 'opportunité à saisir: Saisir les archives peut déclencher une décision culturelle immédiate.',
+        confidence: 'high',
+        markerIds: ['river-gate:culture-aurora:event:event-archive-opening'],
+        rank: 1,
+      },
+    ],
+  });
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -142,6 +163,11 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
       availableFilters: ['all', 'opportunity', 'tension', 'watch'],
       summary: 'Aucun momentum culturel pour ce filtre.',
       items: [],
+    },
+    stabilizationRecommendations: {
+      activeFilter: 'all',
+      summary: 'Aucune recommandation culturelle pour ce filtre.',
+      recommendations: [],
     },
   });
 });
@@ -224,4 +250,83 @@ test('buildCultureTurnReportDeltas filters fragile cultural momentum for tension
     ['fragile', 'tension', 'fog-index', 'attendre', 'low'],
   ]);
   assert.match(report.momentumLayer.items[0].risk, /signal faible/);
+  assert.deepEqual(report.stabilizationRecommendations.recommendations.map((recommendation) => [
+    recommendation.action,
+    recommendation.tone,
+    recommendation.reason,
+    recommendation.expectedEffect,
+  ]), [
+    ['enquêter', 'tension', 'fog-index → fragile → enquêter', 'tension à calmer: risque de laisser passer un signal faible'],
+  ]);
+});
+
+test('buildCultureTurnReportDeltas recommends apaiser and attendre for volatile or observing momentum', () => {
+  const volatileReport = buildCultureTurnReportDeltas({
+    selectedRegionId: 'ember-ford',
+    momentumFilter: 'tension',
+    selectedMarker: {
+      overlayId: 'ember-ford:culture-ember',
+      regionId: 'ember-ford',
+      cultureName: 'Ember Guild',
+      influenceTier: 'strong',
+      influenceScore: 44,
+      discoveries: ['ash-treaty'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'tension',
+        microAction: 'apaiser',
+        consequencePreview: {
+          confidence: 'medium',
+          tradeoff: 'médiation requise avant amplification',
+          summary: 'apaiser: tension de mémoire locale.',
+        },
+      },
+    },
+    previousMarker: {
+      overlayId: 'ember-ford:culture-ember',
+      regionId: 'ember-ford',
+      cultureName: 'Ember Guild',
+      influenceTier: 'strong',
+      influenceScore: 58,
+      discoveries: ['ash-treaty'],
+    },
+  });
+  assert.deepEqual(volatileReport.stabilizationRecommendations.recommendations.map((recommendation) => [recommendation.action, recommendation.tone, recommendation.level]), [
+    ['apaiser', 'tension', 'volatile'],
+  ]);
+
+  const watchReport = buildCultureTurnReportDeltas({
+    selectedRegionId: 'plain-watch',
+    momentumFilter: 'watch',
+    selectedMarker: {
+      overlayId: 'plain-watch:culture-watch',
+      regionId: 'plain-watch',
+      cultureName: 'Plain Watch',
+      influenceTier: 'emerging',
+      influenceScore: 35,
+      discoveries: ['quiet-marker'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'watch',
+        microAction: 'attendre',
+        consequencePreview: {
+          confidence: 'medium',
+          summary: 'attendre: aucun basculement immédiat.',
+        },
+      },
+    },
+    previousMarker: {
+      overlayId: 'plain-watch:culture-watch',
+      regionId: 'plain-watch',
+      cultureName: 'Plain Watch',
+      influenceTier: 'emerging',
+      influenceScore: 35,
+      discoveries: ['quiet-marker'],
+    },
+  });
+  assert.deepEqual(watchReport.stabilizationRecommendations.recommendations.map((recommendation) => [recommendation.action, recommendation.tone, recommendation.level]), [
+    ['attendre', 'watch', 'observing'],
+  ]);
 });


### PR DESCRIPTION
Gamma: Implements #1231.

Summary:
- adds cultural stabilization recommendations derived from momentum layer items
- maps discovery-driven momentum to amplify/support, apaiser, enquêter, or attendre actions
- explains signal → momentum → recommendation chains while preserving opportunity/tension/watch filters
- keeps narrative priorities intact and makes them actionable through turn report data

Validation:
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- npm test -- test/ui/culture/buildCultureTurnReportDeltas.test.js
- npm test

Zeta: ready for validation before merge.