### PR TITLE
Delta: add verification audit trail

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2429,6 +2429,52 @@ function buildIntelligenceProvenancePanel({ confidenceState, safeVerificationHin
   };
 }
 
+function buildVerificationAuditTrail({ confidenceState, safeVerificationHint, verificationPathPreviews, incidentReplay, evidenceTrailMarkers, safeMapMasking }) {
+  const recommendedPath = verificationPathPreviews.find((path) => path.recommended) ?? verificationPathPreviews[0] ?? null;
+  const stepByState = {
+    confirmed: [
+      ['local-observation', 'Observation locale', 'confidence-up', 'Confiance montée: pression visible confirmée sans identité cachée.'],
+      ['cross-check', 'Recoupement', 'residual-risk', 'Risque résiduel maintenu: vérifier seulement les signaux visibles.'],
+    ],
+    suspected: [
+      ['indirect-source', 'Source indirecte', 'confidence-up', 'Confiance montée: signal probable, source non nominative.'],
+      ['partial-confirmation', 'Confirmation partielle', 'residual-risk', 'Risque résiduel: attendre une preuve visible avant extension.'],
+    ],
+    stale: [
+      ['cross-check', 'Recoupement', 'confidence-down', 'Confiance baissée: indice ancien sans fraîcheur confirmée.'],
+      ['dead-end', 'Impasse', 'trail-dismissed', 'Piste écartée provisoirement jusqu’à nouveau signal.'],
+    ],
+    masked: [
+      ['dead-end', 'Impasse', 'masked', 'Entrée généralisée: données trop sensibles ou absentes.'],
+    ],
+  };
+  const steps = (stepByState[confidenceState.state] ?? stepByState.masked).map(([stepId, label, change, safeResult], index) => ({
+    stepId,
+    order: index + 1,
+    label,
+    change,
+    safeResult,
+    evidenceState: evidenceTrailMarkers[index]?.state ?? evidenceTrailMarkers[0]?.state ?? 'masked',
+    fogSafeCopy: `${label}: ${safeResult} Aucun détail de cellule, cible, relais ou cause cachée n’est affiché.`,
+  }));
+
+  return {
+    state: confidenceState.state === 'masked' ? 'redacted-audit' : 'visible-audit',
+    summary: `${steps.length} étape${steps.length > 1 ? 's' : ''} de vérification visible${steps.length > 1 ? 's' : ''}: ${steps.map((step) => step.label).join(', ')}.`,
+    steps,
+    lastChange: steps.at(-1)?.change ?? 'masked',
+    nextUsefulCheck: recommendedPath ? {
+      action: safeVerificationHint.action,
+      label: safeVerificationHint.label,
+      costCue: recommendedPath.costCue,
+      evidenceNeeded: recommendedPath.evidenceNeeded,
+      reason: 'Prochain contrôle utile choisi depuis la provenance visible, sans accéder aux détails cachés.',
+    } : null,
+    incidentContext: incidentReplay.summary,
+    safeMapPolicy: 'Les entrées trop sensibles sont masquées ou généralisées en mode safe-map.',
+  };
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2583,6 +2629,14 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         locationOperations,
         exposedCellCount,
       });
+      const verificationAuditTrail = buildVerificationAuditTrail({
+        confidenceState,
+        safeVerificationHint,
+        verificationPathPreviews,
+        incidentReplay,
+        evidenceTrailMarkers,
+        safeMapMasking,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -2593,6 +2647,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           incidentReplay,
           evidenceTrailMarkers,
           intelligenceProvenancePanel,
+          verificationAuditTrail,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2091,3 +2091,84 @@ test('buildIntrigueMapOverlay exposes fog-safe intelligence provenance panels', 
   assert.equal(byLocation.get('unknown-prov').nextVerificationStep.action, 'ignore');
   assert.match(byLocation.get('unknown-prov').safeMapSummary, /Provenance généralisée/);
 });
+
+test('buildIntrigueMapOverlay exposes fog-safe verification audit trails', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-confirmed-audit',
+      factionId: 'shadow-league',
+      codename: 'Beacon',
+      locationId: 'confirmed-audit',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 82,
+    }),
+    new Cellule({
+      id: 'cell-suspected-audit',
+      factionId: 'shadow-league',
+      codename: 'Needle',
+      locationId: 'suspected-audit',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+    new Cellule({
+      id: 'cell-stale-audit',
+      factionId: 'shadow-league',
+      codename: 'Ember',
+      locationId: 'stale-audit',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      exposure: 20,
+    }),
+    new Cellule({
+      id: 'cell-masked-audit',
+      factionId: 'shadow-league',
+      codename: 'Curtain',
+      locationId: 'masked-audit',
+      memberIds: ['ag-4'],
+      assetIds: ['asset-4'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-suspected-audit',
+      celluleId: 'cell-suspected-audit',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe route rumor',
+      theaterId: 'suspected-audit',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 82,
+      progress: 8,
+      heat: 12,
+      phase: 'planning',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.verificationAuditTrail]));
+
+  assert.equal(byLocation.get('confirmed-audit').state, 'visible-audit');
+  assert.deepEqual(byLocation.get('confirmed-audit').steps.map((step) => step.stepId), ['local-observation', 'cross-check']);
+  assert.equal(byLocation.get('confirmed-audit').steps[0].change, 'confidence-up');
+  assert.equal(byLocation.get('confirmed-audit').lastChange, 'residual-risk');
+  assert.equal(byLocation.get('confirmed-audit').nextUsefulCheck.action, 'observe-locally');
+  assert.match(byLocation.get('confirmed-audit').steps[0].fogSafeCopy, /Aucun détail de cellule, cible, relais ou cause cachée/);
+
+  assert.equal(byLocation.get('suspected-audit').state, 'visible-audit');
+  assert.deepEqual(byLocation.get('suspected-audit').steps.map((step) => step.label), ['Source indirecte', 'Confirmation partielle']);
+  assert.equal(byLocation.get('suspected-audit').steps[0].evidenceState, 'suspected-evidence');
+  assert.equal(byLocation.get('suspected-audit').nextUsefulCheck.action, 'limit-coverage');
+  assert.match(byLocation.get('suspected-audit').incidentContext, /Sabotage suspecté/);
+
+  assert.equal(byLocation.get('stale-audit').state, 'visible-audit');
+  assert.deepEqual(byLocation.get('stale-audit').steps.map((step) => step.change), ['confidence-down', 'trail-dismissed']);
+  assert.equal(byLocation.get('stale-audit').nextUsefulCheck.action, 'wait');
+  assert.match(byLocation.get('stale-audit').summary, /Recoupement, Impasse/);
+
+  assert.equal(byLocation.get('masked-audit').state, 'redacted-audit');
+  assert.deepEqual(byLocation.get('masked-audit').steps.map((step) => step.stepId), ['dead-end']);
+  assert.equal(byLocation.get('masked-audit').lastChange, 'masked');
+  assert.equal(byLocation.get('masked-audit').nextUsefulCheck.action, 'ignore');
+  assert.match(byLocation.get('masked-audit').safeMapPolicy, /masquées ou généralisées/);
+});


### PR DESCRIPTION
Delta: ## Summary
- Adds fog-safe `verificationAuditTrail` entries for intrigue map provenance decisions.
- Lists visible verification steps (observation, recoupement, indirect source, partial confirmation, impasse) with confidence/risk outcomes.
- Reuses the safe verification recommendation path and keeps cells, relays, targets, objectives, and causes hidden or generalized.

Closes #1232.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés intrigue passés et tests complets passés avec `npm test` (676/676); j’attends ta validation avant tout merge.