### PR TITLE
Gamma: Add cultural timing windows

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -342,6 +342,7 @@ function normalizeCoherenceRecommendation(recommendation, index) {
     supportKey: recommendation.supportKey ?? recommendation.action ?? action,
     markerIds: recommendation.markerIds ?? [],
     expiresSoon: recommendation.expiresSoon === true,
+    timingLabel: recommendation.timingLabel ?? recommendation.timingWindow ?? recommendation.window ?? null,
   };
 }
 
@@ -458,6 +459,55 @@ function buildCommitmentBundleName(trajectory) {
   return 'attente';
 }
 
+function buildCulturalTimingWindow(bundle, clusterMembers) {
+  const expiresSoon = clusterMembers.some((member) => member.expiresSoon);
+  const hasImmediateOpportunity = clusterMembers.some((member) => member.tone === 'opportunity' || member.level === 'surging');
+  const hasFragileSignal = clusterMembers.some((member) => member.confidence === 'low' || member.level === 'fragile');
+  const status = expiresSoon
+    ? 'soon-lost'
+    : hasImmediateOpportunity && !hasFragileSignal
+      ? 'immediate'
+      : 'wait';
+  const clusterLabel = [...new Set(clusterMembers.map((member) => member.cultureName))].join(', ');
+  const regionIds = [...new Set(clusterMembers.map((member) => member.regionId))];
+  const timingLabel = clusterMembers.find((member) => member.timingLabel)?.timingLabel
+    ?? (expiresSoon ? 'cette fenêtre risque de se fermer au prochain tour' : status === 'immediate' ? 'agir maintenant conserve le momentum' : 'attendre stabilise la lecture');
+  const delayEffect = expiresSoon
+    ? 'retarder peut faire perdre le momentum et transformer l’opportunité en tension à réévaluer'
+    : status === 'immediate'
+      ? 'retarder baisse la priorité du bundle et peut donner la main aux signaux concurrents'
+      : hasFragileSignal
+        ? 'attendre garde le bundle lisible mais exige une vérification avant engagement'
+        : 'retarder ne change pas encore la décision, surveiller le prochain signal suffit';
+
+  return {
+    timingId: `${bundle.bundleId}:timing:${regionIds.join('+') || 'cluster'}`,
+    bundleId: bundle.bundleId,
+    clusterLabel,
+    regionIds,
+    status,
+    label: status === 'soon-lost' ? 'fenêtre bientôt perdue' : status === 'immediate' ? 'action immédiate' : 'attendre',
+    timingLabel,
+    recommendationIds: clusterMembers.map((member) => member.recommendationId),
+    delayEffect,
+  };
+}
+
+function buildCulturalTimingWindows(bundle, members) {
+  const clusters = members.reduce((groups, member) => {
+    const key = `${member.regionId}:${member.cultureName}`;
+    groups.set(key, [...(groups.get(key) ?? []), member]);
+    return groups;
+  }, new Map());
+
+  return [...clusters.values()]
+    .map((clusterMembers) => buildCulturalTimingWindow(bundle, clusterMembers))
+    .sort((left, right) => {
+      const order = { 'soon-lost': 3, immediate: 2, wait: 1 };
+      return (order[right.status] ?? 0) - (order[left.status] ?? 0) || left.clusterLabel.localeCompare(right.clusterLabel);
+    });
+}
+
 function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = []) {
   const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
   const trajectories = ['apaisement', 'consolidation', 'enquête', 'expansion', 'attente'];
@@ -476,7 +526,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
           ? 'mixed'
           : 'uncertain';
 
-      return {
+      const bundle = {
         bundleId: `culture-commitment:${trajectory}`,
         label: buildCommitmentBundleName(trajectory),
         trajectory,
@@ -488,6 +538,11 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
         explanation: members
           .map((member) => `${member.discoveryId} → ${member.action} → ${state === 'uncertain' ? 'incertain' : buildCommitmentBundleName(trajectory)}`)
           .join(' | '),
+      };
+
+      return {
+        ...bundle,
+        timingWindows: buildCulturalTimingWindows(bundle, members),
       };
     })
     .filter(Boolean);
@@ -545,6 +600,13 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
       });
     });
 
+  const timingWindows = bundles
+    .flatMap((bundle) => bundle.timingWindows)
+    .sort((left, right) => {
+      const order = { 'soon-lost': 3, immediate: 2, wait: 1 };
+      return (order[right.status] ?? 0) - (order[left.status] ?? 0) || left.clusterLabel.localeCompare(right.clusterLabel);
+    });
+
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
     summary: bundles.length === 0
@@ -552,6 +614,10 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
       : `${bundles.length} bundle${bundles.length > 1 ? 's' : ''} d’engagement culturel, ${incompatibilities.length} incompatibilité${incompatibilities.length > 1 ? 's' : ''}.`,
     bundles,
     incompatibilities,
+    timingWindows,
+    timingSummary: timingWindows.length === 0
+      ? 'Aucune fenêtre de timing culturel active.'
+      : `${timingWindows.length} fenêtre${timingWindows.length > 1 ? 's' : ''} de timing culturel après bundle.`,
     dependencyExplanation: bundles.length === 0
       ? 'Aucune dépendance entre marqueurs culturels.'
       : bundles
@@ -640,6 +706,8 @@ export function buildCultureTurnReportDeltas({
         summary: 'Aucun bundle d’engagement culturel disponible.',
         bundles: [],
         incompatibilities: [],
+        timingWindows: [],
+        timingSummary: 'Aucune fenêtre de timing culturel active.',
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
       },
     };

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -176,9 +176,36 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
         actions: ['amplifier'],
         markerIds: ['river-gate:culture-aurora:event:event-archive-opening'],
         explanation: 'archive-routes → amplifier → expansion prudente',
+        timingWindows: [
+          {
+            timingId: 'culture-commitment:expansion:timing:river-gate',
+            bundleId: 'culture-commitment:expansion',
+            clusterLabel: 'Compact d’Aurora',
+            regionIds: ['river-gate'],
+            status: 'immediate',
+            label: 'action immédiate',
+            timingLabel: 'agir maintenant conserve le momentum',
+            recommendationIds: ['river-gate:momentum:strengthened:1:stabilization'],
+            delayEffect: 'retarder baisse la priorité du bundle et peut donner la main aux signaux concurrents',
+          },
+        ],
       },
     ],
     incompatibilities: [],
+    timingWindows: [
+      {
+        timingId: 'culture-commitment:expansion:timing:river-gate',
+        bundleId: 'culture-commitment:expansion',
+        clusterLabel: 'Compact d’Aurora',
+        regionIds: ['river-gate'],
+        status: 'immediate',
+        label: 'action immédiate',
+        timingLabel: 'agir maintenant conserve le momentum',
+        recommendationIds: ['river-gate:momentum:strengthened:1:stabilization'],
+        delayEffect: 'retarder baisse la priorité du bundle et peut donner la main aux signaux concurrents',
+      },
+    ],
+    timingSummary: '1 fenêtre de timing culturel après bundle.',
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
 });
@@ -219,6 +246,8 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
       summary: 'Aucun bundle d’engagement culturel disponible.',
       bundles: [],
       incompatibilities: [],
+      timingWindows: [],
+      timingSummary: 'Aucune fenêtre de timing culturel active.',
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },
   });
@@ -557,4 +586,11 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
   ]);
   assert.match(report.commitmentBundles.dependencyExplanation, /apaisement local: ash-treaty → apaiser/);
   assert.deepEqual(report.commitmentBundles.bundles[1].uncertainRecommendationIds, ['mist:momentum:fragile:stabilization']);
+  assert.deepEqual(report.commitmentBundles.timingWindows.map((window) => [window.clusterLabel, window.status, window.label]), [
+    ['Harbor Compact', 'soon-lost', 'fenêtre bientôt perdue'],
+    ['Compact d’Aurora', 'immediate', 'action immédiate'],
+    ['Ember Guild', 'wait', 'attendre'],
+    ['Mist Circle', 'wait', 'attendre'],
+  ]);
+  assert.match(report.commitmentBundles.timingWindows[0].delayEffect, /perdre le momentum/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -5831,6 +5831,22 @@ function renderCultureTurnReport(report) {
           `).join('')}
         </ul>
       ` : '<span>Culture stable: aucun événement, découverte ou tension nouvelle à remonter.</span>'}
+      <div class="culture-turn-report__timing culture-turn-report__timing--${report.commitmentBundles?.state ?? 'quiet'}" aria-label="Fenêtres de timing culturel après bundle">
+        <span>Timing après bundle</span>
+        <strong>${report.commitmentBundles?.timingSummary ?? 'Aucune fenêtre de timing culturel active.'}</strong>
+        ${(report.commitmentBundles?.timingWindows ?? []).length > 0 ? `
+          <div class="culture-turn-report__timing-list">
+            ${report.commitmentBundles.timingWindows.slice(0, 4).map((window) => `
+              <article class="culture-turn-report__timing-window culture-turn-report__timing-window--${window.status}" data-culture-timing-window="${window.timingId}">
+                <b>${window.clusterLabel}</b>
+                <em>${window.label}</em>
+                <small>${window.timingLabel}</small>
+                <small>Si retard: ${window.delayEffect}</small>
+              </article>
+            `).join('')}
+          </div>
+        ` : '<small>État vide: aucun cluster culturel actif ne force un engagement ce tour.</small>'}
+      </div>
     </div>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -1734,6 +1734,48 @@ button { font: inherit; }
 .culture-turn-report__delta--opportunity { border-color: rgba(251, 191, 36, 0.28); }
 .culture-turn-report__delta--research { border-color: rgba(34, 211, 238, 0.22); }
 .culture-turn-report--quiet > span { color: var(--muted); }
+.culture-turn-report__timing {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid rgba(125, 211, 252, 0.12);
+}
+.culture-turn-report__timing > span {
+  color: var(--accent);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__timing > strong {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.culture-turn-report__timing > small { color: var(--muted); }
+.culture-turn-report__timing-list {
+  display: grid;
+  gap: 6px;
+}
+.culture-turn-report__timing-window {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.32);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.culture-turn-report__timing-window b { color: #e0f2fe; }
+.culture-turn-report__timing-window em {
+  color: var(--accent);
+  font-style: normal;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.culture-turn-report__timing-window small { color: var(--muted); }
+.culture-turn-report__timing-window--immediate { border-color: rgba(34, 211, 238, 0.28); }
+.culture-turn-report__timing-window--wait { border-color: rgba(148, 163, 184, 0.2); }
+.culture-turn-report__timing-window--soon-lost { border-color: rgba(251, 191, 36, 0.4); }
 .hero-stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Gamma: Couvre #1261.

- ajoute des fenêtres de timing par cluster culturel après les bundles d’engagement compatibles
- distingue action immédiate, attente et fenêtre bientôt perdue, avec coût de retard explicite
- conserve un état vide robuste sans signaux culturels actifs
- rend le bloc dans le rapport culturel avec styles compacts

Vérifications:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check
- npm test

Validation Zeta demandée avant tout merge.