### PR TITLE
Beta: Add logistics recovery debt ledger

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2018,7 +2018,7 @@ function getRecoveryBudgetCost(entry, routeFeature) {
     return { stock: 1, convoy: 1, labor: base, routeTime: option?.estimatedDelayTurns ?? 1, portCapacity: routeFeature.transportMode === 'sea' ? 1 : 0, relay: 1 };
   }
 
-  return { stock: 0, convoy: 1, labor: 0, routeTime: 0, portCapacity: 0, relay: 0 };
+  return { stock: 0, convoy: 0, labor: 0, routeTime: 0, portCapacity: 0, relay: 0 };
 }
 
 function getRecoveryBudgetGroup(cost, available, entry) {
@@ -2123,6 +2123,126 @@ function buildRecoveryCapacityBudget(logisticsFeatures, atRiskRecoverySummary) {
   };
 }
 
+
+function getRecoveryDebtStatus(costTotal, availableTotal, overloads = []) {
+  if (overloads.length > 0 || costTotal > availableTotal) {
+    return 'en dette';
+  }
+
+  if (costTotal >= Math.max(1, availableTotal - 1)) {
+    return 'à la limite';
+  }
+
+  return 'sous capacité';
+}
+
+function getRecoveryDebtTone(status) {
+  return status === 'en dette' ? 'critical' : status === 'à la limite' ? 'warning' : 'positive';
+}
+
+function getRecoveryDebtNextAction(status, entry, routeFeature) {
+  if (status === 'sous capacité') {
+    return 'continuer la reprise prévue';
+  }
+
+  if (entry.overloads.some((overload) => overload.resource === 'stock')) {
+    return 'ajouter du stock avant le prochain bundle';
+  }
+
+  if (entry.overloads.some((overload) => overload.resource === 'convoy')) {
+    return 'réserver un convoi prioritaire';
+  }
+
+  if (entry.overloads.some((overload) => overload.resource === 'labor')) {
+    return 'détacher une équipe de réparation';
+  }
+
+  if (routeFeature?.transportMode === 'sea' && entry.overloads.some((overload) => overload.resource === 'portCapacity')) {
+    return 'libérer de la capacité portuaire';
+  }
+
+  return status === 'en dette' ? 'séquencer la reprise sur un tour de plus' : 'garder une réserve de capacité';
+}
+
+function buildRecoveryDebtLedger(logisticsFeatures, recoveryCapacityBudget) {
+  const entries = recoveryCapacityBudget.entries.map((entry) => {
+    const routeFeature = logisticsFeatures.find((feature) => feature.routeId === entry.targetId) ?? null;
+    const costTotal = Object.values(entry.cost).reduce((sum, value) => sum + value, 0);
+    const availableTotal = Object.keys(entry.cost).reduce((sum, key) => sum + (recoveryCapacityBudget.available[key] ?? 0), 0);
+    const remainingCapacity = availableTotal - costTotal;
+    const debtAmount = entry.overloads.reduce((sum, overload) => sum + overload.overBy, Math.max(0, -remainingCapacity));
+    const status = getRecoveryDebtStatus(costTotal, availableTotal, entry.overloads);
+    const nextAction = getRecoveryDebtNextAction(status, entry, routeFeature);
+    const corridor = routeFeature?.cityIds?.length > 1 ? routeFeature.cityIds.join(' → ') : routeFeature?.cityIds?.[0] ?? entry.targetId;
+
+    return {
+      id: `recovery-debt:${entry.targetId}`,
+      targetType: 'route',
+      targetId: entry.targetId,
+      label: routeFeature?.label ?? entry.targetId,
+      routeId: entry.targetId,
+      cityIds: routeFeature?.cityIds ?? [],
+      corridor,
+      linkedRiskEntryId: entry.linkedRiskEntryId,
+      linkedBudgetEntryId: entry.id,
+      linkedCheckpointId: entry.linkedCheckpointId,
+      linkedOptionId: entry.linkedOptionId,
+      action: entry.action,
+      status,
+      tone: getRecoveryDebtTone(status),
+      costTotal,
+      availableTotal,
+      remainingCapacity,
+      debtAmount,
+      debtResources: entry.overloads.map((overload) => overload.resource),
+      nextAction,
+      justification: status === 'en dette'
+        ? `${routeFeature?.label ?? entry.targetId}: ${entry.action} dépasse ${entry.overloads.map((overload) => overload.resource).join(', ') || 'la capacité'}; ${nextAction} réduit la dette restante.`
+        : status === 'à la limite'
+          ? `${routeFeature?.label ?? entry.targetId}: ${entry.action} laisse ${remainingCapacity} marge; ${nextAction} évite de recréer une dette.`
+          : `${routeFeature?.label ?? entry.targetId}: ${entry.action} laisse ${remainingCapacity} marge après checkpoints; impact sous contrôle.`,
+    };
+  }).sort((left, right) => {
+    const rank = { 'en dette': 0, 'à la limite': 1, 'sous capacité': 2 };
+
+    return rank[left.status] - rank[right.status]
+      || right.debtAmount - left.debtAmount
+      || left.label.localeCompare(right.label);
+  });
+  const totals = entries.reduce((sum, entry) => ({
+    cost: sum.cost + entry.costTotal,
+    available: sum.available + entry.availableTotal,
+    debt: sum.debt + entry.debtAmount,
+  }), { cost: 0, available: 0, debt: 0 });
+  const debtEntries = entries.filter((entry) => entry.status === 'en dette');
+  const limitEntries = entries.filter((entry) => entry.status === 'à la limite');
+  const status = debtEntries.length > 0 ? 'en dette' : limitEntries.length > 0 ? 'à la limite' : 'sous capacité';
+  const recommended = debtEntries[0] ?? limitEntries[0] ?? entries[0] ?? null;
+
+  return {
+    id: 'logistics-recovery-debt-ledger',
+    title: 'Ledger dette capacité après reprises',
+    status,
+    summary: entries.length === 0
+      ? 'Aucune dette logistique restante après checkpoints.'
+      : status === 'en dette'
+        ? `${debtEntries.length} route(s)/corridor(s) en dette après bundles de reprise; dette totale ${totals.debt}.`
+        : status === 'à la limite'
+          ? `${limitEntries.length} route(s)/corridor(s) à la limite après reprises; garder une réserve.`
+          : `${entries.length} route(s)/corridor(s) sous capacité après reprises.`,
+    totals,
+    entries,
+    recommendedEntryId: recommended?.id ?? null,
+    recommendedNextAction: recommended?.nextAction ?? 'continuer la surveillance',
+    decisionJustification: recommended?.justification ?? 'Aucun solde restant ne force une décision logistique.',
+    legend: [
+      { key: 'sous capacité', label: 'Sous capacité', tone: 'positive' },
+      { key: 'à la limite', label: 'À la limite', tone: 'warning' },
+      { key: 'en dette', label: 'En dette', tone: 'critical' },
+    ],
+  };
+}
+
 function buildDecisionLegend() {
   return [
     { key: 'critical', label: 'Priorité critique: manque ou saturation immédiate', tone: 'danger' },
@@ -2198,6 +2318,7 @@ function buildEconomyMapLayers(cityOverlays, routeOverlays) {
     };
   });
   const atRiskRecoverySummary = buildAtRiskRecoverySummary(logisticsFeaturesWithPlanners);
+  const recoveryCapacityBudget = buildRecoveryCapacityBudget(logisticsFeaturesWithPlanners, atRiskRecoverySummary);
 
   return {
     cities: {
@@ -2220,7 +2341,8 @@ function buildEconomyMapLayers(cityOverlays, routeOverlays) {
       stressFilters: buildRouteStressFilters(logisticsFeaturesWithPlanners),
       recoveryMarkers: buildRecoveryMarkers(cityFeatures, resourceLayer.features, logisticsFeaturesWithPlanners),
       atRiskRecoverySummary,
-      recoveryCapacityBudget: buildRecoveryCapacityBudget(logisticsFeaturesWithPlanners, atRiskRecoverySummary),
+      recoveryCapacityBudget,
+      recoveryDebtLedger: buildRecoveryDebtLedger(logisticsFeaturesWithPlanners, recoveryCapacityBudget),
       recoveryPlannerLegend: [
         { key: 'repair', label: 'Réparer', tone: 'stable' },
         { key: 'reroute', label: 'Rerouter', tone: 'caution' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1528,6 +1528,32 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
       { key: 'à reporter', label: 'À reporter' },
     ],
   });
+  assert.equal(overlay.layers.logistics.recoveryDebtLedger.id, 'logistics-recovery-debt-ledger');
+  assert.equal(overlay.layers.logistics.recoveryDebtLedger.status, 'en dette');
+  assert.equal(overlay.layers.logistics.recoveryDebtLedger.recommendedEntryId, 'recovery-debt:route-coast');
+  assert.equal(overlay.layers.logistics.recoveryDebtLedger.recommendedNextAction, 'ajouter du stock avant le prochain bundle');
+  assert.match(overlay.layers.logistics.recoveryDebtLedger.summary, /route\(s\)\/corridor\(s\) en dette/);
+  assert.match(overlay.layers.logistics.recoveryDebtLedger.decisionJustification, /Coast Road \(land\).*dépasse stock/);
+  assert.deepEqual(overlay.layers.logistics.recoveryDebtLedger.entries.map((entry) => ({
+    id: entry.id,
+    targetId: entry.targetId,
+    status: entry.status,
+    tone: entry.tone,
+    debtAmount: entry.debtAmount,
+    debtResources: entry.debtResources,
+    nextAction: entry.nextAction,
+  })), [
+    {
+      id: 'recovery-debt:route-coast',
+      targetId: 'route-coast',
+      status: 'en dette',
+      tone: 'critical',
+      debtAmount: 2,
+      debtResources: ['stock'],
+      nextAction: 'ajouter du stock avant le prochain bundle',
+    },
+  ]);
+
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,
     targetId: marker.targetId,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('playable economy overlay renders logistics recovery debt ledger', () => {
+  assert.match(webAppSource, /function renderEconomyRecoveryDebtLedger/);
+  assert.match(webAppSource, /recoveryDebtLedger/);
+  assert.match(webAppSource, /Ledger dette capacité logistique après reprises/);
+  assert.match(webAppSource, /statusClass = ledger.status.replaceAll\(' ', '-'\)[\s\S]*ledger\.recommendedNextAction/);
+  assert.match(webAppSource, /ledger\.decisionJustification/);
+  assert.match(webAppSource, /entry\.corridor/);
+  assert.match(webAppSource, /entry\.nextAction/);
+  assert.match(webAppSource, /renderEconomyRecoveryDebtLedger\(economyView\)/);
+
+  assert.match(stylesSource, /\.economy-recovery-debt/);
+  assert.match(stylesSource, /\.economy-recovery-debt--en-dette/);
+  assert.match(stylesSource, /\.economy-recovery-debt__totals/);
+  assert.match(stylesSource, /\.economy-recovery-debt__entry--critical/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -17828,6 +17828,53 @@ function renderEconomyFocusPanel(economyView) {
   `;
 }
 
+
+function renderEconomyRecoveryDebtLedger(economyView) {
+  const ledger = economyView.overlay.layers?.logistics?.recoveryDebtLedger ?? null;
+
+  if (!ledger) {
+    return '';
+  }
+
+  const entries = ledger.entries.slice(0, 3);
+  const statusClass = ledger.status.replaceAll(' ', '-');
+
+  return `
+    <section class="economy-recovery-debt economy-recovery-debt--${statusClass}" aria-label="Ledger dette capacité logistique après reprises">
+      <div class="economy-recovery-debt__header">
+        <span>Dette recovery</span>
+        <strong>${ledger.title}</strong>
+        <b>${ledger.status}</b>
+      </div>
+      <p>${ledger.summary}</p>
+      <div class="economy-recovery-debt__totals">
+        <span><b>${ledger.totals.debt}</b>dette</span>
+        <span><b>${ledger.totals.cost}</b>coût</span>
+        <span><b>${ledger.totals.available}</b>capacité</span>
+      </div>
+      <ol class="economy-recovery-debt__list">
+        ${entries.map((entry) => `
+          <li class="economy-recovery-debt__entry economy-recovery-debt__entry--${entry.tone}">
+            <div>
+              <strong>${entry.label}</strong>
+              <small>${entry.corridor}</small>
+            </div>
+            <span>${entry.status}</span>
+            <p>${entry.justification}</p>
+            <small>Prochaine action: ${entry.nextAction}</small>
+          </li>
+        `).join('')}
+      </ol>
+      <footer>
+        <span>Décision</span>
+        <strong>${ledger.recommendedNextAction}</strong>
+        <small>${ledger.decisionJustification}</small>
+      </footer>
+    </section>
+  `;
+}
+
+
 function renderEconomySidePanel(economyView, cultureView) {
   const culturePanel = renderCultureSidePanel(cultureView);
 
@@ -17886,6 +17933,7 @@ function renderEconomySidePanel(economyView, cultureView) {
       </section>
       ${renderEconomyKpiStrip(economyView)}
       ${renderEconomyFocusPanel(economyView)}
+      ${renderEconomyRecoveryDebtLedger(economyView)}
       ${selectedRoute && selectedRouteStress ? `
         <article class="economy-route-stress-panel economy-route-stress-panel--${selectedRouteStress.tone}">
           <div class="economy-route-stress-panel__header">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12578,3 +12578,94 @@ button { font: inherit; }
   fill: #fde68a;
   font-size: 0.8px;
 }
+.economy-recovery-debt {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 14px;
+  border-radius: 18px;
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.76), rgba(2, 6, 23, 0.54));
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+.economy-recovery-debt--en-dette { border-color: rgba(251, 113, 133, 0.36); }
+.economy-recovery-debt--à-la-limite { border-color: rgba(245, 158, 11, 0.34); }
+.economy-recovery-debt--sous-capacité { border-color: rgba(74, 222, 128, 0.24); }
+.economy-recovery-debt__header,
+.economy-recovery-debt footer {
+  display: grid;
+  gap: 3px;
+}
+.economy-recovery-debt__header span,
+.economy-recovery-debt footer span {
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.economy-recovery-debt__header strong,
+.economy-recovery-debt footer strong { color: #f8fafc; }
+.economy-recovery-debt__header b {
+  width: fit-content;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(251, 191, 36, 0.14);
+  color: #fde68a;
+  font-size: 11px;
+}
+.economy-recovery-debt p,
+.economy-recovery-debt small {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.economy-recovery-debt__totals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+.economy-recovery-debt__totals span {
+  display: grid;
+  gap: 2px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.34);
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.economy-recovery-debt__totals b { color: #e0f2fe; font-size: 15px; }
+.economy-recovery-debt__list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.economy-recovery-debt__entry {
+  display: grid;
+  gap: 5px;
+  padding: 9px;
+  border-radius: 13px;
+  background: rgba(8, 15, 28, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.economy-recovery-debt__entry div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.economy-recovery-debt__entry strong { color: #f8fafc; }
+.economy-recovery-debt__entry > span {
+  width: fit-content;
+  padding: 2px 7px;
+  border-radius: 999px;
+  color: #fef3c7;
+  background: rgba(245, 158, 11, 0.12);
+  font-size: 11px;
+}
+.economy-recovery-debt__entry--critical { border-color: rgba(251, 113, 133, 0.34); }
+.economy-recovery-debt__entry--warning { border-color: rgba(245, 158, 11, 0.3); }
+.economy-recovery-debt__entry--positive { border-color: rgba(74, 222, 128, 0.22); }


### PR DESCRIPTION
Beta: Closes #1260.\n\n## Summary\n- add a recovery debt ledger derived from the logistics recovery capacity budget\n- classify each route/corridor as sous capacité, à la limite, or en dette\n- surface the recommended next action and decision justification in the economy overlay\n\n## Tests\n- npm test