### PR TITLE
Delta: add exposure budget for intrigue verifications

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2528,6 +2528,66 @@ function buildIntrigueSignalTriageQueue({ locationId, locationName, confidenceSt
   }];
 }
 
+function buildExposureBudgetForPriorityVerifications({ locationId, locationName, verificationPathPreviews, intelligenceProvenancePanel, verificationAuditTrail, intrigueSignalTriageQueue, safeMapMasking }) {
+  const priorityEntry = intrigueSignalTriageQueue.find((entry) => entry.triageClass === 'verify-now') ?? null;
+  if (!priorityEntry || !priorityEntry.nextLeastExposureCheck || intelligenceProvenancePanel.provenanceType === 'unknown') {
+    return {
+      state: 'masked-budget',
+      priorityOnly: true,
+      entries: [],
+      summary: 'Budget masqué: données de provenance ou de confiance insuffisantes pour estimer l’exposition.',
+      safeMapPolicy: 'Aucune cible, relais, méthode sensible ou vérité cachée n’est utilisée pour estimer le budget.',
+    };
+  }
+
+  const compatibleChecks = verificationPathPreviews
+    .filter((path) => !path.unsafe)
+    .map((path) => ({
+      checkId: path.pathId,
+      label: path.label,
+      exposureCost: path.exposureCost,
+      exposureBand: path.exposureCost >= 10 ? 'high' : path.exposureCost >= 7 ? 'medium' : path.exposureCost > 0 ? 'low' : 'unknown',
+      relationship: 'compatible',
+      rationale: `${path.costCue}: ${path.evidenceNeeded}.`,
+    }));
+  const mutuallyRiskyChecks = verificationPathPreviews
+    .filter((path) => path.unsafe)
+    .map((path) => ({
+      checkId: path.pathId,
+      label: path.label,
+      exposureCost: path.exposureCost,
+      exposureBand: 'high',
+      relationship: 'mutually-risky',
+      rationale: 'Augmente le risque si combiné avec une vérification prioritaire visible.',
+      saferFallbackAction: path.saferFallbackAction,
+    }));
+  const entries = [...compatibleChecks, ...mutuallyRiskyChecks];
+  const safestEntry = compatibleChecks.toSorted((left, right) => left.exposureCost - right.exposureCost)[0] ?? null;
+
+  return {
+    state: safeMapMasking.state === 'masked-information' ? 'masked-budget' : 'visible-budget',
+    priorityOnly: true,
+    locationId,
+    locationName,
+    triageClass: priorityEntry.triageClass,
+    entries,
+    nextLeastExposureCheck: safestEntry ? {
+      action: priorityEntry.nextLeastExposureCheck.action,
+      checkId: safestEntry.checkId,
+      label: safestEntry.label,
+      exposureBand: safestEntry.exposureBand,
+      exposureCost: safestEntry.exposureCost,
+      evidenceNeeded: priorityEntry.nextLeastExposureCheck.evidenceNeeded,
+    } : null,
+    comparisonSummary: mutuallyRiskyChecks.length > 0
+      ? 'Une vérification compatible existe; l’élargissement simultané augmente mutuellement le risque.'
+      : 'Les vérifications visibles restent compatibles avec le budget prioritaire.',
+    residualRisk: verificationAuditTrail.lastChange === 'residual-risk' ? 'visible-residual-risk' : 'low-or-unconfirmed',
+    summary: `Budget d’exposition ${safestEntry?.exposureBand ?? 'inconnu'} pour le prochain contrôle prioritaire.`,
+    safeMapPolicy: 'Estimation prudente fondée sur D7/D8/D9; ne révèle jamais cible, relais, méthode sensible ou vérité cachée.',
+  };
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2698,6 +2758,15 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         intelligenceProvenancePanel,
         verificationAuditTrail,
       });
+      const exposureBudgetForPriorityVerifications = buildExposureBudgetForPriorityVerifications({
+        locationId,
+        locationName,
+        verificationPathPreviews,
+        intelligenceProvenancePanel,
+        verificationAuditTrail,
+        intrigueSignalTriageQueue,
+        safeMapMasking,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -2710,6 +2779,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           intelligenceProvenancePanel,
           verificationAuditTrail,
           intrigueSignalTriageQueue,
+          exposureBudgetForPriorityVerifications,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2249,3 +2249,58 @@ test('buildIntrigueMapOverlay exposes fog-safe intrigue signal triage queues', (
   assert.equal(byLocation.get('masked-triage').nextLeastExposureCheck, null);
   assert.match(byLocation.get('masked-triage').fogSafeCopy, /aucune cellule, relais, cible, méthode sensible ou cause cachée/);
 });
+
+test('buildIntrigueMapOverlay exposes fog-safe exposure budgets for priority verifications', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-budget-priority',
+      factionId: 'shadow-league',
+      codename: 'Budget',
+      locationId: 'budget-priority',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 88,
+    }),
+    new Cellule({
+      id: 'cell-budget-masked',
+      factionId: 'shadow-league',
+      codename: 'Curtain',
+      locationId: 'budget-masked',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-budget-priority',
+      celluleId: 'cell-budget-priority',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Pressure visible checkpoint',
+      theaterId: 'budget-priority',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 88,
+      progress: 72,
+      heat: 76,
+      phase: 'execution',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.exposureBudgetForPriorityVerifications]));
+  const priorityBudget = byLocation.get('budget-priority');
+  const maskedBudget = byLocation.get('budget-masked');
+
+  assert.equal(priorityBudget.state, 'visible-budget');
+  assert.equal(priorityBudget.triageClass, 'verify-now');
+  assert.equal(priorityBudget.nextLeastExposureCheck.action, 'observe-locally');
+  assert.equal(priorityBudget.nextLeastExposureCheck.exposureBand, 'medium');
+  assert.equal(priorityBudget.residualRisk, 'visible-residual-risk');
+  assert.deepEqual(priorityBudget.entries.map((entry) => entry.relationship), ['compatible', 'mutually-risky']);
+  assert.match(priorityBudget.comparisonSummary, /augmente mutuellement le risque/);
+  assert.match(priorityBudget.safeMapPolicy, /ne révèle jamais cible, relais, méthode sensible ou vérité cachée/);
+
+  assert.equal(maskedBudget.state, 'masked-budget');
+  assert.deepEqual(maskedBudget.entries, []);
+  assert.equal(maskedBudget.nextLeastExposureCheck, undefined);
+  assert.match(maskedBudget.summary, /données de provenance ou de confiance insuffisantes/);
+});


### PR DESCRIPTION
Delta: ## Summary
- Adds fog-safe `exposureBudgetForPriorityVerifications` for D9 “verify now” intrigue signals.
- Estimates low/medium/high/unknown exposure bands, separates compatible checks from mutually risky broadening, and selects the least-exposure next check.
- Reuses D7/D8/D9 provenance, audit, and triage data without revealing targets, relays, sensitive methods, or hidden truth.

Closes #1252.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés intrigue passés et tests complets passés avec `npm test` (687/687); j’attends ta validation avant tout merge.