### PR TITLE
Epsilon: add climate follow-up compatibility bundles

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1881,6 +1881,54 @@ function describeClimateBundleExpectedEffect(bundle) {
   return 'intervention différée: évite de verrouiller une fenêtre trop contradictoire';
 }
 
+function buildClimateFollowUpCompatibilityBundles(bundle, followUpQueue, preview) {
+  const minimalItems = followUpQueue.filter((item) => item.classification === 'urgent');
+  const safeItems = minimalItems.length > 0
+    ? minimalItems
+    : followUpQueue.filter((item) => item.classification === 'prudent').slice(0, 1).concat(
+      followUpQueue.some((item) => item.classification === 'prudent') ? [] : followUpQueue.filter((item) => item.classification === 'deferrable').slice(0, 1),
+    );
+  const ambitiousItems = followUpQueue.filter((item) => item.classification !== 'deferrable');
+  const conflictSignals = [
+    ...(bundle.resourceConflicts.includes('mitigation') ? ['mitigation'] : []),
+    ...(bundle.resourceConflicts.includes('reserve') ? ['reserve'] : []),
+    ...(preview.coolingOffTurns > 1 || bundle.resourceConflicts.includes('window-timing') ? ['cooling-off-timing'] : []),
+    ...(preview.reboundRegionIds.length > 0 || bundle.resourceConflicts.includes('residual-risk') ? ['regional-residual-risk'] : []),
+  ];
+  const buildBundle = (kind, items) => ({
+    compatibilityBundleId: `${bundle.bundleId}:compat:${kind}`,
+    kind,
+    followUpIds: items.map((item) => item.followUpId),
+    regionIds: items.map((item) => item.regionId),
+    safety: kind === 'minimal-safe' ? 'safe' : (conflictSignals.length > 0 ? 'fragile' : 'safe'),
+    conflictSignals: kind === 'minimal-safe'
+      ? conflictSignals.filter((signal) => signal === 'cooling-off-timing' || signal === 'regional-residual-risk')
+      : conflictSignals,
+    reason: kind === 'minimal-safe'
+      ? 'regroupe seulement les suivis nécessaires sans rouvrir toute la file climat'
+      : 'couvre plus de suivis mais peut consommer réserve, mitigation ou timing de refroidissement',
+  });
+  const minimalSafeBundle = buildBundle('minimal-safe', safeItems);
+  const ambitiousFragileBundle = buildBundle('ambitious-fragile', ambitiousItems.length > 0 ? ambitiousItems : followUpQueue);
+  const pendingIfMinimal = followUpQueue
+    .filter((item) => !minimalSafeBundle.followUpIds.includes(item.followUpId))
+    .map((item) => ({
+      followUpId: item.followUpId,
+      regionId: item.regionId,
+      reason: item.classification === 'deferrable'
+        ? 'différable sans rebond immédiat'
+        : 'à laisser après confirmation de la fenêtre de cooling-off',
+    }));
+
+  return {
+    recommendedMinimalBundleId: minimalSafeBundle.compatibilityBundleId,
+    ambitiousFragileBundleId: ambitiousFragileBundle.compatibilityBundleId,
+    bundles: [minimalSafeBundle, ambitiousFragileBundle],
+    pendingIfMinimal,
+    summary: `${followUpQueue.length} suivi(s), ${pendingIfMinimal.length} laissé(s) en attente si bundle minimal.`,
+  };
+}
+
 function buildClimateBundleFollowUpQueue(bundle, preview) {
   const reboundRegionSet = new Set(preview.reboundRegionIds);
   const conflicts = new Set(bundle.resourceConflicts);
@@ -1958,9 +2006,12 @@ function buildClimateBundleAfterActionPreview(bundle) {
       : `${coolingOffTurns} tour(s) de cooling-off; aucun rebond régional probable si la réserve reste disponible.`,
   };
 
+  const followUpQueue = buildClimateBundleFollowUpQueue(bundle, preview);
+
   return {
     ...preview,
-    followUpQueue: buildClimateBundleFollowUpQueue(bundle, preview),
+    followUpQueue,
+    followUpCompatibility: buildClimateFollowUpCompatibilityBundles(bundle, followUpQueue, preview),
   };
 }
 
@@ -2001,6 +2052,7 @@ function normalizeClimateBundleAfterActionPreview(preview, basePreview) {
         nextAction: String(normalizedItem.nextAction).trim(),
       };
     }),
+    followUpCompatibility: normalizedPreview.followUpCompatibility ?? basePreview.followUpCompatibility,
   };
 }
 

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -4,6 +4,11 @@ import assert from 'node:assert/strict';
 import { buildClimateMapOverlay } from '../../../src/ui/climate/buildClimateMapOverlay.js';
 import { ClimateState } from '../../../src/domain/climate/ClimateState.js';
 
+function stripFollowUpCompatibility(preview) {
+  const { followUpCompatibility, ...rest } = preview;
+  return rest;
+}
+
 test('buildClimateMapOverlay combines seasons, anomalies, and catastrophes into stable regional entries', () => {
   const overlay = buildClimateMapOverlay([
     new ClimateState({
@@ -2283,7 +2288,10 @@ test('buildClimateMapOverlay supports explicit prudent climate bundle overrides'
     ],
   });
 
-  assert.deepEqual(overlay.climateActionBundleAssistant.bundles, [
+  assert.deepEqual(overlay.climateActionBundleAssistant.bundles.map((bundle) => ({
+    ...bundle,
+    afterActionPreview: stripFollowUpCompatibility(bundle.afterActionPreview),
+  })), [
     {
       bundleId: 'climate-bundle:postpone',
       kind: 'postpone',
@@ -2364,7 +2372,7 @@ test('buildClimateMapOverlay previews rebound and cooling-off after prudent clim
 
   const [secureNowBundle, prepareBundle] = overlay.climateActionBundleAssistant.bundles;
 
-  assert.deepEqual(secureNowBundle.afterActionPreview, {
+  assert.deepEqual(stripFollowUpCompatibility(secureNowBundle.afterActionPreview), {
     expectedEffect: 'pression climatique abaissée immédiatement sans rouvrir de conflit majeur',
     coolingOffTurns: 1,
     coolingOffState: 'observe-next-turn',
@@ -2384,7 +2392,7 @@ test('buildClimateMapOverlay previews rebound and cooling-off after prudent clim
       },
     ],
   });
-  assert.deepEqual(prepareBundle.afterActionPreview, {
+  assert.deepEqual(stripFollowUpCompatibility(prepareBundle.afterActionPreview), {
     expectedEffect: 'readiness renforcée avant engagement direct, sans répéter le calendrier saisonnier',
     coolingOffTurns: 2,
     coolingOffState: 'verify-before-reintervention',
@@ -2403,5 +2411,31 @@ test('buildClimateMapOverlay previews rebound and cooling-off after prudent clim
         nextAction: 'placer une vérification de readiness au prochain tour sûr',
       },
     ],
+  });
+  assert.deepEqual(prepareBundle.afterActionPreview.followUpCompatibility, {
+    recommendedMinimalBundleId: 'climate-bundle:prepare:compat:minimal-safe',
+    ambitiousFragileBundleId: 'climate-bundle:prepare:compat:ambitious-fragile',
+    bundles: [
+      {
+        compatibilityBundleId: 'climate-bundle:prepare:compat:minimal-safe',
+        kind: 'minimal-safe',
+        followUpIds: ['climate-bundle:prepare:ridge:follow-up'],
+        regionIds: ['ridge'],
+        safety: 'safe',
+        conflictSignals: ['cooling-off-timing', 'regional-residual-risk'],
+        reason: 'regroupe seulement les suivis nécessaires sans rouvrir toute la file climat',
+      },
+      {
+        compatibilityBundleId: 'climate-bundle:prepare:compat:ambitious-fragile',
+        kind: 'ambitious-fragile',
+        followUpIds: ['climate-bundle:prepare:ridge:follow-up'],
+        regionIds: ['ridge'],
+        safety: 'fragile',
+        conflictSignals: ['mitigation', 'cooling-off-timing', 'regional-residual-risk'],
+        reason: 'couvre plus de suivis mais peut consommer réserve, mitigation ou timing de refroidissement',
+      },
+    ],
+    pendingIfMinimal: [],
+    summary: '1 suivi(s), 0 laissé(s) en attente si bundle minimal.',
   });
 });

--- a/test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
+++ b/test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas renders compatibility bundles for climate rebound follow-up queues', () => {
+  assert.match(webAppSource, /buildAtlasClimateFollowUpCompatibilityBundles/);
+  assert.match(webAppSource, /renderAtlasClimateFollowUpCompatibilityBundles/);
+  assert.match(webAppSource, /Compatibilité suivis climat/);
+  assert.match(webAppSource, /Minimal sûr/);
+  assert.match(webAppSource, /Ambitieux fragile/);
+  assert.match(webAppSource, /cooling-off-timing/);
+  assert.match(webAppSource, /regional-residual-risk/);
+  assert.match(webAppSource, /À laisser en attente si minimal/);
+  assert.match(webAppSource, /renderAtlasClimateReboundFollowUpQueue\(atlasClimateReboundFollowUpQueue\)\}\s*\$\{renderAtlasClimateFollowUpCompatibilityBundles\(atlasClimateFollowUpCompatibilityBundles\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-follow-up-compat/);
+  assert.match(stylesSource, /\.map-world-climate-follow-up-compat__item--minimal-safe/);
+  assert.match(stylesSource, /\.map-world-climate-follow-up-compat__item--ambitious-fragile/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -11085,6 +11085,86 @@ function renderAtlasClimateReboundFollowUpQueue(view) {
   `;
 }
 
+function buildAtlasClimateFollowUpCompatibilityBundles(queueView, reboundView) {
+  if (!queueView || queueView.state === 'empty' || queueView.items.length === 0) {
+    return {
+      state: 'empty',
+      bundles: [],
+      pendingIfMinimal: [],
+      summary: 'Aucun bundle compatible de suivis climat à afficher.',
+    };
+  }
+
+  const urgentItems = queueView.items.filter((item) => item.classification === 'urgent');
+  const prudentItems = queueView.items.filter((item) => item.classification === 'prudent');
+  const minimalItems = urgentItems.length > 0 ? urgentItems : (prudentItems[0] ? [prudentItems[0]] : [queueView.items[0]]);
+  const ambitiousItems = queueView.items.filter((item) => item.classification !== 'deferrable');
+  const conflictSignals = [
+    ...(queueView.items.some((item) => /réserve/i.test(item.ignoredReboundRisk)) ? ['reserve'] : []),
+    ...(queueView.items.some((item) => /readiness|mitigation/i.test(item.nextAction)) ? ['mitigation'] : []),
+    ...(reboundView?.coolingOffTurns > 1 ? ['cooling-off-timing'] : []),
+    ...(queueView.items.some((item) => item.classification !== 'deferrable') ? ['regional-residual-risk'] : []),
+  ];
+  const makeBundle = (kind, items) => ({
+    bundleId: `follow-up-compat:${kind}`,
+    kind,
+    itemIds: items.map((item) => item.followUpId),
+    labels: items.map((item) => item.label),
+    safety: kind === 'minimal-safe' ? 'safe' : (conflictSignals.length > 0 ? 'fragile' : 'safe'),
+    conflictSignals: kind === 'minimal-safe'
+      ? conflictSignals.filter((signal) => signal === 'cooling-off-timing' || signal === 'regional-residual-risk')
+      : conflictSignals,
+    recommendation: kind === 'minimal-safe'
+      ? 'Bundle minimal sûr: jouer seulement les suivis qui empêchent le rebound immédiat.'
+      : 'Bundle ambitieux fragile: couvre plus large mais peut rouvrir réserve, mitigation ou timing.',
+  });
+  const minimalBundle = makeBundle('minimal-safe', minimalItems);
+  const ambitiousBundle = makeBundle('ambitious-fragile', ambitiousItems.length > 0 ? ambitiousItems : queueView.items);
+  const pendingIfMinimal = queueView.items
+    .filter((item) => !minimalBundle.itemIds.includes(item.followUpId))
+    .map((item) => ({
+      label: item.label,
+      classification: item.classification,
+      reason: item.classification === 'deferrable'
+        ? 'peut attendre sans rebound immédiat'
+        : 'à reprendre après confirmation du cooling-off',
+    }));
+
+  return {
+    state: ambitiousBundle.safety === 'fragile' ? 'fragile' : 'ready',
+    bundles: [minimalBundle, ambitiousBundle],
+    pendingIfMinimal,
+    summary: `Compatibilité suivis: minimal sûr ${minimalBundle.labels.join(' → ')}, ambitieux ${ambitiousBundle.safety}; ${pendingIfMinimal.length} attente${pendingIfMinimal.length > 1 ? 's' : ''} si minimal.`,
+  };
+}
+
+function renderAtlasClimateFollowUpCompatibilityBundles(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-follow-up-compat map-world-climate-follow-up-compat--${view.state}" aria-label="Bundles compatibles pour les suivis climatiques">
+      <div class="map-world-climate-follow-up-compat__header">
+        <strong>Compatibilité suivis climat</strong>
+        <span>${view.bundles.length} bundles</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-follow-up-compat__list">
+        ${view.bundles.map((bundle) => `
+          <li class="map-world-climate-follow-up-compat__item map-world-climate-follow-up-compat__item--${bundle.kind}">
+            <b>${bundle.kind === 'minimal-safe' ? 'Minimal sûr' : 'Ambitieux fragile'}</b>
+            <span>${bundle.labels.join(' → ') || 'aucun suivi'}</span>
+            <small><b>Conflits</b> · ${bundle.conflictSignals.length > 0 ? bundle.conflictSignals.join(', ') : 'aucun conflit bloquant'}</small>
+            <small><b>Recommandation</b> · ${bundle.recommendation}</small>
+          </li>
+        `).join('')}
+      </ol>
+      <small><b>À laisser en attente si minimal</b> · ${view.pendingIfMinimal.length > 0 ? view.pendingIfMinimal.map((item) => `${item.label}: ${item.reason}`).join(' | ') : 'rien à reporter'}</small>
+    </section>
+  `;
+}
+
 function renderAtlasClimateCheapestSafeRecoveryCommitment(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'neutral' || !view.cheapestSafeCommitment) {
     return '';
@@ -19106,6 +19186,10 @@ function render() {
     atlasClimateReboundAfterActionBundle,
     atlasClimateCheapestSafeRecoveryCommitment,
   );
+  const atlasClimateFollowUpCompatibilityBundles = buildAtlasClimateFollowUpCompatibilityBundles(
+    atlasClimateReboundFollowUpQueue,
+    atlasClimateReboundAfterActionBundle,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -19157,6 +19241,7 @@ function render() {
           ${renderAtlasClimateCheapestSafeRecoveryCommitment(atlasClimateCheapestSafeRecoveryCommitment)}
           ${renderAtlasClimateReboundAfterActionBundle(atlasClimateReboundAfterActionBundle)}
           ${renderAtlasClimateReboundFollowUpQueue(atlasClimateReboundFollowUpQueue)}
+          ${renderAtlasClimateFollowUpCompatibilityBundles(atlasClimateFollowUpCompatibilityBundles)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -12593,6 +12593,48 @@ button { font: inherit; }
 .map-world-climate-rebound-follow-up__item--urgent { border-color: rgba(248, 113, 113, 0.48); }
 .map-world-climate-rebound-follow-up__item--prudent { border-color: rgba(251, 191, 36, 0.44); }
 .map-world-climate-rebound-follow-up__item--deferrable { border-color: rgba(74, 222, 128, 0.34); }
+.map-world-climate-follow-up-compat {
+  display: grid;
+  gap: 7px;
+  max-width: 58ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.78), rgba(88, 28, 135, 0.22));
+  border: 1px solid rgba(196, 181, 253, 0.42);
+}
+.map-world-climate-follow-up-compat--fragile { border-color: rgba(251, 191, 36, 0.52); }
+.map-world-climate-follow-up-compat__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-follow-up-compat p,
+.map-world-climate-follow-up-compat span,
+.map-world-climate-follow-up-compat small {
+  color: #ede9fe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-follow-up-compat__list {
+  display: grid;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.map-world-climate-follow-up-compat__item {
+  display: grid;
+  gap: 3px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  border: 1px solid rgba(196, 181, 253, 0.24);
+  background: rgba(46, 16, 101, 0.28);
+}
+.map-world-climate-follow-up-compat__item--minimal-safe { border-color: rgba(74, 222, 128, 0.38); }
+.map-world-climate-follow-up-compat__item--ambitious-fragile { border-color: rgba(251, 191, 36, 0.48); }
 
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);


### PR DESCRIPTION
Epsilon: Implements #1284.

## Summary
- adds compatibility bundle data for climate follow-up queues with minimal-safe and ambitious-fragile groupings
- surfaces mitigation, reserve, cooling-off timing, and residual regional risk conflicts
- renders an atlas compatibility card explaining recommended bundles and what stays pending if the minimal bundle is chosen

## Tests
- npm test -- --test-reporter=spec test/ui/climate/buildClimateMapOverlay.test.js test/ui/climate/webAtlasClimateReboundFollowUpQueue.test.js test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
- npm test
