### PR TITLE
Alpha: summarize contested province priorities

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1988,6 +1988,116 @@ function buildFrontRecoveryRecommendations(frontPressureReplay) {
   };
 }
 
+
+function operationalPriorityForAction(actionCode) {
+  if (['hold-line', 'hold-and-observe'].includes(actionCode)) return 'tenir';
+  if (['reinforce-front', 'consolidate-support'].includes(actionCode)) return 'renforcer';
+  if (['exploit-breach', 'limited-probe'].includes(actionCode)) return 'exploiter';
+  if (actionCode === 'wait') return 'différer';
+  return 'surveiller';
+}
+
+function priorityRank(priority) {
+  return {
+    renforcer: 0,
+    tenir: 1,
+    exploiter: 2,
+    surveiller: 3,
+    différer: 4,
+  }[priority] ?? 5;
+}
+
+function buildOperationalPriorityConflict(entry, activeFrame) {
+  if (entry.actionCode === 'consolidate-support') {
+    return { type: 'soutien manquant', reason: 'la recommandation dépend d’un soutien à rétablir avant reprise' };
+  }
+
+  if (entry.actionCode === 'limited-probe') {
+    return { type: 'risque de sur-extension', reason: 'l’opportunité existe mais la pression adjacente reste élevée' };
+  }
+
+  if (entry.actionCode === 'exploit-breach' && activeFrame?.adjacentPressure.length > 0) {
+    return { type: 'fronts adjacents incompatibles', reason: 'une exploitation peut exposer les fronts voisins signalés par le replay' };
+  }
+
+  return null;
+}
+
+function buildOperationalPrioritySummary(renderedProvinces, frontPressureReplay, frontRecoveryRecommendations) {
+  const contestedProvinces = renderedProvinces.filter((province) => province.contested);
+  const activeFrame = frontPressureReplay.activeFrame;
+  const activeProvinceId = activeFrame?.provinceId ?? contestedProvinces[0]?.provinceId ?? null;
+  const activeProvince = renderedProvinces.find((province) => province.provinceId === activeProvinceId) ?? null;
+  const entries = frontRecoveryRecommendations.recommendations.map((recommendation, index) => {
+    const priority = operationalPriorityForAction(recommendation.actionCode);
+    const conflict = buildOperationalPriorityConflict(recommendation, activeFrame);
+
+    return {
+      order: index + 1,
+      provinceId: activeProvinceId,
+      provinceLabel: activeFrame?.provinceLabel ?? activeProvince?.label ?? 'Province contestée',
+      priority,
+      actionCode: recommendation.actionCode,
+      actionLabel: recommendation.label,
+      reason: recommendation.reason,
+      risk: recommendation.risk,
+      marker: recommendation.safest ? 'option sûre' : recommendation.opportunistic ? 'option opportuniste' : 'option de suivi',
+      conflict,
+    };
+  });
+
+  const replayProvinceIds = new Set(frontPressureReplay.frames.map((frame) => frame.provinceId));
+  const uncoveredContested = contestedProvinces.filter((province) => !replayProvinceIds.has(province.provinceId));
+  uncoveredContested.forEach((province) => {
+    entries.push({
+      order: entries.length + 1,
+      provinceId: province.provinceId,
+      provinceLabel: province.label,
+      priority: 'surveiller',
+      actionCode: 'watch-front',
+      actionLabel: 'Surveiller le front',
+      reason: 'province contestée sans replay exploitable dans la fenêtre active',
+      risk: 'incertain: données de replay incomplètes',
+      marker: 'fallback',
+      conflict: { type: 'historique incomplet', reason: 'aucune recommandation locale fiable pour cette province' },
+    });
+  });
+
+  const sortedEntries = entries
+    .slice()
+    .sort((left, right) => priorityRank(left.priority) - priorityRank(right.priority) || left.order - right.order)
+    .map((entry, index) => ({ ...entry, order: index + 1 }));
+  const priorities = ['tenir', 'renforcer', 'exploiter', 'surveiller', 'différer'].map((priority) => ({
+    priority,
+    entries: sortedEntries.filter((entry) => entry.priority === priority),
+  }));
+
+  return {
+    empty: sortedEntries.length === 0,
+    fallbackMessage: frontRecoveryRecommendations.fallbackMessage
+      ?? (uncoveredContested.length > 0 ? 'Certaines provinces contestées n’ont pas encore de replay exploitable.' : null),
+    priorities,
+    conflicts: sortedEntries.map((entry) => entry.conflict ? {
+      provinceId: entry.provinceId,
+      provinceLabel: entry.provinceLabel,
+      actionCode: entry.actionCode,
+      type: entry.conflict.type,
+      reason: entry.conflict.reason,
+    } : null).filter(Boolean),
+    actionOrder: sortedEntries.map((entry) => ({
+      order: entry.order,
+      provinceId: entry.provinceId,
+      provinceLabel: entry.provinceLabel,
+      priority: entry.priority,
+      actionLabel: entry.actionLabel,
+      marker: entry.marker,
+    })),
+    summary: sortedEntries.length === 0
+      ? 'Aucune priorité opérationnelle disponible.'
+      : `${sortedEntries.length} priorité${sortedEntries.length > 1 ? 's' : ''}: ${sortedEntries.map((entry) => `${entry.priority} ${entry.provinceLabel}`).join(' → ')}`,
+  };
+}
+
 function buildKeyboardActionPlanner(renderedProvinces, options) {
   const activeProvince = renderedProvinces.find(
     (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
@@ -2221,6 +2331,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const afterActionMapRecap = buildAfterActionMapRecap(renderedProvinces, keyboardActionPlanner, normalizedOptions);
   const frontPressureReplay = buildFrontPressureTimelineReplay(renderedProvinces, normalizedOptions);
   const frontRecoveryRecommendations = buildFrontRecoveryRecommendations(frontPressureReplay);
+  const operationalPrioritySummary = buildOperationalPrioritySummary(renderedProvinces, frontPressureReplay, frontRecoveryRecommendations);
 
   return {
     title,
@@ -2231,6 +2342,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     afterActionMapRecap,
     frontPressureReplay,
     frontRecoveryRecommendations,
+    operationalPrioritySummary,
     stats: {
       provinceCount: stats.provinceCount,
       contestedCount: stats.contestedCount,

--- a/src/ui/war/buildStrategicMapPreviewHtml.js
+++ b/src/ui/war/buildStrategicMapPreviewHtml.js
@@ -310,6 +310,33 @@ function renderFrontRecoveryRecommendations(shell) {
   `;
 }
 
+
+function renderOperationalPrioritySummary(shell) {
+  const summary = shell.operationalPrioritySummary;
+  const orderItems = summary.actionOrder.map((entry) => `
+    <li class="operational-priority-order operational-priority-order--${escapeHtml(entry.priority)}">
+      <span>${entry.order}. ${escapeHtml(entry.provinceLabel)} · ${escapeHtml(entry.priority)}</span>
+      <strong>${escapeHtml(entry.actionLabel)}</strong>
+      <small>${escapeHtml(entry.marker)}</small>
+    </li>
+  `).join('');
+  const conflicts = summary.conflicts.map((conflict) => `
+    <li class="operational-priority-conflict">
+      <span>${escapeHtml(conflict.provinceLabel)} · ${escapeHtml(conflict.type)}</span>
+      <small>${escapeHtml(conflict.reason)}</small>
+    </li>
+  `).join('');
+
+  return `
+    <section class="operational-priority" aria-label="Synthèse de priorité opérationnelle des provinces contestées">
+      <h2>Priorités opérationnelles</h2>
+      <p>${escapeHtml(summary.fallbackMessage ?? summary.summary)}</p>
+      ${summary.empty ? '<small class="operational-priority-empty">Aucune priorité à afficher.</small>' : `<ol>${orderItems}</ol>`}
+      ${summary.conflicts.length > 0 ? `<div class="operational-priority-conflicts"><span>Conflits proches</span><ul>${conflicts}</ul></div>` : ''}
+    </section>
+  `;
+}
+
 function renderProvinceActionQueueValidation(shell) {
   const validation = shell.keyboardActionPlanner.actionQueueValidation;
   const entries = validation.entries.map((entry) => {
@@ -482,6 +509,19 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .front-recovery-item.is-opportunistic strong { color:#fde68a; }
     .front-recovery-item small { color:#dbeafe; }
     .front-recovery-item em { color:#bae6fd; font-size:11px; font-style:normal; }
+    .operational-priority { display:grid; gap:10px; }
+    .operational-priority p, .operational-priority-empty { margin:0; color:#cbd5e1; font-size:12px; }
+    .operational-priority ol, .operational-priority ul { display:grid; gap:6px; margin:0; padding:0; }
+    .operational-priority-order, .operational-priority-conflict { display:grid; gap:3px; border:1px solid rgba(148,163,184,0.18); border-radius:12px; padding:7px 9px; }
+    .operational-priority-order--renforcer { border-color:rgba(74,222,128,0.42); }
+    .operational-priority-order--tenir { border-color:rgba(96,165,250,0.42); }
+    .operational-priority-order--exploiter { border-color:rgba(251,191,36,0.48); }
+    .operational-priority-order--surveiller, .operational-priority-order--différer { border-color:rgba(148,163,184,0.32); }
+    .operational-priority-order strong { color:#bfdbfe; font-size:12px; }
+    .operational-priority-order small, .operational-priority-conflict small { color:#cbd5e1; }
+    .operational-priority-conflicts { display:grid; gap:6px; border-top:1px solid rgba(148,163,184,0.14); padding-top:7px; }
+    .operational-priority-conflicts > span { color:#fca5a5; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
+    .operational-priority-conflict { border-color:rgba(248,113,113,0.36); }
     table { width:100%; border-collapse:collapse; font-size:13px; }
     th, td { padding:10px 8px; border-bottom:1px solid rgba(148, 163, 184, 0.14); text-align:left; }
     th { color:#93c5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
@@ -529,6 +569,7 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
         ${renderAfterActionMapRecap(shell)}
         ${renderFrontPressureReplay(shell)}
         ${renderFrontRecoveryRecommendations(shell)}
+        ${renderOperationalPrioritySummary(shell)}
         <section>
           <h2>Lecture</h2>
           <ul>

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -222,6 +222,56 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     opportunisticActionCode: null,
     recommendations: [],
   });
+  assert.deepEqual(shell.operationalPrioritySummary, {
+    empty: false,
+    fallbackMessage: 'Recommandations indisponibles sans historique de pression du front.',
+    priorities: [
+      { priority: 'tenir', entries: [] },
+      { priority: 'renforcer', entries: [] },
+      { priority: 'exploiter', entries: [] },
+      {
+        priority: 'surveiller',
+        entries: [
+          {
+            order: 1,
+            provinceId: 'prov-c',
+            provinceLabel: 'Colline rouge',
+            priority: 'surveiller',
+            actionCode: 'watch-front',
+            actionLabel: 'Surveiller le front',
+            reason: 'province contestée sans replay exploitable dans la fenêtre active',
+            risk: 'incertain: données de replay incomplètes',
+            marker: 'fallback',
+            conflict: {
+              type: 'historique incomplet',
+              reason: 'aucune recommandation locale fiable pour cette province',
+            },
+          },
+        ],
+      },
+      { priority: 'différer', entries: [] },
+    ],
+    conflicts: [
+      {
+        provinceId: 'prov-c',
+        provinceLabel: 'Colline rouge',
+        actionCode: 'watch-front',
+        type: 'historique incomplet',
+        reason: 'aucune recommandation locale fiable pour cette province',
+      },
+    ],
+    actionOrder: [
+      {
+        order: 1,
+        provinceId: 'prov-c',
+        provinceLabel: 'Colline rouge',
+        priority: 'surveiller',
+        actionLabel: 'Surveiller le front',
+        marker: 'fallback',
+      },
+    ],
+    summary: '1 priorité: surveiller Colline rouge',
+  });
   assert.deepEqual(shell.stats, {
     provinceCount: 2,
     contestedCount: 1,
@@ -647,6 +697,49 @@ test('StrategicMapShell builds a scrub-ready front pressure timeline replay', ()
       },
     ],
   });
+  assert.deepEqual(shell.operationalPrioritySummary.actionOrder, [
+    {
+      order: 1,
+      provinceId: 'front',
+      provinceLabel: 'Front rouge',
+      priority: 'renforcer',
+      actionLabel: 'Consolider le soutien',
+      marker: 'option sûre',
+    },
+    {
+      order: 2,
+      provinceId: 'front',
+      provinceLabel: 'Front rouge',
+      priority: 'renforcer',
+      actionLabel: 'Renforcer le front',
+      marker: 'option de suivi',
+    },
+    {
+      order: 3,
+      provinceId: 'front',
+      provinceLabel: 'Front rouge',
+      priority: 'exploiter',
+      actionLabel: 'Sonder prudemment la brèche',
+      marker: 'option opportuniste',
+    },
+  ]);
+  assert.deepEqual(shell.operationalPrioritySummary.conflicts, [
+    {
+      provinceId: 'front',
+      provinceLabel: 'Front rouge',
+      actionCode: 'consolidate-support',
+      type: 'soutien manquant',
+      reason: 'la recommandation dépend d’un soutien à rétablir avant reprise',
+    },
+    {
+      provinceId: 'front',
+      provinceLabel: 'Front rouge',
+      actionCode: 'limited-probe',
+      type: 'risque de sur-extension',
+      reason: 'l’opportunité existe mais la pression adjacente reste élevée',
+    },
+  ]);
+  assert.equal(shell.operationalPrioritySummary.summary, '3 priorités: renforcer Front rouge → renforcer Front rouge → exploiter Front rouge');
 });
 
 test('StrategicMapShell reports incomplete front pressure replay history', () => {
@@ -679,6 +772,17 @@ test('StrategicMapShell reports incomplete front pressure replay history', () =>
       },
     ],
   });
+  assert.equal(shell.operationalPrioritySummary.fallbackMessage, 'Historique incomplet: attendre ou consolider avant une reprise risquée.');
+  assert.deepEqual(shell.operationalPrioritySummary.actionOrder, [
+    {
+      order: 1,
+      provinceId: 'front',
+      provinceLabel: 'Front rouge',
+      priority: 'tenir',
+      actionLabel: 'Attendre et observer',
+      marker: 'option sûre',
+    },
+  ]);
 });
 
 test('StrategicMapShell projects intrigue presence and sabotage risk into the map overlay slot', () => {

--- a/test/ui/war/buildStrategicMapPreviewHtml.test.js
+++ b/test/ui/war/buildStrategicMapPreviewHtml.test.js
@@ -43,6 +43,11 @@ test('buildStrategicMapPreviewHtml renders a screenshot-ready preview from the g
   assert.match(html, /Sonder prudemment la brèche/);
   assert.match(html, /option la plus sûre/);
   assert.match(html, /option opportuniste/);
+  assert.match(html, /Synthèse de priorité opérationnelle des provinces contestées/);
+  assert.match(html, /Priorités opérationnelles/);
+  assert.match(html, /Conflits proches/);
+  assert.match(html, /soutien manquant/);
+  assert.match(html, /risque de sur-extension/);
   assert.match(html, /class="province is-contested is-occupied is-selected is-queued is-recently-affected"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /Porte du Fleuve/);


### PR DESCRIPTION
Alpha: Implements #1239.

Summary:
- adds a deterministic operational priority summary for contested provinces
- groups recovery recommendations into compact priorities: tenir, renforcer, exploiter, surveiller, différer
- surfaces nearby conflicts such as missing support, adjacent-front incompatibility, and over-extension risk
- renders a next-turn action order plus fallback guidance when contested provinces lack usable replay data

Tests:
- npm test
- git diff --check

Zeta: ready for validation before merge.
