### PR TITLE
Beta: Add repayment capacity side-effect warnings

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2346,15 +2346,58 @@ function buildRecoveryDebtRepaymentPriorities(logisticsFeatures, recoveryDebtLed
 }
 
 
-function buildRepaymentScenarioOption(priority, debtEntry, mode) {
+function getRepaymentSideEffectSource(priority, debtEntry, routeFeature) {
+  if (debtEntry?.debtResources?.includes('stock')) {
+    return 'stock';
+  }
+
+  if (debtEntry?.debtResources?.includes('labor')) {
+    return 'main-d’œuvre';
+  }
+
+  if (debtEntry?.debtResources?.includes('convoy') || routeFeature?.bottleneckIntensity === 'critical') {
+    return 'route';
+  }
+
+  if (priority.repaymentScore >= 90) {
+    return 'priorité concurrente';
+  }
+
+  return routeFeature?.cityIds?.length ? 'ville' : 'capacité de reprise';
+}
+
+function buildRepaymentSideEffectWarning(priority, debtEntry, routeFeature, option) {
+  const source = getRepaymentSideEffectSource(priority, debtEntry, routeFeature);
+
+  if (option.remainingBlocked > 0) {
+    return {
+      severity: 'danger',
+      source,
+      text: `${source}: ${option.remainingBlocked} capacité reste bloquée après ${option.label.toLowerCase()}.`,
+      nextArbitrage: `Arbitrer ${priority.nextAction} avant de lancer un second remboursement.`,
+    };
+  }
+
+  if (option.capacityConsumed >= Math.max(2, routeFeature?.capacityRemaining ?? 0) || priority.repaymentScore >= 90) {
+    return {
+      severity: 'costly',
+      source,
+      text: `${source}: ${option.label.toLowerCase()} consomme ${option.capacityConsumed} capacité de reprise ce tour.`,
+      nextArbitrage: 'Confirmer que cette capacité ne manque pas à une route ou ville concurrente.',
+    };
+  }
+
+  return null;
+}
+
+function buildRepaymentScenarioOption(priority, debtEntry, routeFeature, mode) {
   const debtAmount = Math.max(0, debtEntry?.debtAmount ?? priority.debtAmount ?? 0);
   const fullCapacity = Math.max(1, debtAmount || Math.ceil((debtEntry?.costTotal ?? 1) / 2));
   const capacityConsumed = mode === 'complete' ? fullCapacity : Math.max(1, Math.ceil(fullCapacity / 2));
   const remainingBlocked = Math.max(0, debtAmount - capacityConsumed);
   const label = mode === 'complete' ? 'Remboursement complet' : 'Remboursement partiel';
   const status = remainingBlocked === 0 ? 'reprise sécurisée' : 'blocage résiduel';
-
-  return {
+  const option = {
     id: `${priority.id}:${mode}`,
     mode,
     label,
@@ -2369,14 +2412,20 @@ function buildRepaymentScenarioOption(priority, debtEntry, mode) {
       ? 'Aucun blocage majeur restant sur cette dette prioritaire.'
       : `${remainingBlocked} capacité encore bloquée; ${priority.blockingImpact}`,
   };
+
+  return {
+    ...option,
+    sideEffectWarning: buildRepaymentSideEffectWarning(priority, debtEntry, routeFeature, option),
+  };
 }
 
-function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymentPriorities) {
+function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymentPriorities, logisticsFeatures = []) {
   const candidates = repaymentPriorities.priorities.slice(0, 3);
   const scenarios = candidates.map((priority) => {
     const debtEntry = recoveryDebtLedger.entries.find((entry) => entry.id === priority.debtEntryId) ?? null;
-    const partial = buildRepaymentScenarioOption(priority, debtEntry, 'partial');
-    const complete = buildRepaymentScenarioOption(priority, debtEntry, 'complete');
+    const routeFeature = logisticsFeatures.find((feature) => feature.routeId === priority.targetId) ?? null;
+    const partial = buildRepaymentScenarioOption(priority, debtEntry, routeFeature, 'partial');
+    const complete = buildRepaymentScenarioOption(priority, debtEntry, routeFeature, 'complete');
     const minimalViableAction = partial.remainingBlocked === 0
       ? partial.label
       : `${priority.nextAction}: couvrir au moins ${partial.capacityConsumed} capacité maintenant, puis planifier ${partial.remainingBlocked} au prochain tour`;
@@ -2393,6 +2442,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
       options: [partial, complete],
       ledgerLink: debtEntry?.id ?? priority.debtEntryId,
       priorityLink: priority.id,
+      sideEffectWarningCount: [partial, complete].filter((option) => option.sideEffectWarning).length,
       summary: `${priority.label}: partiel consomme ${partial.capacityConsumed} et laisse ${partial.remainingBlocked} bloqué; complet consomme ${complete.capacityConsumed} et laisse ${complete.remainingBlocked} bloqué.`,
     };
   });
@@ -2406,6 +2456,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
     scenarios,
     topScenarioId: scenarios[0]?.id ?? null,
     minimalViableAction: scenarios[0]?.minimalViableAction ?? 'continuer la surveillance',
+    warningCount: scenarios.reduce((count, scenario) => count + scenario.sideEffectWarningCount, 0),
     legend: [
       { key: 'partial', label: 'Partiel: débloque une portion', tone: 'warning' },
       { key: 'complete', label: 'Complet: sécurise la reprise', tone: 'positive' },
@@ -2516,7 +2567,7 @@ function buildEconomyMapLayers(cityOverlays, routeOverlays) {
       recoveryCapacityBudget,
       recoveryDebtLedger,
       recoveryDebtRepaymentPriorities,
-      recoveryDebtRepaymentScenarioPreviews: buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, recoveryDebtRepaymentPriorities),
+      recoveryDebtRepaymentScenarioPreviews: buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, recoveryDebtRepaymentPriorities, logisticsFeaturesWithPlanners),
       recoveryPlannerLegend: [
         { key: 'repair', label: 'Réparer', tone: 'stable' },
         { key: 'reroute', label: 'Rerouter', tone: 'caution' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1581,6 +1581,7 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
 
   assert.equal(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.id, 'logistics-recovery-repayment-scenarios');
   assert.equal(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.topScenarioId, 'recovery-repayment-scenario:route-coast');
+  assert.equal(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.warningCount, 2);
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.summary, /partiel et complet/);
   assert.deepEqual(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.scenarios.map((scenario) => ({
     id: scenario.id,
@@ -1600,10 +1601,14 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
     capacityConsumed: option.capacityConsumed,
     remainingBlocked: option.remainingBlocked,
     status: option.status,
+    warningSeverity: option.sideEffectWarning?.severity ?? null,
+    warningSource: option.sideEffectWarning?.source ?? null,
   })), [
-    { mode: 'partial', capacityConsumed: 1, remainingBlocked: 1, status: 'blocage résiduel' },
-    { mode: 'complete', capacityConsumed: 2, remainingBlocked: 0, status: 'reprise sécurisée' },
+    { mode: 'partial', capacityConsumed: 1, remainingBlocked: 1, status: 'blocage résiduel', warningSeverity: 'danger', warningSource: 'stock' },
+    { mode: 'complete', capacityConsumed: 2, remainingBlocked: 0, status: 'reprise sécurisée', warningSeverity: 'costly', warningSource: 'stock' },
   ]);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.scenarios[0].options[0].sideEffectWarning.text, /capacité reste bloquée/);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.scenarios[0].options[1].sideEffectWarning.nextArbitrage, /route ou ville concurrente/);
 
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -29,6 +29,9 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(webAppSource, /option\.capacityConsumed/);
   assert.match(webAppSource, /option\.remainingBlocked/);
   assert.match(webAppSource, /scenario\.minimalViableAction/);
+  assert.match(webAppSource, /sideEffectWarning/);
+  assert.match(webAppSource, /economy-repayment-scenario__warning/);
+  assert.match(webAppSource, /option\.sideEffectWarning\.nextArbitrage/);
   assert.match(webAppSource, /renderEconomyRecoveryRepaymentScenarios\(economyView\)/);
 
   assert.match(stylesSource, /\.economy-recovery-debt/);
@@ -43,4 +46,6 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(stylesSource, /\.economy-repayment-scenarios/);
   assert.match(stylesSource, /\.economy-repayment-scenario__option--warning/);
   assert.match(stylesSource, /\.economy-repayment-scenario__option--positive/);
+  assert.match(stylesSource, /\.economy-repayment-scenario__warning--danger/);
+  assert.match(stylesSource, /\.economy-repayment-scenario__warning--costly/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -18432,6 +18432,13 @@ function renderEconomyRecoveryRepaymentScenarios(economyView) {
                   <span>Capacité ${option.capacityConsumed} · bloqué ${option.remainingBlocked}</span>
                   <p>${option.probableEffect}</p>
                   <small>${option.blockedAfter}</small>
+                  ${option.sideEffectWarning ? `
+                    <aside class="economy-repayment-scenario__warning economy-repayment-scenario__warning--${option.sideEffectWarning.severity}">
+                      <b>${option.sideEffectWarning.source}</b>
+                      <span>${option.sideEffectWarning.text}</span>
+                      <small>${option.sideEffectWarning.nextArbitrage}</small>
+                    </aside>
+                  ` : ''}
                 </div>
               `).join('')}
             </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13090,3 +13090,25 @@ button { font: inherit; }
   fill: #94a3b8;
   font-size: 0.68px;
 }
+.economy-repayment-scenario__warning {
+  display: grid;
+  gap: 4px;
+  padding: 7px;
+  border-radius: 10px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.economy-repayment-scenario__warning b {
+  color: #f8fafc;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.economy-repayment-scenario__warning span,
+.economy-repayment-scenario__warning small {
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.economy-repayment-scenario__warning--danger { border-color: rgba(251, 113, 133, 0.42); }
+.economy-repayment-scenario__warning--costly { border-color: rgba(245, 158, 11, 0.34); }


### PR DESCRIPTION
Beta: Closes #1291.\n\n## Summary\n- add lightweight side-effect warnings to repayment scenario options\n- distinguish residual dangerous bottlenecks from merely costly repayments\n- show risk source plus the next useful arbitration without automating the decision\n\n## Tests\n- node --test test/ui/economy/buildEconomyMapOverlay.test.js test/ui/economy/webEconomyRecoveryDebtLedger.test.js\n- npm test\n- git diff --check