### PR TITLE
Gamma: Add cultural prompt history drawer

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -634,7 +634,97 @@ function buildCulturalPromptChoiceComparison(followUpPrompts, bundles, timingWin
   };
 }
 
-function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = []) {
+function normalizeCulturalPromptHistoryEntry(entry, index) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const promptLabel = normalizeText(entry.promptLabel ?? entry.label ?? entry.title, 'prompt culturel');
+  const clusterLabel = normalizeText(entry.clusterLabel ?? entry.territory ?? entry.regionName ?? entry.regionId, 'territoire culturel');
+  const theme = normalizeText(entry.theme ?? entry.bundleLabel ?? entry.trajectory ?? promptLabel, promptLabel);
+
+  return {
+    historyId: entry.historyId ?? entry.decisionId ?? `culture-prompt-history:${index}`,
+    turn: Number.isFinite(entry.turn) ? entry.turn : null,
+    regionId: normalizeText(entry.regionId ?? entry.locationId, 'province'),
+    clusterLabel,
+    theme,
+    promptLabel,
+    choiceState: entry.choiceState ?? entry.state ?? 'seen',
+    outcome: entry.outcome ?? entry.result ?? 'historique conservé',
+    repeated: entry.repeated === true,
+  };
+}
+
+function buildCulturalPromptHistoryDrawer(promptChoiceComparison, promptHistory = [], regionId = 'province') {
+  const historyEntries = promptHistory
+    .map((entry, index) => normalizeCulturalPromptHistoryEntry(entry, index))
+    .filter(Boolean)
+    .sort((left, right) => (right.turn ?? 0) - (left.turn ?? 0))
+    .slice(0, 5);
+  const currentEntries = promptChoiceComparison.entries.map((entry) => {
+    const repeatedMatch = historyEntries.find((historyEntry) =>
+      historyEntry.clusterLabel === entry.clusterLabel
+      || (historyEntry.promptLabel === entry.promptLabel && historyEntry.clusterLabel === entry.clusterLabel)
+      || (historyEntry.theme === entry.promptLabel && historyEntry.clusterLabel === entry.clusterLabel));
+
+    return {
+      promptId: entry.promptId,
+      promptLabel: entry.promptLabel,
+      clusterLabel: entry.clusterLabel,
+      role: entry.role,
+      repeatState: repeatedMatch ? 'repeated' : 'new',
+      repeatReason: repeatedMatch
+        ? `ressemble à ${repeatedMatch.promptLabel} (${repeatedMatch.clusterLabel})${repeatedMatch.turn ? ` vu au tour ${repeatedMatch.turn}` : ''}`
+        : 'aucune décision récente similaire dans la limite affichée',
+      narrativeImpact: entry.narrativeImpact,
+    };
+  });
+  const combined = [
+    ...currentEntries.map((entry) => ({ ...entry, source: 'current', theme: entry.promptLabel })),
+    ...historyEntries.map((entry) => ({
+      source: 'history',
+      historyId: entry.historyId,
+      turn: entry.turn,
+      promptLabel: entry.promptLabel,
+      clusterLabel: entry.clusterLabel,
+      theme: entry.theme,
+      choiceState: entry.choiceState,
+      outcome: entry.outcome,
+      repeatState: entry.repeated ? 'repeated' : 'seen',
+    })),
+  ];
+  const groups = [...combined.reduce((map, entry) => {
+    const key = `${entry.clusterLabel}:${entry.theme}`;
+    const existing = map.get(key) ?? {
+      groupId: `culture-prompt-history:${key}`,
+      clusterLabel: entry.clusterLabel,
+      theme: entry.theme,
+      entries: [],
+      hasRepeat: false,
+    };
+    existing.entries.push(entry);
+    existing.hasRepeat = existing.hasRepeat || entry.repeatState === 'repeated';
+    map.set(key, existing);
+    return map;
+  }, new Map()).values()].slice(0, 4);
+
+  return {
+    state: groups.length === 0 ? 'quiet' : groups.some((group) => group.hasRepeat) ? 'repeat-warning' : 'ready',
+    summary: groups.length === 0
+      ? 'Aucun historique de prompt culturel à afficher.'
+      : `${groups.length} groupe${groups.length > 1 ? 's' : ''} d’historique culturel limité${groups.length > 1 ? 's' : ''} à comparer.`,
+    displayLimit: 5,
+    regionId,
+    currentEntries,
+    groups,
+    emptyHint: historyEntries.length === 0
+      ? 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.'
+      : 'Historique limité aux décisions récentes pour garder le drawer lisible.',
+  };
+}
+
+function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = [], promptHistory = [], regionId = 'province') {
   const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
   const trajectories = ['apaisement', 'consolidation', 'enquête', 'expansion', 'attente'];
   const bundles = trajectories
@@ -735,6 +825,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
 
   const followUpPrompts = buildCulturalFollowUpPrompts(bundles, incompatibilities);
   const promptChoiceComparison = buildCulturalPromptChoiceComparison(followUpPrompts, bundles, timingWindows);
+  const promptHistoryDrawer = buildCulturalPromptHistoryDrawer(promptChoiceComparison, promptHistory, regionId);
 
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
@@ -749,6 +840,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
       : `${timingWindows.length} fenêtre${timingWindows.length > 1 ? 's' : ''} de timing culturel après bundle.`,
     followUpPrompts,
     promptChoiceComparison,
+    promptHistoryDrawer,
     dependencyExplanation: bundles.length === 0
       ? 'Aucune dépendance entre marqueurs culturels.'
       : bundles
@@ -780,6 +872,7 @@ export function buildCultureTurnReportDeltas({
   previousMarker = null,
   momentumFilter = 'all',
   activeRecommendations = [],
+  promptHistory = [],
 } = {}) {
   const regionId = normalizeText(selectedRegionId ?? selectedMarker?.regionId ?? selectedCluster?.regionIds?.[0], 'province');
   const timelineRecap = buildDiscoveryTimelineRecap(localTimeline, selectedMarker, selectedCluster, regionId);
@@ -794,7 +887,7 @@ export function buildCultureTurnReportDeltas({
   });
   const stabilizationRecommendations = buildCultureStabilizationRecommendations(momentumLayer);
   const recommendationCoherence = buildCultureRecommendationCoherenceSummary(stabilizationRecommendations, activeRecommendations);
-  const commitmentBundles = buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations);
+  const commitmentBundles = buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations, promptHistory, regionId);
   const deltas = dedupeAndSort([
     ...buildTimelineDeltas(localTimeline, regionId),
     ...buildMarkerDeltas(selectedMarker, regionId),
@@ -849,6 +942,15 @@ export function buildCultureTurnReportDeltas({
           summary: 'Aucun arbitrage de prompt culturel disponible.',
           entries: [],
           noChoiceRisk: 'Aucun momentum culturel à arbitrer.',
+        },
+        promptHistoryDrawer: {
+          state: 'quiet',
+          summary: 'Aucun historique de prompt culturel à afficher.',
+          displayLimit: 5,
+          regionId,
+          currentEntries: [],
+          groups: [],
+          emptyHint: 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.',
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
       },

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -244,6 +244,45 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       ],
       noChoiceRisk: 'ne rien choisir dilue le momentum actif et laisse les signaux concurrents reprendre la priorité',
     },
+    promptHistoryDrawer: {
+      state: 'ready',
+      summary: '1 groupe d’historique culturel limité à comparer.',
+      displayLimit: 5,
+      regionId: 'river-gate',
+      currentEntries: [
+        {
+          promptId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+          promptLabel: 'Ouvrir le récit d’expansion',
+          clusterLabel: 'Compact d’Aurora',
+          role: 'best-safe',
+          repeatState: 'new',
+          repeatReason: 'aucune décision récente similaire dans la limite affichée',
+          narrativeImpact: 'Ouvrir le récit d’expansion garde expansion prudente lisible et transforme Compact d’Aurora en suivi narratif immédiat.',
+        },
+      ],
+      groups: [
+        {
+          groupId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion',
+          clusterLabel: 'Compact d’Aurora',
+          theme: 'Ouvrir le récit d’expansion',
+          entries: [
+            {
+              promptId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+              promptLabel: 'Ouvrir le récit d’expansion',
+              clusterLabel: 'Compact d’Aurora',
+              role: 'best-safe',
+              repeatState: 'new',
+              repeatReason: 'aucune décision récente similaire dans la limite affichée',
+              narrativeImpact: 'Ouvrir le récit d’expansion garde expansion prudente lisible et transforme Compact d’Aurora en suivi narratif immédiat.',
+              source: 'current',
+              theme: 'Ouvrir le récit d’expansion',
+            },
+          ],
+          hasRepeat: false,
+        },
+      ],
+      emptyHint: 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.',
+    },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
 });
@@ -296,6 +335,15 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         summary: 'Aucun arbitrage de prompt culturel disponible.',
         entries: [],
         noChoiceRisk: 'Aucun momentum culturel à arbitrer.',
+      },
+      promptHistoryDrawer: {
+        state: 'quiet',
+        summary: 'Aucun historique de prompt culturel à afficher.',
+        displayLimit: 5,
+        regionId: 'quiet-field',
+        currentEntries: [],
+        groups: [],
+        emptyHint: 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.',
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },
@@ -577,6 +625,18 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
       influenceScore: 70,
       discoveries: ['archive-routes'],
     },
+    promptHistory: [
+      {
+        decisionId: 'turn-7-aurora-expansion',
+        turn: 7,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'chosen',
+        outcome: 'forum culturel déjà lancé',
+      },
+    ],
     activeRecommendations: [
       {
         recommendationId: 'ember:momentum:volatile:stabilization',
@@ -658,4 +718,13 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
   ]);
   assert.match(report.commitmentBundles.promptChoiceComparison.entries[0].narrativeImpact, /préserver le momentum/);
   assert.match(report.commitmentBundles.promptChoiceComparison.noChoiceRisk, /momentum|fenêtre/);
+  assert.equal(report.commitmentBundles.promptHistoryDrawer.state, 'repeat-warning');
+  assert.equal(report.commitmentBundles.promptHistoryDrawer.displayLimit, 5);
+  assert.deepEqual(report.commitmentBundles.promptHistoryDrawer.currentEntries.map((entry) => [entry.clusterLabel, entry.repeatState]), [
+    ['Compact d’Aurora', 'repeated'],
+    ['Harbor Compact', 'new'],
+    ['Ember Guild', 'new'],
+  ]);
+  assert.match(report.commitmentBundles.promptHistoryDrawer.currentEntries[0].repeatReason, /tour 7/);
+  assert.equal(report.commitmentBundles.promptHistoryDrawer.groups[0].hasRepeat, true);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6248,6 +6248,34 @@ function renderCultureTurnReport(report) {
           </div>
         ` : '<small>État vide: aucun prompt compatible, risqué ou à attendre à comparer.</small>'}
       </div>
+      <details class="culture-turn-report__history culture-turn-report__history--${report.commitmentBundles?.promptHistoryDrawer?.state ?? 'quiet'}" aria-label="Historique des prompts culturels de carte">
+        <summary>
+          <span>Historique culturel</span>
+          <strong>${report.commitmentBundles?.promptHistoryDrawer?.summary ?? 'Aucun historique de prompt culturel à afficher.'}</strong>
+        </summary>
+        <small>${report.commitmentBundles?.promptHistoryDrawer?.emptyHint ?? 'Historique limité aux décisions récentes pour garder le drawer lisible.'} Limite: ${report.commitmentBundles?.promptHistoryDrawer?.displayLimit ?? 5} entrées.</small>
+        ${(report.commitmentBundles?.promptHistoryDrawer?.currentEntries ?? []).length > 0 ? `
+          <div class="culture-turn-report__history-current">
+            ${report.commitmentBundles.promptHistoryDrawer.currentEntries.map((entry) => `
+              <span class="culture-turn-report__history-pill culture-turn-report__history-pill--${entry.repeatState}">
+                <b>${entry.promptLabel}</b>
+                <small>${entry.clusterLabel} · ${entry.repeatState === 'repeated' ? 'déjà proche' : 'nouveau'} · ${entry.repeatReason}</small>
+              </span>
+            `).join('')}
+          </div>
+        ` : ''}
+        ${(report.commitmentBundles?.promptHistoryDrawer?.groups ?? []).length > 0 ? `
+          <div class="culture-turn-report__history-groups">
+            ${report.commitmentBundles.promptHistoryDrawer.groups.map((group) => `
+              <article class="culture-turn-report__history-group ${group.hasRepeat ? 'culture-turn-report__history-group--repeat' : ''}">
+                <b>${group.clusterLabel}</b>
+                <em>${group.theme}</em>
+                <small>${group.entries.length} entrée${group.entries.length > 1 ? 's' : ''}${group.hasRepeat ? ' · répétition possible' : ''}</small>
+              </article>
+            `).join('')}
+          </div>
+        ` : '<small>État vide: aucune décision précédente à regrouper pour cette sélection.</small>'}
+      </details>
     </div>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -1860,6 +1860,56 @@ button { font: inherit; }
 .culture-turn-report__choice-entry--best-safe { border-color: rgba(74, 222, 128, 0.34); }
 .culture-turn-report__choice-entry--risky-useful { border-color: rgba(251, 191, 36, 0.44); }
 .culture-turn-report__choice-entry--wait { border-color: rgba(148, 163, 184, 0.26); }
+.culture-turn-report__history {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid rgba(14, 165, 233, 0.12);
+}
+.culture-turn-report__history summary {
+  display: grid;
+  gap: 2px;
+  cursor: pointer;
+}
+.culture-turn-report__history summary span {
+  color: #93c5fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__history summary strong {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.culture-turn-report__history > small { color: var(--muted); }
+.culture-turn-report__history-current,
+.culture-turn-report__history-groups {
+  display: grid;
+  gap: 6px;
+  margin-top: 7px;
+}
+.culture-turn-report__history-pill,
+.culture-turn-report__history-group {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.38);
+  border: 1px solid rgba(147, 197, 253, 0.18);
+}
+.culture-turn-report__history-pill b,
+.culture-turn-report__history-group b { color: #dbeafe; }
+.culture-turn-report__history-pill small,
+.culture-turn-report__history-group small { color: var(--muted); }
+.culture-turn-report__history-group em {
+  color: #93c5fd;
+  font-style: normal;
+  font-size: 11px;
+}
+.culture-turn-report__history-pill--repeated,
+.culture-turn-report__history-group--repeat { border-color: rgba(251, 191, 36, 0.44); }
+.culture-turn-report__history-pill--new { border-color: rgba(74, 222, 128, 0.24); }
 .hero-stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
Gamma: Implements MAP-G14 for #1292.\n\nSummary:\n- adds compact prompt history drawer data tied to current map selection;\n- groups current and recent cultural prompt decisions by territory/theme with a clear display limit;\n- marks prompts that resemble recent choices so repeated decisions are visible;\n- renders the history drawer alongside prompt comparison without replacing MAP-G11/G12/G13 outputs.\n\nChecks:\n- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js\n- node --check web/app.js\n- git diff --check\n- npm test