### PR TITLE
Alpha: resolve overlapping province commitments

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -2181,6 +2181,112 @@ function buildOperationalCommitmentChecklist(operationalPrioritySummary) {
   };
 }
 
+
+function buildCommitmentConflictReason(items, queueEntries) {
+  const blockedItems = items.filter((item) => item.status === 'bloqué');
+  const waitingItems = items.filter((item) => item.status === 'attente');
+  const executableItems = items.filter((item) => item.status === 'engageable' || item.status === 'tenir');
+  const conflictingQueue = queueEntries.find((entry) => entry.status === 'blocked' || entry.status === 'conflict') ?? null;
+  const actionLabels = new Set([...items.map((item) => item.actionLabel), ...queueEntries.map((entry) => entry.actionLabel)]);
+
+  if (blockedItems.length > 0) {
+    const prerequisite = blockedItems[0].prerequisite?.label ?? 'prérequis bloquant';
+    return {
+      conflictType: 'prérequis bloquant',
+      decision: 'bloquer',
+      recommendedAction: `Corriger ${prerequisite}`,
+      tacticalReason: `${blockedItems.length} engagement${blockedItems.length > 1 ? 's' : ''} demandent un prérequis avant résolution.`,
+      remainingRisk: executableItems.length > 0
+        ? `${executableItems.length} option${executableItems.length > 1 ? 's' : ''} exécutable${executableItems.length > 1 ? 's' : ''}, mais le chevauchement reste risqué tant que ${prerequisite} manque.`
+        : `aucune option sûre tant que ${prerequisite} manque`,
+    };
+  }
+
+  if (conflictingQueue) {
+    return {
+      conflictType: 'ordre incompatible',
+      decision: 'remplacer',
+      recommendedAction: conflictingQueue.safeReplacement?.label ?? 'Remplacer par l’action sûre proposée',
+      tacticalReason: conflictingQueue.reason,
+      remainingRisk: conflictingQueue.safeReplacement?.reason ?? 'risque réduit en évitant l’ordre incompatible',
+    };
+  }
+
+  if (actionLabels.size <= 1 && items.length + queueEntries.length > 1) {
+    return {
+      conflictType: 'engagement redondant',
+      decision: 'différer',
+      recommendedAction: items[0]?.actionLabel ?? queueEntries[0]?.actionLabel ?? 'Différer le doublon',
+      tacticalReason: 'plusieurs signaux proposent la même action sur le même front',
+      remainingRisk: 'risque faible: garder un seul engagement actif et relire au prochain tour',
+    };
+  }
+
+  if (waitingItems.length > 0 && executableItems.length > 0) {
+    return {
+      conflictType: 'fenêtre partielle',
+      decision: 'exécuter',
+      recommendedAction: executableItems[0].actionLabel,
+      tacticalReason: `${executableItems[0].provinceLabel} a une option prête pendant que ${waitingItems.length} engagement${waitingItems.length > 1 ? 's' : ''} restent en attente.`,
+      remainingRisk: 'risque maîtrisé si les engagements en attente ne sont pas validés automatiquement',
+    };
+  }
+
+  if (items.length + queueEntries.length > 1 && actionLabels.size > 1) {
+    return {
+      conflictType: 'intentions concurrentes',
+      decision: 'remplacer',
+      recommendedAction: executableItems[0]?.actionLabel ?? items[0]?.actionLabel ?? queueEntries[0]?.actionLabel ?? 'Choisir un seul engagement',
+      tacticalReason: 'plusieurs intentions différentes ciblent la même province ou le même front',
+      remainingRisk: 'risque moyen: choisir une intention et différer les autres',
+    };
+  }
+
+  return null;
+}
+
+function buildOperationalCommitmentConflictResolver(keyboardActionPlanner, operationalCommitmentChecklist) {
+  const queueEntries = keyboardActionPlanner.actionQueueValidation.entries;
+  const provinceIds = [...new Set([
+    ...operationalCommitmentChecklist.checklistItems.map((item) => item.provinceId),
+    ...queueEntries.map((entry) => entry.provinceId),
+  ])];
+
+  const decisions = provinceIds.map((provinceId) => {
+    const commitmentItems = operationalCommitmentChecklist.checklistItems.filter((item) => item.provinceId === provinceId);
+    const provinceQueueEntries = queueEntries.filter((entry) => entry.provinceId === provinceId);
+    const signalCount = commitmentItems.length + provinceQueueEntries.length;
+    if (signalCount <= 1) return null;
+
+    const reason = buildCommitmentConflictReason(commitmentItems, provinceQueueEntries);
+    if (!reason) return null;
+    const provinceLabel = commitmentItems[0]?.provinceLabel ?? provinceQueueEntries[0]?.provinceLabel ?? provinceId;
+
+    return {
+      provinceId,
+      provinceLabel,
+      signalCount,
+      relatedItems: [
+        ...commitmentItems.map((item) => ({ source: 'commitment', label: item.actionLabel, status: item.status })),
+        ...provinceQueueEntries.map((entry) => ({ source: 'queue', label: entry.actionLabel, status: entry.status })),
+      ],
+      keyboardHint: `Focus ${provinceLabel}: ${reason.decision} puis valider ou tabuler vers l’option suivante.`,
+      ...reason,
+    };
+  }).filter(Boolean);
+
+  return {
+    empty: decisions.length === 0,
+    fallbackMessage: decisions.length === 0
+      ? 'Aucun chevauchement de commitment détecté: les engagements peuvent être lus séparément.'
+      : null,
+    decisions,
+    summary: decisions.length === 0
+      ? 'Aucun conflit d’engagement à résoudre.'
+      : `${decisions.length} conflit${decisions.length > 1 ? 's' : ''}: ${decisions.map((decision) => `${decision.decision} ${decision.provinceLabel}`).join(' → ')}`,
+  };
+}
+
 function buildKeyboardActionPlanner(renderedProvinces, options) {
   const activeProvince = renderedProvinces.find(
     (province) => province.selectionState.selected || province.selectionState.focused || province.selectionState.hovered,
@@ -2416,6 +2522,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
   const frontRecoveryRecommendations = buildFrontRecoveryRecommendations(frontPressureReplay);
   const operationalPrioritySummary = buildOperationalPrioritySummary(renderedProvinces, frontPressureReplay, frontRecoveryRecommendations);
   const operationalCommitmentChecklist = buildOperationalCommitmentChecklist(operationalPrioritySummary);
+  const operationalCommitmentConflictResolver = buildOperationalCommitmentConflictResolver(keyboardActionPlanner, operationalCommitmentChecklist);
 
   return {
     title,
@@ -2428,6 +2535,7 @@ export function buildStrategicMapShell(provinces, options = {}) {
     frontRecoveryRecommendations,
     operationalPrioritySummary,
     operationalCommitmentChecklist,
+    operationalCommitmentConflictResolver,
     stats: {
       provinceCount: stats.provinceCount,
       contestedCount: stats.contestedCount,

--- a/src/ui/war/buildStrategicMapPreviewHtml.js
+++ b/src/ui/war/buildStrategicMapPreviewHtml.js
@@ -369,6 +369,32 @@ function renderOperationalCommitmentChecklist(shell) {
   `;
 }
 
+
+function renderOperationalCommitmentConflictResolver(shell) {
+  const resolver = shell.operationalCommitmentConflictResolver;
+  const decisions = resolver.decisions.map((decision) => {
+    const related = decision.relatedItems.map((item) => `${item.source}: ${item.label} (${item.status})`).join(' · ');
+    return `
+      <li class="commitment-resolver-decision commitment-resolver-decision--${escapeHtml(decision.decision)}">
+        <span>${escapeHtml(decision.provinceLabel)} · ${escapeHtml(decision.conflictType)} · ${decision.signalCount} signaux</span>
+        <strong>${escapeHtml(decision.decision)} — ${escapeHtml(decision.recommendedAction)}</strong>
+        <small>${escapeHtml(decision.tacticalReason)}</small>
+        <em>${escapeHtml(decision.remainingRisk)}</em>
+        <kbd>${escapeHtml(decision.keyboardHint)}</kbd>
+        <small>${escapeHtml(related)}</small>
+      </li>
+    `;
+  }).join('');
+
+  return `
+    <section class="commitment-resolver" aria-label="Résolveur de conflits des engagements de province">
+      <h2>Résolveur commitment</h2>
+      <p>${escapeHtml(resolver.fallbackMessage ?? resolver.summary)}</p>
+      ${resolver.empty ? '<small class="commitment-resolver-empty">Aucun conflit d’engagement détecté.</small>' : `<ol>${decisions}</ol>`}
+    </section>
+  `;
+}
+
 function renderProvinceActionQueueValidation(shell) {
   const validation = shell.keyboardActionPlanner.actionQueueValidation;
   const entries = validation.entries.map((entry) => {
@@ -571,6 +597,18 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
     .commitment-risk-summary article > span { color:#93c5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
     .commitment-risk-summary li { display:grid; gap:2px; border:1px solid rgba(148,163,184,0.16); border-radius:10px; padding:6px 8px; }
     .commitment-risk-summary small { color:#cbd5e1; }
+    .commitment-resolver { display:grid; gap:10px; }
+    .commitment-resolver p, .commitment-resolver-empty { margin:0; color:#cbd5e1; font-size:12px; }
+    .commitment-resolver ol { display:grid; gap:6px; margin:0; padding:0; }
+    .commitment-resolver-decision { display:grid; gap:4px; border:1px solid rgba(148,163,184,0.18); border-radius:12px; padding:8px 10px; }
+    .commitment-resolver-decision--exécuter { border-color:rgba(74,222,128,0.44); background:rgba(22,101,52,0.10); }
+    .commitment-resolver-decision--différer { border-color:rgba(251,191,36,0.42); background:rgba(120,53,15,0.10); }
+    .commitment-resolver-decision--remplacer { border-color:rgba(96,165,250,0.44); background:rgba(30,64,175,0.10); }
+    .commitment-resolver-decision--bloquer { border-color:rgba(248,113,113,0.44); background:rgba(127,29,29,0.10); }
+    .commitment-resolver-decision strong { color:#bfdbfe; font-size:12px; }
+    .commitment-resolver-decision small, .commitment-resolver-decision em { color:#cbd5e1; font-size:11px; }
+    .commitment-resolver-decision em { font-style:normal; color:#bae6fd; }
+    .commitment-resolver-decision kbd { justify-self:start; border:1px solid rgba(148,163,184,0.24); border-radius:8px; padding:3px 6px; color:#fde68a; background:rgba(15,23,42,0.52); font-size:11px; }
     table { width:100%; border-collapse:collapse; font-size:13px; }
     th, td { padding:10px 8px; border-bottom:1px solid rgba(148, 163, 184, 0.14); text-align:left; }
     th { color:#93c5fd; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; }
@@ -620,6 +658,7 @@ export function buildStrategicMapPreviewHtml(generatedMap, options = {}) {
         ${renderFrontRecoveryRecommendations(shell)}
         ${renderOperationalPrioritySummary(shell)}
         ${renderOperationalCommitmentChecklist(shell)}
+        ${renderOperationalCommitmentConflictResolver(shell)}
         <section>
           <h2>Lecture</h2>
           <ul>

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -305,6 +305,12 @@ test('StrategicMapShell sorts provinces, derives headline stats and exposes over
     ],
     summary: '0 prêt · 1 en attente · 0 bloqué',
   });
+  assert.deepEqual(shell.operationalCommitmentConflictResolver, {
+    empty: true,
+    fallbackMessage: 'Aucun chevauchement de commitment détecté: les engagements peuvent être lus séparément.',
+    decisions: [],
+    summary: 'Aucun conflit d’engagement à résoudre.',
+  });
   assert.deepEqual(shell.stats, {
     provinceCount: 2,
     contestedCount: 1,
@@ -474,6 +480,29 @@ test('StrategicMapShell validates province action queues and suggests a safe rep
       label: 'Garder en réserve',
       reason: 'attendre résolution du blocage',
     },
+  });
+  assert.deepEqual(shell.operationalCommitmentConflictResolver, {
+    empty: false,
+    fallbackMessage: null,
+    decisions: [
+      {
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        signalCount: 3,
+        relatedItems: [
+          { source: 'commitment', label: 'Surveiller le front', status: 'attente' },
+          { source: 'queue', label: 'Avancer après front instable', status: 'ready' },
+          { source: 'queue', label: 'Rejouer même cible', status: 'conflict' },
+        ],
+        keyboardHint: 'Focus Front rouge: remplacer puis valider ou tabuler vers l’option suivante.',
+        conflictType: 'ordre incompatible',
+        decision: 'remplacer',
+        recommendedAction: 'Renforcer le front',
+        tacticalReason: 'cible déjà engagée',
+        remainingRisk: 'front contesté et pression militaire visible',
+      },
+    ],
+    summary: '1 conflit: remplacer Front rouge',
   });
 });
 
@@ -846,6 +875,29 @@ test('StrategicMapShell builds a scrub-ready front pressure timeline replay', ()
       },
     ],
     summary: '1 prêt · 0 en attente · 2 bloqué',
+  });
+  assert.deepEqual(shell.operationalCommitmentConflictResolver, {
+    empty: false,
+    fallbackMessage: null,
+    decisions: [
+      {
+        provinceId: 'front',
+        provinceLabel: 'Front rouge',
+        signalCount: 3,
+        relatedItems: [
+          { source: 'commitment', label: 'Consolider le soutien', status: 'bloqué' },
+          { source: 'commitment', label: 'Renforcer le front', status: 'bloqué' },
+          { source: 'commitment', label: 'Sonder prudemment la brèche', status: 'engageable' },
+        ],
+        keyboardHint: 'Focus Front rouge: bloquer puis valider ou tabuler vers l’option suivante.',
+        conflictType: 'prérequis bloquant',
+        decision: 'bloquer',
+        recommendedAction: 'Corriger soutien adjacent à rétablir',
+        tacticalReason: '2 engagements demandent un prérequis avant résolution.',
+        remainingRisk: '1 option exécutable, mais le chevauchement reste risqué tant que soutien adjacent à rétablir manque.',
+      },
+    ],
+    summary: '1 conflit: bloquer Front rouge',
   });
 });
 

--- a/test/ui/war/buildStrategicMapPreviewHtml.test.js
+++ b/test/ui/war/buildStrategicMapPreviewHtml.test.js
@@ -54,6 +54,11 @@ test('buildStrategicMapPreviewHtml renders a screenshot-ready preview from the g
   assert.match(html, /Risques bloquants/);
   assert.match(html, /soutien adjacent à rétablir/);
   assert.match(html, /peut être engagé maintenant/);
+  assert.match(html, /Résolveur de conflits des engagements de province/);
+  assert.match(html, /Résolveur commitment/);
+  assert.match(html, /prérequis bloquant/);
+  assert.match(html, /Corriger soutien adjacent à rétablir/);
+  assert.match(html, /Focus Porte du Fleuve/);
   assert.match(html, /class="province is-contested is-occupied is-selected is-queued is-recently-affected"/);
   assert.match(html, /tabindex="0"/);
   assert.match(html, /Porte du Fleuve/);


### PR DESCRIPTION
Alpha: Implements #1259.

Summary:
- adds an operational commitment conflict resolver for overlapping province commitments and queued orders
- detects incompatible, redundant, blocked, and partial-window overlaps on the same province/front
- recommends execute, defer, replace, or block with tactical reason, remaining risk, related signals, and keyboard hint
- renders an accessible resolver panel in the strategic map preview with a clear empty state

Tests:
- npm test -- test/ui/war/StrategicMapShell.test.js test/ui/war/buildStrategicMapPreviewHtml.test.js
- npm test
- git diff --check

Zeta: ready for validation before merge.
