### PR TITLE
Gamma: add cultural commitment bundles

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -339,14 +339,21 @@ function normalizeCoherenceRecommendation(recommendation, index) {
     expectedEffect: recommendation.expectedEffect ?? 'effet culturel à confirmer',
     trajectory,
     rank: recommendation.rank ?? index + 1,
+    supportKey: recommendation.supportKey ?? recommendation.action ?? action,
+    markerIds: recommendation.markerIds ?? [],
+    expiresSoon: recommendation.expiresSoon === true,
   };
 }
 
-function buildCultureRecommendationCoherenceSummary(stabilizationRecommendations, activeRecommendations = []) {
-  const recommendations = [
+function collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations = []) {
+  return [
     ...(stabilizationRecommendations?.recommendations ?? []),
     ...(activeRecommendations ?? []),
   ].map(normalizeCoherenceRecommendation);
+}
+
+function buildCultureRecommendationCoherenceSummary(stabilizationRecommendations, activeRecommendations = []) {
+  const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
   const trajectoryOrder = ['consolidation', 'expansion', 'apaisement', 'enquête', 'attente'];
   const trajectoryGroups = trajectoryOrder
     .map((trajectory) => {
@@ -431,6 +438,129 @@ function buildCultureRecommendationCoherenceSummary(stabilizationRecommendations
   };
 }
 
+function buildCommitmentBundleName(trajectory) {
+  if (trajectory === 'apaisement') {
+    return 'apaisement local';
+  }
+
+  if (trajectory === 'consolidation') {
+    return 'consolidation régionale';
+  }
+
+  if (trajectory === 'enquête') {
+    return 'enquête';
+  }
+
+  if (trajectory === 'expansion') {
+    return 'expansion prudente';
+  }
+
+  return 'attente';
+}
+
+function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = []) {
+  const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
+  const trajectories = ['apaisement', 'consolidation', 'enquête', 'expansion', 'attente'];
+  const bundles = trajectories
+    .map((trajectory) => {
+      const members = recommendations.filter((recommendation) => recommendation.trajectory === trajectory);
+      if (members.length === 0) {
+        return null;
+      }
+
+      const uncertainMembers = members.filter((member) => member.confidence === 'low' || member.level === 'fragile');
+      const safeMembers = members.filter((member) => !uncertainMembers.includes(member));
+      const state = safeMembers.length > 0 && uncertainMembers.length === 0
+        ? 'safe'
+        : safeMembers.length > 0
+          ? 'mixed'
+          : 'uncertain';
+
+      return {
+        bundleId: `culture-commitment:${trajectory}`,
+        label: buildCommitmentBundleName(trajectory),
+        trajectory,
+        state,
+        safeRecommendationIds: safeMembers.map((member) => member.recommendationId),
+        uncertainRecommendationIds: uncertainMembers.map((member) => member.recommendationId),
+        actions: [...new Set(members.map((member) => member.action))],
+        markerIds: [...new Set(members.flatMap((member) => member.markerIds))],
+        explanation: members
+          .map((member) => `${member.discoveryId} → ${member.action} → ${state === 'uncertain' ? 'incertain' : buildCommitmentBundleName(trajectory)}`)
+          .join(' | '),
+      };
+    })
+    .filter(Boolean);
+  const incompatibilities = [];
+  const supportGroups = recommendations.reduce((groups, recommendation) => {
+    groups.set(recommendation.supportKey, [...(groups.get(recommendation.supportKey) ?? []), recommendation]);
+    return groups;
+  }, new Map());
+
+  supportGroups.forEach((members, supportKey) => {
+    if (members.length > 1 && supportKey !== 'attendre') {
+      incompatibilities.push({
+        incompatibilityId: `culture-commitment:support:${supportKey}`,
+        type: 'same-support-required',
+        severity: 'choice',
+        recommendationIds: members.map((member) => member.recommendationId),
+        reason: `même soutien requis: ${supportKey}`,
+      });
+    }
+  });
+
+  const expansion = recommendations.filter((recommendation) => recommendation.trajectory === 'expansion');
+  const apaisement = recommendations.filter((recommendation) => recommendation.trajectory === 'apaisement');
+  if (expansion.length > 0 && apaisement.length > 0) {
+    incompatibilities.push({
+      incompatibilityId: 'culture-commitment:timing:expansion-apaisement',
+      type: 'contradictory-narrative-timing',
+      severity: 'sequence',
+      recommendationIds: [...expansion, ...apaisement].map((member) => member.recommendationId),
+      reason: 'timing narratif contradictoire: apaiser avant expansion active',
+    });
+  }
+
+  recommendations
+    .filter((recommendation) => recommendation.confidence === 'low')
+    .forEach((recommendation) => {
+      incompatibilities.push({
+        incompatibilityId: `${recommendation.recommendationId}:low-confidence-commitment`,
+        type: 'low-confidence',
+        severity: 'uncertain',
+        recommendationIds: [recommendation.recommendationId],
+        reason: `${recommendation.discoveryId}: confiance trop basse pour engagement sûr`,
+      });
+    });
+
+  recommendations
+    .filter((recommendation) => recommendation.expiresSoon)
+    .forEach((recommendation) => {
+      incompatibilities.push({
+        incompatibilityId: `${recommendation.recommendationId}:expiring-opportunity`,
+        type: 'expiring-opportunity',
+        severity: 'urgent',
+        recommendationIds: [recommendation.recommendationId],
+        reason: `${recommendation.discoveryId}: opportunité qui expire`,
+      });
+    });
+
+  return {
+    state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
+    summary: bundles.length === 0
+      ? 'Aucun bundle d’engagement culturel disponible.'
+      : `${bundles.length} bundle${bundles.length > 1 ? 's' : ''} d’engagement culturel, ${incompatibilities.length} incompatibilité${incompatibilities.length > 1 ? 's' : ''}.`,
+    bundles,
+    incompatibilities,
+    dependencyExplanation: bundles.length === 0
+      ? 'Aucune dépendance entre marqueurs culturels.'
+      : bundles
+        .slice(0, 3)
+        .map((bundle) => `${bundle.label}: ${bundle.explanation}`)
+        .join(' | '),
+  };
+}
+
 function dedupeAndSort(deltas) {
   return [...new Map(deltas.map((delta) => [
     `${delta.tone}:${delta.label}:${delta.value}:${delta.regionId}`,
@@ -467,6 +597,7 @@ export function buildCultureTurnReportDeltas({
   });
   const stabilizationRecommendations = buildCultureStabilizationRecommendations(momentumLayer);
   const recommendationCoherence = buildCultureRecommendationCoherenceSummary(stabilizationRecommendations, activeRecommendations);
+  const commitmentBundles = buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations);
   const deltas = dedupeAndSort([
     ...buildTimelineDeltas(localTimeline, regionId),
     ...buildMarkerDeltas(selectedMarker, regionId),
@@ -504,6 +635,13 @@ export function buildCultureTurnReportDeltas({
         explanation: 'Aucun signal récent → recommandation → cohérence.',
         uncertainRecommendationIds: [],
       },
+      commitmentBundles: {
+        state: 'quiet',
+        summary: 'Aucun bundle d’engagement culturel disponible.',
+        bundles: [],
+        incompatibilities: [],
+        dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
+      },
     };
   }
 
@@ -518,5 +656,6 @@ export function buildCultureTurnReportDeltas({
     momentumLayer,
     stabilizationRecommendations,
     recommendationCoherence,
+    commitmentBundles,
   };
 }

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -162,6 +162,25 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
     explanation: 'archive-routes → amplifier → expansion',
     uncertainRecommendationIds: [],
   });
+  assert.deepEqual(report.commitmentBundles, {
+    state: 'compatible',
+    summary: '1 bundle d’engagement culturel, 0 incompatibilité.',
+    bundles: [
+      {
+        bundleId: 'culture-commitment:expansion',
+        label: 'expansion prudente',
+        trajectory: 'expansion',
+        state: 'safe',
+        safeRecommendationIds: ['river-gate:momentum:strengthened:1:stabilization'],
+        uncertainRecommendationIds: [],
+        actions: ['amplifier'],
+        markerIds: ['river-gate:culture-aurora:event:event-archive-opening'],
+        explanation: 'archive-routes → amplifier → expansion prudente',
+      },
+    ],
+    incompatibilities: [],
+    dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
+  });
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -194,6 +213,13 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
       tensions: [],
       explanation: 'Aucun signal récent → recommandation → cohérence.',
       uncertainRecommendationIds: [],
+    },
+    commitmentBundles: {
+      state: 'quiet',
+      summary: 'Aucun bundle d’engagement culturel disponible.',
+      bundles: [],
+      incompatibilities: [],
+      dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },
   });
 });
@@ -440,4 +466,95 @@ test('buildCultureTurnReportDeltas summarizes coherence tensions between active 
   ]);
   assert.match(report.recommendationCoherence.explanation, /archive-routes → amplifier → expansion/);
   assert.deepEqual(report.recommendationCoherence.uncertainRecommendationIds, ['mist:momentum:fragile:stabilization']);
+});
+
+test('buildCultureTurnReportDeltas groups compatible and incompatible cultural commitment bundles', () => {
+  const report = buildCultureTurnReportDeltas({
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'explorer',
+        consequencePreview: {
+          confidence: 'high',
+          opportunity: 'archives ouvertes',
+          summary: 'explorer: archives ouvertes.',
+          visibleMarkerIds: ['river-gate:culture-aurora:event:event-archive-opening'],
+        },
+      },
+    },
+    previousMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'emerging',
+      influenceScore: 70,
+      discoveries: ['archive-routes'],
+    },
+    activeRecommendations: [
+      {
+        recommendationId: 'ember:momentum:volatile:stabilization',
+        regionId: 'ember-ford',
+        cultureName: 'Ember Guild',
+        action: 'apaiser',
+        tone: 'tension',
+        level: 'volatile',
+        discoveryId: 'ash-treaty',
+        confidence: 'medium',
+        supportKey: 'envoy',
+        markerIds: ['ember-marker'],
+        rank: 2,
+      },
+      {
+        recommendationId: 'mist:momentum:fragile:stabilization',
+        regionId: 'mist-hills',
+        cultureName: 'Mist Circle',
+        action: 'enquêter',
+        tone: 'tension',
+        level: 'fragile',
+        discoveryId: 'fog-index',
+        confidence: 'low',
+        supportKey: 'survey-team',
+        markerIds: ['mist-marker'],
+        rank: 3,
+      },
+      {
+        recommendationId: 'harbor:momentum:surge:stabilization',
+        regionId: 'harbor',
+        cultureName: 'Harbor Compact',
+        action: 'amplifier',
+        tone: 'opportunity',
+        level: 'surging',
+        discoveryId: 'harbor-forum',
+        confidence: 'high',
+        supportKey: 'amplifier',
+        expiresSoon: true,
+        markerIds: ['harbor-marker'],
+        rank: 4,
+      },
+    ],
+  });
+
+  assert.equal(report.commitmentBundles.state, 'needs-choice');
+  assert.deepEqual(report.commitmentBundles.bundles.map((bundle) => [bundle.label, bundle.state, bundle.actions]), [
+    ['apaisement local', 'safe', ['apaiser']],
+    ['enquête', 'uncertain', ['enquêter']],
+    ['expansion prudente', 'safe', ['amplifier']],
+  ]);
+  assert.deepEqual(report.commitmentBundles.incompatibilities.map((incompatibility) => [incompatibility.type, incompatibility.severity]), [
+    ['same-support-required', 'choice'],
+    ['contradictory-narrative-timing', 'sequence'],
+    ['low-confidence', 'uncertain'],
+    ['expiring-opportunity', 'urgent'],
+  ]);
+  assert.match(report.commitmentBundles.dependencyExplanation, /apaisement local: ash-treaty → apaiser/);
+  assert.deepEqual(report.commitmentBundles.bundles[1].uncertainRecommendationIds, ['mist:momentum:fragile:stabilization']);
 });


### PR DESCRIPTION
Gamma: Implements #1251.

Summary:
- adds cultural commitment bundles derived from G9 recommendation coherence
- groups compatible commitments into local appeasement, regional consolidation, investigation, cautious expansion, and wait bundles
- marks incompatible commitments for shared support, contradictory timing, low confidence, and expiring opportunities
- keeps uncertain trajectories separate from safe commitments with marker dependency explanations

Validation:
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- npm test -- test/ui/culture/buildCultureTurnReportDeltas.test.js
- npm test

Zeta: ready for validation before merge.