### PR TITLE
Alpha: Add MAP-A11 commitment conflict resolver

### DIFF
--- a/test/ui/war/webAtlasMilitaryCommitmentConflictResolver.test.js
+++ b/test/ui/war/webAtlasMilitaryCommitmentConflictResolver.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military commitment conflict resolver combines commitments orders and recovery warnings', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryCommitmentConflictResolver\(commitment, commitmentConflicts, commitmentCoverage, commitmentPriority, commitmentWarnings\)/);
+  assert.match(webAppSource, /pickAtlasMilitaryResolverSource\(commitmentConflicts, commitmentPriority, commitmentWarnings\)/);
+  assert.match(webAppSource, /ordre de province ou suivi de récupération/);
+  assert.match(webAppSource, /renderAtlasMilitaryCommitmentConflictResolver\(commitmentResolver\)/);
+});
+
+test('atlas military commitment conflict resolver recommends execute defer replace or block', () => {
+  assert.match(webAppSource, /decision: 'exécuter'/);
+  assert.match(webAppSource, /decision: 'différer'/);
+  assert.match(webAppSource, /decision: 'remplacer'/);
+  assert.match(webAppSource, /decision: 'bloquer'/);
+  assert.match(webAppSource, /risque restant: aucun conflit visible/);
+  assert.match(webAppSource, /Décision recommandée \$\{recommendation\.decision\}/);
+});
+
+test('atlas military commitment conflict resolver renders accessible readable states', () => {
+  assert.match(webAppSource, /Résolveur des engagements militaires superposés/);
+  assert.match(webAppSource, /data-atlas-commitment-resolver/);
+  assert.match(webAppSource, /atlas-military-commitment-resolver__empty/);
+  assert.match(stylesSource, /\.atlas-military-commitment-resolver__panel/);
+  assert.match(stylesSource, /\.atlas-military-resolver-row--block rect/);
+  assert.match(stylesSource, /\.atlas-military-resolver-row--execute rect/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1470,6 +1470,114 @@ function renderAtlasMilitaryCommitmentNextTurnWarnings(warningSummary) {
 }
 
 
+
+function pickAtlasMilitaryResolverSource(commitmentConflicts, commitmentPriority, commitmentWarnings) {
+  const blockingWarning = (commitmentWarnings?.warnings ?? [])
+    .find((warning) => warning.tone === 'critical' || warning.debtTone === 'absent') ?? null;
+  if (blockingWarning) {
+    return {
+      decision: 'bloquer',
+      tone: 'block',
+      label: blockingWarning.label,
+      reason: `${blockingWarning.frontRoute} reste exposé: ${blockingWarning.degradation}`,
+      risk: blockingWarning.action,
+      priority: blockingWarning.urgencyScore,
+    };
+  }
+
+  const replacementConflict = (commitmentConflicts?.conflicts ?? [])
+    .find((conflict) => conflict.severity === 'haute') ?? null;
+  if (replacementConflict) {
+    return {
+      decision: 'remplacer',
+      tone: 'replace',
+      label: replacementConflict.provinceLabel,
+      reason: replacementConflict.explanation,
+      risk: replacementConflict.decision,
+      priority: replacementConflict.priority,
+    };
+  }
+
+  const delayConflict = (commitmentConflicts?.conflicts ?? [])
+    .find((conflict) => conflict.label.includes('stabilisée')) ?? null;
+  if (delayConflict) {
+    return {
+      decision: 'différer',
+      tone: 'defer',
+      label: delayConflict.provinceLabel,
+      reason: delayConflict.explanation,
+      risk: delayConflict.decision,
+      priority: delayConflict.priority,
+    };
+  }
+
+  const topPriority = (commitmentPriority?.priorities ?? [])[0] ?? null;
+  if (topPriority && topPriority.tone === 'high') {
+    return {
+      decision: 'différer',
+      tone: 'defer',
+      label: topPriority.label,
+      reason: topPriority.reason,
+      risk: `risque restant: ${topPriority.delayLabel}`,
+      priority: topPriority.urgencyScore,
+    };
+  }
+
+  return null;
+}
+
+function buildAtlasMilitaryCommitmentConflictResolver(commitment, commitmentConflicts, commitmentCoverage, commitmentPriority, commitmentWarnings) {
+  if (!commitment || commitment.empty || !commitment.stages.length) {
+    return {
+      recommendations: [],
+      summary: 'Aucun conflit: aucun engagement, ordre de province ou suivi de récupération préparé.',
+      empty: true,
+    };
+  }
+
+  const source = pickAtlasMilitaryResolverSource(commitmentConflicts, commitmentPriority, commitmentWarnings);
+  const targetLabel = commitment.selectedOption?.targetProvinceLabel ?? commitment.selectedOption?.target ?? 'province ciblée';
+  const fallback = {
+    decision: 'exécuter',
+    tone: 'execute',
+    label: targetLabel,
+    reason: `${targetLabel} reste cohérente avec ${commitment.stages.length} étape${commitment.stages.length > 1 ? 's' : ''} préparée${commitment.stages.length > 1 ? 's' : ''}.`,
+    risk: (commitmentCoverage?.uncoveredFronts?.length ?? 0) > 0
+      ? `risque restant: ${commitmentCoverage.uncoveredFronts[0].label} à surveiller`
+      : 'risque restant: aucun conflit visible',
+    priority: 36,
+  };
+
+  const recommendation = source ?? fallback;
+  return {
+    recommendations: [{
+      resolverId: `resolver:${recommendation.decision}:${recommendation.label}`,
+      ...recommendation,
+    }],
+    summary: `${recommendation.decision}: ${recommendation.reason}; ${recommendation.risk}.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryCommitmentConflictResolver(resolver) {
+  const height = resolver.empty ? 8 : 8 + (resolver.recommendations.length * 5.2);
+  return `
+    <g class="atlas-military-commitment-resolver" aria-label="Résolveur des engagements militaires superposés: ${resolver.summary}">
+      <rect class="atlas-military-commitment-resolver__panel" x="3" y="44" width="38" height="${height}" rx="2.4"></rect>
+      <text class="atlas-military-commitment-resolver__title" x="5" y="47.4">Résolveur engagements</text>
+      ${resolver.empty ? `<text class="atlas-military-commitment-resolver__empty" x="5" y="50.8">${resolver.summary}</text>` : resolver.recommendations.map((recommendation, index) => `
+        <g class="atlas-military-resolver-row atlas-military-resolver-row--${recommendation.tone}" data-atlas-commitment-resolver="${recommendation.resolverId}" aria-label="Décision recommandée ${recommendation.decision}: ${recommendation.reason}; ${recommendation.risk}">
+          <rect x="5" y="${49.4 + index * 5.2}" width="4.9" height="3.2" rx="0.9"></rect>
+          <text class="atlas-military-resolver-row__decision" x="11" y="${50.5 + index * 5.2}">${recommendation.decision} · ${recommendation.label}</text>
+          <text class="atlas-military-resolver-row__reason" x="11" y="${52.1 + index * 5.2}">${recommendation.reason}</text>
+          <text class="atlas-military-resolver-row__risk" x="11" y="${53.7 + index * 5.2}">${recommendation.risk}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
+
 function getAtlasMilitaryWarningDegradationScore(warning) {
   if (warning.debtTone === 'absent') return 24;
   if (warning.debtTone === 'threat') return 18;
@@ -2434,6 +2542,7 @@ function renderAtlasMilitaryLayer(shell) {
   const commitmentDebt = buildAtlasMilitaryCommitmentDebtSummary(commitmentCoverage, stagedCommitment, shell);
   const commitmentPriority = buildAtlasMilitaryCommitmentDebtPriorities(commitmentDebt, commitmentCoverage, stagedCommitment);
   const commitmentWarnings = buildAtlasMilitaryCommitmentNextTurnWarnings(commitmentPriority, commitmentDebt, commitmentCoverage, stagedCommitment);
+  const commitmentResolver = buildAtlasMilitaryCommitmentConflictResolver(stagedCommitment, commitmentConflicts, commitmentCoverage, commitmentPriority, commitmentWarnings);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -2465,6 +2574,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryCommitmentDebtSummary(commitmentDebt)}
       ${renderAtlasMilitaryCommitmentDebtPriorities(commitmentPriority)}
       ${renderAtlasMilitaryCommitmentNextTurnWarnings(commitmentWarnings)}
+      ${renderAtlasMilitaryCommitmentConflictResolver(commitmentResolver)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -10819,6 +10819,7 @@ button { font: inherit; }
 .atlas-military-commitment-priority,
 .atlas-military-commitment-warning,
 .atlas-military-warning-stack,
+.atlas-military-commitment-resolver,
 .atlas-military-warning-relief,
 .atlas-military-best-order,
 .atlas-military-fallback-order,
@@ -12500,3 +12501,38 @@ button { font: inherit; }
 .province-node__action-affordance--available { border-color: rgba(74, 222, 128, 0.42); color: #bbf7d0; }
 .province-node__action-affordance--discouraged,
 .province-node__action-affordance--blocked { border-color: rgba(251, 191, 36, 0.48); color: #fde68a; }
+
+.atlas-military-commitment-resolver__panel {
+  fill: rgba(49, 46, 129, 0.78);
+  stroke: rgba(165, 180, 252, 0.42);
+  stroke-width: 0.35;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-commitment-resolver__title,
+.atlas-military-resolver-row text,
+.atlas-military-commitment-resolver__empty {
+  fill: #e0e7ff;
+  font-size: 1.12px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.88);
+  stroke-width: 0.32;
+}
+.atlas-military-resolver-row rect {
+  fill: rgba(129, 140, 248, 0.68);
+  stroke: rgba(224, 231, 255, 0.78);
+  stroke-width: 0.22;
+}
+.atlas-military-resolver-row--execute rect { fill: rgba(74, 222, 128, 0.78); }
+.atlas-military-resolver-row--defer rect { fill: rgba(251, 191, 36, 0.78); }
+.atlas-military-resolver-row--replace rect { fill: rgba(168, 85, 247, 0.76); }
+.atlas-military-resolver-row--block rect { fill: rgba(248, 113, 113, 0.88); }
+.atlas-military-resolver-row__reason {
+  fill: #c7d2fe;
+  font-size: 0.82px;
+}
+.atlas-military-resolver-row__risk,
+.atlas-military-commitment-resolver__empty {
+  fill: #fde68a;
+  font-size: 0.8px;
+}


### PR DESCRIPTION
Alpha: Implements #1259.

Summary:
- adds an aggregate resolver for overlapping staged commitments, province orders, and recovery warnings
- surfaces recommended decisions: exécuter, différer, remplacer, or bloquer, with tactical reason and remaining risk
- adds accessible SVG labels, empty-state copy, and MAP-consistent styling

Tests:
- node --test test/ui/war/webAtlasMilitaryCommitmentConflictResolver.test.js
- npm test

Ready for Zeta review.