### PR TITLE
Alpha: Add MAP-A14 carry-over outcome timeline

### DIFF
--- a/test/ui/war/webAtlasMilitaryCarryOverOutcomeTimeline.test.js
+++ b/test/ui/war/webAtlasMilitaryCarryOverOutcomeTimeline.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military outcome timeline derives compact province history from carry-over queue', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryCarryOverOutcomeTimeline\(carryOverQueue\)/);
+  assert.match(webAppSource, /const items = carryOverQueue\?\.items \?\? \[\]/);
+  assert.match(webAppSource, /items\.slice\(0, 3\)\.map/);
+  assert.match(webAppSource, /renderAtlasMilitaryCarryOverOutcomeTimeline\(carryOverOutcomeTimeline\)/);
+});
+
+test('atlas military outcome timeline shows recent results decision impact and next carry-over', () => {
+  assert.match(webAppSource, /step: 'résultat'/);
+  assert.match(webAppSource, /step: 'décision'/);
+  assert.match(webAppSource, /step: 'prochain'/);
+  assert.match(webAppSource, /ordre maintenu/);
+  assert.match(webAppSource, /ordre à revoir/);
+  assert.match(webAppSource, /conflit non résolu/);
+});
+
+test('atlas military outcome timeline stays compact accessible and has an empty state', () => {
+  assert.match(webAppSource, /Timeline carry-over vide: aucune province contestée à suivre/);
+  assert.match(webAppSource, /Timeline des décisions de provinces contestées/);
+  assert.match(webAppSource, /data-atlas-outcome-timeline/);
+  assert.match(webAppSource, /is-decision-changing/);
+  assert.match(stylesSource, /\.atlas-military-outcome-timeline__panel/);
+  assert.match(stylesSource, /\.atlas-military-outcome-timeline-entry\.is-decision-changing circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1749,6 +1749,68 @@ function renderAtlasMilitaryNextTurnCarryOverQueue(queue) {
   `;
 }
 
+
+function getAtlasMilitaryTimelineDecisionImpact(item) {
+  if (item.sourceStatus === 'appliqué') return 'ordre maintenu';
+  if (item.kind === 'obligatoire' || item.sourceStatus === 'annulé') return 'conflit non résolu';
+  if (item.kind === 'opportuniste' || item.sourceStatus === 'à revoir') return 'ordre à revoir';
+  return 'surveillance maintenue';
+}
+
+function buildAtlasMilitaryCarryOverOutcomeTimeline(carryOverQueue) {
+  const items = carryOverQueue?.items ?? [];
+  if (!items.length) {
+    return {
+      timelines: [],
+      summary: 'Timeline carry-over vide: aucune province contestée à suivre.',
+      empty: true,
+    };
+  }
+
+  const timelines = items.slice(0, 3).map((item) => {
+    const entries = [
+      { step: 'résultat', label: item.sourceStatus, emphasis: item.sourceStatus !== 'appliqué' },
+      { step: 'décision', label: getAtlasMilitaryTimelineDecisionImpact(item), emphasis: item.kind !== 'à surveiller' },
+      { step: 'prochain', label: item.kind, emphasis: item.kind === 'obligatoire' },
+    ];
+    return {
+      timelineId: `carry-over-timeline:${item.provinceLabel}`,
+      provinceLabel: item.provinceLabel,
+      tone: item.tone,
+      impact: getAtlasMilitaryTimelineDecisionImpact(item),
+      condition: item.condition,
+      entries,
+    };
+  });
+
+  return {
+    timelines,
+    summary: `${timelines.length} timeline${timelines.length > 1 ? 's' : ''} compacte${timelines.length > 1 ? 's' : ''} de province contestée.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryCarryOverOutcomeTimeline(timeline) {
+  const height = timeline.empty ? 7 : 6.5 + (timeline.timelines.length * 5.4);
+  return `
+    <g class="atlas-military-outcome-timeline" aria-label="Timeline des décisions de provinces contestées: ${timeline.summary}">
+      <rect class="atlas-military-outcome-timeline__panel" x="82" y="44" width="15" height="${height}" rx="2.1"></rect>
+      <text class="atlas-military-outcome-timeline__title" x="83" y="46.8">Timeline</text>
+      ${timeline.empty ? `<text class="atlas-military-outcome-timeline__empty" x="83" y="50">${timeline.summary}</text>` : timeline.timelines.map((row, index) => `
+        <g class="atlas-military-outcome-timeline-row atlas-military-outcome-timeline-row--${row.tone}" data-atlas-outcome-timeline="${row.timelineId}" aria-label="${row.provinceLabel}: ${row.impact}; condition prochain tour: ${row.condition}">
+          <text class="atlas-military-outcome-timeline-row__province" x="83" y="${49.5 + index * 5.4}">${row.provinceLabel}</text>
+          ${row.entries.map((entry, entryIndex) => `
+            <g class="atlas-military-outcome-timeline-entry ${entry.emphasis ? 'is-decision-changing' : ''}" aria-label="${entry.step}: ${entry.label}">
+              <circle cx="${83.4 + entryIndex * 4.1}" cy="${51.3 + index * 5.4}" r="0.6"></circle>
+              <text x="${84.2 + entryIndex * 4.1}" y="${52 + index * 5.4}">${entry.label}</text>
+            </g>
+          `).join('')}
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryCommitmentConflictResolver(resolver) {
   const height = resolver.empty ? 8 : 8 + (resolver.recommendations.length * 5.2);
   return `
@@ -2735,6 +2797,7 @@ function renderAtlasMilitaryLayer(shell) {
   const commitmentResolver = buildAtlasMilitaryCommitmentConflictResolver(stagedCommitment, commitmentConflicts, commitmentCoverage, commitmentPriority, commitmentWarnings);
   const postResolutionAudit = buildAtlasMilitaryPostResolutionOrderAudit(stagedCommitment, commitmentConflicts, commitmentCoverage, commitmentWarnings, commitmentResolver);
   const nextTurnCarryOverQueue = buildAtlasMilitaryNextTurnCarryOverQueue(postResolutionAudit, shell);
+  const carryOverOutcomeTimeline = buildAtlasMilitaryCarryOverOutcomeTimeline(nextTurnCarryOverQueue);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -2769,6 +2832,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryCommitmentConflictResolver(commitmentResolver)}
       ${renderAtlasMilitaryPostResolutionOrderAudit(postResolutionAudit)}
       ${renderAtlasMilitaryNextTurnCarryOverQueue(nextTurnCarryOverQueue)}
+      ${renderAtlasMilitaryCarryOverOutcomeTimeline(carryOverOutcomeTimeline)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -10948,6 +10948,7 @@ button { font: inherit; }
 .atlas-military-commitment-resolver,
 .atlas-military-post-resolution-audit,
 .atlas-military-carry-over-queue,
+.atlas-military-outcome-timeline,
 .atlas-military-warning-relief,
 .atlas-military-best-order,
 .atlas-military-fallback-order,
@@ -13048,3 +13049,44 @@ button { font: inherit; }
 .economy-repayment-scenario__option b { color: #e0f2fe; }
 .economy-repayment-scenario__option--warning { border-color: rgba(245, 158, 11, 0.34); }
 .economy-repayment-scenario__option--positive { border-color: rgba(74, 222, 128, 0.28); }
+
+
+.atlas-military-outcome-timeline__panel {
+  fill: rgba(15, 23, 42, 0.76);
+  stroke: rgba(125, 211, 252, 0.42);
+  stroke-width: 0.3;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-outcome-timeline__title,
+.atlas-military-outcome-timeline-row text,
+.atlas-military-outcome-timeline__empty {
+  fill: #e0f2fe;
+  font-size: 0.92px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.26;
+}
+.atlas-military-outcome-timeline-row__province {
+  fill: #bae6fd;
+  font-size: 0.86px;
+}
+.atlas-military-outcome-timeline-entry circle {
+  fill: rgba(148, 163, 184, 0.78);
+  stroke: rgba(224, 242, 254, 0.72);
+  stroke-width: 0.16;
+}
+.atlas-military-outcome-timeline-entry text {
+  fill: #cbd5e1;
+  font-size: 0.42px;
+}
+.atlas-military-outcome-timeline-entry.is-decision-changing circle {
+  fill: rgba(251, 191, 36, 0.9);
+}
+.atlas-military-outcome-timeline-row--required .atlas-military-outcome-timeline-entry.is-decision-changing circle {
+  fill: rgba(248, 113, 113, 0.9);
+}
+.atlas-military-outcome-timeline__empty {
+  fill: #94a3b8;
+  font-size: 0.68px;
+}


### PR DESCRIPTION
Alpha: Implements #1290.

Summary:
- adds a compact stacked timeline derived from carry-over outcomes
- shows recent result, immediate decision impact, and next carry-over per contested province
- highlights decision-changing entries and includes a discreet empty state

Tests:
- node --test test/ui/war/webAtlasMilitaryCarryOverOutcomeTimeline.test.js
- npm test

Ready for Zeta review.