### PR TITLE
Gamma: Add cultural prompt choice comparison

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -576,6 +576,64 @@ function buildCulturalFollowUpPrompts(bundles, incompatibilities) {
   };
 }
 
+function buildCulturalPromptChoiceEntry(prompt, bundles, timingWindows) {
+  const bundle = bundles.find((candidate) => candidate.bundleId === prompt.bundleId);
+  const window = timingWindows.find((candidate) => candidate.timingId === prompt.timingId);
+  const role = prompt.state === 'compatible'
+    ? 'best-safe'
+    : prompt.state === 'risky'
+      ? 'risky-useful'
+      : 'wait';
+  const narrativeImpact = role === 'best-safe'
+    ? `${prompt.label} garde ${bundle?.label ?? 'l’engagement'} lisible et transforme ${prompt.clusterLabel} en suivi narratif immédiat.`
+    : role === 'risky-useful'
+      ? `${prompt.label} peut préserver le momentum de ${prompt.clusterLabel}, mais le choix doit absorber le risque: ${prompt.riskReason ?? 'précondition fragile'}.`
+      : `${prompt.label} reste en attente: ${prompt.riskReason ?? 'conditions prématurées'} sans devenir recommandation forte.`;
+  const lostMomentumRisk = window?.status === 'soon-lost'
+    ? 'ne rien choisir peut perdre la fenêtre au prochain tour'
+    : window?.status === 'immediate'
+      ? 'ne rien choisir dilue le momentum actif et laisse les signaux concurrents reprendre la priorité'
+      : 'ne rien choisir conserve le suivi, mais reporte l’arbitrage narratif';
+
+  return {
+    comparisonId: `${prompt.promptId}:choice-comparison`,
+    promptId: prompt.promptId,
+    role,
+    label: role === 'best-safe' ? 'meilleur suivi sûr' : role === 'risky-useful' ? 'suivi risqué mais utile' : 'suivi à attendre',
+    clusterLabel: prompt.clusterLabel,
+    promptLabel: prompt.label,
+    narrativeImpact,
+    lostMomentumRisk,
+    recommendationIds: prompt.recommendationIds,
+  };
+}
+
+function buildCulturalPromptChoiceComparison(followUpPrompts, bundles, timingWindows) {
+  const entries = followUpPrompts.prompts.map((prompt) => buildCulturalPromptChoiceEntry(prompt, bundles, timingWindows));
+  const hasSafe = entries.some((entry) => entry.role === 'best-safe');
+  const hasRisky = entries.some((entry) => entry.role === 'risky-useful');
+  const state = entries.length === 0
+    ? 'quiet'
+    : hasSafe
+      ? 'ready'
+      : hasRisky
+        ? 'risky'
+        : 'wait';
+
+  return {
+    state,
+    summary: entries.length === 0
+      ? 'Aucun arbitrage de prompt culturel disponible.'
+      : `${entries.length} choix de prompt culturel comparé${entries.length > 1 ? 's' : ''}.`,
+    entries,
+    noChoiceRisk: entries.length === 0
+      ? 'Aucun momentum culturel à arbitrer.'
+      : entries.find((entry) => entry.role === 'risky-useful')?.lostMomentumRisk
+        ?? entries.find((entry) => entry.role === 'best-safe')?.lostMomentumRisk
+        ?? 'ne rien choisir garde les prompts prématurés en attente sans renforcer le récit',
+  };
+}
+
 function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = []) {
   const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
   const trajectories = ['apaisement', 'consolidation', 'enquête', 'expansion', 'attente'];
@@ -676,6 +734,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
     });
 
   const followUpPrompts = buildCulturalFollowUpPrompts(bundles, incompatibilities);
+  const promptChoiceComparison = buildCulturalPromptChoiceComparison(followUpPrompts, bundles, timingWindows);
 
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
@@ -689,6 +748,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
       ? 'Aucune fenêtre de timing culturel active.'
       : `${timingWindows.length} fenêtre${timingWindows.length > 1 ? 's' : ''} de timing culturel après bundle.`,
     followUpPrompts,
+    promptChoiceComparison,
     dependencyExplanation: bundles.length === 0
       ? 'Aucune dépendance entre marqueurs culturels.'
       : bundles
@@ -783,6 +843,12 @@ export function buildCultureTurnReportDeltas({
           state: 'quiet',
           summary: 'Aucun prompt de suivi culturel après timing.',
           prompts: [],
+        },
+        promptChoiceComparison: {
+          state: 'quiet',
+          summary: 'Aucun arbitrage de prompt culturel disponible.',
+          entries: [],
+          noChoiceRisk: 'Aucun momentum culturel à arbitrer.',
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
       },

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -226,6 +226,24 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
         },
       ],
     },
+    promptChoiceComparison: {
+      state: 'ready',
+      summary: '1 choix de prompt culturel comparé.',
+      entries: [
+        {
+          comparisonId: 'culture-commitment:expansion:timing:river-gate:follow-up:choice-comparison',
+          promptId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+          role: 'best-safe',
+          label: 'meilleur suivi sûr',
+          clusterLabel: 'Compact d’Aurora',
+          promptLabel: 'Ouvrir le récit d’expansion',
+          narrativeImpact: 'Ouvrir le récit d’expansion garde expansion prudente lisible et transforme Compact d’Aurora en suivi narratif immédiat.',
+          lostMomentumRisk: 'ne rien choisir dilue le momentum actif et laisse les signaux concurrents reprendre la priorité',
+          recommendationIds: ['river-gate:momentum:strengthened:1:stabilization'],
+        },
+      ],
+      noChoiceRisk: 'ne rien choisir dilue le momentum actif et laisse les signaux concurrents reprendre la priorité',
+    },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
 });
@@ -272,6 +290,12 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         state: 'quiet',
         summary: 'Aucun prompt de suivi culturel après timing.',
         prompts: [],
+      },
+      promptChoiceComparison: {
+        state: 'quiet',
+        summary: 'Aucun arbitrage de prompt culturel disponible.',
+        entries: [],
+        noChoiceRisk: 'Aucun momentum culturel à arbitrer.',
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },
@@ -626,4 +650,12 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
   ]);
   assert.match(report.commitmentBundles.followUpPrompts.prompts[0].reasonNow, /fenêtre recommandée/);
   assert.match(report.commitmentBundles.followUpPrompts.prompts[2].riskReason, /conditions culturelles|timing narratif/);
+  assert.equal(report.commitmentBundles.promptChoiceComparison.state, 'risky');
+  assert.deepEqual(report.commitmentBundles.promptChoiceComparison.entries.map((entry) => [entry.clusterLabel, entry.role, entry.label]), [
+    ['Compact d’Aurora', 'risky-useful', 'suivi risqué mais utile'],
+    ['Harbor Compact', 'risky-useful', 'suivi risqué mais utile'],
+    ['Ember Guild', 'wait', 'suivi à attendre'],
+  ]);
+  assert.match(report.commitmentBundles.promptChoiceComparison.entries[0].narrativeImpact, /préserver le momentum/);
+  assert.match(report.commitmentBundles.promptChoiceComparison.noChoiceRisk, /momentum|fenêtre/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6082,6 +6082,23 @@ function renderCultureTurnReport(report) {
           </div>
         ` : '<small>État vide: aucun suivi narratif à proposer tant qu’aucune fenêtre n’est recommandée ou choisie.</small>'}
       </div>
+      <div class="culture-turn-report__choice culture-turn-report__choice--${report.commitmentBundles?.promptChoiceComparison?.state ?? 'quiet'}" aria-label="Arbitrage entre prompts culturels">
+        <span>Arbitrage des prompts</span>
+        <strong>${report.commitmentBundles?.promptChoiceComparison?.summary ?? 'Aucun arbitrage de prompt culturel disponible.'}</strong>
+        <small>Si aucun choix: ${report.commitmentBundles?.promptChoiceComparison?.noChoiceRisk ?? 'Aucun momentum culturel à arbitrer.'}</small>
+        ${(report.commitmentBundles?.promptChoiceComparison?.entries ?? []).length > 0 ? `
+          <div class="culture-turn-report__choice-list">
+            ${report.commitmentBundles.promptChoiceComparison.entries.map((entry) => `
+              <article class="culture-turn-report__choice-entry culture-turn-report__choice-entry--${entry.role}" data-culture-prompt-choice="${entry.comparisonId}">
+                <b>${entry.label}</b>
+                <em>${entry.clusterLabel} · ${entry.promptLabel}</em>
+                <small>${entry.narrativeImpact}</small>
+                <small>Risque d’inaction: ${entry.lostMomentumRisk}</small>
+              </article>
+            `).join('')}
+          </div>
+        ` : '<small>État vide: aucun prompt compatible, risqué ou à attendre à comparer.</small>'}
+      </div>
     </div>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -1818,6 +1818,48 @@ button { font: inherit; }
 .culture-turn-report__follow-up-prompt--compatible { border-color: rgba(74, 222, 128, 0.28); }
 .culture-turn-report__follow-up-prompt--risky { border-color: rgba(251, 191, 36, 0.42); }
 .culture-turn-report__follow-up-prompt--premature { border-color: rgba(148, 163, 184, 0.24); }
+.culture-turn-report__choice {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid rgba(167, 139, 250, 0.12);
+}
+.culture-turn-report__choice > span {
+  color: #f0abfc;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__choice > strong {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.culture-turn-report__choice > small { color: var(--muted); }
+.culture-turn-report__choice-list {
+  display: grid;
+  gap: 6px;
+}
+.culture-turn-report__choice-entry {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(49, 46, 129, 0.24);
+  border: 1px solid rgba(240, 171, 252, 0.18);
+}
+.culture-turn-report__choice-entry b { color: #fae8ff; }
+.culture-turn-report__choice-entry em {
+  color: #f0abfc;
+  font-style: normal;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.culture-turn-report__choice-entry small { color: var(--muted); }
+.culture-turn-report__choice-entry--best-safe { border-color: rgba(74, 222, 128, 0.34); }
+.culture-turn-report__choice-entry--risky-useful { border-color: rgba(251, 191, 36, 0.44); }
+.culture-turn-report__choice-entry--wait { border-color: rgba(148, 163, 184, 0.26); }
 .hero-stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Gamma: Implements MAP-G13 for #1282.\n\nSummary:\n- compares G12 cultural follow-up prompts against active bundles and timing windows;\n- marks best safe follow-up, risky-but-useful follow-up, and prompts to wait on without strengthening premature states;\n- explains narrative impact plus lost momentum risk if no prompt is chosen;\n- renders a separate prompt arbitration block so G11/G12 timing and generation remain distinct.\n\nChecks:\n- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js\n- node --check web/app.js\n- git diff --check\n- npm test