### PR TITLE
Delta: add intrigue signal triage queue

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2475,6 +2475,59 @@ function buildVerificationAuditTrail({ confidenceState, safeVerificationHint, ve
   };
 }
 
+function buildIntrigueSignalTriageQueue({ locationId, locationName, confidenceState, safeMapMasking, intelligenceProvenancePanel, verificationAuditTrail }) {
+  const decisionByState = {
+    confirmed: {
+      triageClass: 'verify-now',
+      priority: 1,
+      label: 'Vérifier maintenant',
+      rationale: 'Provenance observée et audit visible indiquent une confiance haute avec risque résiduel.',
+    },
+    suspected: {
+      triageClass: safeMapMasking.state === 'active-risk' ? 'verify-now' : 'monitor',
+      priority: safeMapMasking.state === 'active-risk' ? 2 : 3,
+      label: safeMapMasking.state === 'active-risk' ? 'Vérifier maintenant' : 'Surveiller',
+      rationale: 'Provenance déduite: garder sous surveillance et contrôler seulement si la pression visible monte.',
+    },
+    stale: {
+      triageClass: 'dismiss-provisionally',
+      priority: 4,
+      label: 'Écarter provisoirement',
+      rationale: 'Audit en baisse ou impasse: attendre un signal frais avant d’exposer une vérification.',
+    },
+    masked: {
+      triageClass: 'keep-masked',
+      priority: 5,
+      label: 'Garder masqué',
+      rationale: 'Mode sûr: signal trop sensible ou insuffisant pour guider une action.',
+    },
+  };
+  const decision = decisionByState[confidenceState.state] ?? decisionByState.masked;
+  const nextUsefulCheck = decision.triageClass === 'verify-now' || decision.triageClass === 'monitor'
+    ? verificationAuditTrail.nextUsefulCheck
+    : null;
+
+  return [{
+    queueId: `triage:${locationId}`,
+    locationId,
+    locationName,
+    triageClass: decision.triageClass,
+    priority: decision.priority,
+    label: decision.label,
+    rationale: `${decision.rationale} Source ${intelligenceProvenancePanel.sourceLabel.toLowerCase()}, dernier changement ${verificationAuditTrail.lastChange}.`,
+    provenanceType: intelligenceProvenancePanel.provenanceType,
+    confidence: confidenceState.label,
+    residualRisk: verificationAuditTrail.lastChange === 'residual-risk' ? 'visible-residual-risk' : 'low-or-unconfirmed',
+    nextLeastExposureCheck: nextUsefulCheck ? {
+      action: nextUsefulCheck.action,
+      label: nextUsefulCheck.label,
+      costCue: nextUsefulCheck.costCue,
+      evidenceNeeded: nextUsefulCheck.evidenceNeeded,
+    } : null,
+    fogSafeCopy: 'Classement basé uniquement sur provenance, audit, confiance et risque visibles; aucune cellule, relais, cible, méthode sensible ou cause cachée révélée.',
+  }];
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2637,6 +2690,14 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         evidenceTrailMarkers,
         safeMapMasking,
       });
+      const intrigueSignalTriageQueue = buildIntrigueSignalTriageQueue({
+        locationId,
+        locationName,
+        confidenceState,
+        safeMapMasking,
+        intelligenceProvenancePanel,
+        verificationAuditTrail,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -2648,6 +2709,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           evidenceTrailMarkers,
           intelligenceProvenancePanel,
           verificationAuditTrail,
+          intrigueSignalTriageQueue,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2172,3 +2172,80 @@ test('buildIntrigueMapOverlay exposes fog-safe verification audit trails', () =>
   assert.equal(byLocation.get('masked-audit').nextUsefulCheck.action, 'ignore');
   assert.match(byLocation.get('masked-audit').safeMapPolicy, /masquées ou généralisées/);
 });
+
+test('buildIntrigueMapOverlay exposes fog-safe intrigue signal triage queues', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-verify-triage',
+      factionId: 'shadow-league',
+      codename: 'Signal',
+      locationId: 'verify-triage',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 86,
+    }),
+    new Cellule({
+      id: 'cell-monitor-triage',
+      factionId: 'shadow-league',
+      codename: 'Watcher',
+      locationId: 'monitor-triage',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+    new Cellule({
+      id: 'cell-dismiss-triage',
+      factionId: 'shadow-league',
+      codename: 'Old Echo',
+      locationId: 'dismiss-triage',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      exposure: 19,
+    }),
+    new Cellule({
+      id: 'cell-masked-triage',
+      factionId: 'shadow-league',
+      codename: 'Curtain',
+      locationId: 'masked-triage',
+      memberIds: ['ag-4'],
+      assetIds: ['asset-4'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-monitor-triage',
+      celluleId: 'cell-monitor-triage',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Probe route rumor',
+      theaterId: 'monitor-triage',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 76,
+      progress: 7,
+      heat: 10,
+      phase: 'planning',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.intrigueSignalTriageQueue[0]]));
+
+  assert.equal(byLocation.get('verify-triage').triageClass, 'verify-now');
+  assert.equal(byLocation.get('verify-triage').priority, 1);
+  assert.equal(byLocation.get('verify-triage').nextLeastExposureCheck.action, 'observe-locally');
+  assert.equal(byLocation.get('verify-triage').residualRisk, 'visible-residual-risk');
+  assert.match(byLocation.get('verify-triage').rationale, /Source observation directe expurgée/);
+
+  assert.equal(byLocation.get('monitor-triage').triageClass, 'monitor');
+  assert.equal(byLocation.get('monitor-triage').label, 'Surveiller');
+  assert.equal(byLocation.get('monitor-triage').nextLeastExposureCheck.action, 'limit-coverage');
+  assert.equal(byLocation.get('monitor-triage').provenanceType, 'inferred');
+
+  assert.equal(byLocation.get('dismiss-triage').triageClass, 'dismiss-provisionally');
+  assert.equal(byLocation.get('dismiss-triage').nextLeastExposureCheck, null);
+  assert.match(byLocation.get('dismiss-triage').rationale, /attendre un signal frais/);
+
+  assert.equal(byLocation.get('masked-triage').triageClass, 'keep-masked');
+  assert.equal(byLocation.get('masked-triage').priority, 5);
+  assert.equal(byLocation.get('masked-triage').nextLeastExposureCheck, null);
+  assert.match(byLocation.get('masked-triage').fogSafeCopy, /aucune cellule, relais, cible, méthode sensible ou cause cachée/);
+});


### PR DESCRIPTION
Delta: ## Summary
- Adds fog-safe `intrigueSignalTriageQueue` entries after provenance/audit processing.
- Classifies signals as verify now, monitor, keep masked, or dismiss provisionally using visible provenance, audit trail, confidence, and residual risk.
- Reuses the least-exposure verification recommendation for priority entries without revealing cells, relays, targets, sensitive methods, or hidden causes.

Closes #1242.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés intrigue passés et tests complets passés avec `npm test` (680/680); j’attends ta validation avant tout merge.