### PR TITLE
Alpha: add operational commitment checklist

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -2098,6 +2098,89 @@ function buildOperationalPrioritySummary(renderedProvinces, frontPressureReplay,
   };
 }
 
+
+function prerequisiteForPriorityEntry(entry, conflicts) {
+  const matchingConflict = conflicts.find((item) => item.provinceId === entry.provinceId && item.actionCode === entry.actionCode)
+    ?? conflicts.find((item) => item.provinceId === entry.provinceId && (
+    item.type === 'soutien manquant' && entry.priority === 'renforcer'
+    || item.type === 'risque de sur-extension' && entry.priority === 'exploiter'
+    || item.type === 'fronts adjacents incompatibles' && entry.priority === 'exploiter'
+    || item.type === 'historique incomplet' && entry.priority === 'surveiller'
+  ));
+
+  if (matchingConflict?.type === 'soutien manquant') return { code: 'adjacent-support', label: 'soutien adjacent à rétablir', blocking: true };
+  if (matchingConflict?.type === 'risque de sur-extension') return { code: 'overextension-check', label: 'limiter la sur-extension', blocking: false };
+  if (matchingConflict?.type === 'fronts adjacents incompatibles') return { code: 'front-compatibility', label: 'front adjacent incompatible', blocking: true };
+  if (matchingConflict?.type === 'historique incomplet') return { code: 'intel-confidence', label: 'renseignement trop incertain', blocking: true };
+  if (entry.priority === 'renforcer') return { code: 'logistics-ready', label: 'logistique critique vérifiée', blocking: false };
+  if (entry.priority === 'exploiter') return { code: 'weather-window', label: 'fenêtre météo à confirmer', blocking: false };
+  return null;
+}
+
+function commitmentStatusForEntry(entry, prerequisite) {
+  if (entry.priority === 'surveiller' || entry.priority === 'différer') return 'attente';
+  if (prerequisite?.blocking) return 'bloqué';
+  if (entry.priority === 'tenir') return 'tenir';
+  return 'engageable';
+}
+
+function buildOperationalCommitmentChecklist(operationalPrioritySummary) {
+  const detailedEntries = operationalPrioritySummary.priorities.flatMap((priority) => priority.entries);
+  const checklistItems = operationalPrioritySummary.actionOrder.map((entry) => {
+    const detailedEntry = detailedEntries.find((item) => item.order === entry.order && item.provinceId === entry.provinceId) ?? entry;
+    const prerequisite = prerequisiteForPriorityEntry(detailedEntry, operationalPrioritySummary.conflicts);
+    const status = commitmentStatusForEntry(entry, prerequisite);
+
+    return {
+      order: entry.order,
+      provinceId: entry.provinceId,
+      provinceLabel: entry.provinceLabel,
+      actionLabel: entry.actionLabel,
+      priority: entry.priority,
+      status,
+      prerequisite,
+      risk: prerequisite?.blocking
+        ? `bloquant: ${prerequisite.label}`
+        : prerequisite
+          ? `accepté sous contrôle: ${prerequisite.label}`
+          : 'accepté: aucun prérequis bloquant détecté',
+      decisionHint: status === 'engageable'
+        ? 'peut être engagé maintenant'
+        : status === 'tenir'
+          ? 'tenir sans escalade automatique'
+          : status === 'attente'
+            ? 'laisser en attente et relire au prochain tour'
+            : 'corriger le prérequis avant engagement',
+    };
+  });
+  const blockingRisks = checklistItems.filter((item) => item.prerequisite?.blocking).map((item) => ({
+    provinceId: item.provinceId,
+    provinceLabel: item.provinceLabel,
+    prerequisite: item.prerequisite.label,
+  }));
+  const acceptedRisks = checklistItems.filter((item) => !item.prerequisite?.blocking && item.status !== 'attente').map((item) => ({
+    provinceId: item.provinceId,
+    provinceLabel: item.provinceLabel,
+    risk: item.risk,
+  }));
+
+  return {
+    empty: checklistItems.length === 0,
+    fallbackMessage: checklistItems.length === 0
+      ? 'Checklist indisponible: aucune priorité opérationnelle exploitable.'
+      : operationalPrioritySummary.fallbackMessage,
+    readyCount: checklistItems.filter((item) => item.status === 'engageable' || item.status === 'tenir').length,
+    waitingCount: checklistItems.filter((item) => item.status === 'attente').length,
+    blockedCount: checklistItems.filter((item) => item.status === 'bloqué').length,
+    checklistItems,
+    acceptedRisks,
+    blockingRisks,
+    summary: checklistItems.length === 0
+      ? 'Aucun engagement à vérifier.'
+      : `${checklistItems.filter((item) => item.status === 'engageable' || item.status === 'tenir').length} prêt · ${checklistItems.filter((item) => item.status === 'attente').length} en attente · ${checklistItems.filter((item) => item.status === 'bloqué').length} bloqué`,
+  };
+}
+
 function buildKeyboardActionPlanner(renderedProvinces, options) {
   const activeProvince = renderedProvinces.find(
     (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
@@ -2332,6 +2415,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const frontPressureReplay = buildFrontPressureTimelineReplay(renderedProvinces, normalizedOptions);
   const frontRecoveryRecommendations = buildFrontRecoveryRecommendations(frontPressureReplay);
   const operationalPrioritySummary = buildOperationalPrioritySummary(renderedProvinces, frontPressureReplay, frontRecoveryRecommendations);
+  const operationalCommitmentChecklist = buildOperationalCommitmentChecklist(operationalPrioritySummary);
 
   return {
     title,
@@ -2343,6 +2427,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     frontPressureReplay,
     frontRecoveryRecommendations,
     operationalPrioritySummary,
+    operationalCommitmentChecklist,
     stats: {
       provinceCount: stats.provinceCount,
       contestedCount: stats.contestedCount,

--- a/src/ui/war/buildStrategicMapPreviewHtml.js
+++ b/src/ui/war/buildStrategicMapPreviewHtml.js
@@ -337,6 +337,38 @@ function renderOperationalPrioritySummary(shell) {
   `;
 }
 
+
+function renderOperationalCommitmentChecklist(shell) {
+  const checklist = shell.operationalCommitmentChecklist;
+  const items = checklist.checklistItems.map((item) => `
+    <li class="commitment-checklist-item commitment-checklist-item--${escapeHtml(item.status)}">
+      <span>${item.order}. ${escapeHtml(item.provinceLabel)} · ${escapeHtml(item.priority)} · ${escapeHtml(item.status)}</span>
+      <strong>${escapeHtml(item.actionLabel)}</strong>
+      <small>${escapeHtml(item.risk)}</small>
+      <em>${escapeHtml(item.decisionHint)}</em>
+    </li>
+  `).join('');
+  const acceptedRisks = checklist.acceptedRisks.map((risk) => `
+    <li><span>${escapeHtml(risk.provinceLabel)}</span><small>${escapeHtml(risk.risk)}</small></li>
+  `).join('');
+  const blockingRisks = checklist.blockingRisks.map((risk) => `
+    <li><span>${escapeHtml(risk.provinceLabel)}</span><small>${escapeHtml(risk.prerequisite)}</small></li>
+  `).join('');
+
+  return `
+    <section class="commitment-checklist" aria-label="Checklist de commitment opérationnel des provinces contestées">
+      <h2>Checklist commitment</h2>
+      <p>${escapeHtml(checklist.fallbackMessage ?? checklist.summary)}</p>
+      <div class="commitment-checklist-counts"><span>${checklist.readyCount} prêt</span><span>${checklist.waitingCount} attente</span><span>${checklist.blockedCount} bloqué</span></div>
+      ${checklist.empty ? '<small class="commitment-checklist-empty">Aucun engagement à vérifier.</small>' : `<ol>${items}</ol>`}
+      <div class="commitment-risk-summary">
+        <article><span>Risques acceptés</span>${acceptedRisks ? `<ul>${acceptedRisks}</ul>` : '<small>Aucun risque accepté.</small>'}</article>
+        <article><span>Risques bloquants</span>${blockingRisks ? `<ul>${blockingRisks}</ul>` : '<small>Aucun blocage.</small>'}</article>
+      </div>
+    </section>
+  `;
+}
+
 function renderProvinceActionQueueValidation(shell) {
   const validation = shell.keyboardActionPlanner.actionQueueValidation;
   const entries = validation.entries.map((entry) => {
@@ -522,6 +554,23 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .operational-priority-conflicts { display:grid; gap:6px; border-top:1px solid rgba(148,163,184,0.14); padding-top:7px; }
     .operational-priority-conflicts > span { color:#fca5a5; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
     .operational-priority-conflict { border-color:rgba(248,113,113,0.36); }
+    .commitment-checklist { display:grid; gap:10px; }
+    .commitment-checklist p, .commitment-checklist-empty { margin:0; color:#cbd5e1; font-size:12px; }
+    .commitment-checklist ol, .commitment-checklist ul { display:grid; gap:6px; margin:0; padding:0; }
+    .commitment-checklist-counts { display:flex; flex-wrap:wrap; gap:6px; }
+    .commitment-checklist-counts span { border:1px solid rgba(148,163,184,0.22); border-radius:999px; padding:3px 8px; color:#dbeafe; font-size:11px; }
+    .commitment-checklist-item { display:grid; gap:3px; border:1px solid rgba(148,163,184,0.18); border-radius:12px; padding:7px 9px; }
+    .commitment-checklist-item--engageable, .commitment-checklist-item--tenir { border-color:rgba(74,222,128,0.44); background:rgba(22,101,52,0.10); }
+    .commitment-checklist-item--attente { border-color:rgba(251,191,36,0.42); background:rgba(120,53,15,0.10); }
+    .commitment-checklist-item--bloqué { border-color:rgba(248,113,113,0.42); background:rgba(127,29,29,0.10); }
+    .commitment-checklist-item strong { color:#bfdbfe; font-size:12px; }
+    .commitment-checklist-item small { color:#cbd5e1; }
+    .commitment-checklist-item em { color:#bae6fd; font-size:11px; font-style:normal; }
+    .commitment-risk-summary { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+    .commitment-risk-summary article { display:grid; gap:5px; border-top:1px solid rgba(148,163,184,0.14); padding-top:7px; }
+    .commitment-risk-summary article > span { color:#93c5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
+    .commitment-risk-summary li { display:grid; gap:2px; border:1px solid rgba(148,163,184,0.16); border-radius:10px; padding:6px 8px; }
+    .commitment-risk-summary small { color:#cbd5e1; }
     table { width:100%; border-collapse:collapse; font-size:13px; }
     th, td { padding:10px 8px; border-bottom:1px solid rgba(148, 163, 184, 0.14); text-align:left; }
     th { color:#93c5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
@@ -570,6 +619,7 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
         ${renderFrontPressureReplay(shell)}
         ${renderFrontRecoveryRecommendations(shell)}
         ${renderOperationalPrioritySummary(shell)}
+        ${renderOperationalCommitmentChecklist(shell)}
         <section>
           <h2>Lecture</h2>
           <ul>

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -272,6 +272,39 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     ],
     summary: '1 priorité: surveiller Colline rouge',
   });
+  assert.deepEqual(shell.operationalCommitmentChecklist, {
+    empty: false,
+    fallbackMessage: 'Recommandations indisponibles sans historique de pression du front.',
+    readyCount: 0,
+    waitingCount: 1,
+    blockedCount: 0,
+    checklistItems: [
+      {
+        order: 1,
+        provinceId: 'prov-c',
+        provinceLabel: 'Colline rouge',
+        actionLabel: 'Surveiller le front',
+        priority: 'surveiller',
+        status: 'attente',
+        prerequisite: {
+          code: 'intel-confidence',
+          label: 'renseignement trop incertain',
+          blocking: true,
+        },
+        risk: 'bloquant: renseignement trop incertain',
+        decisionHint: 'laisser en attente et relire au prochain tour',
+      },
+    ],
+    acceptedRisks: [],
+    blockingRisks: [
+      {
+        provinceId: 'prov-c',
+        provinceLabel: 'Colline rouge',
+        prerequisite: 'renseignement trop incertain',
+      },
+    ],
+    summary: '0 prêt · 1 en attente · 0 bloqué',
+  });
   assert.deepEqual(shell.stats, {
     provinceCount: 2,
     contestedCount: 1,
@@ -740,6 +773,80 @@ test('StrategicMapShell builds a scrub-ready front pressure timeline replay', ()
     },
   ]);
   assert.equal(shell.operationalPrioritySummary.summary, '3 priorités: renforcer Front rouge → renforcer Front rouge → exploiter Front rouge');
+  assert.deepEqual(shell.operationalCommitmentChecklist, {
+    empty: false,
+    fallbackMessage: null,
+    readyCount: 1,
+    waitingCount: 0,
+    blockedCount: 2,
+    checklistItems: [
+      {
+        order: 1,
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        actionLabel: 'Consolider le soutien',
+        priority: 'renforcer',
+        status: 'bloqué',
+        prerequisite: {
+          code: 'adjacent-support',
+          label: 'soutien adjacent à rétablir',
+          blocking: true,
+        },
+        risk: 'bloquant: soutien adjacent à rétablir',
+        decisionHint: 'corriger le prérequis avant engagement',
+      },
+      {
+        order: 2,
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        actionLabel: 'Renforcer le front',
+        priority: 'renforcer',
+        status: 'bloqué',
+        prerequisite: {
+          code: 'adjacent-support',
+          label: 'soutien adjacent à rétablir',
+          blocking: true,
+        },
+        risk: 'bloquant: soutien adjacent à rétablir',
+        decisionHint: 'corriger le prérequis avant engagement',
+      },
+      {
+        order: 3,
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        actionLabel: 'Sonder prudemment la brèche',
+        priority: 'exploiter',
+        status: 'engageable',
+        prerequisite: {
+          code: 'overextension-check',
+          label: 'limiter la sur-extension',
+          blocking: false,
+        },
+        risk: 'accepté sous contrôle: limiter la sur-extension',
+        decisionHint: 'peut être engagé maintenant',
+      },
+    ],
+    acceptedRisks: [
+      {
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        risk: 'accepté sous contrôle: limiter la sur-extension',
+      },
+    ],
+    blockingRisks: [
+      {
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        prerequisite: 'soutien adjacent à rétablir',
+      },
+      {
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        prerequisite: 'soutien adjacent à rétablir',
+      },
+    ],
+    summary: '1 prêt · 0 en attente · 2 bloqué',
+  });
 });
 
 test('StrategicMapShell reports incomplete front pressure replay history', () => {
@@ -781,6 +888,16 @@ test('StrategicMapShell reports incomplete front pressure replay history', () =>
       priority: 'tenir',
       actionLabel: 'Attendre et observer',
       marker: 'option sûre',
+    },
+  ]);
+  assert.equal(shell.operationalCommitmentChecklist.readyCount, 1);
+  assert.equal(shell.operationalCommitmentChecklist.waitingCount, 0);
+  assert.equal(shell.operationalCommitmentChecklist.blockedCount, 0);
+  assert.deepEqual(shell.operationalCommitmentChecklist.acceptedRisks, [
+    {
+      provinceId: 'front',
+      provinceLabel: 'Front rouge',
+      risk: 'accepté: aucun prérequis bloquant détecté',
     },
   ]);
 });

--- a/test/ui/war/buildStrategicMapPreviewHtml.test.js
+++ b/test/ui/war/buildStrategicMapPreviewHtml.test.js
@@ -48,6 +48,12 @@ test('buildStrategicMapPreviewHtml renders a screenshot-ready preview from the g
   assert.match(html, /Conflits proches/);
   assert.match(html, /soutien manquant/);
   assert.match(html, /risque de sur-extension/);
+  assert.match(html, /Checklist de commitment opérationnel des provinces contestées/);
+  assert.match(html, /Checklist commitment/);
+  assert.match(html, /Risques acceptés/);
+  assert.match(html, /Risques bloquants/);
+  assert.match(html, /soutien adjacent à rétablir/);
+  assert.match(html, /peut être engagé maintenant/);
   assert.match(html, /class="province is-contested is-occupied is-selected is-queued is-recently-affected"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /Porte du Fleuve/);


### PR DESCRIPTION
Alpha: Implements #1249.

Summary:
- adds an operational commitment checklist derived from the A9 priority summary
- classifies contested province actions as ready/hold, waiting, or blocked before turn validation
- surfaces missing prerequisites such as adjacent support, critical logistics, weather confirmation, and uncertain intelligence
- renders compact accepted-vs-blocking risk summaries in the strategic map preview

Tests:
- npm test -- test/ui/war/StrategicMapShell.test.js test/ui/war/buildStrategicMapPreviewHtml.test.js
- npm test
- git diff --check

Zeta: ready for validation before merge.
