### PR TITLE
Beta: Add logistics debt repayment priorities

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2243,6 +2243,108 @@ function buildRecoveryDebtLedger(logisticsFeatures, recoveryCapacityBudget) {
   };
 }
 
+
+function getRecoveryDebtRepaymentImpact(entry, routeFeature) {
+  if (entry.status === 'en dette') {
+    if (entry.debtResources.includes('stock')) {
+      return `${entry.label}: stock de reprise manquant, les pénuries aval peuvent rester ouvertes.`;
+    }
+
+    if (entry.debtResources.includes('convoy')) {
+      return `${entry.label}: convoi non réservé, le corridor peut re-bloquer la reprise.`;
+    }
+
+    if (entry.debtResources.includes('labor')) {
+      return `${entry.label}: réparation sous-dotée, délai de reprise prolongé.`;
+    }
+
+    return `${entry.label}: dette ouverte, capacité de reprise cannibalisée sur le corridor.`;
+  }
+
+  if (entry.status === 'à la limite') {
+    return `${entry.label}: marge ${entry.remainingCapacity}, une nouvelle perturbation peut rouvrir la dette.`;
+  }
+
+  return `${entry.label}: peut attendre sans pénalité majeure tant que la capacité reste stable.`;
+}
+
+function getRecoveryDebtRepaymentGain(entry, routeFeature) {
+  if (entry.status === 'en dette') {
+    return entry.debtResources.length > 0
+      ? `Rembourser ${entry.debtResources.join(', ')} libère ${entry.debtAmount} capacité et sécurise ${entry.corridor}.`
+      : `Rembourser la dette libère ${entry.debtAmount} capacité sur ${entry.corridor}.`;
+  }
+
+  if (entry.status === 'à la limite') {
+    return `Créer une réserve évite une nouvelle dette si ${routeFeature?.label ?? entry.label} subit un choc.`;
+  }
+
+  return `Aucun gain urgent: garder ${entry.remainingCapacity} marge pour une dette plus bloquante.`;
+}
+
+function buildRecoveryDebtRepaymentPriorities(logisticsFeatures, recoveryDebtLedger) {
+  const statusScore = { 'en dette': 80, 'à la limite': 35, 'sous capacité': 5 };
+  const priorities = recoveryDebtLedger.entries.map((entry) => {
+    const routeFeature = logisticsFeatures.find((feature) => feature.routeId === entry.targetId) ?? null;
+    const riskScore = Math.ceil((routeFeature?.riskLevel ?? 0) / 10);
+    const bottleneckScore = routeFeature?.bottleneckIntensity === 'critical'
+      ? 16
+      : routeFeature?.bottleneckIntensity === 'high'
+        ? 10
+        : routeFeature?.bottleneckIntensity === 'medium'
+          ? 5
+          : 0;
+    const repaymentScore = (statusScore[entry.status] ?? 0) + (entry.debtAmount * 12) + riskScore + bottleneckScore;
+    const canWait = entry.status === 'sous capacité' || (entry.status === 'à la limite' && repaymentScore < 55);
+
+    return {
+      id: `recovery-repayment:${entry.targetId}`,
+      debtEntryId: entry.id,
+      targetType: entry.targetType,
+      targetId: entry.targetId,
+      label: entry.label,
+      corridor: entry.corridor,
+      rank: 0,
+      status: entry.status,
+      tone: canWait ? 'positive' : entry.tone,
+      repaymentScore,
+      canWait,
+      debtAmount: entry.debtAmount,
+      blockingImpact: getRecoveryDebtRepaymentImpact(entry, routeFeature),
+      expectedGain: getRecoveryDebtRepaymentGain(entry, routeFeature),
+      nextAction: entry.nextAction,
+      reason: canWait
+        ? `${entry.label}: pénalité faible, attendre ne bloque pas la reprise principale.`
+        : `${entry.label}: score ${repaymentScore}, ${entry.status}; traiter maintenant protège ${entry.corridor}.`,
+    };
+  }).sort((left, right) => Number(left.canWait) - Number(right.canWait)
+    || right.repaymentScore - left.repaymentScore
+    || left.label.localeCompare(right.label))
+    .map((priority, index) => ({ ...priority, rank: index + 1 }));
+  const blocking = priorities.filter((priority) => !priority.canWait).slice(0, 3);
+  const waitable = priorities.filter((priority) => priority.canWait);
+
+  return {
+    id: 'logistics-recovery-repayment-priorities',
+    title: 'Priorités remboursement dette logistique',
+    summary: priorities.length === 0
+      ? 'Aucune dette logistique à prioriser.'
+      : blocking.length === 0
+        ? `${waitable.length} dette(s) peuvent attendre sans pénalité majeure.`
+        : `${blocking.length} dette(s) bloquante(s) à rembourser en priorité; ${waitable.length} peuvent attendre.`,
+    priorities: blocking,
+    waitable,
+    topPriorityId: blocking[0]?.id ?? waitable[0]?.id ?? null,
+    nextAction: blocking[0]?.nextAction ?? waitable[0]?.nextAction ?? 'continuer la surveillance',
+    decisionJustification: blocking[0]?.reason ?? waitable[0]?.reason ?? 'Aucune dette restante ne demande de remboursement.',
+    legend: [
+      { key: 'blocking', label: 'Bloquante: rembourser maintenant', tone: 'critical' },
+      { key: 'watch', label: 'À surveiller: réserve utile', tone: 'warning' },
+      { key: 'can-wait', label: 'Peut attendre', tone: 'positive' },
+    ],
+  };
+}
+
 function buildDecisionLegend() {
   return [
     { key: 'critical', label: 'Priorité critique: manque ou saturation immédiate', tone: 'danger' },
@@ -2319,6 +2421,7 @@ function buildEconomyMapLayers(cityOverlays, routeOverlays) {
   });
   const atRiskRecoverySummary = buildAtRiskRecoverySummary(logisticsFeaturesWithPlanners);
   const recoveryCapacityBudget = buildRecoveryCapacityBudget(logisticsFeaturesWithPlanners, atRiskRecoverySummary);
+  const recoveryDebtLedger = buildRecoveryDebtLedger(logisticsFeaturesWithPlanners, recoveryCapacityBudget);
 
   return {
     cities: {
@@ -2342,7 +2445,8 @@ function buildEconomyMapLayers(cityOverlays, routeOverlays) {
       recoveryMarkers: buildRecoveryMarkers(cityFeatures, resourceLayer.features, logisticsFeaturesWithPlanners),
       atRiskRecoverySummary,
       recoveryCapacityBudget,
-      recoveryDebtLedger: buildRecoveryDebtLedger(logisticsFeaturesWithPlanners, recoveryCapacityBudget),
+      recoveryDebtLedger,
+      recoveryDebtRepaymentPriorities: buildRecoveryDebtRepaymentPriorities(logisticsFeaturesWithPlanners, recoveryDebtLedger),
       recoveryPlannerLegend: [
         { key: 'repair', label: 'Réparer', tone: 'stable' },
         { key: 'reroute', label: 'Rerouter', tone: 'caution' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1554,6 +1554,31 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
     },
   ]);
 
+  assert.equal(overlay.layers.logistics.recoveryDebtRepaymentPriorities.id, 'logistics-recovery-repayment-priorities');
+  assert.equal(overlay.layers.logistics.recoveryDebtRepaymentPriorities.topPriorityId, 'recovery-repayment:route-coast');
+  assert.equal(overlay.layers.logistics.recoveryDebtRepaymentPriorities.nextAction, 'ajouter du stock avant le prochain bundle');
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentPriorities.summary, /dette\(s\) bloquante\(s\) à rembourser en priorité/);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentPriorities.decisionJustification, /traiter maintenant protège/);
+  assert.deepEqual(overlay.layers.logistics.recoveryDebtRepaymentPriorities.priorities.map((priority) => ({
+    id: priority.id,
+    targetId: priority.targetId,
+    rank: priority.rank,
+    canWait: priority.canWait,
+    debtAmount: priority.debtAmount,
+    nextAction: priority.nextAction,
+  })), [
+    {
+      id: 'recovery-repayment:route-coast',
+      targetId: 'route-coast',
+      rank: 1,
+      canWait: false,
+      debtAmount: 2,
+      nextAction: 'ajouter du stock avant le prochain bundle',
+    },
+  ]);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentPriorities.priorities[0].blockingImpact, /stock de reprise manquant/);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentPriorities.priorities[0].expectedGain, /Rembourser stock/);
+
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,
     targetId: marker.targetId,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -15,8 +15,20 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(webAppSource, /entry\.nextAction/);
   assert.match(webAppSource, /renderEconomyRecoveryDebtLedger\(economyView\)/);
 
+  assert.match(webAppSource, /function renderEconomyRecoveryRepaymentPriorities/);
+  assert.match(webAppSource, /recoveryDebtRepaymentPriorities/);
+  assert.match(webAppSource, /Priorités de remboursement de dette logistique/);
+  assert.match(webAppSource, /priority\.blockingImpact/);
+  assert.match(webAppSource, /priority\.expectedGain/);
+  assert.match(webAppSource, /view\.waitable/);
+  assert.match(webAppSource, /renderEconomyRecoveryRepaymentPriorities\(economyView\)/);
+
   assert.match(stylesSource, /\.economy-recovery-debt/);
   assert.match(stylesSource, /\.economy-recovery-debt--en-dette/);
   assert.match(stylesSource, /\.economy-recovery-debt__totals/);
   assert.match(stylesSource, /\.economy-recovery-debt__entry--critical/);
+
+  assert.match(stylesSource, /\.economy-repayment-priorities/);
+  assert.match(stylesSource, /\.economy-repayment-priorities__item--critical/);
+  assert.match(stylesSource, /\.economy-repayment-priorities__wait/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -18068,6 +18068,49 @@ function renderEconomyRecoveryDebtLedger(economyView) {
 }
 
 
+function renderEconomyRecoveryRepaymentPriorities(economyView) {
+  const view = economyView.overlay.layers?.logistics?.recoveryDebtRepaymentPriorities ?? null;
+
+  if (!view) {
+    return '';
+  }
+
+  return `
+    <section class="economy-repayment-priorities" aria-label="Priorités de remboursement de dette logistique">
+      <div class="economy-repayment-priorities__header">
+        <span>Priorités remboursement</span>
+        <strong>${view.title}</strong>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="economy-repayment-priorities__list">
+        ${view.priorities.map((priority) => `
+          <li class="economy-repayment-priorities__item economy-repayment-priorities__item--${priority.tone}">
+            <div>
+              <b>#${priority.rank} · ${priority.label}</b>
+              <small>${priority.corridor}</small>
+            </div>
+            <p>${priority.blockingImpact}</p>
+            <p>${priority.expectedGain}</p>
+            <strong>${priority.nextAction}</strong>
+          </li>
+        `).join('')}
+      </ol>
+      ${view.waitable.length > 0 ? `
+        <div class="economy-repayment-priorities__wait">
+          <span>Peut attendre</span>
+          <small>${view.waitable.map((priority) => `${priority.label}: ${priority.blockingImpact}`).join(' · ')}</small>
+        </div>
+      ` : ''}
+      <footer>
+        <span>Décision</span>
+        <strong>${view.nextAction}</strong>
+        <small>${view.decisionJustification}</small>
+      </footer>
+    </section>
+  `;
+}
+
+
 function renderEconomySidePanel(economyView, cultureView) {
   const culturePanel = renderCultureSidePanel(cultureView);
 
@@ -18127,6 +18170,7 @@ function renderEconomySidePanel(economyView, cultureView) {
       ${renderEconomyKpiStrip(economyView)}
       ${renderEconomyFocusPanel(economyView)}
       ${renderEconomyRecoveryDebtLedger(economyView)}
+      ${renderEconomyRecoveryRepaymentPriorities(economyView)}
       ${selectedRoute && selectedRouteStress ? `
         <article class="economy-route-stress-panel economy-route-stress-panel--${selectedRouteStress.tone}">
           <div class="economy-route-stress-panel__header">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12714,7 +12714,6 @@ button { font: inherit; }
 .economy-recovery-debt__entry--warning { border-color: rgba(245, 158, 11, 0.3); }
 .economy-recovery-debt__entry--positive { border-color: rgba(74, 222, 128, 0.22); }
 
-
 .atlas-military-post-resolution-audit__panel {
   fill: rgba(15, 23, 42, 0.8);
   stroke: rgba(125, 211, 252, 0.46);
@@ -12748,4 +12747,75 @@ button { font: inherit; }
 .atlas-military-post-resolution-audit__empty {
   fill: #fde68a;
   font-size: 0.76px;
+.economy-repayment-priorities {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 14px;
+  border-radius: 18px;
+  background: linear-gradient(150deg, rgba(8, 15, 28, 0.78), rgba(15, 23, 42, 0.5));
+  border: 1px solid rgba(103, 232, 249, 0.16);
+}
+.economy-repayment-priorities__header,
+.economy-repayment-priorities footer {
+  display: grid;
+  gap: 3px;
+}
+.economy-repayment-priorities__header span,
+.economy-repayment-priorities footer span,
+.economy-repayment-priorities__wait span {
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.economy-repayment-priorities__header strong,
+.economy-repayment-priorities footer strong { color: #f8fafc; }
+.economy-repayment-priorities p,
+.economy-repayment-priorities small {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.economy-repayment-priorities__list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.economy-repayment-priorities__item {
+  display: grid;
+  gap: 6px;
+  padding: 9px;
+  border-radius: 13px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.economy-repayment-priorities__item div {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.economy-repayment-priorities__item b,
+.economy-repayment-priorities__item strong { color: #f8fafc; }
+.economy-repayment-priorities__item > strong {
+  width: fit-content;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(34, 211, 238, 0.12);
+  color: #cffafe;
+  font-size: 11px;
+}
+.economy-repayment-priorities__item--critical { border-color: rgba(251, 113, 133, 0.36); }
+.economy-repayment-priorities__item--warning { border-color: rgba(245, 158, 11, 0.32); }
+.economy-repayment-priorities__item--positive { border-color: rgba(74, 222, 128, 0.22); }
+.economy-repayment-priorities__wait {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(22, 101, 52, 0.12);
+  border: 1px solid rgba(74, 222, 128, 0.18);
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -12747,6 +12747,7 @@ button { font: inherit; }
 .atlas-military-post-resolution-audit__empty {
   fill: #fde68a;
   font-size: 0.76px;
+}
 .economy-repayment-priorities {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
Beta: Closes #1271.\n\n## Summary\n- derive ordered repayment priorities from the recovery debt ledger\n- show blocking impact, expected gain, and concrete next action per route/corridor\n- identify debts that can wait without major penalty in the economy side panel\n\n## Tests\n- npm test