### PR TITLE
Alpha: Add MAP-A12 post-resolution order audit

### DIFF
--- a/test/ui/war/webAtlasMilitaryPostResolutionOrderAudit.test.js
+++ b/test/ui/war/webAtlasMilitaryPostResolutionOrderAudit.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military post resolution audit reuses resolver conflict and warning signals', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryPostResolutionOrderAudit\(commitment, commitmentConflicts, commitmentCoverage, commitmentWarnings, commitmentResolver\)/);
+  assert.match(webAppSource, /commitmentResolver\?\.recommendations\?\.\[0\]\?\.decision/);
+  assert.match(webAppSource, /for \(const conflict of commitmentConflicts\?\.conflicts \?\? \[\]\)/);
+  assert.match(webAppSource, /for \(const warning of commitmentWarnings\?\.warnings \?\? \[\]\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryPostResolutionOrderAudit\(postResolutionAudit\)/);
+});
+
+test('atlas military post resolution audit groups contested province outcomes by status', () => {
+  assert.match(webAppSource, /status === 'appliqué'/);
+  assert.match(webAppSource, /status === 'reporté'/);
+  assert.match(webAppSource, /status === 'annulé'/);
+  assert.match(webAppSource, /'à revoir'/);
+  assert.match(webAppSource, /auditByProvince\.set\(label, candidate\)/);
+  assert.match(webAppSource, /cause principale: \$\{row\.cause\}/);
+});
+
+test('atlas military post resolution audit exposes accessible empty and correction cues', () => {
+  assert.match(webAppSource, /Audit post-résolution vide: aucun ordre contesté à vérifier/);
+  assert.match(webAppSource, /prochaine correction: ajouter couverture ou reporter l’ordre secondaire/);
+  assert.match(webAppSource, /data-atlas-post-resolution-audit/);
+  assert.match(webAppSource, /Audit post-résolution des ordres contestés/);
+  assert.match(stylesSource, /\.atlas-military-post-resolution-audit__panel/);
+  assert.match(stylesSource, /\.atlas-military-post-resolution-row--cancelled rect/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1559,6 +1559,113 @@ function buildAtlasMilitaryCommitmentConflictResolver(commitment, commitmentConf
   };
 }
 
+
+function getAtlasMilitaryAuditStatusForDecision(decision) {
+  if (decision === 'exécuter') return 'appliqué';
+  if (decision === 'différer') return 'reporté';
+  if (decision === 'remplacer' || decision === 'bloquer') return 'annulé';
+  return 'à revoir';
+}
+
+function buildAtlasMilitaryPostResolutionOrderAudit(commitment, commitmentConflicts, commitmentCoverage, commitmentWarnings, commitmentResolver) {
+  if (!commitment || commitment.empty || !commitment.stages.length) {
+    return {
+      rows: [],
+      summary: 'Audit post-résolution vide: aucun ordre contesté à vérifier.',
+      empty: true,
+    };
+  }
+
+  const auditByProvince = new Map();
+  const pushAuditRow = (label, status, cause, nextCorrection, priority = 0) => {
+    if (!label) return;
+    const previous = auditByProvince.get(label);
+    const candidate = {
+      auditId: `post-resolution:${label}:${status}`,
+      provinceLabel: label,
+      status,
+      tone: status === 'appliqué' ? 'applied' : status === 'reporté' ? 'delayed' : status === 'annulé' ? 'cancelled' : 'review',
+      cause,
+      nextCorrection,
+      priority,
+    };
+    if (!previous || candidate.priority > previous.priority) {
+      auditByProvince.set(label, candidate);
+    }
+  };
+
+  const targetLabel = commitment.selectedOption?.targetProvinceLabel ?? commitment.selectedOption?.target ?? null;
+  const resolverDecision = commitmentResolver?.recommendations?.[0]?.decision ?? 'exécuter';
+  pushAuditRow(
+    targetLabel,
+    getAtlasMilitaryAuditStatusForDecision(resolverDecision),
+    commitmentResolver?.recommendations?.[0]?.reason ?? 'ordre résolu sans conflit bloquant',
+    commitmentResolver?.recommendations?.[0]?.risk ?? 'prochaine correction: surveiller le front couvert',
+    commitmentResolver?.recommendations?.[0]?.priority ?? 32,
+  );
+
+  for (const conflict of commitmentConflicts?.conflicts ?? []) {
+    const status = conflict.severity === 'haute' ? 'annulé' : 'reporté';
+    pushAuditRow(
+      conflict.provinceLabel,
+      status,
+      conflict.explanation,
+      conflict.decision,
+      conflict.priority,
+    );
+  }
+
+  for (const warning of commitmentWarnings?.warnings ?? []) {
+    pushAuditRow(
+      warning.label,
+      warning.tone === 'critical' ? 'annulé' : 'à revoir',
+      warning.degradation,
+      warning.action,
+      warning.urgencyScore,
+    );
+  }
+
+  for (const front of commitmentCoverage?.uncoveredFronts ?? []) {
+    pushAuditRow(
+      front.label,
+      'à revoir',
+      front.reason,
+      'prochaine correction: ajouter couverture ou reporter l’ordre secondaire',
+      front.pressure,
+    );
+  }
+
+  const rows = [...auditByProvince.values()]
+    .sort((left, right) => right.priority - left.priority || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 4);
+
+  return {
+    rows,
+    summary: rows.length > 0
+      ? `${rows.length} province${rows.length > 1 ? 's' : ''} auditée${rows.length > 1 ? 's' : ''} après résolution des ordres.`
+      : 'Audit post-résolution clair: aucun report, annulation ou correction restante.',
+    empty: rows.length === 0,
+  };
+}
+
+function renderAtlasMilitaryPostResolutionOrderAudit(audit) {
+  const height = audit.empty ? 8 : 7 + (audit.rows.length * 4.9);
+  return `
+    <g class="atlas-military-post-resolution-audit" aria-label="Audit post-résolution des ordres contestés: ${audit.summary}">
+      <rect class="atlas-military-post-resolution-audit__panel" x="44" y="44" width="36" height="${height}" rx="2.4"></rect>
+      <text class="atlas-military-post-resolution-audit__title" x="46" y="47.2">Audit post-résolution</text>
+      ${audit.empty ? `<text class="atlas-military-post-resolution-audit__empty" x="46" y="50.6">${audit.summary}</text>` : audit.rows.map((row, index) => `
+        <g class="atlas-military-post-resolution-row atlas-military-post-resolution-row--${row.tone}" data-atlas-post-resolution-audit="${row.auditId}" aria-label="${row.provinceLabel}: ${row.status}; cause principale: ${row.cause}; ${row.nextCorrection}">
+          <rect x="46" y="${49.1 + index * 4.9}" width="5" height="3" rx="0.8"></rect>
+          <text class="atlas-military-post-resolution-row__status" x="52" y="${50.1 + index * 4.9}">${row.status} · ${row.provinceLabel}</text>
+          <text class="atlas-military-post-resolution-row__cause" x="52" y="${51.7 + index * 4.9}">${row.cause}</text>
+          <text class="atlas-military-post-resolution-row__next" x="52" y="${53.3 + index * 4.9}">${row.nextCorrection}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryCommitmentConflictResolver(resolver) {
   const height = resolver.empty ? 8 : 8 + (resolver.recommendations.length * 5.2);
   return `
@@ -2543,6 +2650,7 @@ function renderAtlasMilitaryLayer(shell) {
   const commitmentPriority = buildAtlasMilitaryCommitmentDebtPriorities(commitmentDebt, commitmentCoverage, stagedCommitment);
   const commitmentWarnings = buildAtlasMilitaryCommitmentNextTurnWarnings(commitmentPriority, commitmentDebt, commitmentCoverage, stagedCommitment);
   const commitmentResolver = buildAtlasMilitaryCommitmentConflictResolver(stagedCommitment, commitmentConflicts, commitmentCoverage, commitmentPriority, commitmentWarnings);
+  const postResolutionAudit = buildAtlasMilitaryPostResolutionOrderAudit(stagedCommitment, commitmentConflicts, commitmentCoverage, commitmentWarnings, commitmentResolver);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -2575,6 +2683,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryCommitmentDebtPriorities(commitmentPriority)}
       ${renderAtlasMilitaryCommitmentNextTurnWarnings(commitmentWarnings)}
       ${renderAtlasMilitaryCommitmentConflictResolver(commitmentResolver)}
+      ${renderAtlasMilitaryPostResolutionOrderAudit(postResolutionAudit)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -10862,6 +10862,7 @@ button { font: inherit; }
 .atlas-military-commitment-warning,
 .atlas-military-warning-stack,
 .atlas-military-commitment-resolver,
+.atlas-military-post-resolution-audit,
 .atlas-military-warning-relief,
 .atlas-military-best-order,
 .atlas-military-fallback-order,
@@ -12669,3 +12670,39 @@ button { font: inherit; }
 .economy-recovery-debt__entry--critical { border-color: rgba(251, 113, 133, 0.34); }
 .economy-recovery-debt__entry--warning { border-color: rgba(245, 158, 11, 0.3); }
 .economy-recovery-debt__entry--positive { border-color: rgba(74, 222, 128, 0.22); }
+
+
+.atlas-military-post-resolution-audit__panel {
+  fill: rgba(15, 23, 42, 0.8);
+  stroke: rgba(125, 211, 252, 0.46);
+  stroke-width: 0.35;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-post-resolution-audit__title,
+.atlas-military-post-resolution-row text,
+.atlas-military-post-resolution-audit__empty {
+  fill: #e0f2fe;
+  font-size: 1.06px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.3;
+}
+.atlas-military-post-resolution-row rect {
+  fill: rgba(148, 163, 184, 0.75);
+  stroke: rgba(224, 242, 254, 0.74);
+  stroke-width: 0.2;
+}
+.atlas-military-post-resolution-row--applied rect { fill: rgba(74, 222, 128, 0.78); }
+.atlas-military-post-resolution-row--delayed rect { fill: rgba(251, 191, 36, 0.78); }
+.atlas-military-post-resolution-row--cancelled rect { fill: rgba(248, 113, 113, 0.86); }
+.atlas-military-post-resolution-row--review rect { fill: rgba(96, 165, 250, 0.78); }
+.atlas-military-post-resolution-row__cause {
+  fill: #bae6fd;
+  font-size: 0.78px;
+}
+.atlas-military-post-resolution-row__next,
+.atlas-military-post-resolution-audit__empty {
+  fill: #fde68a;
+  font-size: 0.76px;
+}


### PR DESCRIPTION
Alpha: Implements #1270.

Summary:
- adds a post-resolution audit panel reusing existing commitment resolver, conflict, coverage, and warning signals
- groups contested province outcomes as appliqué, reporté, annulé, or à revoir
- explains the main cause plus the next useful correction without adding a new simulation

Tests:
- node --test test/ui/war/webAtlasMilitaryPostResolutionOrderAudit.test.js
- npm test

Ready for Zeta review.