### PR TITLE
Epsilon: add climate action bundle assistant

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1813,6 +1813,147 @@ function buildClimatePrioritySummary(climateSafeWindowCalendar, climateRecoveryR
 }
 
 
+function getClimateBundleKind(priority) {
+  if (priority.priority === 'act-now') {
+    return 'secure-now';
+  }
+
+  if (priority.priority === 'prepare-first') {
+    return 'prepare';
+  }
+
+  if (priority.priority === 'defer') {
+    return 'monitor';
+  }
+
+  return 'postpone';
+}
+
+function describeClimateBundleViability(kind, priorities, conflicts) {
+  if (kind === 'secure-now') {
+    return priorities.some((priority) => priority.confidenceBand === 'uncertain') || conflicts.length > 0
+      ? 'fragile'
+      : 'viable';
+  }
+
+  if (kind === 'prepare') {
+    return priorities.some((priority) => priority.confidenceBand === 'uncertain') ? 'fragile' : 'viable';
+  }
+
+  if (kind === 'monitor') {
+    return conflicts.includes('residual-risk') || conflicts.includes('window-timing') ? 'fragile' : 'viable';
+  }
+
+  return 'discouraged';
+}
+
+function describeClimateBundleReason(kind, viability, conflicts) {
+  if (viability === 'viable') {
+    return kind === 'secure-now'
+      ? 'actions combinables maintenant sans conflit majeur de ressources'
+      : 'bundle utilisable avec préparation ou surveillance limitée';
+  }
+
+  if (viability === 'fragile') {
+    return conflicts.length > 0
+      ? `fragile: conflits ${conflicts.join(', ')} à arbitrer avant engagement`
+      : 'fragile: prévisions ou fenêtres à confirmer avant engagement';
+  }
+
+  return 'déconseillé: reporter évite de sur-vendre une fenêtre contradictoire ou trop risquée';
+}
+
+function normalizeClimateBundleOverride(override, baseBundle) {
+  const kind = String(override.kind ?? override.bundleKind ?? baseBundle.kind).trim().toLowerCase();
+  const viability = String(override.viability ?? baseBundle.viability).trim().toLowerCase();
+
+  return {
+    ...baseBundle,
+    ...override,
+    bundleId: String(override.bundleId ?? baseBundle.bundleId).trim(),
+    kind: ['secure-now', 'prepare', 'monitor', 'postpone'].includes(kind) ? kind : baseBundle.kind,
+    priorityIds: requireArray(override.priorityIds ?? baseBundle.priorityIds, 'ClimateMapOverlay climateActionBundle priorityIds')
+      .map((priorityId) => String(priorityId).trim())
+      .filter(Boolean),
+    regionIds: requireArray(override.regionIds ?? baseBundle.regionIds, 'ClimateMapOverlay climateActionBundle regionIds')
+      .map((regionId) => String(regionId).trim())
+      .filter(Boolean),
+    viability: ['viable', 'fragile', 'discouraged'].includes(viability) ? viability : baseBundle.viability,
+    resourceConflicts: requireArray(
+      override.resourceConflicts ?? baseBundle.resourceConflicts,
+      'ClimateMapOverlay climateActionBundle resourceConflicts',
+    ).map((conflict) => String(conflict).trim()).filter(Boolean),
+    reason: String(override.reason ?? baseBundle.reason).trim(),
+    confidenceNote: String(override.confidenceNote ?? baseBundle.confidenceNote).trim(),
+  };
+}
+
+function buildClimateActionBundleAssistant(climatePrioritySummary, normalizedOptions) {
+  const explicitBundles = Array.isArray(normalizedOptions.climateActionBundles)
+    ? normalizedOptions.climateActionBundles
+    : Array.isArray(normalizedOptions.climateActionBundleAssistant)
+      ? normalizedOptions.climateActionBundleAssistant
+      : [];
+
+  if (climatePrioritySummary.priorities.length === 0) {
+    return {
+      title: 'Assistant bundles actions climat',
+      fallback: 'Aucune priorité climatique inter-régions à grouper.',
+      bundles: [],
+      bundleConflicts: [],
+      summary: 'Aucun bundle climatique pour le tour courant.',
+    };
+  }
+
+  const grouped = climatePrioritySummary.priorities.reduce((acc, priority) => {
+    const kind = getClimateBundleKind(priority);
+    if (!acc.has(kind)) {
+      acc.set(kind, []);
+    }
+    acc.get(kind).push(priority);
+    return acc;
+  }, new Map());
+
+  const bundles = [...grouped.entries()].map(([kind, priorities]) => {
+    const conflicts = [...new Set(priorities.flatMap((priority) => priority.resourceConflicts))];
+    const viability = describeClimateBundleViability(kind, priorities, conflicts);
+    const baseBundle = {
+      bundleId: `climate-bundle:${kind}`,
+      kind,
+      priorityIds: priorities.map((priority) => priority.priorityId),
+      regionIds: [...new Set(priorities.flatMap((priority) => priority.regionIds))],
+      viability,
+      resourceConflicts: conflicts,
+      reason: describeClimateBundleReason(kind, viability, conflicts),
+      confidenceNote: priorities.some((priority) => priority.confidenceBand === 'uncertain')
+        ? 'prudence: au moins une prévision reste incertaine'
+        : 'confiance cohérente avec les prévisions disponibles',
+    };
+    const override = explicitBundles.find((bundle) => (bundle.kind ?? bundle.bundleKind ?? baseBundle.kind) === kind);
+
+    return override ? normalizeClimateBundleOverride(override, baseBundle) : baseBundle;
+  }).sort((left, right) => {
+    const rank = { 'secure-now': 0, prepare: 1, monitor: 2, postpone: 3 };
+
+    return (rank[left.kind] ?? 3) - (rank[right.kind] ?? 3) || left.bundleId.localeCompare(right.bundleId);
+  });
+
+  const bundleConflicts = [...new Set(bundles.flatMap((bundle) => bundle.resourceConflicts))];
+  const counts = bundles.reduce((acc, bundle) => {
+    acc[bundle.viability] = (acc[bundle.viability] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return {
+    title: 'Assistant bundles actions climat',
+    fallback: null,
+    bundles,
+    bundleConflicts,
+    summary: `${counts.viable ?? 0} bundle(s) viable(s), ${counts.fragile ?? 0} fragile(s), ${counts.discouraged ?? 0} déconseillé(s).`,
+  };
+}
+
+
 function buildClimateAftermathRecap(regions, climateAlerts, normalizedOptions) {
   const alertsByRegion = new Map(climateAlerts.map((alert) => [alert.regionId, alert]));
   const explicitEvents = Array.isArray(normalizedOptions.climateAftermathEvents)
@@ -2383,6 +2524,10 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
     climateRecoveryReadiness,
     normalizedOptions,
   );
+  const climateActionBundleAssistant = buildClimateActionBundleAssistant(
+    climatePrioritySummary,
+    normalizedOptions,
+  );
   const selectedClimateImpactComparison = buildSelectedClimateImpactComparison(regions, normalizedOptions, seasonPreview);
   const selectedClimateTimingRecommendation = buildSelectedClimateTimingRecommendation(selectedClimateImpactComparison);
   const selectedClimateMitigationChoices = buildSelectedClimateMitigationChoices(
@@ -2421,6 +2566,7 @@ export function buildClimateMapOverlay(climateStates, options = {}) {
       climateSafeWindowCalendar,
       climateRecoveryReadiness,
       climatePrioritySummary,
+      climateActionBundleAssistant,
     } : {}),
     selectedClimateImpactComparison,
     selectedClimateTimingRecommendation,

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -2166,3 +2166,133 @@ test('buildClimateMapOverlay keeps cross-region climate priority overrides conse
     },
   ]);
 });
+
+test('buildClimateMapOverlay groups climate priorities into prudent action bundles', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'delta', season: 'spring', temperatureC: 18, precipitationLevel: 70, droughtIndex: 12 },
+    { regionId: 'ridge', season: 'spring', temperatureC: 29, precipitationLevel: 18, droughtIndex: 68, anomaly: 'drought' },
+  ], {
+    climateAftermathEvents: [
+      {
+        eventId: 'delta-ready',
+        regionId: 'delta',
+        observedImpact: 'route stabilisée',
+        severity: 'minor',
+        appliedMitigation: 'digues inspectées',
+        confidenceBand: 'probable',
+        resilienceState: 'resilient',
+      },
+      {
+        eventId: 'ridge-risk',
+        regionId: 'ridge',
+        observedImpact: 'sols fragiles',
+        severity: 'moderate',
+        missingMitigation: 'réservoir non renforcé',
+        confidenceBand: 'uncertain',
+        resilienceState: 'strained',
+      },
+    ],
+    climateSafeWindows: [
+      {
+        aftermathEventId: 'delta-ready',
+        windowId: 'delta-ready:now',
+        label: 'tour actuel',
+        state: 'safe',
+        affectedRegionIds: ['delta'],
+        confidenceBand: 'probable',
+      },
+      {
+        aftermathEventId: 'ridge-risk',
+        windowId: 'ridge-risk:later',
+        label: 'prochain tour',
+        state: 'safe',
+        affectedRegionIds: ['ridge'],
+        confidenceBand: 'uncertain',
+      },
+    ],
+  });
+
+  assert.deepEqual(overlay.climateActionBundleAssistant.bundles.map((bundle) => ({
+    kind: bundle.kind,
+    priorityIds: bundle.priorityIds,
+    regionIds: bundle.regionIds,
+    viability: bundle.viability,
+    resourceConflicts: bundle.resourceConflicts,
+    confidenceNote: bundle.confidenceNote,
+  })), [
+    {
+      kind: 'secure-now',
+      priorityIds: ['delta-ready:now:readiness:priority'],
+      regionIds: ['delta'],
+      viability: 'viable',
+      resourceConflicts: [],
+      confidenceNote: 'confiance cohérente avec les prévisions disponibles',
+    },
+    {
+      kind: 'prepare',
+      priorityIds: ['ridge-risk:later:readiness:priority'],
+      regionIds: ['ridge'],
+      viability: 'fragile',
+      resourceConflicts: ['mitigation', 'local-resilience', 'residual-risk'],
+      confidenceNote: 'prudence: au moins une prévision reste incertaine',
+    },
+  ]);
+  assert.equal(overlay.climateActionBundleAssistant.summary, '1 bundle(s) viable(s), 1 fragile(s), 0 déconseillé(s).');
+});
+
+test('buildClimateMapOverlay supports explicit prudent climate bundle overrides', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'delta', season: 'spring', temperatureC: 18, precipitationLevel: 70, droughtIndex: 12 },
+  ], {
+    climateAftermathEvents: [
+      {
+        eventId: 'delta-risk',
+        regionId: 'delta',
+        observedImpact: 'route encore instable',
+        severity: 'major',
+        missingMitigation: 'réserve absente',
+        confidenceBand: 'probable',
+        resilienceState: 'strained',
+      },
+    ],
+    climateSafeWindows: [
+      {
+        aftermathEventId: 'delta-risk',
+        windowId: 'delta-risk:now',
+        label: 'tour actuel',
+        state: 'risky',
+        affectedRegionIds: ['delta'],
+        confidenceBand: 'probable',
+      },
+    ],
+    climatePrioritySummary: [
+      {
+        windowId: 'delta-risk:now',
+        priority: 'avoid',
+        resourceConflicts: ['reserve', 'window-timing', 'residual-risk'],
+        reason: 'fenêtre trop exposée',
+      },
+    ],
+    climateActionBundles: [
+      {
+        kind: 'postpone',
+        viability: 'discouraged',
+        reason: 'ne pas combiner avec une reprise agricole ce tour',
+        confidenceNote: 'prudence maintenue malgré confiance probable',
+      },
+    ],
+  });
+
+  assert.deepEqual(overlay.climateActionBundleAssistant.bundles, [
+    {
+      bundleId: 'climate-bundle:postpone',
+      kind: 'postpone',
+      priorityIds: ['delta-risk:now:readiness:priority'],
+      regionIds: ['delta'],
+      viability: 'discouraged',
+      resourceConflicts: ['reserve', 'window-timing', 'residual-risk'],
+      reason: 'ne pas combiner avec une reprise agricole ce tour',
+      confidenceNote: 'prudence maintenue malgré confiance probable',
+    },
+  ]);
+});


### PR DESCRIPTION
Epsilon: Adds a prudent climate action bundle assistant for #1253.

- groups E9 priorities into secure-now / prepare / monitor / postpone bundles
- surfaces bundle-level reserve, mitigation, timing-window, local-resilience, and residual-risk conflicts
- explains whether each bundle is viable, fragile, or discouraged
- keeps uncertain or contradictory forecasts conservative and supports explicit bundle overrides

Tests:
- `npm test -- test/ui/climate/buildClimateMapOverlay.test.js`
- `npm test`
- `git diff --check`

Closes #1253