### PR TITLE
Delta: Add fog-safe intrigue recheck queue

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2749,6 +2749,82 @@ function buildVerificationOutcomeRecap({ locationId, locationName, verificationC
   };
 }
 
+function buildIntrigueRecheckQueue({ locationId, locationName, verificationOutcomeRecap, verificationAuditTrail, intelligenceProvenancePanel, exposureBudgetForPriorityVerifications }) {
+  if (verificationOutcomeRecap.state === 'masked-recap') {
+    return {
+      state: 'masked-recheck-queue',
+      locationId,
+      locationName,
+      entries: [],
+      blockedRechecks: [{
+        reason: 'Ne pas relancer: provenance ou budget encore masqué, risque de transformer une absence de preuve en indice caché.',
+        triggerCondition: 'Attendre une provenance visible ou un nouveau signal cartographique autorisé.',
+      }],
+      budgetLink: 'masked-budget',
+      provenanceLink: intelligenceProvenancePanel.sourceLabel,
+      summary: 'File de re-vérification masquée: aucune relance sûre tant que provenance et budget restent insuffisants.',
+      safeMapPolicy: 'Planification D13 uniquement; aucune cellule, relais, cible, méthode sensible ou cause cachée n’est révélée.',
+    };
+  }
+
+  const remainingBudget = verificationOutcomeRecap.exposureBudgetRemaining ?? 0;
+  const provenanceLink = `${intelligenceProvenancePanel.provenanceType}:${verificationAuditTrail.lastChange}`;
+  const retainedCheck = verificationOutcomeRecap.retainedVerifications[0] ?? null;
+  const baseTrigger = verificationAuditTrail.lastChange === 'residual-risk'
+    ? 'Relancer seulement si le risque résiduel reste visible après le prochain passage sûr.'
+    : 'Relancer seulement si un nouveau signal visible augmente la confiance sans élargir la couverture.';
+  const entries = verificationOutcomeRecap.remainingUncertainties
+    .filter((uncertainty) => !/Aucun conflit/.test(uncertainty))
+    .map((uncertainty, index) => {
+      const enoughBudget = remainingBudget >= 3;
+      return {
+        queueId: `${locationId}:recheck:${index + 1}`,
+        uncertainty,
+        status: enoughBudget ? 'queued-for-safe-window' : 'wait-for-budget',
+        safeWindow: enoughBudget ? 'prochain créneau de faible exposition' : 'après récupération de budget d’exposition visible',
+        triggerCondition: baseTrigger,
+        recommendedCheck: retainedCheck ? {
+          checkId: retainedCheck.checkId,
+          label: retainedCheck.label,
+          exposureBand: retainedCheck.exposureBand,
+        } : verificationOutcomeRecap.nextSafeVerification,
+        budgetRemaining: remainingBudget,
+        provenanceLink,
+        resultLink: verificationOutcomeRecap.sourceResolverState,
+      };
+    });
+  const delayedBlocks = verificationOutcomeRecap.delayedVerifications.map((verification) => ({
+    checkId: verification.checkId,
+    label: verification.label,
+    reason: 'Ne pas relancer maintenant: le resolver a retardé ce contrôle car il augmente trop l’exposition.',
+    exposureBand: verification.exposureBand,
+    triggerCondition: 'Reconsidérer seulement si le budget restant augmente et si une provenance visible confirme le besoin.',
+  }));
+  const abandonedBlocks = verificationOutcomeRecap.abandonedVerifications.map((verification) => ({
+    label: verification.label,
+    reason: verification.reason,
+    exposureBand: 'avoid',
+    triggerCondition: 'Ne relancer qu’en présence d’un nouveau signal visible, jamais sur information cachée.',
+  }));
+
+  return {
+    state: entries.length > 0 ? 'rechecks-planned' : 'no-recheck-needed',
+    locationId,
+    locationName,
+    entries,
+    blockedRechecks: [...delayedBlocks, ...abandonedBlocks],
+    budgetLink: exposureBudgetForPriorityVerifications.state,
+    budgetRemaining: remainingBudget,
+    provenanceLink,
+    retainedResultIds: verificationOutcomeRecap.retainedVerifications.map((verification) => verification.checkId),
+    delayedResultIds: verificationOutcomeRecap.delayedVerifications.map((verification) => verification.checkId),
+    summary: entries.length > 0
+      ? `${entries.length} incertitude(s) à re-vérifier plus tard sans dépasser le budget visible.`
+      : 'Aucune re-vérification planifiée: les incertitudes restantes ne justifient pas une relance sûre.',
+    safeMapPolicy: 'File de re-vérification D13 dérivée du récap D12, du budget restant et de la provenance visible; elle ne révèle jamais cellule, relais, cible, méthode sensible ou cause cachée.',
+  };
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -2944,6 +3020,14 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         verificationAuditTrail,
         intrigueSignalTriageQueue,
       });
+      const intrigueRecheckQueue = buildIntrigueRecheckQueue({
+        locationId,
+        locationName,
+        verificationOutcomeRecap,
+        verificationAuditTrail,
+        intelligenceProvenancePanel,
+        exposureBudgetForPriorityVerifications,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -2959,6 +3043,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           exposureBudgetForPriorityVerifications,
           verificationConflictResolver,
           verificationOutcomeRecap,
+          intrigueRecheckQueue,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2419,3 +2419,64 @@ test('buildIntrigueMapOverlay recaps verification resolver outcomes without leak
   assert.equal(masked.nextSafeVerification, null);
   assert.match(masked.remainingUncertainties.join(' '), /Provenance insuffisante/);
 });
+
+test('buildIntrigueMapOverlay plans fog-safe recheck queues for unresolved intrigue uncertainties', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-recheck-queue',
+      factionId: 'shadow-league',
+      codename: 'Queue',
+      locationId: 'recheck-queue',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 92,
+    }),
+    new Cellule({
+      id: 'cell-recheck-masked',
+      factionId: 'shadow-league',
+      codename: 'Masked Queue',
+      locationId: 'recheck-masked',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-recheck-queue',
+      celluleId: 'cell-recheck-queue',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Keep uncertainty visible',
+      theaterId: 'recheck-queue',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 92,
+      progress: 80,
+      heat: 86,
+      phase: 'execution',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.intrigueRecheckQueue]));
+  const queue = byLocation.get('recheck-queue');
+  const masked = byLocation.get('recheck-masked');
+
+  assert.equal(queue.state, 'rechecks-planned');
+  assert.equal(queue.budgetRemaining, 4);
+  assert.equal(queue.budgetLink, 'visible-budget');
+  assert.equal(queue.provenanceLink, 'observed:residual-risk');
+  assert.equal(queue.entries[0].status, 'queued-for-safe-window');
+  assert.equal(queue.entries[0].safeWindow, 'prochain créneau de faible exposition');
+  assert.equal(queue.entries[0].recommendedCheck.checkId, 'observe-local-confirmation');
+  assert.match(queue.entries[0].triggerCondition, /risque résiduel reste visible/);
+  assert.equal(queue.blockedRechecks[0].checkId, 'broad-coverage-now');
+  assert.match(queue.blockedRechecks[0].reason, /augmente trop l’exposition/);
+  assert.deepEqual(queue.retainedResultIds, ['observe-local-confirmation']);
+  assert.deepEqual(queue.delayedResultIds, ['broad-coverage-now']);
+  assert.match(queue.safeMapPolicy, /budget restant et de la provenance visible/);
+
+  assert.equal(masked.state, 'masked-recheck-queue');
+  assert.deepEqual(masked.entries, []);
+  assert.equal(masked.blockedRechecks.length, 1);
+  assert.match(masked.blockedRechecks[0].triggerCondition, /provenance visible/);
+  assert.match(masked.safeMapPolicy, /aucune cellule, relais, cible, méthode sensible ou cause cachée/);
+});


### PR DESCRIPTION
Delta: Implements #1283.

Summary:
- adds a fog-safe intrigueRecheckQueue derived from the D12 outcome recap, remaining budget, and visible provenance;
- lists unresolved uncertainties for later safe recheck windows/triggers;
- flags delayed or abandoned checks that should not be relaunched because they would consume too much exposure;
- keeps the queue as planning only, without duplicating the resolver or recap and without revealing hidden cell/relay/target/cause details.

Validation:
- node --check src/ui/intrigue/buildIntrigueMapOverlay.js
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test (700 passing)
- node --check web/app.js
- git diff --check

Closes #1283