### PR TITLE
Epsilon: add climate priority summary

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1672,6 +1672,147 @@ function buildClimateRecoveryReadiness(climateAftermathRecap, climateSafeWindowC
   };
 }
 
+function classifyClimatePriority(recommendation, window) {
+  if (recommendation.status === 'ready' && recommendation.confidenceBand !== 'uncertain') {
+    return 'act-now';
+  }
+
+  if (recommendation.status === 'discouraged') {
+    return window?.state === 'critical' || recommendation.confidenceBand === 'uncertain' ? 'avoid' : 'defer';
+  }
+
+  if (recommendation.confidenceBand === 'uncertain') {
+    return 'prepare-first';
+  }
+
+  return window?.state === 'safe' ? 'prepare-first' : 'defer';
+}
+
+function describeClimatePriorityReason(priority, recommendation, window) {
+  if (priority === 'act-now') {
+    return 'fenêtre exploitable avec prérequis readiness validés';
+  }
+
+  if (priority === 'prepare-first') {
+    return recommendation.confidenceBand === 'uncertain'
+      ? 'prévision incertaine: confirmer et renforcer avant engagement'
+      : 'préparer les prérequis manquants avant d’utiliser la fenêtre';
+  }
+
+  if (priority === 'defer') {
+    return `reporter: ${window?.label ?? 'fenêtre'} reste moins favorable ou trop coûteuse`;
+  }
+
+  return 'éviter pour ce tour: risque résiduel ou fenêtre critique trop exposée';
+}
+
+function buildClimateResourceConflicts(recommendation, window) {
+  const conflicts = [];
+  const prerequisites = recommendation.prerequisites ?? {};
+
+  if (String(prerequisites.reserve ?? '').includes('renforcée') || String(prerequisites.reserve ?? '').includes('requise')) {
+    conflicts.push('reserve');
+  }
+
+  if (String(prerequisites.mitigationActive ?? '').startsWith('manquante')) {
+    conflicts.push('mitigation');
+  }
+
+  if (String(prerequisites.localResilience ?? '').includes('consolider')) {
+    conflicts.push('local-resilience');
+  }
+
+  if (window?.state !== 'safe') {
+    conflicts.push('window-timing');
+  }
+
+  if (String(prerequisites.residualRisk ?? '').includes('élevé') || String(prerequisites.residualRisk ?? '').includes('incertain')) {
+    conflicts.push('residual-risk');
+  }
+
+  return [...new Set(conflicts)];
+}
+
+function normalizeClimatePriorityOverride(override, basePriority) {
+  const priority = String(override.priority ?? basePriority.priority).trim().toLowerCase();
+
+  return {
+    ...basePriority,
+    ...override,
+    priorityId: String(override.priorityId ?? basePriority.priorityId).trim(),
+    regionIds: requireArray(override.regionIds ?? basePriority.regionIds, 'ClimateMapOverlay climatePriority regionIds')
+      .map((regionId) => String(regionId).trim())
+      .filter(Boolean),
+    priority: ['act-now', 'prepare-first', 'defer', 'avoid'].includes(priority) ? priority : basePriority.priority,
+    windowId: String(override.windowId ?? basePriority.windowId).trim(),
+    readinessRecommendationId: String(override.readinessRecommendationId ?? basePriority.readinessRecommendationId).trim(),
+    resourceConflicts: requireArray(
+      override.resourceConflicts ?? basePriority.resourceConflicts,
+      'ClimateMapOverlay climatePriority resourceConflicts',
+    ).map((conflict) => String(conflict).trim()).filter(Boolean),
+    confidenceBand: normalizeConfidenceBand(override.confidenceBand) ?? basePriority.confidenceBand,
+    reason: String(override.reason ?? basePriority.reason).trim(),
+  };
+}
+
+function buildClimatePrioritySummary(climateSafeWindowCalendar, climateRecoveryReadiness, normalizedOptions) {
+  const windowsById = new Map(climateSafeWindowCalendar.windows.map((window) => [window.windowId, window]));
+  const explicitPriorities = Array.isArray(normalizedOptions.climatePrioritySummary)
+    ? normalizedOptions.climatePrioritySummary
+    : Array.isArray(normalizedOptions.climateCrossRegionPriorities)
+      ? normalizedOptions.climateCrossRegionPriorities
+      : [];
+
+  if (climateRecoveryReadiness.recommendations.length === 0) {
+    return {
+      title: 'Synthèse priorités climat inter-régions',
+      fallback: 'Aucune recommandation de readiness climat à agréger.',
+      priorities: [],
+      resourceConflicts: [],
+      summary: 'Aucune priorité climatique inter-régions.',
+    };
+  }
+
+  const priorities = climateRecoveryReadiness.recommendations.map((recommendation) => {
+    const window = windowsById.get(recommendation.windowId);
+    const priority = classifyClimatePriority(recommendation, window);
+    const basePriority = {
+      priorityId: `${recommendation.recommendationId}:priority`,
+      regionIds: window?.affectedRegionIds ? [...window.affectedRegionIds] : [],
+      priority,
+      windowId: recommendation.windowId,
+      readinessRecommendationId: recommendation.recommendationId,
+      confidenceBand: recommendation.confidenceBand,
+      resourceConflicts: buildClimateResourceConflicts(recommendation, window),
+      reason: describeClimatePriorityReason(priority, recommendation, window),
+    };
+    const override = explicitPriorities.find((item) => (
+      item.windowId ?? item.readinessRecommendationId ?? basePriority.windowId
+    ) === basePriority.windowId || item.readinessRecommendationId === basePriority.readinessRecommendationId);
+
+    return override ? normalizeClimatePriorityOverride(override, basePriority) : basePriority;
+  }).sort((left, right) => {
+    const rank = { 'act-now': 0, 'prepare-first': 1, defer: 2, avoid: 3 };
+
+    return (rank[left.priority] ?? 2) - (rank[right.priority] ?? 2) || left.priorityId.localeCompare(right.priorityId);
+  });
+
+  const resourceConflicts = [...new Set(priorities.flatMap((priority) => priority.resourceConflicts))];
+  const counts = priorities.reduce((acc, priority) => {
+    acc[priority.priority] = (acc[priority.priority] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return {
+    title: 'Synthèse priorités climat inter-régions',
+    fallback: null,
+    priorities,
+    resourceConflicts,
+    summary: `${counts['act-now'] ?? 0} à agir, ${counts['prepare-first'] ?? 0} à préparer, ${counts.defer ?? 0} à reporter, ${counts.avoid ?? 0} à éviter.`,
+  };
+}
+
+
 function buildClimateAftermathRecap(regions, climateAlerts, normalizedOptions) {
   const alertsByRegion = new Map(climateAlerts.map((alert) => [alert.regionId, alert]));
   const explicitEvents = Array.isArray(normalizedOptions.climateAftermathEvents)
@@ -2237,6 +2378,11 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     climateSafeWindowCalendar,
     normalizedOptions,
   );
+  const climatePrioritySummary = buildClimatePrioritySummary(
+    climateSafeWindowCalendar,
+    climateRecoveryReadiness,
+    normalizedOptions,
+  );
   const selectedClimateImpactComparison = buildSelectedClimateImpactComparison(regions, normalizedOptions, seasonPreview);
   const selectedClimateTimingRecommendation = buildSelectedClimateTimingRecommendation(selectedClimateImpactComparison);
   const selectedClimateMitigationChoices = buildSelectedClimateMitigationChoices(
@@ -2274,6 +2420,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
       climateAftermathRecap,
       climateSafeWindowCalendar,
       climateRecoveryReadiness,
+      climatePrioritySummary,
     } : {}),
     selectedClimateImpactComparison,
     selectedClimateTimingRecommendation,

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -2041,3 +2041,128 @@ test('buildClimateMapOverlay keeps uncertain readiness recommendations conservat
     },
   ]);
 });
+
+test('buildClimateMapOverlay summarizes cross-region climate priorities from readiness windows', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'delta', season: 'spring', temperatureC: 18, precipitationLevel: 70, droughtIndex: 12 },
+    { regionId: 'ridge', season: 'spring', temperatureC: 29, precipitationLevel: 18, droughtIndex: 68, anomaly: 'drought' },
+  ], {
+    climateAftermathEvents: [
+      {
+        eventId: 'delta-ready',
+        regionId: 'delta',
+        observedImpact: 'route stabilisée',
+        severity: 'minor',
+        appliedMitigation: 'digues inspectées',
+        confidenceBand: 'probable',
+        resilienceState: 'resilient',
+      },
+      {
+        eventId: 'ridge-risk',
+        regionId: 'ridge',
+        observedImpact: 'sols fragiles',
+        severity: 'moderate',
+        missingMitigation: 'réservoir non renforcé',
+        confidenceBand: 'uncertain',
+        resilienceState: 'strained',
+      },
+    ],
+    climateSafeWindows: [
+      {
+        aftermathEventId: 'delta-ready',
+        windowId: 'delta-ready:now',
+        label: 'tour actuel',
+        state: 'safe',
+        affectedRegionIds: ['delta'],
+        confidenceBand: 'probable',
+      },
+      {
+        aftermathEventId: 'ridge-risk',
+        windowId: 'ridge-risk:later',
+        label: 'prochain tour',
+        state: 'safe',
+        affectedRegionIds: ['ridge'],
+        confidenceBand: 'uncertain',
+      },
+    ],
+  });
+
+  assert.deepEqual(overlay.climatePrioritySummary.priorities.map((priority) => ({
+    regionIds: priority.regionIds,
+    priority: priority.priority,
+    windowId: priority.windowId,
+    readinessRecommendationId: priority.readinessRecommendationId,
+    confidenceBand: priority.confidenceBand,
+    resourceConflicts: priority.resourceConflicts,
+    reason: priority.reason,
+  })), [
+    {
+      regionIds: ['delta'],
+      priority: 'act-now',
+      windowId: 'delta-ready:now',
+      readinessRecommendationId: 'delta-ready:now:readiness',
+      confidenceBand: 'probable',
+      resourceConflicts: [],
+      reason: 'fenêtre exploitable avec prérequis readiness validés',
+    },
+    {
+      regionIds: ['ridge'],
+      priority: 'prepare-first',
+      windowId: 'ridge-risk:later',
+      readinessRecommendationId: 'ridge-risk:later:readiness',
+      confidenceBand: 'uncertain',
+      resourceConflicts: ['mitigation', 'local-resilience', 'residual-risk'],
+      reason: 'prévision incertaine: confirmer et renforcer avant engagement',
+    },
+  ]);
+  assert.equal(overlay.climatePrioritySummary.summary, '1 à agir, 1 à préparer, 0 à reporter, 0 à éviter.');
+});
+
+test('buildClimateMapOverlay keeps cross-region climate priority overrides conservative', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'delta', season: 'spring', temperatureC: 18, precipitationLevel: 70, droughtIndex: 12 },
+  ], {
+    climateAftermathEvents: [
+      {
+        eventId: 'delta-risk',
+        regionId: 'delta',
+        observedImpact: 'route encore instable',
+        severity: 'major',
+        missingMitigation: 'réserve absente',
+        confidenceBand: 'probable',
+        resilienceState: 'strained',
+      },
+    ],
+    climateSafeWindows: [
+      {
+        aftermathEventId: 'delta-risk',
+        windowId: 'delta-risk:now',
+        label: 'tour actuel',
+        state: 'risky',
+        affectedRegionIds: ['delta'],
+        confidenceBand: 'probable',
+      },
+    ],
+    climatePrioritySummary: [
+      {
+        windowId: 'delta-risk:now',
+        priority: 'defer',
+        resourceConflicts: ['reserve', 'window-timing'],
+        reason: 'réserve partagée avec une autre région plus prête',
+      },
+    ],
+  });
+
+  assert.deepEqual(overlay.climatePrioritySummary.priorities, [
+    {
+      priorityId: 'delta-risk:now:readiness:priority',
+      regionIds: ['delta'],
+      priority: 'defer',
+      windowId: 'delta-risk:now',
+      readinessRecommendationId: 'delta-risk:now:readiness',
+      confidenceBand: 'probable',
+      resourceConflicts: ['reserve', 'window-timing'],
+      reason: 'réserve partagée avec une autre région plus prête',
+    },
+  ]);
+});


### PR DESCRIPTION
Epsilon: Adds a cross-region climate priority summary for #1243.

- aggregates E7 safe windows and E8 readiness recommendations into act-now / prepare-first / defer / avoid priorities
- explains resource conflicts across reserve, mitigation, local resilience, window timing, and residual risk
- links each priority back to window ids, readiness recommendation ids, and affected regions
- keeps uncertain or contradictory forecasts conservative while supporting explicit priority overrides

Tests:
- `npm test -- test/ui/climate/buildClimateMapOverlay.test.js`
- `npm test`
- `git diff --check`

Closes #1243