### PR TITLE
Delta: Add fog-safe recheck uncertainty ageing

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2749,6 +2749,38 @@ function buildVerificationOutcomeRecap({ locationId, locationName, verificationC
   };
 }
 
+function buildRecheckAgeIndicator({ index, enoughBudget, verificationAuditTrail }) {
+  const hasResidualRisk = verificationAuditTrail.lastChange === 'residual-risk';
+  if (hasResidualRisk && enoughBudget && index === 0) {
+    return {
+      state: 'urgent',
+      label: 'Urgent',
+      priority: 3,
+      reliabilityCue: 'Signal visible ancien ou résiduel: re-vérification prochaine recommandée.',
+      origin: 'unknown-origin',
+      fallback: 'Origine non datée: priorité estimée depuis la provenance visible et le budget restant.',
+    };
+  }
+  if (hasResidualRisk || !enoughBudget) {
+    return {
+      state: 'watch',
+      label: 'À surveiller',
+      priority: 2,
+      reliabilityCue: 'Fiabilité à surveiller: attendre un créneau sûr ou du budget visible.',
+      origin: 'unknown-origin',
+      fallback: 'Origine non datée: vieillissement affiché comme surveillance prudente.',
+    };
+  }
+  return {
+    state: 'fresh',
+    label: 'Frais',
+    priority: 1,
+    reliabilityCue: 'Signal encore frais: re-vérification non urgente.',
+    origin: 'unknown-origin',
+    fallback: 'Origine non datée: indicateur borné au statut de fiabilité visible.',
+  };
+}
+
 function buildIntrigueRecheckQueue({ locationId, locationName, verificationOutcomeRecap, verificationAuditTrail, intelligenceProvenancePanel, exposureBudgetForPriorityVerifications }) {
   if (verificationOutcomeRecap.state === 'masked-recap') {
     return {
@@ -2777,12 +2809,15 @@ function buildIntrigueRecheckQueue({ locationId, locationName, verificationOutco
     .filter((uncertainty) => !/Aucun conflit/.test(uncertainty))
     .map((uncertainty, index) => {
       const enoughBudget = remainingBudget >= 3;
+      const ageIndicator = buildRecheckAgeIndicator({ index, enoughBudget, verificationAuditTrail });
       return {
         queueId: `${locationId}:recheck:${index + 1}`,
         uncertainty,
         status: enoughBudget ? 'queued-for-safe-window' : 'wait-for-budget',
         safeWindow: enoughBudget ? 'prochain créneau de faible exposition' : 'après récupération de budget d’exposition visible',
         triggerCondition: baseTrigger,
+        ageIndicator,
+        priorityLabel: ageIndicator.label,
         recommendedCheck: retainedCheck ? {
           checkId: retainedCheck.checkId,
           label: retainedCheck.label,
@@ -2818,6 +2853,9 @@ function buildIntrigueRecheckQueue({ locationId, locationName, verificationOutco
     provenanceLink,
     retainedResultIds: verificationOutcomeRecap.retainedVerifications.map((verification) => verification.checkId),
     delayedResultIds: verificationOutcomeRecap.delayedVerifications.map((verification) => verification.checkId),
+    ageingSummary: entries.length > 0
+      ? entries.map((entry) => `${entry.ageIndicator.label}: ${entry.uncertainty}`).join(' | ')
+      : 'Aucun vieillissement d’incertitude à afficher.',
     summary: entries.length > 0
       ? `${entries.length} incertitude(s) à re-vérifier plus tard sans dépasser le budget visible.`
       : 'Aucune re-vérification planifiée: les incertitudes restantes ne justifient pas une relance sûre.',

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2480,3 +2480,70 @@ test('buildIntrigueMapOverlay plans fog-safe recheck queues for unresolved intri
   assert.match(masked.blockedRechecks[0].triggerCondition, /provenance visible/);
   assert.match(masked.safeMapPolicy, /aucune cellule, relais, cible, méthode sensible ou cause cachée/);
 });
+
+test('buildIntrigueMapOverlay marks ageing priority for fog-safe recheck queue uncertainties', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-ageing-urgent',
+      factionId: 'shadow-league',
+      codename: 'Ageing',
+      locationId: 'ageing-urgent',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 92,
+    }),
+    new Cellule({
+      id: 'cell-ageing-watch',
+      factionId: 'shadow-league',
+      codename: 'Budget Watch',
+      locationId: 'ageing-watch',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 99,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-ageing-urgent',
+      celluleId: 'cell-ageing-urgent',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Age visible uncertainty',
+      theaterId: 'ageing-urgent',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 92,
+      progress: 80,
+      heat: 86,
+      phase: 'execution',
+    }),
+    new OperationClandestine({
+      id: 'op-ageing-watch',
+      celluleId: 'cell-ageing-watch',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Consume visible budget',
+      theaterId: 'ageing-watch',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 99,
+      progress: 94,
+      heat: 99,
+      phase: 'execution',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.intrigueRecheckQueue]));
+  const urgentQueue = byLocation.get('ageing-urgent');
+  assert.equal(byLocation.get('ageing-watch').entries[0].ageIndicator.state, 'urgent');
+
+  assert.equal(urgentQueue.entries[0].ageIndicator.state, 'urgent');
+  assert.equal(urgentQueue.entries[0].priorityLabel, 'Urgent');
+  assert.equal(urgentQueue.entries[0].ageIndicator.origin, 'unknown-origin');
+  assert.match(urgentQueue.entries[0].ageIndicator.fallback, /Origine non datée/);
+  assert.match(urgentQueue.entries[0].ageIndicator.reliabilityCue, /re-vérification prochaine/);
+  assert.match(urgentQueue.ageingSummary, /Urgent:/);
+
+  assert.equal(urgentQueue.entries[1].ageIndicator.state, 'watch');
+  assert.equal(urgentQueue.entries[1].priorityLabel, 'À surveiller');
+  assert.match(urgentQueue.entries[1].ageIndicator.reliabilityCue, /attendre un créneau sûr/);
+  assert.match(urgentQueue.entries[1].ageIndicator.fallback, /vieillissement affiché comme surveillance prudente/);
+});


### PR DESCRIPTION
Delta: Implements #1293.

Summary:
- adds fog-safe ageing indicators to intrigue recheck queue entries;
- distinguishes fresh/watch/urgent reliability states with short labels and priority cues;
- includes an explicit unknown-origin fallback when no source date/turn exists;
- keeps the indicator limited to reliability/ageing and visible provenance/budget, without exposing hidden truth, cell, relay, target, method, or cause details.

Validation:
- node --check src/ui/intrigue/buildIntrigueMapOverlay.js
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test (705 passing)
- node --check web/app.js
- git diff --check

Closes #1293