### PR TITLE
Epsilon: add climate rebound follow-up queue

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1881,6 +1881,47 @@ function describeClimateBundleExpectedEffect(bundle) {
   return 'intervention différée: évite de verrouiller une fenêtre trop contradictoire';
 }
 
+function buildClimateBundleFollowUpQueue(bundle, preview) {
+  const reboundRegionSet = new Set(preview.reboundRegionIds);
+  const conflicts = new Set(bundle.resourceConflicts);
+  return bundle.regionIds.map((regionId) => {
+    const hasRebound = reboundRegionSet.has(regionId);
+    const classification = hasRebound
+      ? (preview.reboundRisk === 'high' ? 'urgent' : 'prudent')
+      : conflicts.has('window-timing')
+        ? 'prudent'
+        : 'deferrable';
+    const reason = classification === 'urgent'
+      ? 'rebond élevé après bundle fragile ou déconseillé'
+      : classification === 'prudent'
+        ? 'fenêtre encore sensible: vérifier avant nouvelle mitigation'
+        : 'signal stable: suivi léger suffit après cooling-off';
+    const ignoredReboundRisk = classification === 'urgent'
+      ? 'retour en alerte probable si aucun suivi n’est joué'
+      : classification === 'prudent'
+        ? 'pression régionale peut remonter si la réserve disparaît'
+        : 'rebond faible sauf nouveau signal saisonnier';
+    const nextAction = classification === 'urgent'
+      ? 'jouer le suivi minimal avant tout autre bundle climat'
+      : classification === 'prudent'
+        ? 'placer une vérification de readiness au prochain tour sûr'
+        : 'différer et garder seulement une veille météo';
+
+    return {
+      followUpId: `${bundle.bundleId}:${regionId}:follow-up`,
+      bundleId: bundle.bundleId,
+      regionId,
+      classification,
+      reason,
+      ignoredReboundRisk,
+      nextAction,
+    };
+  }).sort((left, right) => {
+    const rank = { urgent: 0, prudent: 1, deferrable: 2 };
+    return (rank[left.classification] ?? 2) - (rank[right.classification] ?? 2) || left.regionId.localeCompare(right.regionId);
+  });
+}
+
 function buildClimateBundleAfterActionPreview(bundle) {
   const conflicts = new Set(bundle.resourceConflicts);
   const reboundRegionIds = conflicts.has('residual-risk') || conflicts.has('window-timing') || bundle.viability !== 'viable'
@@ -1905,8 +1946,7 @@ function buildClimateBundleAfterActionPreview(bundle) {
       : bundle.kind === 'monitor'
         ? 'poser une veille légère et n’agir que si le risque remonte'
         : 'ne rien empiler: attendre une fenêtre moins contradictoire';
-
-  return {
+  const preview = {
     expectedEffect: describeClimateBundleExpectedEffect(bundle),
     coolingOffTurns,
     coolingOffState,
@@ -1916,6 +1956,11 @@ function buildClimateBundleAfterActionPreview(bundle) {
     summary: reboundRegionIds.length > 0
       ? `${coolingOffTurns} tour(s) de cooling-off; rebond probable sur ${reboundRegionIds.join(', ')}.`
       : `${coolingOffTurns} tour(s) de cooling-off; aucun rebond régional probable si la réserve reste disponible.`,
+  };
+
+  return {
+    ...preview,
+    followUpQueue: buildClimateBundleFollowUpQueue(bundle, preview),
   };
 }
 
@@ -1941,6 +1986,21 @@ function normalizeClimateBundleAfterActionPreview(preview, basePreview) {
     ).map((regionId) => String(regionId).trim()).filter(Boolean),
     minimalAction: String(normalizedPreview.minimalAction ?? basePreview.minimalAction).trim(),
     summary: String(normalizedPreview.summary ?? basePreview.summary).trim(),
+    followUpQueue: requireArray(
+      normalizedPreview.followUpQueue ?? basePreview.followUpQueue,
+      'ClimateMapOverlay climateActionBundle afterActionPreview followUpQueue',
+    ).map((item) => {
+      const normalizedItem = requireObject(item, 'ClimateMapOverlay climateActionBundle afterActionPreview followUpQueue item');
+      return {
+        followUpId: String(normalizedItem.followUpId).trim(),
+        bundleId: String(normalizedItem.bundleId).trim(),
+        regionId: String(normalizedItem.regionId).trim(),
+        classification: String(normalizedItem.classification).trim(),
+        reason: String(normalizedItem.reason).trim(),
+        ignoredReboundRisk: String(normalizedItem.ignoredReboundRisk).trim(),
+        nextAction: String(normalizedItem.nextAction).trim(),
+      };
+    }),
   };
 }
 

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -2301,6 +2301,17 @@ test('buildClimateMapOverlay supports explicit prudent climate bundle overrides'
         reboundRegionIds: ['delta'],
         minimalAction: 'ne rien empiler: attendre une fenêtre moins contradictoire',
         summary: '3 tour(s) de cooling-off; rebond probable sur delta.',
+        followUpQueue: [
+          {
+            followUpId: 'climate-bundle:postpone:delta:follow-up',
+            bundleId: 'climate-bundle:postpone',
+            regionId: 'delta',
+            classification: 'urgent',
+            reason: 'rebond élevé après bundle fragile ou déconseillé',
+            ignoredReboundRisk: 'retour en alerte probable si aucun suivi n’est joué',
+            nextAction: 'jouer le suivi minimal avant tout autre bundle climat',
+          },
+        ],
       },
     },
   ]);
@@ -2361,6 +2372,17 @@ test('buildClimateMapOverlay previews rebound and cooling-off after prudent clim
     reboundRegionIds: [],
     minimalAction: 'garder une réserve locale et relire les marqueurs de rebond au tour suivant',
     summary: '1 tour(s) de cooling-off; aucun rebond régional probable si la réserve reste disponible.',
+    followUpQueue: [
+      {
+        followUpId: 'climate-bundle:secure-now:delta:follow-up',
+        bundleId: 'climate-bundle:secure-now',
+        regionId: 'delta',
+        classification: 'deferrable',
+        reason: 'signal stable: suivi léger suffit après cooling-off',
+        ignoredReboundRisk: 'rebond faible sauf nouveau signal saisonnier',
+        nextAction: 'différer et garder seulement une veille météo',
+      },
+    ],
   });
   assert.deepEqual(prepareBundle.afterActionPreview, {
     expectedEffect: 'readiness renforcée avant engagement direct, sans répéter le calendrier saisonnier',
@@ -2370,5 +2392,16 @@ test('buildClimateMapOverlay previews rebound and cooling-off after prudent clim
     reboundRegionIds: ['ridge'],
     minimalAction: 'sécuriser une readiness minimale avant toute mitigation supplémentaire',
     summary: '2 tour(s) de cooling-off; rebond probable sur ridge.',
+    followUpQueue: [
+      {
+        followUpId: 'climate-bundle:prepare:ridge:follow-up',
+        bundleId: 'climate-bundle:prepare',
+        regionId: 'ridge',
+        classification: 'prudent',
+        reason: 'fenêtre encore sensible: vérifier avant nouvelle mitigation',
+        ignoredReboundRisk: 'pression régionale peut remonter si la réserve disparaît',
+        nextAction: 'placer une vérification de readiness au prochain tour sûr',
+      },
+    ],
   });
 });

--- a/test/ui/climate/webAtlasClimateReboundFollowUpQueue.test.js
+++ b/test/ui/climate/webAtlasClimateReboundFollowUpQueue.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas renders a post-preview climate rebound follow-up queue', () => {
+  assert.match(webAppSource, /buildAtlasClimateReboundFollowUpQueue/);
+  assert.match(webAppSource, /renderAtlasClimateReboundFollowUpQueue/);
+  assert.match(webAppSource, /File suivis rebound/);
+  assert.match(webAppSource, /Raison/);
+  assert.match(webAppSource, /Si ignoré/);
+  assert.match(webAppSource, /Prochaine action/);
+  assert.match(webAppSource, /urgent/);
+  assert.match(webAppSource, /prudent/);
+  assert.match(webAppSource, /deferrable/);
+  assert.match(webAppSource, /renderAtlasClimateReboundAfterActionBundle\(atlasClimateReboundAfterActionBundle\)\}\s*\$\{renderAtlasClimateReboundFollowUpQueue\(atlasClimateReboundFollowUpQueue\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-rebound-follow-up/);
+  assert.match(stylesSource, /\.map-world-climate-rebound-follow-up__item--urgent/);
+  assert.match(stylesSource, /\.map-world-climate-rebound-follow-up__item--prudent/);
+  assert.match(stylesSource, /\.map-world-climate-rebound-follow-up__item--deferrable/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -10774,6 +10774,90 @@ function renderAtlasClimateReboundAfterActionBundle(view) {
   `;
 }
 
+function buildAtlasClimateReboundFollowUpQueue(reboundView, commitmentView) {
+  if (!reboundView || reboundView.state === 'empty' || !commitmentView?.cheapestSafeCommitment) {
+    return {
+      state: 'empty',
+      items: [],
+      summary: 'Aucune file de suivi climat post-preview à afficher.',
+    };
+  }
+
+  const labels = reboundView.reboundProvinceLabels.length > 0
+    ? reboundView.reboundProvinceLabels
+    : [commitmentView.cheapestSafeCommitment.deadlineCovered].filter(Boolean);
+  const followThroughSummary = commitmentView.safestClimateFollowThroughAfterDeadlineTradeoff?.summary ?? '';
+  const nextCommitment = commitmentView.nextClimateCommitment ?? null;
+  const items = labels.map((label, index) => {
+    const classification = reboundView.reboundRisk === 'probable' && index === 0
+      ? 'urgent'
+      : reboundView.reboundRisk === 'watch' || nextCommitment?.deadlineTargeted === label || index === 0
+        ? 'prudent'
+        : 'deferrable';
+    const reason = classification === 'urgent'
+      ? 'rebond probable après la preview: sécuriser avant nouveau bundle'
+      : classification === 'prudent'
+        ? 'signal sensible mais couvert par un suivi léger au prochain tour sûr'
+        : 'signal résiduel moins exposé que la première fenêtre';
+    const ignoredReboundRisk = classification === 'urgent'
+      ? 'l’alerte climat peut revenir dès le prochain cycle si ignorée'
+      : classification === 'prudent'
+        ? 'la pression peut remonter si la réserve ou la readiness est dépensée ailleurs'
+        : 'rebond limité sauf aggravation saisonnière';
+    const nextAction = classification === 'urgent'
+      ? (commitmentView.followUpClimatePayoffRecommendation?.nextAction ?? reboundView.minimalAction)
+      : classification === 'prudent'
+        ? (nextCommitment?.action ?? 'vérifier readiness puis attendre un signal clair')
+        : 'différer: garder une veille et ne pas rouvrir l’assistant bundle';
+
+    return {
+      followUpId: `post-preview:${label}:${index + 1}`,
+      rank: index + 1,
+      label,
+      classification,
+      reason,
+      ignoredReboundRisk,
+      nextAction,
+    };
+  }).sort((left, right) => {
+    const rank = { urgent: 0, prudent: 1, deferrable: 2 };
+    return (rank[left.classification] ?? 2) - (rank[right.classification] ?? 2) || left.rank - right.rank;
+  }).map((item, index) => ({ ...item, rank: index + 1 }));
+
+  return {
+    state: items.some((item) => item.classification === 'urgent') ? 'urgent' : 'ready',
+    items,
+    summary: `${items.length} suivi${items.length > 1 ? 's' : ''} post-preview classé${items.length > 1 ? 's' : ''}; ${followThroughSummary || 'file non redondante avec les bundles précédents.'}`,
+  };
+}
+
+function renderAtlasClimateReboundFollowUpQueue(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-rebound-follow-up map-world-climate-rebound-follow-up--${view.state}" aria-label="File de suivi climat après preview de rebound">
+      <div class="map-world-climate-rebound-follow-up__header">
+        <strong>File suivis rebound</strong>
+        <span>${view.items.length} suivi${view.items.length > 1 ? 's' : ''}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-rebound-follow-up__list">
+        ${view.items.map((item) => `
+          <li class="map-world-climate-rebound-follow-up__item map-world-climate-rebound-follow-up__item--${item.classification}">
+            <b>${item.rank}. ${item.label}</b>
+            <span>${item.classification}</span>
+            <small><b>Raison</b> · ${item.reason}</small>
+            <small><b>Si ignoré</b> · ${item.ignoredReboundRisk}</small>
+            <small><b>Prochaine action</b> · ${item.nextAction}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'neutral' || !view.cheapestSafeCommitment) {
     return '';
@@ -18747,6 +18831,10 @@ function render() {
   const atlasClimateRecoveryPlanProjection = buildAtlasClimateRecoveryPlanProjection(atlasClimateFirstRecoveryPressureReliefExplanation, atlasClimateRecoveryCollateralReliefRanking);
   const atlasClimateCheapestSafeRecoveryCommitment = buildAtlasClimateCheapestSafeRecoveryCommitment(atlasClimateRecoveryPlanProjection);
   const atlasClimateReboundAfterActionBundle = buildAtlasClimateReboundAfterActionBundle(atlasClimateCheapestSafeRecoveryCommitment);
+  const atlasClimateReboundFollowUpQueue = buildAtlasClimateReboundFollowUpQueue(
+    atlasClimateReboundAfterActionBundle,
+    atlasClimateCheapestSafeRecoveryCommitment,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -18797,6 +18885,7 @@ function render() {
           ${renderAtlasClimateRecoveryPlanProjection(atlasClimateRecoveryPlanProjection)}
           ${renderAtlasClimateCheapestSafeRecoveryCommitment(atlasClimateCheapestSafeRecoveryCommitment)}
           ${renderAtlasClimateReboundAfterActionBundle(atlasClimateReboundAfterActionBundle)}
+          ${renderAtlasClimateReboundFollowUpQueue(atlasClimateReboundFollowUpQueue)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12464,6 +12464,49 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+.map-world-climate-rebound-follow-up {
+  display: grid;
+  gap: 7px;
+  max-width: 58ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.78), rgba(14, 116, 144, 0.22));
+  border: 1px solid rgba(103, 232, 249, 0.4);
+}
+.map-world-climate-rebound-follow-up--urgent { border-color: rgba(251, 191, 36, 0.54); }
+.map-world-climate-rebound-follow-up__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-rebound-follow-up p,
+.map-world-climate-rebound-follow-up span,
+.map-world-climate-rebound-follow-up small {
+  color: #cffafe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-rebound-follow-up__list {
+  display: grid;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.map-world-climate-rebound-follow-up__item {
+  display: grid;
+  gap: 3px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  border: 1px solid rgba(103, 232, 249, 0.22);
+  background: rgba(8, 47, 73, 0.34);
+}
+.map-world-climate-rebound-follow-up__item--urgent { border-color: rgba(248, 113, 113, 0.48); }
+.map-world-climate-rebound-follow-up__item--prudent { border-color: rgba(251, 191, 36, 0.44); }
+.map-world-climate-rebound-follow-up__item--deferrable { border-color: rgba(74, 222, 128, 0.34); }
 
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);


### PR DESCRIPTION
Epsilon: Implements #1274.

## Summary
- adds follow-up queue data to climate bundle after-action previews, classifying urgent, prudent, and deferrable follow-ups by rebound risk
- renders an atlas post-preview follow-up queue with reason, ignored-risk consequence, and next action
- adds styling and targeted coverage for the new queue

## Tests
- npm test -- --test-reporter=spec test/ui/climate/buildClimateMapOverlay.test.js test/ui/climate/webAtlasClimateReboundAfterActionBundle.test.js test/ui/climate/webAtlasClimateReboundFollowUpQueue.test.js
- npm test
