### PR TITLE
Beta: Add logistics repayment scenario previews

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2345,6 +2345,74 @@ function buildRecoveryDebtRepaymentPriorities(logisticsFeatures, recoveryDebtLed
   };
 }
 
+
+function buildRepaymentScenarioOption(priority, debtEntry, mode) {
+  const debtAmount = Math.max(0, debtEntry?.debtAmount ?? priority.debtAmount ?? 0);
+  const fullCapacity = Math.max(1, debtAmount || Math.ceil((debtEntry?.costTotal ?? 1) / 2));
+  const capacityConsumed = mode === 'complete' ? fullCapacity : Math.max(1, Math.ceil(fullCapacity / 2));
+  const remainingBlocked = Math.max(0, debtAmount - capacityConsumed);
+  const label = mode === 'complete' ? 'Remboursement complet' : 'Remboursement partiel';
+  const status = remainingBlocked === 0 ? 'reprise sécurisée' : 'blocage résiduel';
+
+  return {
+    id: `${priority.id}:${mode}`,
+    mode,
+    label,
+    capacityConsumed,
+    remainingBlocked,
+    status,
+    tone: remainingBlocked === 0 ? 'positive' : 'warning',
+    probableEffect: remainingBlocked === 0
+      ? `${priority.label}: ${priority.expectedGain}`
+      : `${priority.label}: réduit la dette de ${capacityConsumed}, mais ${remainingBlocked} capacité reste bloquée sur ${priority.corridor}.`,
+    blockedAfter: remainingBlocked === 0
+      ? 'Aucun blocage majeur restant sur cette dette prioritaire.'
+      : `${remainingBlocked} capacité encore bloquée; ${priority.blockingImpact}`,
+  };
+}
+
+function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymentPriorities) {
+  const candidates = repaymentPriorities.priorities.slice(0, 3);
+  const scenarios = candidates.map((priority) => {
+    const debtEntry = recoveryDebtLedger.entries.find((entry) => entry.id === priority.debtEntryId) ?? null;
+    const partial = buildRepaymentScenarioOption(priority, debtEntry, 'partial');
+    const complete = buildRepaymentScenarioOption(priority, debtEntry, 'complete');
+    const minimalViableAction = partial.remainingBlocked === 0
+      ? partial.label
+      : `${priority.nextAction}: couvrir au moins ${partial.capacityConsumed} capacité maintenant, puis planifier ${partial.remainingBlocked} au prochain tour`;
+
+    return {
+      id: `recovery-repayment-scenario:${priority.targetId}`,
+      priorityId: priority.id,
+      debtEntryId: priority.debtEntryId,
+      targetId: priority.targetId,
+      label: priority.label,
+      corridor: priority.corridor,
+      rank: priority.rank,
+      minimalViableAction,
+      options: [partial, complete],
+      ledgerLink: debtEntry?.id ?? priority.debtEntryId,
+      priorityLink: priority.id,
+      summary: `${priority.label}: partiel consomme ${partial.capacityConsumed} et laisse ${partial.remainingBlocked} bloqué; complet consomme ${complete.capacityConsumed} et laisse ${complete.remainingBlocked} bloqué.`,
+    };
+  });
+
+  return {
+    id: 'logistics-recovery-repayment-scenarios',
+    title: 'Scénarios remboursement dettes prioritaires',
+    summary: scenarios.length === 0
+      ? 'Aucun scénario de remboursement urgent à prévisualiser.'
+      : `${scenarios.length} scénario(s) de reprise comparent remboursement partiel et complet.`,
+    scenarios,
+    topScenarioId: scenarios[0]?.id ?? null,
+    minimalViableAction: scenarios[0]?.minimalViableAction ?? 'continuer la surveillance',
+    legend: [
+      { key: 'partial', label: 'Partiel: débloque une portion', tone: 'warning' },
+      { key: 'complete', label: 'Complet: sécurise la reprise', tone: 'positive' },
+    ],
+  };
+}
+
 function buildDecisionLegend() {
   return [
     { key: 'critical', label: 'Priorité critique: manque ou saturation immédiate', tone: 'danger' },
@@ -2422,6 +2490,7 @@ function buildEconomyMapLayers(cityOverlays, routeOverlays) {
   const atRiskRecoverySummary = buildAtRiskRecoverySummary(logisticsFeaturesWithPlanners);
   const recoveryCapacityBudget = buildRecoveryCapacityBudget(logisticsFeaturesWithPlanners, atRiskRecoverySummary);
   const recoveryDebtLedger = buildRecoveryDebtLedger(logisticsFeaturesWithPlanners, recoveryCapacityBudget);
+  const recoveryDebtRepaymentPriorities = buildRecoveryDebtRepaymentPriorities(logisticsFeaturesWithPlanners, recoveryDebtLedger);
 
   return {
     cities: {
@@ -2446,7 +2515,8 @@ function buildEconomyMapLayers(cityOverlays, routeOverlays) {
       atRiskRecoverySummary,
       recoveryCapacityBudget,
       recoveryDebtLedger,
-      recoveryDebtRepaymentPriorities: buildRecoveryDebtRepaymentPriorities(logisticsFeaturesWithPlanners, recoveryDebtLedger),
+      recoveryDebtRepaymentPriorities,
+      recoveryDebtRepaymentScenarioPreviews: buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, recoveryDebtRepaymentPriorities),
       recoveryPlannerLegend: [
         { key: 'repair', label: 'Réparer', tone: 'stable' },
         { key: 'reroute', label: 'Rerouter', tone: 'caution' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1579,6 +1579,32 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentPriorities.priorities[0].blockingImpact, /stock de reprise manquant/);
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentPriorities.priorities[0].expectedGain, /Rembourser stock/);
 
+  assert.equal(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.id, 'logistics-recovery-repayment-scenarios');
+  assert.equal(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.topScenarioId, 'recovery-repayment-scenario:route-coast');
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.summary, /partiel et complet/);
+  assert.deepEqual(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.scenarios.map((scenario) => ({
+    id: scenario.id,
+    priorityId: scenario.priorityId,
+    debtEntryId: scenario.debtEntryId,
+    minimalViableAction: scenario.minimalViableAction,
+  })), [
+    {
+      id: 'recovery-repayment-scenario:route-coast',
+      priorityId: 'recovery-repayment:route-coast',
+      debtEntryId: 'recovery-debt:route-coast',
+      minimalViableAction: 'ajouter du stock avant le prochain bundle: couvrir au moins 1 capacité maintenant, puis planifier 1 au prochain tour',
+    },
+  ]);
+  assert.deepEqual(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.scenarios[0].options.map((option) => ({
+    mode: option.mode,
+    capacityConsumed: option.capacityConsumed,
+    remainingBlocked: option.remainingBlocked,
+    status: option.status,
+  })), [
+    { mode: 'partial', capacityConsumed: 1, remainingBlocked: 1, status: 'blocage résiduel' },
+    { mode: 'complete', capacityConsumed: 2, remainingBlocked: 0, status: 'reprise sécurisée' },
+  ]);
+
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,
     targetId: marker.targetId,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -23,6 +23,14 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(webAppSource, /view\.waitable/);
   assert.match(webAppSource, /renderEconomyRecoveryRepaymentPriorities\(economyView\)/);
 
+  assert.match(webAppSource, /function renderEconomyRecoveryRepaymentScenarios/);
+  assert.match(webAppSource, /recoveryDebtRepaymentScenarioPreviews/);
+  assert.match(webAppSource, /Scénarios de reprise après remboursement logistique/);
+  assert.match(webAppSource, /option\.capacityConsumed/);
+  assert.match(webAppSource, /option\.remainingBlocked/);
+  assert.match(webAppSource, /scenario\.minimalViableAction/);
+  assert.match(webAppSource, /renderEconomyRecoveryRepaymentScenarios\(economyView\)/);
+
   assert.match(stylesSource, /\.economy-recovery-debt/);
   assert.match(stylesSource, /\.economy-recovery-debt--en-dette/);
   assert.match(stylesSource, /\.economy-recovery-debt__totals/);
@@ -31,4 +39,8 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(stylesSource, /\.economy-repayment-priorities/);
   assert.match(stylesSource, /\.economy-repayment-priorities__item--critical/);
   assert.match(stylesSource, /\.economy-repayment-priorities__wait/);
+
+  assert.match(stylesSource, /\.economy-repayment-scenarios/);
+  assert.match(stylesSource, /\.economy-repayment-scenario__option--warning/);
+  assert.match(stylesSource, /\.economy-repayment-scenario__option--positive/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -18229,6 +18229,50 @@ function renderEconomyRecoveryRepaymentPriorities(economyView) {
 }
 
 
+function renderEconomyRecoveryRepaymentScenarios(economyView) {
+  const view = economyView.overlay.layers?.logistics?.recoveryDebtRepaymentScenarioPreviews ?? null;
+
+  if (!view) {
+    return '';
+  }
+
+  return `
+    <section class="economy-repayment-scenarios" aria-label="Scénarios de reprise après remboursement logistique">
+      <div class="economy-repayment-scenarios__header">
+        <span>Scénarios reprise</span>
+        <strong>${view.title}</strong>
+      </div>
+      <p>${view.summary}</p>
+      <div class="economy-repayment-scenarios__list">
+        ${view.scenarios.map((scenario) => `
+          <article class="economy-repayment-scenario">
+            <div class="economy-repayment-scenario__title">
+              <strong>#${scenario.rank} · ${scenario.label}</strong>
+              <small>${scenario.corridor}</small>
+            </div>
+            <p>${scenario.summary}</p>
+            <div class="economy-repayment-scenario__options">
+              ${scenario.options.map((option) => `
+                <div class="economy-repayment-scenario__option economy-repayment-scenario__option--${option.tone}">
+                  <b>${option.label}</b>
+                  <span>Capacité ${option.capacityConsumed} · bloqué ${option.remainingBlocked}</span>
+                  <p>${option.probableEffect}</p>
+                  <small>${option.blockedAfter}</small>
+                </div>
+              `).join('')}
+            </div>
+            <footer>
+              <span>Action minimale viable</span>
+              <strong>${scenario.minimalViableAction}</strong>
+            </footer>
+          </article>
+        `).join('')}
+      </div>
+    </section>
+  `;
+}
+
+
 function renderEconomySidePanel(economyView, cultureView) {
   const culturePanel = renderCultureSidePanel(cultureView);
 
@@ -18289,6 +18333,7 @@ function renderEconomySidePanel(economyView, cultureView) {
       ${renderEconomyFocusPanel(economyView)}
       ${renderEconomyRecoveryDebtLedger(economyView)}
       ${renderEconomyRecoveryRepaymentPriorities(economyView)}
+      ${renderEconomyRecoveryRepaymentScenarios(economyView)}
       ${selectedRoute && selectedRouteStress ? `
         <article class="economy-route-stress-panel economy-route-stress-panel--${selectedRouteStress.tone}">
           <div class="economy-route-stress-panel__header">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12940,3 +12940,69 @@ button { font: inherit; }
   fill: #fde68a;
   font-size: 0.74px;
 }
+
+.economy-repayment-scenarios {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 14px;
+  border-radius: 18px;
+  background: linear-gradient(150deg, rgba(3, 7, 18, 0.78), rgba(12, 74, 110, 0.22));
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.economy-repayment-scenarios__header,
+.economy-repayment-scenario footer {
+  display: grid;
+  gap: 3px;
+}
+.economy-repayment-scenarios__header span,
+.economy-repayment-scenario footer span {
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.economy-repayment-scenarios__header strong,
+.economy-repayment-scenario__title strong,
+.economy-repayment-scenario footer strong { color: #f8fafc; }
+.economy-repayment-scenarios p,
+.economy-repayment-scenarios small,
+.economy-repayment-scenario__option span {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.economy-repayment-scenarios__list {
+  display: grid;
+  gap: 9px;
+}
+.economy-repayment-scenario {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.36);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.economy-repayment-scenario__title {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.economy-repayment-scenario__options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.economy-repayment-scenario__option {
+  display: grid;
+  gap: 5px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.48);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+.economy-repayment-scenario__option b { color: #e0f2fe; }
+.economy-repayment-scenario__option--warning { border-color: rgba(245, 158, 11, 0.34); }
+.economy-repayment-scenario__option--positive { border-color: rgba(74, 222, 128, 0.28); }


### PR DESCRIPTION
Beta: Closes #1281.\n\n## Summary\n- add scenario previews for priority logistics debt repayment\n- compare partial vs complete repayment with consumed capacity and remaining blocked capacity\n- surface the minimal viable action linked back to the ledger and repayment priorities\n\n## Tests\n- node --test test/ui/economy/buildEconomyMapOverlay.test.js test/ui/economy/webEconomyRecoveryDebtLedger.test.js\n- npm test\n- git diff --check