### PR TITLE
Gamma: add cultural recommendation coherence summary

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -302,6 +302,135 @@ function buildCultureStabilizationRecommendations(momentumLayer) {
   };
 }
 
+function buildRecommendationTrajectory(action) {
+  if (action === 'soutenir') {
+    return 'consolidation';
+  }
+
+  if (action === 'amplifier') {
+    return 'expansion';
+  }
+
+  if (action === 'apaiser') {
+    return 'apaisement';
+  }
+
+  if (action === 'enquêter') {
+    return 'enquête';
+  }
+
+  return 'attente';
+}
+
+function normalizeCoherenceRecommendation(recommendation, index) {
+  const action = recommendation.action ?? recommendation.suggestedAction ?? 'attendre';
+  const trajectory = recommendation.trajectory ?? buildRecommendationTrajectory(action);
+
+  return {
+    recommendationId: recommendation.recommendationId ?? `culture-recommendation:${index + 1}`,
+    regionId: recommendation.regionId ?? 'province',
+    cultureName: recommendation.cultureName ?? 'Culture locale',
+    action,
+    tone: recommendation.tone ?? 'watch',
+    level: recommendation.level ?? 'observing',
+    discoveryId: recommendation.discoveryId ?? 'signal culturel',
+    confidence: recommendation.confidence ?? 'low',
+    chain: recommendation.chain ?? `${recommendation.discoveryId ?? 'signal culturel'} → ${recommendation.level ?? 'observing'} → ${action}`,
+    expectedEffect: recommendation.expectedEffect ?? 'effet culturel à confirmer',
+    trajectory,
+    rank: recommendation.rank ?? index + 1,
+  };
+}
+
+function buildCultureRecommendationCoherenceSummary(stabilizationRecommendations, activeRecommendations = []) {
+  const recommendations = [
+    ...(stabilizationRecommendations?.recommendations ?? []),
+    ...(activeRecommendations ?? []),
+  ].map(normalizeCoherenceRecommendation);
+  const trajectoryOrder = ['consolidation', 'expansion', 'apaisement', 'enquête', 'attente'];
+  const trajectoryGroups = trajectoryOrder
+    .map((trajectory) => {
+      const members = recommendations.filter((recommendation) => recommendation.trajectory === trajectory);
+      return members.length === 0 ? null : {
+        trajectory,
+        count: members.length,
+        actions: [...new Set(members.map((member) => member.action))],
+        recommendationIds: members.map((member) => member.recommendationId),
+        summary: `${trajectory}: ${members.map((member) => member.cultureName).join(', ')}`,
+      };
+    })
+    .filter(Boolean);
+  const tensions = [];
+  const expansionRecommendations = recommendations.filter((recommendation) => recommendation.trajectory === 'expansion');
+  const apaisementRecommendations = recommendations.filter((recommendation) => recommendation.trajectory === 'apaisement');
+
+  recommendations.forEach((recommendation) => {
+    if ((recommendation.action === 'amplifier' || recommendation.action === 'soutenir')
+      && (recommendation.level === 'fragile' || recommendation.confidence === 'low')) {
+      tensions.push({
+        tensionId: `${recommendation.recommendationId}:fragile-amplification`,
+        level: 'warning',
+        label: 'amplification fragile',
+        recommendationIds: [recommendation.recommendationId],
+        reason: `${recommendation.discoveryId} → ${recommendation.action}: signal encore fragile`,
+      });
+    }
+
+    if (recommendation.action === 'enquêter' && recommendation.confidence === 'low') {
+      tensions.push({
+        tensionId: `${recommendation.recommendationId}:low-confidence-investigation`,
+        level: 'uncertain',
+        label: 'enquête incertaine',
+        recommendationIds: [recommendation.recommendationId],
+        reason: `${recommendation.discoveryId} → enquêter: confiance trop basse pour sur-vendre la lecture`,
+      });
+    }
+  });
+
+  if (expansionRecommendations.length > 1) {
+    tensions.push({
+      tensionId: 'culture-coherence:competing-opportunities',
+      level: 'conflict',
+      label: 'opportunités concurrentes',
+      recommendationIds: expansionRecommendations.map((recommendation) => recommendation.recommendationId),
+      reason: `${expansionRecommendations.length} opportunités demandent amplification en parallèle`,
+    });
+  }
+
+  apaisementRecommendations
+    .filter((recommendation) => recommendation.rank > 1 || expansionRecommendations.length > 0)
+    .forEach((recommendation) => {
+      tensions.push({
+        tensionId: `${recommendation.recommendationId}:late-appeasement`,
+        level: 'warning',
+        label: 'apaisement tardif',
+        recommendationIds: [recommendation.recommendationId],
+        reason: `${recommendation.discoveryId} → apaiser: risque de passer après une expansion active`,
+      });
+    });
+
+  return {
+    state: recommendations.length === 0 ? 'quiet' : tensions.some((tension) => tension.level === 'conflict') ? 'conflict' : tensions.length > 0 ? 'mixed' : 'coherent',
+    activeFilter: stabilizationRecommendations?.activeFilter ?? 'all',
+    summary: recommendations.length === 0
+      ? 'Aucune cohérence culturelle à synthétiser.'
+      : tensions.length === 0
+        ? `${recommendations.length} recommandation${recommendations.length > 1 ? 's' : ''} sur une trajectoire culturelle cohérente.`
+        : `${tensions.length} tension${tensions.length > 1 ? 's' : ''} entre recommandations culturelles actives.`,
+    trajectoryGroups,
+    tensions,
+    explanation: recommendations.length === 0
+      ? 'Aucun signal récent → recommandation → cohérence.'
+      : recommendations
+        .slice(0, 3)
+        .map((recommendation) => `${recommendation.discoveryId} → ${recommendation.action} → ${recommendation.trajectory}`)
+        .join(' | '),
+    uncertainRecommendationIds: recommendations
+      .filter((recommendation) => recommendation.confidence === 'low' || recommendation.level === 'fragile')
+      .map((recommendation) => recommendation.recommendationId),
+  };
+}
+
 function dedupeAndSort(deltas) {
   return [...new Map(deltas.map((delta) => [
     `${delta.tone}:${delta.label}:${delta.value}:${delta.regionId}`,
@@ -323,6 +452,7 @@ export function buildCultureTurnReportDeltas({
   consequenceChips = [],
   previousMarker = null,
   momentumFilter = 'all',
+  activeRecommendations = [],
 } = {}) {
   const regionId = normalizeText(selectedRegionId ?? selectedMarker?.regionId ?? selectedCluster?.regionIds?.[0], 'province');
   const timelineRecap = buildDiscoveryTimelineRecap(localTimeline, selectedMarker, selectedCluster, regionId);
@@ -336,6 +466,7 @@ export function buildCultureTurnReportDeltas({
     momentumFilter,
   });
   const stabilizationRecommendations = buildCultureStabilizationRecommendations(momentumLayer);
+  const recommendationCoherence = buildCultureRecommendationCoherenceSummary(stabilizationRecommendations, activeRecommendations);
   const deltas = dedupeAndSort([
     ...buildTimelineDeltas(localTimeline, regionId),
     ...buildMarkerDeltas(selectedMarker, regionId),
@@ -364,6 +495,15 @@ export function buildCultureTurnReportDeltas({
         summary: 'Aucune recommandation culturelle pour ce filtre.',
         recommendations: [],
       },
+      recommendationCoherence: {
+        state: 'quiet',
+        activeFilter: momentumFilter,
+        summary: 'Aucune cohérence culturelle à synthétiser.',
+        trajectoryGroups: [],
+        tensions: [],
+        explanation: 'Aucun signal récent → recommandation → cohérence.',
+        uncertainRecommendationIds: [],
+      },
     };
   }
 
@@ -377,5 +517,6 @@ export function buildCultureTurnReportDeltas({
     influenceDiffs,
     momentumLayer,
     stabilizationRecommendations,
+    recommendationCoherence,
   };
 }

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -145,6 +145,23 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       },
     ],
   });
+  assert.deepEqual(report.recommendationCoherence, {
+    state: 'coherent',
+    activeFilter: 'all',
+    summary: '1 recommandation sur une trajectoire culturelle cohérente.',
+    trajectoryGroups: [
+      {
+        trajectory: 'expansion',
+        count: 1,
+        actions: ['amplifier'],
+        recommendationIds: ['river-gate:momentum:strengthened:1:stabilization'],
+        summary: 'expansion: Compact d’Aurora',
+      },
+    ],
+    tensions: [],
+    explanation: 'archive-routes → amplifier → expansion',
+    uncertainRecommendationIds: [],
+  });
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -168,6 +185,15 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
       activeFilter: 'all',
       summary: 'Aucune recommandation culturelle pour ce filtre.',
       recommendations: [],
+    },
+    recommendationCoherence: {
+      state: 'quiet',
+      activeFilter: 'all',
+      summary: 'Aucune cohérence culturelle à synthétiser.',
+      trajectoryGroups: [],
+      tensions: [],
+      explanation: 'Aucun signal récent → recommandation → cohérence.',
+      uncertainRecommendationIds: [],
     },
   });
 });
@@ -329,4 +355,89 @@ test('buildCultureTurnReportDeltas recommends apaiser and attendre for volatile 
   assert.deepEqual(watchReport.stabilizationRecommendations.recommendations.map((recommendation) => [recommendation.action, recommendation.tone, recommendation.level]), [
     ['attendre', 'watch', 'observing'],
   ]);
+});
+
+test('buildCultureTurnReportDeltas summarizes coherence tensions between active cultural recommendations', () => {
+  const report = buildCultureTurnReportDeltas({
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'explorer',
+        consequencePreview: {
+          confidence: 'high',
+          opportunity: 'archives ouvertes',
+          summary: 'explorer: archives ouvertes.',
+        },
+      },
+    },
+    previousMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'emerging',
+      influenceScore: 70,
+      discoveries: ['archive-routes'],
+    },
+    activeRecommendations: [
+      {
+        recommendationId: 'harbor:momentum:surge:stabilization',
+        regionId: 'harbor',
+        cultureName: 'Harbor Compact',
+        action: 'amplifier',
+        tone: 'opportunity',
+        level: 'surging',
+        discoveryId: 'harbor-forum',
+        confidence: 'high',
+        chain: 'harbor-forum → influence renforcée → amplifier',
+        rank: 2,
+      },
+      {
+        recommendationId: 'mist:momentum:fragile:stabilization',
+        regionId: 'mist-hills',
+        cultureName: 'Mist Circle',
+        action: 'enquêter',
+        tone: 'tension',
+        level: 'fragile',
+        discoveryId: 'fog-index',
+        confidence: 'low',
+        chain: 'fog-index → fragile → enquêter',
+        rank: 3,
+      },
+      {
+        recommendationId: 'ember:momentum:volatile:stabilization',
+        regionId: 'ember-ford',
+        cultureName: 'Ember Guild',
+        action: 'apaiser',
+        tone: 'tension',
+        level: 'volatile',
+        discoveryId: 'ash-treaty',
+        confidence: 'medium',
+        chain: 'ash-treaty → volatile → apaiser',
+        rank: 4,
+      },
+    ],
+  });
+
+  assert.equal(report.recommendationCoherence.state, 'conflict');
+  assert.deepEqual(report.recommendationCoherence.trajectoryGroups.map((group) => [group.trajectory, group.count]), [
+    ['expansion', 2],
+    ['apaisement', 1],
+    ['enquête', 1],
+  ]);
+  assert.deepEqual(report.recommendationCoherence.tensions.map((tension) => [tension.label, tension.level]), [
+    ['enquête incertaine', 'uncertain'],
+    ['opportunités concurrentes', 'conflict'],
+    ['apaisement tardif', 'warning'],
+  ]);
+  assert.match(report.recommendationCoherence.explanation, /archive-routes → amplifier → expansion/);
+  assert.deepEqual(report.recommendationCoherence.uncertainRecommendationIds, ['mist:momentum:fragile:stabilization']);
 });


### PR DESCRIPTION
Gamma: Implements #1241.

Summary:
- adds a recommendation coherence summary to the culture turn report
- groups active recommendations into consolidation, expansion, appeasement, investigation, and wait trajectories
- detects fragile amplification, late appeasement, low-confidence investigation, and competing opportunities
- keeps uncertain states explicit without replacing narrative priorities

Validation:
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- npm test -- test/ui/culture/buildCultureTurnReportDeltas.test.js
- npm test

Zeta: ready for validation before merge.