### PR TITLE
Delta: Add intrigue verification outcome recap

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2654,6 +2654,101 @@ function buildVerificationConflictResolver({ locationId, locationName, intellige
   };
 }
 
+function buildVerificationOutcomeRecap({ locationId, locationName, verificationConflictResolver, exposureBudgetForPriorityVerifications, verificationAuditTrail, intrigueSignalTriageQueue }) {
+  const budgetEntries = exposureBudgetForPriorityVerifications.entries ?? [];
+  const findBudgetEntry = (check) => check
+    ? budgetEntries.find((entry) => entry.checkId === check.checkId) ?? null
+    : null;
+  const launchedBudgetEntry = findBudgetEntry(verificationConflictResolver.launchNow);
+  const delayedBudgetEntry = findBudgetEntry(verificationConflictResolver.defer);
+  const consumedExposure = launchedBudgetEntry?.exposureCost ?? 0;
+  const priorityExposureCeiling = 12;
+  const budgetRemaining = exposureBudgetForPriorityVerifications.state === 'masked-budget'
+    ? null
+    : Math.max(0, priorityExposureCeiling - consumedExposure);
+  const firstTriageEntry = intrigueSignalTriageQueue[0] ?? null;
+
+  if (verificationConflictResolver.state === 'masked-conflict') {
+    return {
+      state: 'masked-recap',
+      locationId,
+      locationName,
+      summary: 'Récapitulatif masqué: le resolver ne confirme aucune décision exploitable sans provenance visible.',
+      retainedVerifications: [],
+      delayedVerifications: [],
+      abandonedVerifications: [],
+      exposureConsumed: 0,
+      exposureBudgetRemaining: null,
+      remainingUncertainties: [
+        'Provenance insuffisante: conserver une lecture agrégée sous fog-of-war.',
+        'Aucun coût d’exposition n’est affiché tant que le contrôle prioritaire reste masqué.',
+      ],
+      nextSafeVerification: null,
+      sourceResolverState: verificationConflictResolver.state,
+      safeMapPolicy: 'Récapitulatif dérivé du resolver D11; aucune cellule, relais, cible, méthode sensible ou cause cachée n’est révélée.',
+    };
+  }
+
+  const retainedVerifications = verificationConflictResolver.launchNow ? [{
+    checkId: verificationConflictResolver.launchNow.checkId,
+    label: verificationConflictResolver.launchNow.label,
+    exposureBand: verificationConflictResolver.launchNow.exposureBand,
+    exposureCost: consumedExposure,
+    outcome: 'retained',
+    reason: verificationConflictResolver.launchNow.reason ?? 'Contrôle retenu par le resolver comme option visible la moins exposée.',
+  }] : [];
+  const delayedVerifications = verificationConflictResolver.defer ? [{
+    checkId: verificationConflictResolver.defer.checkId,
+    label: verificationConflictResolver.defer.label,
+    exposureBand: verificationConflictResolver.defer.exposureBand,
+    exposureCost: delayedBudgetEntry?.exposureCost ?? null,
+    outcome: 'delayed',
+    reason: verificationConflictResolver.defer.reason,
+  }] : [];
+  const abandonedVerifications = verificationConflictResolver.abandonIfNeeded ? [{
+    label: verificationConflictResolver.abandonIfNeeded.label,
+    outcome: 'abandoned-if-no-new-signal',
+    reason: verificationConflictResolver.abandonIfNeeded.reason,
+  }] : [];
+  const remainingUncertainties = [
+    verificationAuditTrail.lastChange === 'residual-risk'
+      ? 'Risque résiduel visible: la cause précise et les relais restent masqués.'
+      : 'Risque faible ou non confirmé: ne pas convertir l’absence de preuve en certitude.',
+    delayedVerifications.length > 0
+      ? 'Un contrôle large reste différé car il consommerait trop d’exposition visible.'
+      : 'Aucun conflit d’exposition restant dans les contrôles visibles.',
+    firstTriageEntry?.residualRisk === 'visible-residual-risk'
+      ? 'La file de triage garde une incertitude visible à revalider sans cible cachée.'
+      : null,
+  ].filter(Boolean);
+  const nextSafeVerification = retainedVerifications[0] ? {
+    action: exposureBudgetForPriorityVerifications.nextLeastExposureCheck?.action ?? firstTriageEntry?.nextLeastExposureCheck?.action ?? 'monitor',
+    checkId: retainedVerifications[0].checkId,
+    label: retainedVerifications[0].label,
+    exposureBand: retainedVerifications[0].exposureBand,
+    evidenceNeeded: exposureBudgetForPriorityVerifications.nextLeastExposureCheck?.evidenceNeeded ?? firstTriageEntry?.nextLeastExposureCheck?.evidenceNeeded ?? 'Signal visible supplémentaire requis.',
+  } : null;
+
+  return {
+    state: verificationConflictResolver.state === 'conflict-detected' ? 'resolved-with-deferrals' : 'resolved-cleanly',
+    locationId,
+    locationName,
+    summary: retainedVerifications.length > 0
+      ? `Resolver appliqué: ${retainedVerifications.length} vérification retenue, ${delayedVerifications.length} retardée, ${abandonedVerifications.length} abandonnée sous condition.`
+      : 'Resolver appliqué: aucune vérification immédiate retenue.',
+    retainedVerifications,
+    delayedVerifications,
+    abandonedVerifications,
+    exposureConsumed: consumedExposure,
+    exposureBudgetRemaining: budgetRemaining,
+    exposureBudgetCeiling: priorityExposureCeiling,
+    remainingUncertainties,
+    nextSafeVerification,
+    sourceResolverState: verificationConflictResolver.state,
+    safeMapPolicy: 'Récapitulatif du résultat D12 uniquement; il réutilise budget, triage et resolver visibles sans révéler cellule, relais, cible, méthode sensible ou cause cachée.',
+  };
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2841,6 +2936,14 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         intrigueSignalTriageQueue,
         exposureBudgetForPriorityVerifications,
       });
+      const verificationOutcomeRecap = buildVerificationOutcomeRecap({
+        locationId,
+        locationName,
+        verificationConflictResolver,
+        exposureBudgetForPriorityVerifications,
+        verificationAuditTrail,
+        intrigueSignalTriageQueue,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -2855,6 +2958,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           intrigueSignalTriageQueue,
           exposureBudgetForPriorityVerifications,
           verificationConflictResolver,
+          verificationOutcomeRecap,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2360,3 +2360,62 @@ test('buildIntrigueMapOverlay resolves fog-safe verification exposure conflicts'
   assert.match(masked.summary, /budget ou provenance insuffisant/);
   assert.match(masked.safeMapPolicy, /Aucune cible, relais, méthode sensible ou vérité cachée/);
 });
+
+test('buildIntrigueMapOverlay recaps verification resolver outcomes without leaking fog-of-war details', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-outcome-recap',
+      factionId: 'shadow-league',
+      codename: 'Outcome',
+      locationId: 'outcome-recap',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 92,
+    }),
+    new Cellule({
+      id: 'cell-outcome-masked',
+      factionId: 'shadow-league',
+      codename: 'Hidden',
+      locationId: 'outcome-masked',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-outcome-recap',
+      celluleId: 'cell-outcome-recap',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Verify visible aftermath',
+      theaterId: 'outcome-recap',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 92,
+      progress: 80,
+      heat: 86,
+      phase: 'execution',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.verificationOutcomeRecap]));
+  const recap = byLocation.get('outcome-recap');
+  const masked = byLocation.get('outcome-masked');
+
+  assert.equal(recap.state, 'resolved-with-deferrals');
+  assert.equal(recap.sourceResolverState, 'conflict-detected');
+  assert.equal(recap.retainedVerifications[0].checkId, 'observe-local-confirmation');
+  assert.equal(recap.retainedVerifications[0].outcome, 'retained');
+  assert.equal(recap.delayedVerifications[0].checkId, 'broad-coverage-now');
+  assert.equal(recap.delayedVerifications[0].outcome, 'delayed');
+  assert.equal(recap.exposureConsumed, 8);
+  assert.equal(recap.exposureBudgetRemaining, 4);
+  assert.equal(recap.nextSafeVerification.checkId, 'observe-local-confirmation');
+  assert.match(recap.remainingUncertainties.join(' '), /cause précise et les relais restent masqués/);
+  assert.match(recap.safeMapPolicy, /sans révéler cellule, relais, cible, méthode sensible ou cause cachée/);
+
+  assert.equal(masked.state, 'masked-recap');
+  assert.deepEqual(masked.retainedVerifications, []);
+  assert.equal(masked.exposureBudgetRemaining, null);
+  assert.equal(masked.nextSafeVerification, null);
+  assert.match(masked.remainingUncertainties.join(' '), /Provenance insuffisante/);
+});


### PR DESCRIPTION
Delta: Implements #1273.

Summary:
- adds a fog-safe verificationOutcomeRecap derived from the existing verification conflict resolver;
- lists retained, delayed, and conditionally abandoned verification outcomes;
- exposes consumed exposure, remaining budget, remaining uncertainties, and next safe verification without revealing hidden cell/relay/target/cause details.

Validation:
- node --check src/ui/intrigue/buildIntrigueMapOverlay.js
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test (699 passing)
- node --check web/app.js
- git diff --check

Closes #1273