### PR TITLE
Gamma: Add cultural follow-up prompts

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -343,6 +343,7 @@ function normalizeCoherenceRecommendation(recommendation, index) {
     markerIds: recommendation.markerIds ?? [],
     expiresSoon: recommendation.expiresSoon === true,
     timingLabel: recommendation.timingLabel ?? recommendation.timingWindow ?? recommendation.window ?? null,
+    timingChoiceState: recommendation.timingChoiceState ?? recommendation.choiceState ?? (recommendation.chosen === true ? 'chosen' : 'recommended'),
   };
 }
 
@@ -472,6 +473,9 @@ function buildCulturalTimingWindow(bundle, clusterMembers) {
   const regionIds = [...new Set(clusterMembers.map((member) => member.regionId))];
   const timingLabel = clusterMembers.find((member) => member.timingLabel)?.timingLabel
     ?? (expiresSoon ? 'cette fenêtre risque de se fermer au prochain tour' : status === 'immediate' ? 'agir maintenant conserve le momentum' : 'attendre stabilise la lecture');
+  const choiceState = clusterMembers.some((member) => member.timingChoiceState === 'chosen' || member.timingChoiceState === 'committed')
+    ? 'chosen'
+    : 'recommended';
   const delayEffect = expiresSoon
     ? 'retarder peut faire perdre le momentum et transformer l’opportunité en tension à réévaluer'
     : status === 'immediate'
@@ -488,6 +492,7 @@ function buildCulturalTimingWindow(bundle, clusterMembers) {
     status,
     label: status === 'soon-lost' ? 'fenêtre bientôt perdue' : status === 'immediate' ? 'action immédiate' : 'attendre',
     timingLabel,
+    choiceState,
     recommendationIds: clusterMembers.map((member) => member.recommendationId),
     delayEffect,
   };
@@ -506,6 +511,69 @@ function buildCulturalTimingWindows(bundle, members) {
       const order = { 'soon-lost': 3, immediate: 2, wait: 1 };
       return (order[right.status] ?? 0) - (order[left.status] ?? 0) || left.clusterLabel.localeCompare(right.clusterLabel);
     });
+}
+
+function buildCulturalFollowUpPrompt(window, bundle, incompatibilities) {
+  const relatedIncompatibilities = incompatibilities.filter((incompatibility) =>
+    (incompatibility.recommendationIds ?? []).some((recommendationId) => window.recommendationIds.includes(recommendationId)));
+  const hasBlockingIncompatibility = relatedIncompatibilities.some((incompatibility) => incompatibility.severity === 'choice' || incompatibility.severity === 'sequence');
+  const hasUncertainty = bundle.state === 'uncertain'
+    || bundle.uncertainRecommendationIds.some((recommendationId) => window.recommendationIds.includes(recommendationId));
+  const promptState = window.status === 'wait' || hasUncertainty
+    ? 'premature'
+    : window.status === 'soon-lost' || hasBlockingIncompatibility
+      ? 'risky'
+      : 'compatible';
+  const trajectoryCopy = {
+    apaisement: 'Préparer la médiation locale',
+    consolidation: 'Ancrer le soutien régional',
+    enquête: 'Lancer une vérification culturelle',
+    expansion: 'Ouvrir le récit d’expansion',
+    attente: 'Planifier une observation courte',
+  };
+  const nextStepCopy = {
+    compatible: 'enchaîner avec un suivi narratif court et mesurable',
+    risky: 'sécuriser le prérequis avant d’engager le suivi complet',
+    premature: 'attendre un signal plus net avant de promettre un résultat culturel',
+  };
+  const reason = window.choiceState === 'chosen'
+    ? `fenêtre choisie: ${window.timingLabel}`
+    : `fenêtre recommandée: ${window.timingLabel}`;
+
+  return {
+    promptId: `${window.timingId}:follow-up`,
+    timingId: window.timingId,
+    bundleId: bundle.bundleId,
+    clusterLabel: window.clusterLabel,
+    state: promptState,
+    label: trajectoryCopy[bundle.trajectory] ?? 'Préparer le suivi culturel',
+    reasonNow: `${reason}; engagement actif ${bundle.label}`,
+    nextStep: nextStepCopy[promptState],
+    riskReason: promptState === 'compatible'
+      ? null
+      : hasUncertainty
+        ? 'conditions culturelles encore fragiles'
+        : relatedIncompatibilities[0]?.reason ?? window.delayEffect,
+    recommendationIds: window.recommendationIds,
+  };
+}
+
+function buildCulturalFollowUpPrompts(bundles, incompatibilities) {
+  const prompts = bundles
+    .flatMap((bundle) => bundle.timingWindows.map((window) => buildCulturalFollowUpPrompt(window, bundle, incompatibilities)))
+    .sort((left, right) => {
+      const stateOrder = { risky: 3, compatible: 2, premature: 1 };
+      return (stateOrder[right.state] ?? 0) - (stateOrder[left.state] ?? 0) || left.clusterLabel.localeCompare(right.clusterLabel);
+    })
+    .slice(0, 3);
+
+  return {
+    state: prompts.length === 0 ? 'quiet' : prompts.some((prompt) => prompt.state === 'risky') ? 'mixed' : prompts.every((prompt) => prompt.state === 'premature') ? 'premature' : 'ready',
+    summary: prompts.length === 0
+      ? 'Aucun prompt de suivi culturel après timing.'
+      : `${prompts.length} prompt${prompts.length > 1 ? 's' : ''} de suivi culturel après timing.`,
+    prompts,
+  };
 }
 
 function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = []) {
@@ -607,6 +675,8 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
       return (order[right.status] ?? 0) - (order[left.status] ?? 0) || left.clusterLabel.localeCompare(right.clusterLabel);
     });
 
+  const followUpPrompts = buildCulturalFollowUpPrompts(bundles, incompatibilities);
+
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
     summary: bundles.length === 0
@@ -618,6 +688,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
     timingSummary: timingWindows.length === 0
       ? 'Aucune fenêtre de timing culturel active.'
       : `${timingWindows.length} fenêtre${timingWindows.length > 1 ? 's' : ''} de timing culturel après bundle.`,
+    followUpPrompts,
     dependencyExplanation: bundles.length === 0
       ? 'Aucune dépendance entre marqueurs culturels.'
       : bundles
@@ -708,6 +779,11 @@ export function buildCultureTurnReportDeltas({
         incompatibilities: [],
         timingWindows: [],
         timingSummary: 'Aucune fenêtre de timing culturel active.',
+        followUpPrompts: {
+          state: 'quiet',
+          summary: 'Aucun prompt de suivi culturel après timing.',
+          prompts: [],
+        },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
       },
     };

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -185,6 +185,7 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
             status: 'immediate',
             label: 'action immédiate',
             timingLabel: 'agir maintenant conserve le momentum',
+            choiceState: 'recommended',
             recommendationIds: ['river-gate:momentum:strengthened:1:stabilization'],
             delayEffect: 'retarder baisse la priorité du bundle et peut donner la main aux signaux concurrents',
           },
@@ -201,11 +202,30 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
         status: 'immediate',
         label: 'action immédiate',
         timingLabel: 'agir maintenant conserve le momentum',
+        choiceState: 'recommended',
         recommendationIds: ['river-gate:momentum:strengthened:1:stabilization'],
         delayEffect: 'retarder baisse la priorité du bundle et peut donner la main aux signaux concurrents',
       },
     ],
     timingSummary: '1 fenêtre de timing culturel après bundle.',
+    followUpPrompts: {
+      state: 'ready',
+      summary: '1 prompt de suivi culturel après timing.',
+      prompts: [
+        {
+          promptId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+          timingId: 'culture-commitment:expansion:timing:river-gate',
+          bundleId: 'culture-commitment:expansion',
+          clusterLabel: 'Compact d’Aurora',
+          state: 'compatible',
+          label: 'Ouvrir le récit d’expansion',
+          reasonNow: 'fenêtre recommandée: agir maintenant conserve le momentum; engagement actif expansion prudente',
+          nextStep: 'enchaîner avec un suivi narratif court et mesurable',
+          riskReason: null,
+          recommendationIds: ['river-gate:momentum:strengthened:1:stabilization'],
+        },
+      ],
+    },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
 });
@@ -248,6 +268,11 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
       incompatibilities: [],
       timingWindows: [],
       timingSummary: 'Aucune fenêtre de timing culturel active.',
+      followUpPrompts: {
+        state: 'quiet',
+        summary: 'Aucun prompt de suivi culturel après timing.',
+        prompts: [],
+      },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },
   });
@@ -593,4 +618,12 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
     ['Mist Circle', 'wait', 'attendre'],
   ]);
   assert.match(report.commitmentBundles.timingWindows[0].delayEffect, /perdre le momentum/);
+  assert.equal(report.commitmentBundles.followUpPrompts.state, 'mixed');
+  assert.deepEqual(report.commitmentBundles.followUpPrompts.prompts.map((prompt) => [prompt.clusterLabel, prompt.state, prompt.label]), [
+    ['Compact d’Aurora', 'risky', 'Ouvrir le récit d’expansion'],
+    ['Harbor Compact', 'risky', 'Ouvrir le récit d’expansion'],
+    ['Ember Guild', 'premature', 'Préparer la médiation locale'],
+  ]);
+  assert.match(report.commitmentBundles.followUpPrompts.prompts[0].reasonNow, /fenêtre recommandée/);
+  assert.match(report.commitmentBundles.followUpPrompts.prompts[2].riskReason, /conditions culturelles|timing narratif/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -5957,6 +5957,22 @@ function renderCultureTurnReport(report) {
           </div>
         ` : '<small>État vide: aucun cluster culturel actif ne force un engagement ce tour.</small>'}
       </div>
+      <div class="culture-turn-report__follow-up culture-turn-report__follow-up--${report.commitmentBundles?.followUpPrompts?.state ?? 'quiet'}" aria-label="Prompts de suivi culturel après choix de timing">
+        <span>Suivis après décision</span>
+        <strong>${report.commitmentBundles?.followUpPrompts?.summary ?? 'Aucun prompt de suivi culturel après timing.'}</strong>
+        ${(report.commitmentBundles?.followUpPrompts?.prompts ?? []).length > 0 ? `
+          <div class="culture-turn-report__follow-up-list">
+            ${report.commitmentBundles.followUpPrompts.prompts.map((prompt) => `
+              <article class="culture-turn-report__follow-up-prompt culture-turn-report__follow-up-prompt--${prompt.state}" data-culture-follow-up-prompt="${prompt.promptId}">
+                <b>${prompt.label}</b>
+                <em>${prompt.clusterLabel} · ${prompt.state === 'compatible' ? 'compatible' : prompt.state === 'risky' ? 'risqué' : 'prématuré'}</em>
+                <small>${prompt.reasonNow}</small>
+                <small>${prompt.nextStep}${prompt.riskReason ? ` · ${prompt.riskReason}` : ''}</small>
+              </article>
+            `).join('')}
+          </div>
+        ` : '<small>État vide: aucun suivi narratif à proposer tant qu’aucune fenêtre n’est recommandée ou choisie.</small>'}
+      </div>
     </div>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -1776,6 +1776,48 @@ button { font: inherit; }
 .culture-turn-report__timing-window--immediate { border-color: rgba(34, 211, 238, 0.28); }
 .culture-turn-report__timing-window--wait { border-color: rgba(148, 163, 184, 0.2); }
 .culture-turn-report__timing-window--soon-lost { border-color: rgba(251, 191, 36, 0.4); }
+.culture-turn-report__follow-up {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid rgba(125, 211, 252, 0.1);
+}
+.culture-turn-report__follow-up > span {
+  color: #c4b5fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__follow-up > strong {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.culture-turn-report__follow-up > small { color: var(--muted); }
+.culture-turn-report__follow-up-list {
+  display: grid;
+  gap: 6px;
+}
+.culture-turn-report__follow-up-prompt {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.34);
+  border: 1px solid rgba(196, 181, 253, 0.18);
+}
+.culture-turn-report__follow-up-prompt b { color: #f5f3ff; }
+.culture-turn-report__follow-up-prompt em {
+  color: #c4b5fd;
+  font-style: normal;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.culture-turn-report__follow-up-prompt small { color: var(--muted); }
+.culture-turn-report__follow-up-prompt--compatible { border-color: rgba(74, 222, 128, 0.28); }
+.culture-turn-report__follow-up-prompt--risky { border-color: rgba(251, 191, 36, 0.42); }
+.culture-turn-report__follow-up-prompt--premature { border-color: rgba(148, 163, 184, 0.24); }
 .hero-stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Gamma: Implements MAP-G12 for #1272.\n\nSummary:\n- derives 2-3 cultural follow-up prompts from recommended/chosen timing windows and active commitment bundles;\n- explains why each prompt is relevant now and whether it is compatible, risky, or premature;\n- renders the follow-up prompt block in the culture turn report without duplicating bundle/timing window content.\n\nChecks:\n- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js\n- node --check web/app.js\n- git diff --check\n- npm test