### PR TITLE
Delta: add verification conflict resolver

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2588,6 +2588,72 @@ function buildExposureBudgetForPriorityVerifications({ locationId, locationName,
   };
 }
 
+function buildVerificationConflictResolver({ locationId, locationName, intelligenceProvenancePanel, verificationAuditTrail, intrigueSignalTriageQueue, exposureBudgetForPriorityVerifications }) {
+  const triageEntry = intrigueSignalTriageQueue[0] ?? null;
+  const compatibleEntry = exposureBudgetForPriorityVerifications.entries?.find((entry) => entry.relationship === 'compatible') ?? null;
+  const riskyEntry = exposureBudgetForPriorityVerifications.entries?.find((entry) => entry.relationship === 'mutually-risky') ?? null;
+
+  if (!triageEntry || exposureBudgetForPriorityVerifications.state === 'masked-budget') {
+    return {
+      state: 'masked-conflict',
+      locationId,
+      locationName,
+      summary: 'Conflit non résolu: budget ou provenance insuffisant, conserver un affichage généralisé.',
+      launchNow: null,
+      defer: null,
+      abandonIfNeeded: null,
+      consequence: 'Le joueur évite une vérification fondée sur des détails non autorisés.',
+      provenanceLink: intelligenceProvenancePanel.sourceLabel,
+      safeMapPolicy: 'Aucune cible, relais, méthode sensible ou vérité cachée n’est révélée.',
+    };
+  }
+
+  if (!riskyEntry) {
+    return {
+      state: 'calm-budget-sufficient',
+      locationId,
+      locationName,
+      summary: 'Budget suffisant: aucune vérification visible ne concurrence le contrôle prioritaire.',
+      launchNow: compatibleEntry ? {
+        checkId: compatibleEntry.checkId,
+        label: compatibleEntry.label,
+        exposureBand: compatibleEntry.exposureBand,
+      } : null,
+      defer: null,
+      abandonIfNeeded: null,
+      consequence: 'Le contrôle peut être lancé sans augmenter un conflit d’exposition visible.',
+      provenanceLink: `${intelligenceProvenancePanel.provenanceType}:${verificationAuditTrail.lastChange}`,
+      safeMapPolicy: 'Décision reliée uniquement aux signaux/provenances exposés.',
+    };
+  }
+
+  return {
+    state: 'conflict-detected',
+    locationId,
+    locationName,
+    summary: 'Conflit détecté: le budget prioritaire ne couvre pas tous les contrôles visibles.',
+    launchNow: compatibleEntry ? {
+      checkId: compatibleEntry.checkId,
+      label: compatibleEntry.label,
+      exposureBand: compatibleEntry.exposureBand,
+      reason: 'Contrôle compatible avec le budget prioritaire et la provenance visible.',
+    } : null,
+    defer: {
+      checkId: riskyEntry.checkId,
+      label: riskyEntry.label,
+      exposureBand: riskyEntry.exposureBand,
+      reason: 'À différer car il augmente mutuellement le risque d’exposition.',
+    },
+    abandonIfNeeded: triageEntry.residualRisk === 'low-or-unconfirmed' ? {
+      label: triageEntry.label,
+      reason: 'Abandon provisoire si aucun nouveau signal visible ne renforce la provenance.',
+    } : null,
+    consequence: 'Conséquence fog-safe: priorité à la vérification la moins exposée; les chemins larges restent différés sans révéler de détail interdit.',
+    provenanceLink: `${intelligenceProvenancePanel.provenanceType}:${verificationAuditTrail.lastChange}`,
+    safeMapPolicy: 'Résolution fondée sur D7/D8/D9/D10; ne révèle jamais cible, relais, méthode sensible ou vérité cachée.',
+  };
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2767,6 +2833,14 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         intrigueSignalTriageQueue,
         safeMapMasking,
       });
+      const verificationConflictResolver = buildVerificationConflictResolver({
+        locationId,
+        locationName,
+        intelligenceProvenancePanel,
+        verificationAuditTrail,
+        intrigueSignalTriageQueue,
+        exposureBudgetForPriorityVerifications,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -2780,6 +2854,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           verificationAuditTrail,
           intrigueSignalTriageQueue,
           exposureBudgetForPriorityVerifications,
+          verificationConflictResolver,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2304,3 +2304,59 @@ test('buildIntrigueMapOverlay exposes fog-safe exposure budgets for priority ver
   assert.equal(maskedBudget.nextLeastExposureCheck, undefined);
   assert.match(maskedBudget.summary, /données de provenance ou de confiance insuffisantes/);
 });
+
+test('buildIntrigueMapOverlay resolves fog-safe verification exposure conflicts', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-conflict-resolver',
+      factionId: 'shadow-league',
+      codename: 'Resolver',
+      locationId: 'conflict-resolver',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 90,
+    }),
+    new Cellule({
+      id: 'cell-masked-resolver',
+      factionId: 'shadow-league',
+      codename: 'Unknown',
+      locationId: 'masked-resolver',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-conflict-resolver',
+      celluleId: 'cell-conflict-resolver',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Contest a visible route',
+      theaterId: 'conflict-resolver',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 90,
+      progress: 78,
+      heat: 82,
+      phase: 'execution',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.verificationConflictResolver]));
+  const conflict = byLocation.get('conflict-resolver');
+  const masked = byLocation.get('masked-resolver');
+
+  assert.equal(conflict.state, 'conflict-detected');
+  assert.equal(conflict.launchNow.checkId, 'observe-local-confirmation');
+  assert.equal(conflict.defer.checkId, 'broad-coverage-now');
+  assert.equal(conflict.defer.exposureBand, 'high');
+  assert.equal(conflict.abandonIfNeeded, null);
+  assert.equal(conflict.provenanceLink, 'observed:residual-risk');
+  assert.match(conflict.consequence, /priorité à la vérification la moins exposée/);
+  assert.match(conflict.safeMapPolicy, /ne révèle jamais cible, relais, méthode sensible ou vérité cachée/);
+
+  assert.equal(masked.state, 'masked-conflict');
+  assert.equal(masked.launchNow, null);
+  assert.equal(masked.defer, null);
+  assert.match(masked.summary, /budget ou provenance insuffisant/);
+  assert.match(masked.safeMapPolicy, /Aucune cible, relais, méthode sensible ou vérité cachée/);
+});


### PR DESCRIPTION
Delta: ## Summary
- Adds fog-safe `verificationConflictResolver` output for exposure-budget conflicts.
- Recommends which priority verification to launch, which broad/risky verification to defer, and when to keep/abandon masked work.
- Provides calm “budget sufficient” and masked states while linking decisions only to exposed provenance/audit/triage/budget signals.

Closes #1262.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test
- git diff --check

Delta: Zeta, la PR est prête pour validation. Tests ciblés intrigue passés et tests complets passés avec `npm test` (688/688); j’attends ta validation avant tout merge.