### PR TITLE
Epsilon: add climate follow-up risk deltas

### DIFF
--- a/src/ui/climate/buildClimateMapOverlay.js
+++ b/src/ui/climate/buildClimateMapOverlay.js
@@ -1881,6 +1881,39 @@ function describeClimateBundleExpectedEffect(bundle) {
   return 'intervention différée: évite de verrouiller une fenêtre trop contradictoire';
 }
 
+function describeClimateFollowUpRiskDelta(item, bundle, preview) {
+  const conflicts = new Set(bundle.resourceConflicts);
+  if (preview.reboundRisk === 'low' && item.classification === 'deferrable') {
+    return {
+      state: 'reduced',
+      label: 'risque réduit',
+      cause: 'ressource: réserve conservée et signal régional stable',
+    };
+  }
+
+  if (item.classification === 'urgent' || preview.reboundRisk === 'high') {
+    return {
+      state: 'worsening-probable',
+      label: 'aggravation probable si ignoré',
+      cause: conflicts.has('residual-risk') ? 'catastrophe/risque régional résiduel' : 'ressource: conflit de réserve ou mitigation',
+    };
+  }
+
+  if (item.classification === 'prudent' || conflicts.has('window-timing')) {
+    return {
+      state: 'stable-risk',
+      label: 'risque stable sous surveillance',
+      cause: preview.coolingOffTurns > 1 ? 'saison: timing de cooling-off encore actif' : 'ressource: readiness à confirmer',
+    };
+  }
+
+  return {
+    state: 'unknown',
+    label: 'delta inconnu',
+    cause: 'données insuffisantes pour estimer le delta sans sur-promettre',
+  };
+}
+
 function buildClimateFollowUpCompatibilityBundles(bundle, followUpQueue, preview) {
   const minimalItems = followUpQueue.filter((item) => item.classification === 'urgent');
   const safeItems = minimalItems.length > 0
@@ -1895,19 +1928,27 @@ function buildClimateFollowUpCompatibilityBundles(bundle, followUpQueue, preview
     ...(preview.coolingOffTurns > 1 || bundle.resourceConflicts.includes('window-timing') ? ['cooling-off-timing'] : []),
     ...(preview.reboundRegionIds.length > 0 || bundle.resourceConflicts.includes('residual-risk') ? ['regional-residual-risk'] : []),
   ];
-  const buildBundle = (kind, items) => ({
-    compatibilityBundleId: `${bundle.bundleId}:compat:${kind}`,
-    kind,
-    followUpIds: items.map((item) => item.followUpId),
-    regionIds: items.map((item) => item.regionId),
-    safety: kind === 'minimal-safe' ? 'safe' : (conflictSignals.length > 0 ? 'fragile' : 'safe'),
-    conflictSignals: kind === 'minimal-safe'
-      ? conflictSignals.filter((signal) => signal === 'cooling-off-timing' || signal === 'regional-residual-risk')
-      : conflictSignals,
-    reason: kind === 'minimal-safe'
-      ? 'regroupe seulement les suivis nécessaires sans rouvrir toute la file climat'
-      : 'couvre plus de suivis mais peut consommer réserve, mitigation ou timing de refroidissement',
-  });
+  const buildBundle = (kind, items) => {
+    const riskDeltas = items.map((item) => ({
+      followUpId: item.followUpId,
+      regionId: item.regionId,
+      ...item.riskDelta,
+    }));
+    return {
+      compatibilityBundleId: `${bundle.bundleId}:compat:${kind}`,
+      kind,
+      followUpIds: items.map((item) => item.followUpId),
+      regionIds: items.map((item) => item.regionId),
+      safety: kind === 'minimal-safe' ? 'safe' : (conflictSignals.length > 0 ? 'fragile' : 'safe'),
+      conflictSignals: kind === 'minimal-safe'
+        ? conflictSignals.filter((signal) => signal === 'cooling-off-timing' || signal === 'regional-residual-risk')
+        : conflictSignals,
+      riskDeltas,
+      reason: kind === 'minimal-safe'
+        ? 'regroupe seulement les suivis nécessaires sans rouvrir toute la file climat'
+        : 'couvre plus de suivis mais peut consommer réserve, mitigation ou timing de refroidissement',
+    };
+  };
   const minimalSafeBundle = buildBundle('minimal-safe', safeItems);
   const ambitiousFragileBundle = buildBundle('ambitious-fragile', ambitiousItems.length > 0 ? ambitiousItems : followUpQueue);
   const pendingIfMinimal = followUpQueue
@@ -1955,7 +1996,7 @@ function buildClimateBundleFollowUpQueue(bundle, preview) {
         ? 'placer une vérification de readiness au prochain tour sûr'
         : 'différer et garder seulement une veille météo';
 
-    return {
+    const item = {
       followUpId: `${bundle.bundleId}:${regionId}:follow-up`,
       bundleId: bundle.bundleId,
       regionId,
@@ -1963,6 +2004,11 @@ function buildClimateBundleFollowUpQueue(bundle, preview) {
       reason,
       ignoredReboundRisk,
       nextAction,
+    };
+
+    return {
+      ...item,
+      riskDelta: describeClimateFollowUpRiskDelta(item, bundle, preview),
     };
   }).sort((left, right) => {
     const rank = { urgent: 0, prudent: 1, deferrable: 2 };
@@ -2050,6 +2096,7 @@ function normalizeClimateBundleAfterActionPreview(preview, basePreview) {
         reason: String(normalizedItem.reason).trim(),
         ignoredReboundRisk: String(normalizedItem.ignoredReboundRisk).trim(),
         nextAction: String(normalizedItem.nextAction).trim(),
+        riskDelta: normalizedItem.riskDelta ?? { state: 'unknown', label: 'delta inconnu', cause: 'données insuffisantes' },
       };
     }),
     followUpCompatibility: normalizedPreview.followUpCompatibility ?? basePreview.followUpCompatibility,

--- a/test/ui/climate/buildClimateMapOverlay.test.js
+++ b/test/ui/climate/buildClimateMapOverlay.test.js
@@ -2318,6 +2318,11 @@ test('buildClimateMapOverlay supports explicit prudent climate bundle overrides'
             reason: 'rebond élevé après bundle fragile ou déconseillé',
             ignoredReboundRisk: 'retour en alerte probable si aucun suivi n’est joué',
             nextAction: 'jouer le suivi minimal avant tout autre bundle climat',
+            riskDelta: {
+              state: 'worsening-probable',
+              label: 'aggravation probable si ignoré',
+              cause: 'catastrophe/risque régional résiduel',
+            },
           },
         ],
       },
@@ -2389,6 +2394,11 @@ test('buildClimateMapOverlay previews rebound and cooling-off after prudent clim
         reason: 'signal stable: suivi léger suffit après cooling-off',
         ignoredReboundRisk: 'rebond faible sauf nouveau signal saisonnier',
         nextAction: 'différer et garder seulement une veille météo',
+        riskDelta: {
+          state: 'reduced',
+          label: 'risque réduit',
+          cause: 'ressource: réserve conservée et signal régional stable',
+        },
       },
     ],
   });
@@ -2409,6 +2419,11 @@ test('buildClimateMapOverlay previews rebound and cooling-off after prudent clim
         reason: 'fenêtre encore sensible: vérifier avant nouvelle mitigation',
         ignoredReboundRisk: 'pression régionale peut remonter si la réserve disparaît',
         nextAction: 'placer une vérification de readiness au prochain tour sûr',
+        riskDelta: {
+          state: 'stable-risk',
+          label: 'risque stable sous surveillance',
+          cause: 'saison: timing de cooling-off encore actif',
+        },
       },
     ],
   });
@@ -2423,6 +2438,15 @@ test('buildClimateMapOverlay previews rebound and cooling-off after prudent clim
         regionIds: ['ridge'],
         safety: 'safe',
         conflictSignals: ['cooling-off-timing', 'regional-residual-risk'],
+        riskDeltas: [
+          {
+            followUpId: 'climate-bundle:prepare:ridge:follow-up',
+            regionId: 'ridge',
+            state: 'stable-risk',
+            label: 'risque stable sous surveillance',
+            cause: 'saison: timing de cooling-off encore actif',
+          },
+        ],
         reason: 'regroupe seulement les suivis nécessaires sans rouvrir toute la file climat',
       },
       {
@@ -2432,8 +2456,17 @@ test('buildClimateMapOverlay previews rebound and cooling-off after prudent clim
         regionIds: ['ridge'],
         safety: 'fragile',
         conflictSignals: ['mitigation', 'cooling-off-timing', 'regional-residual-risk'],
+        riskDeltas: [
+          {
+            followUpId: 'climate-bundle:prepare:ridge:follow-up',
+            regionId: 'ridge',
+            state: 'stable-risk',
+            label: 'risque stable sous surveillance',
+            cause: 'saison: timing de cooling-off encore actif',
+          },
+        ],
         reason: 'couvre plus de suivis mais peut consommer réserve, mitigation ou timing de refroidissement',
-      },
+      }
     ],
     pendingIfMinimal: [],
     summary: '1 suivi(s), 0 laissé(s) en attente si bundle minimal.',

--- a/test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
+++ b/test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
@@ -14,6 +14,11 @@ test('atlas renders compatibility bundles for climate rebound follow-up queues',
   assert.match(webAppSource, /cooling-off-timing/);
   assert.match(webAppSource, /regional-residual-risk/);
   assert.match(webAppSource, /À laisser en attente si minimal/);
+  assert.match(webAppSource, /Delta risque/);
+  assert.match(webAppSource, /worsening-probable/);
+  assert.match(webAppSource, /stable-risk/);
+  assert.match(webAppSource, /reduced/);
+  assert.match(webAppSource, /delta inconnu/);
   assert.match(webAppSource, /renderAtlasClimateReboundFollowUpQueue\(atlasClimateReboundFollowUpQueue\)\}\s*\$\{renderAtlasClimateFollowUpCompatibilityBundles\(atlasClimateFollowUpCompatibilityBundles\)\}/);
 
   assert.match(stylesSource, /\.map-world-climate-follow-up-compat/);

--- a/web/app.js
+++ b/web/app.js
@@ -11105,6 +11105,34 @@ function buildAtlasClimateFollowUpCompatibilityBundles(queueView, reboundView) {
     ...(reboundView?.coolingOffTurns > 1 ? ['cooling-off-timing'] : []),
     ...(queueView.items.some((item) => item.classification !== 'deferrable') ? ['regional-residual-risk'] : []),
   ];
+  const describeRiskDelta = (item) => {
+    if (item.classification === 'urgent') {
+      return {
+        state: 'worsening-probable',
+        label: 'aggravation probable',
+        cause: 'catastrophe/risque régional résiduel',
+      };
+    }
+    if (item.classification === 'prudent') {
+      return {
+        state: 'stable-risk',
+        label: 'risque stable',
+        cause: reboundView?.coolingOffTurns > 1 ? 'saison: cooling-off encore actif' : 'ressource: readiness à confirmer',
+      };
+    }
+    if (item.classification === 'deferrable') {
+      return {
+        state: 'reduced',
+        label: 'risque réduit',
+        cause: 'ressource: réserve conservée et signal stable',
+      };
+    }
+    return {
+      state: 'unknown',
+      label: 'delta inconnu',
+      cause: 'données insuffisantes pour éviter une précision excessive',
+    };
+  };
   const makeBundle = (kind, items) => ({
     bundleId: `follow-up-compat:${kind}`,
     kind,
@@ -11114,6 +11142,7 @@ function buildAtlasClimateFollowUpCompatibilityBundles(queueView, reboundView) {
     conflictSignals: kind === 'minimal-safe'
       ? conflictSignals.filter((signal) => signal === 'cooling-off-timing' || signal === 'regional-residual-risk')
       : conflictSignals,
+    riskDeltas: items.map((item) => ({ followUpId: item.followUpId, label: item.label, ...describeRiskDelta(item) })),
     recommendation: kind === 'minimal-safe'
       ? 'Bundle minimal sûr: jouer seulement les suivis qui empêchent le rebound immédiat.'
       : 'Bundle ambitieux fragile: couvre plus large mais peut rouvrir réserve, mitigation ou timing.',
@@ -11156,6 +11185,7 @@ function renderAtlasClimateFollowUpCompatibilityBundles(view) {
             <b>${bundle.kind === 'minimal-safe' ? 'Minimal sûr' : 'Ambitieux fragile'}</b>
             <span>${bundle.labels.join(' → ') || 'aucun suivi'}</span>
             <small><b>Conflits</b> · ${bundle.conflictSignals.length > 0 ? bundle.conflictSignals.join(', ') : 'aucun conflit bloquant'}</small>
+            <small><b>Delta risque</b> · ${bundle.riskDeltas.length > 0 ? bundle.riskDeltas.map((delta) => `${delta.label}: ${delta.state}, ${delta.cause}`).join(' | ') : 'delta inconnu: données insuffisantes'}</small>
             <small><b>Recommandation</b> · ${bundle.recommendation}</small>
           </li>
         `).join('')}


### PR DESCRIPTION
Epsilon: Implements #1294.

## Summary
- adds compact risk delta states to climate follow-ups and compatibility bundles
- distinguishes reduced, stable, worsening-probable, and unknown deltas with concise causes
- renders bundle risk deltas in the atlas compatibility card without over-promising uncertain data

## Tests
- npm test -- --test-reporter=spec test/ui/climate/buildClimateMapOverlay.test.js test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
- npm test
