### PR TITLE
Epsilon: add climate rebound preview after action bundles

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1863,11 +1863,91 @@ function describeClimateBundleReason(kind, viability, conflicts) {
   return 'déconseillé: reporter évite de sur-vendre une fenêtre contradictoire ou trop risquée';
 }
 
+function describeClimateBundleExpectedEffect(bundle) {
+  if (bundle.kind === 'secure-now') {
+    return bundle.viability === 'viable'
+      ? 'pression climatique abaissée immédiatement sans rouvrir de conflit majeur'
+      : 'pression abaissée mais fenêtre encore sensible aux arbitrages de ressources';
+  }
+
+  if (bundle.kind === 'prepare') {
+    return 'readiness renforcée avant engagement direct, sans répéter le calendrier saisonnier';
+  }
+
+  if (bundle.kind === 'monitor') {
+    return 'surveillance maintenue: pas de dépense lourde tant que le signal reste stable';
+  }
+
+  return 'intervention différée: évite de verrouiller une fenêtre trop contradictoire';
+}
+
+function buildClimateBundleAfterActionPreview(bundle) {
+  const conflicts = new Set(bundle.resourceConflicts);
+  const reboundRegionIds = conflicts.has('residual-risk') || conflicts.has('window-timing') || bundle.viability !== 'viable'
+    ? bundle.regionIds
+    : [];
+  const coolingOffTurns = bundle.kind === 'secure-now'
+    ? (bundle.viability === 'viable' ? 1 : 2)
+    : bundle.kind === 'prepare'
+      ? 2
+      : bundle.kind === 'monitor'
+        ? 1
+        : 3;
+  const coolingOffState = bundle.viability === 'viable'
+    ? 'observe-next-turn'
+    : bundle.viability === 'fragile'
+      ? 'verify-before-reintervention'
+      : 'do-not-reintervene';
+  const minimalAction = bundle.kind === 'secure-now'
+    ? 'garder une réserve locale et relire les marqueurs de rebond au tour suivant'
+    : bundle.kind === 'prepare'
+      ? 'sécuriser une readiness minimale avant toute mitigation supplémentaire'
+      : bundle.kind === 'monitor'
+        ? 'poser une veille légère et n’agir que si le risque remonte'
+        : 'ne rien empiler: attendre une fenêtre moins contradictoire';
+
+  return {
+    expectedEffect: describeClimateBundleExpectedEffect(bundle),
+    coolingOffTurns,
+    coolingOffState,
+    reboundRisk: reboundRegionIds.length > 0 ? (bundle.viability === 'discouraged' ? 'high' : 'probable') : 'low',
+    reboundRegionIds,
+    minimalAction,
+    summary: reboundRegionIds.length > 0
+      ? `${coolingOffTurns} tour(s) de cooling-off; rebond probable sur ${reboundRegionIds.join(', ')}.`
+      : `${coolingOffTurns} tour(s) de cooling-off; aucun rebond régional probable si la réserve reste disponible.`,
+  };
+}
+
+function normalizeClimateBundleAfterActionPreview(preview, basePreview) {
+  if (preview === undefined) {
+    return basePreview;
+  }
+
+  const normalizedPreview = requireObject(preview, 'ClimateMapOverlay climateActionBundle afterActionPreview');
+
+  return {
+    ...basePreview,
+    ...normalizedPreview,
+    expectedEffect: String(normalizedPreview.expectedEffect ?? basePreview.expectedEffect).trim(),
+    coolingOffTurns: Number.isFinite(normalizedPreview.coolingOffTurns) && normalizedPreview.coolingOffTurns >= 0
+      ? normalizedPreview.coolingOffTurns
+      : basePreview.coolingOffTurns,
+    coolingOffState: String(normalizedPreview.coolingOffState ?? basePreview.coolingOffState).trim(),
+    reboundRisk: String(normalizedPreview.reboundRisk ?? basePreview.reboundRisk).trim(),
+    reboundRegionIds: requireArray(
+      normalizedPreview.reboundRegionIds ?? basePreview.reboundRegionIds,
+      'ClimateMapOverlay climateActionBundle afterActionPreview reboundRegionIds',
+    ).map((regionId) => String(regionId).trim()).filter(Boolean),
+    minimalAction: String(normalizedPreview.minimalAction ?? basePreview.minimalAction).trim(),
+    summary: String(normalizedPreview.summary ?? basePreview.summary).trim(),
+  };
+}
+
 function normalizeClimateBundleOverride(override, baseBundle) {
   const kind = String(override.kind ?? override.bundleKind ?? baseBundle.kind).trim().toLowerCase();
   const viability = String(override.viability ?? baseBundle.viability).trim().toLowerCase();
-
-  return {
+  const normalizedBundle = {
     ...baseBundle,
     ...override,
     bundleId: String(override.bundleId ?? baseBundle.bundleId).trim(),
@@ -1885,6 +1965,14 @@ function normalizeClimateBundleOverride(override, baseBundle) {
     ).map((conflict) => String(conflict).trim()).filter(Boolean),
     reason: String(override.reason ?? baseBundle.reason).trim(),
     confidenceNote: String(override.confidenceNote ?? baseBundle.confidenceNote).trim(),
+  };
+
+  return {
+    ...normalizedBundle,
+    afterActionPreview: normalizeClimateBundleAfterActionPreview(
+      override.afterActionPreview,
+      buildClimateBundleAfterActionPreview(normalizedBundle),
+    ),
   };
 }
 
@@ -1929,9 +2017,13 @@ function buildClimateActionBundleAssistant(climatePrioritySummary, normalizedOpt
         ? 'prudence: au moins une prévision reste incertaine'
         : 'confiance cohérente avec les prévisions disponibles',
     };
+    const baseBundleWithPreview = {
+      ...baseBundle,
+      afterActionPreview: buildClimateBundleAfterActionPreview(baseBundle),
+    };
     const override = explicitBundles.find((bundle) => (bundle.kind ?? bundle.bundleKind ?? baseBundle.kind) === kind);
 
-    return override ? normalizeClimateBundleOverride(override, baseBundle) : baseBundle;
+    return override ? normalizeClimateBundleOverride(override, baseBundleWithPreview) : baseBundleWithPreview;
   }).sort((left, right) => {
     const rank = { 'secure-now': 0, prepare: 1, monitor: 2, postpone: 3 };
 

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -2293,6 +2293,82 @@ test('buildClimateMapOverlay supports explicit prudent climate bundle overrides'
       resourceConflicts: ['reserve', 'window-timing', 'residual-risk'],
       reason: 'ne pas combiner avec une reprise agricole ce tour',
       confidenceNote: 'prudence maintenue malgré confiance probable',
+      afterActionPreview: {
+        expectedEffect: 'intervention différée: évite de verrouiller une fenêtre trop contradictoire',
+        coolingOffTurns: 3,
+        coolingOffState: 'do-not-reintervene',
+        reboundRisk: 'high',
+        reboundRegionIds: ['delta'],
+        minimalAction: 'ne rien empiler: attendre une fenêtre moins contradictoire',
+        summary: '3 tour(s) de cooling-off; rebond probable sur delta.',
+      },
     },
   ]);
+});
+
+test('buildClimateMapOverlay previews rebound and cooling-off after prudent climate bundles', () => {
+  const overlay = buildClimateMapOverlay([
+    { regionId: 'delta', season: 'spring', temperatureC: 18, precipitationLevel: 70, droughtIndex: 12 },
+    { regionId: 'ridge', season: 'spring', temperatureC: 29, precipitationLevel: 18, droughtIndex: 68, anomaly: 'drought' },
+  ], {
+    climateAftermathEvents: [
+      {
+        eventId: 'delta-ready',
+        regionId: 'delta',
+        observedImpact: 'route stabilisée',
+        severity: 'minor',
+        appliedMitigation: 'digues inspectées',
+        confidenceBand: 'probable',
+        resilienceState: 'resilient',
+      },
+      {
+        eventId: 'ridge-risk',
+        regionId: 'ridge',
+        observedImpact: 'sols fragiles',
+        severity: 'moderate',
+        missingMitigation: 'réservoir non renforcé',
+        confidenceBand: 'uncertain',
+        resilienceState: 'strained',
+      },
+    ],
+    climateSafeWindows: [
+      {
+        aftermathEventId: 'delta-ready',
+        windowId: 'delta-ready:now',
+        label: 'tour actuel',
+        state: 'safe',
+        affectedRegionIds: ['delta'],
+        confidenceBand: 'probable',
+      },
+      {
+        aftermathEventId: 'ridge-risk',
+        windowId: 'ridge-risk:later',
+        label: 'prochain tour',
+        state: 'safe',
+        affectedRegionIds: ['ridge'],
+        confidenceBand: 'uncertain',
+      },
+    ],
+  });
+
+  const [secureNowBundle, prepareBundle] = overlay.climateActionBundleAssistant.bundles;
+
+  assert.deepEqual(secureNowBundle.afterActionPreview, {
+    expectedEffect: 'pression climatique abaissée immédiatement sans rouvrir de conflit majeur',
+    coolingOffTurns: 1,
+    coolingOffState: 'observe-next-turn',
+    reboundRisk: 'low',
+    reboundRegionIds: [],
+    minimalAction: 'garder une réserve locale et relire les marqueurs de rebond au tour suivant',
+    summary: '1 tour(s) de cooling-off; aucun rebond régional probable si la réserve reste disponible.',
+  });
+  assert.deepEqual(prepareBundle.afterActionPreview, {
+    expectedEffect: 'readiness renforcée avant engagement direct, sans répéter le calendrier saisonnier',
+    coolingOffTurns: 2,
+    coolingOffState: 'verify-before-reintervention',
+    reboundRisk: 'probable',
+    reboundRegionIds: ['ridge'],
+    minimalAction: 'sécuriser une readiness minimale avant toute mitigation supplémentaire',
+    summary: '2 tour(s) de cooling-off; rebond probable sur ridge.',
+  });
 });

--- a/test/ui/climate/webAtlasClimateReboundAfterActionBundle.test.js
+++ b/test/ui/climate/webAtlasClimateReboundAfterActionBundle.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas renders post-bundle climate rebound preview after the safe recovery commitment', () => {
+  assert.match(webAppSource, /buildAtlasClimateReboundAfterActionBundle/);
+  assert.match(webAppSource, /renderAtlasClimateReboundAfterActionBundle/);
+  assert.match(webAppSource, /Après bundle climat/);
+  assert.match(webAppSource, /cooling-off/);
+  assert.match(webAppSource, /Rebond probable/);
+  assert.match(webAppSource, /Action minimale/);
+  assert.match(webAppSource, /renderAtlasClimateCheapestSafeRecoveryCommitment\(atlasClimateCheapestSafeRecoveryCommitment\)\}\s*\$\{renderAtlasClimateReboundAfterActionBundle\(atlasClimateReboundAfterActionBundle\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-post-bundle-rebound/);
+  assert.match(stylesSource, /\.map-world-climate-post-bundle-rebound--risky/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -10587,6 +10587,67 @@ function buildAtlasClimateCheapestSafeRecoveryCommitment(recoveryProjectionView)
   };
 }
 
+function buildAtlasClimateReboundAfterActionBundle(view) {
+  if (!view || view.state === 'neutral' || !view.cheapestSafeCommitment) {
+    return {
+      state: 'empty',
+      summary: 'Aucun bundle climatique actif à prévisualiser après action.',
+      reboundProvinceLabels: [],
+    };
+  }
+
+  const commitment = view.cheapestSafeCommitment;
+  const rebound = view.climateRiskReboundAfterTopPayoff ?? null;
+  const reboundProvinceLabels = [commitment.deadlineCovered, ...(view.nextClimateCommitment?.remainsAfterCommitment ?? [])]
+    .filter(Boolean)
+    .filter((label, index, all) => all.indexOf(label) === index)
+    .slice(0, 3);
+  const coolingOffTurns = view.remainingDeadlinePressure?.state === 'clear'
+    ? 1
+    : view.remainingDeadlinePressure?.deadlineStillThreatened
+      ? 2
+      : 1;
+  const reboundRisk = rebound?.state === 'rebound-likely' || view.remainingDeadlinePressure?.deadlineStillThreatened
+    ? 'probable'
+    : reboundProvinceLabels.length > 1
+      ? 'watch'
+      : 'low';
+
+  return {
+    state: reboundRisk === 'probable' ? 'risky' : 'ready',
+    bundleLabel: commitment.action,
+    expectedEffect: `${commitment.pressureReduced}; ${commitment.safeBecause}`,
+    coolingOffTurns,
+    coolingOffState: coolingOffTurns > 1 ? 'vérifier avant réintervention' : 'observer le prochain tour',
+    reboundRisk,
+    reboundProvinceLabels,
+    minimalAction: view.safestClimateFollowThroughAfterDeadlineTradeoff?.recommendation
+      ?? view.remainingDeadlinePressure?.nextAction
+      ?? 'Garder une réserve minimale et relire la fenêtre avant toute nouvelle action.',
+    summary: `Après bundle: ${coolingOffTurns} tour(s) de cooling-off, risque de rebond ${reboundRisk}${reboundProvinceLabels.length > 0 ? ` sur ${reboundProvinceLabels.join(' → ')}` : ''}.`,
+  };
+}
+
+function renderAtlasClimateReboundAfterActionBundle(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <aside class="map-world-climate-post-bundle-rebound map-world-climate-post-bundle-rebound--${view.state}" aria-label="Aperçu rebond climat après bundle d’action prudent">
+      <div class="map-world-climate-post-bundle-rebound__header">
+        <strong>Après bundle climat</strong>
+        <span>${view.coolingOffTurns} tour(s) cooling-off</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Effet attendu</b> · ${view.expectedEffect}</small>
+      <small><b>État cooling-off</b> · ${view.coolingOffState}</small>
+      <small><b>Rebond probable</b> · ${view.reboundProvinceLabels.length > 0 ? view.reboundProvinceLabels.join(' → ') : 'aucune province prioritaire'}</small>
+      <small><b>Action minimale</b> · ${view.minimalAction}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'neutral' || !view.cheapestSafeCommitment) {
     return '';
@@ -18511,6 +18572,7 @@ function render() {
   const atlasClimateFirstRecoveryPressureReliefExplanation = buildAtlasClimateFirstRecoveryPressureReliefExplanation(atlasClimateRecoveryCollateralReliefRanking);
   const atlasClimateRecoveryPlanProjection = buildAtlasClimateRecoveryPlanProjection(atlasClimateFirstRecoveryPressureReliefExplanation, atlasClimateRecoveryCollateralReliefRanking);
   const atlasClimateCheapestSafeRecoveryCommitment = buildAtlasClimateCheapestSafeRecoveryCommitment(atlasClimateRecoveryPlanProjection);
+  const atlasClimateReboundAfterActionBundle = buildAtlasClimateReboundAfterActionBundle(atlasClimateCheapestSafeRecoveryCommitment);
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -18560,6 +18622,7 @@ function render() {
           ${renderAtlasClimateFirstRecoveryPressureReliefExplanation(atlasClimateFirstRecoveryPressureReliefExplanation)}
           ${renderAtlasClimateRecoveryPlanProjection(atlasClimateRecoveryPlanProjection)}
           ${renderAtlasClimateCheapestSafeRecoveryCommitment(atlasClimateCheapestSafeRecoveryCommitment)}
+          ${renderAtlasClimateReboundAfterActionBundle(atlasClimateReboundAfterActionBundle)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12396,6 +12396,31 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+.map-world-climate-post-bundle-rebound {
+  display: grid;
+  gap: 6px;
+  max-width: 56ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(12, 74, 110, 0.76), rgba(113, 63, 18, 0.24));
+  border: 1px solid rgba(125, 211, 252, 0.44);
+}
+.map-world-climate-post-bundle-rebound--risky { border-color: rgba(251, 191, 36, 0.54); }
+.map-world-climate-post-bundle-rebound__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-post-bundle-rebound p,
+.map-world-climate-post-bundle-rebound span,
+.map-world-climate-post-bundle-rebound small {
+  color: #e0f2fe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
 
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);


### PR DESCRIPTION
Epsilon: Implements #1263.

## Summary
- adds after-action preview data to prudent climate bundles: expected effect, cooling-off duration/state, rebound risk regions, and minimal securing action
- renders the atlas post-bundle rebound card after the minimal safe climate recovery commitment
- adds CSS and coverage for the new preview

## Tests
- npm test -- --test-reporter=spec test/ui/climate/buildClimateMapOverlay.test.js test/ui/climate/webAtlasClimateReboundAfterActionBundle.test.js
- npm test
