### PR TITLE
Alpha: Add MAP-A13 next-turn carry-over queue

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextTurnCarryOverQueue.test.js
+++ b/test/ui/war/webAtlasMilitaryNextTurnCarryOverQueue.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military carry-over queue derives next-turn follow-ups from post-resolution audit rows', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryNextTurnCarryOverQueue\(postResolutionAudit, shell\)/);
+  assert.match(webAppSource, /const auditRows = postResolutionAudit\?\.rows \?\? \[\]/);
+  assert.match(webAppSource, /getAtlasMilitaryCarryOverKind\(row\.status\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryNextTurnCarryOverQueue\(nextTurnCarryOverQueue\)/);
+});
+
+test('atlas military carry-over queue separates required opportunistic and watch follow-ups', () => {
+  assert.match(webAppSource, /return 'obligatoire'/);
+  assert.match(webAppSource, /return 'opportuniste'/);
+  assert.match(webAppSource, /return 'à surveiller'/);
+  assert.match(webAppSource, /kind === 'obligatoire' \? 'required'/);
+  assert.match(webAppSource, /kind === 'opportuniste' \? 'opportunistic'/);
+});
+
+test('atlas military carry-over queue explains resolution conditions and visible dependencies', () => {
+  assert.match(webAppSource, /résolu si le front critique ou le blocage transversal est levé/);
+  assert.match(webAppSource, /résolu si la province redevient couverte par un ordre prioritaire/);
+  assert.match(webAppSource, /dependencies\.push\('logistique'\)/);
+  assert.match(webAppSource, /dependencies\.push\('renseignement'\)/);
+  assert.match(webAppSource, /dependencies\.push\('météo'\)/);
+  assert.match(webAppSource, /data-atlas-carry-over-queue/);
+  assert.match(stylesSource, /\.atlas-military-carry-over-queue__panel/);
+  assert.match(stylesSource, /\.atlas-military-carry-over-item--required rect/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1666,6 +1666,89 @@ function renderAtlasMilitaryPostResolutionOrderAudit(audit) {
   `;
 }
 
+
+function getAtlasMilitaryCarryOverKind(status) {
+  if (status === 'annulé' || status === 'reporté') return 'obligatoire';
+  if (status === 'à revoir') return 'opportuniste';
+  return 'à surveiller';
+}
+
+function getAtlasMilitaryCarryOverCondition(row) {
+  if (row.status === 'annulé') return 'résolu si le front critique ou le blocage transversal est levé';
+  if (row.status === 'reporté') return 'résolu si la province redevient couverte par un ordre prioritaire';
+  if (row.status === 'à revoir') return 'résolu si la pression reste stable après reconnaissance';
+  return 'résolu si aucun nouveau conflit voisin n’apparaît';
+}
+
+function getAtlasMilitaryCarryOverDependencies(row, shell) {
+  const province = (shell?.provinces ?? []).find((candidate) => candidate.label === row.provinceLabel) ?? null;
+  const dependencies = [];
+  if (province?.supplyLevel === 'collapsed' || province?.supplyLevel === 'strained') dependencies.push('logistique');
+  const exposedCellule = province
+    ? intrigueCellules.find((cellule) => cellule.locationId === province.provinceId && cellule.exposure >= 60)
+    : null;
+  if (exposedCellule) dependencies.push('renseignement');
+  if (province?.contested && (province.supplyLevel === 'strained' || row.status !== 'appliqué')) dependencies.push('météo');
+  return dependencies.length > 0 ? dependencies : ['aucune dépendance visible'];
+}
+
+function buildAtlasMilitaryNextTurnCarryOverQueue(postResolutionAudit, shell) {
+  const auditRows = postResolutionAudit?.rows ?? [];
+  if (!auditRows.length) {
+    return {
+      items: [],
+      summary: 'File prochain tour vide: aucun résultat contesté à reporter.',
+      empty: true,
+    };
+  }
+
+  const items = auditRows.map((row) => {
+    const kind = getAtlasMilitaryCarryOverKind(row.status);
+    const dependencies = getAtlasMilitaryCarryOverDependencies(row, shell);
+    return {
+      carryId: `carry-over:${row.provinceLabel}:${kind}`,
+      provinceLabel: row.provinceLabel,
+      kind,
+      tone: kind === 'obligatoire' ? 'required' : kind === 'opportuniste' ? 'opportunistic' : 'watch',
+      sourceStatus: row.status,
+      condition: getAtlasMilitaryCarryOverCondition(row),
+      dependencies,
+      nextStep: kind === 'obligatoire'
+        ? row.nextCorrection
+        : kind === 'opportuniste'
+          ? `option: ${row.nextCorrection}`
+          : `surveiller: ${row.cause}`,
+      priority: (row.priority ?? 0) + (kind === 'obligatoire' ? 30 : kind === 'opportuniste' ? 12 : 0),
+    };
+  })
+    .sort((left, right) => right.priority - left.priority || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 4);
+
+  return {
+    items,
+    summary: `${items.length} suivi${items.length > 1 ? 's' : ''} reporté${items.length > 1 ? 's' : ''} vers le prochain tour.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryNextTurnCarryOverQueue(queue) {
+  const height = queue.empty ? 8 : 7 + (queue.items.length * 5.1);
+  return `
+    <g class="atlas-military-carry-over-queue" aria-label="File de carry-over militaire prochain tour: ${queue.summary}">
+      <rect class="atlas-military-carry-over-queue__panel" x="44" y="68" width="36" height="${height}" rx="2.4"></rect>
+      <text class="atlas-military-carry-over-queue__title" x="46" y="71.2">Carry-over prochain tour</text>
+      ${queue.empty ? `<text class="atlas-military-carry-over-queue__empty" x="46" y="74.6">${queue.summary}</text>` : queue.items.map((item, index) => `
+        <g class="atlas-military-carry-over-item atlas-military-carry-over-item--${item.tone}" data-atlas-carry-over-queue="${item.carryId}" aria-label="${item.provinceLabel}: suivi ${item.kind}, depuis ${item.sourceStatus}; condition: ${item.condition}; dépendances: ${item.dependencies.join(', ')}">
+          <rect x="46" y="${73.1 + index * 5.1}" width="5.2" height="3.1" rx="0.8"></rect>
+          <text class="atlas-military-carry-over-item__kind" x="52.2" y="${74.2 + index * 5.1}">${item.kind} · ${item.provinceLabel}</text>
+          <text class="atlas-military-carry-over-item__condition" x="52.2" y="${75.8 + index * 5.1}">${item.condition}</text>
+          <text class="atlas-military-carry-over-item__dependencies" x="52.2" y="${77.4 + index * 5.1}">${item.dependencies.join(' · ')}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryCommitmentConflictResolver(resolver) {
   const height = resolver.empty ? 8 : 8 + (resolver.recommendations.length * 5.2);
   return `
@@ -2651,6 +2734,7 @@ function renderAtlasMilitaryLayer(shell) {
   const commitmentWarnings = buildAtlasMilitaryCommitmentNextTurnWarnings(commitmentPriority, commitmentDebt, commitmentCoverage, stagedCommitment);
   const commitmentResolver = buildAtlasMilitaryCommitmentConflictResolver(stagedCommitment, commitmentConflicts, commitmentCoverage, commitmentPriority, commitmentWarnings);
   const postResolutionAudit = buildAtlasMilitaryPostResolutionOrderAudit(stagedCommitment, commitmentConflicts, commitmentCoverage, commitmentWarnings, commitmentResolver);
+  const nextTurnCarryOverQueue = buildAtlasMilitaryNextTurnCarryOverQueue(postResolutionAudit, shell);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -2684,6 +2768,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryCommitmentNextTurnWarnings(commitmentWarnings)}
       ${renderAtlasMilitaryCommitmentConflictResolver(commitmentResolver)}
       ${renderAtlasMilitaryPostResolutionOrderAudit(postResolutionAudit)}
+      ${renderAtlasMilitaryNextTurnCarryOverQueue(nextTurnCarryOverQueue)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -10905,6 +10905,7 @@ button { font: inherit; }
 .atlas-military-warning-stack,
 .atlas-military-commitment-resolver,
 .atlas-military-post-resolution-audit,
+.atlas-military-carry-over-queue,
 .atlas-military-warning-relief,
 .atlas-military-best-order,
 .atlas-military-fallback-order,
@@ -12861,4 +12862,39 @@ button { font: inherit; }
   border-radius: 12px;
   background: rgba(22, 101, 52, 0.12);
   border: 1px solid rgba(74, 222, 128, 0.18);
+}
+
+
+.atlas-military-carry-over-queue__panel {
+  fill: rgba(30, 41, 59, 0.82);
+  stroke: rgba(196, 181, 253, 0.48);
+  stroke-width: 0.35;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-carry-over-queue__title,
+.atlas-military-carry-over-item text,
+.atlas-military-carry-over-queue__empty {
+  fill: #ede9fe;
+  font-size: 1.04px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.3;
+}
+.atlas-military-carry-over-item rect {
+  fill: rgba(148, 163, 184, 0.74);
+  stroke: rgba(237, 233, 254, 0.75);
+  stroke-width: 0.2;
+}
+.atlas-military-carry-over-item--required rect { fill: rgba(248, 113, 113, 0.86); }
+.atlas-military-carry-over-item--opportunistic rect { fill: rgba(251, 191, 36, 0.8); }
+.atlas-military-carry-over-item--watch rect { fill: rgba(96, 165, 250, 0.78); }
+.atlas-military-carry-over-item__condition {
+  fill: #ddd6fe;
+  font-size: 0.76px;
+}
+.atlas-military-carry-over-item__dependencies,
+.atlas-military-carry-over-queue__empty {
+  fill: #fde68a;
+  font-size: 0.74px;
 }


### PR DESCRIPTION
Alpha: Implements #1280.

Summary:
- adds a next-turn carry-over queue derived from the MAP-A12 post-resolution audit
- separates follow-ups as obligatoire, opportuniste, or à surveiller
- explains the next-turn resolution condition per province and surfaces visible logistique/renseignement/météo dependencies without adding a new simulation

Tests:
- node --test test/ui/war/webAtlasMilitaryNextTurnCarryOverQueue.test.js
- npm test

Ready for Zeta review.