### PR TITLE
Alpha: Add MAP-A15 carry-over confidence handoff

### DIFF
--- a/test/ui/war/webAtlasMilitaryCarryOverConfidenceHandoff.test.js
+++ b/test/ui/war/webAtlasMilitaryCarryOverConfidenceHandoff.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military confidence handoff aggregates visible carry-over outcomes by province', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryCarryOverConfidenceHandoff\(carryOverQueue, outcomeTimeline\)/);
+  assert.match(webAppSource, /const items = carryOverQueue\?\.items \?\? \[\]/);
+  assert.match(webAppSource, /timelineByProvince\.get\(item\.provinceLabel\)/);
+  assert.match(webAppSource, /buildAtlasMilitaryCarryOverConfidenceHandoff\(nextTurnCarryOverQueue, carryOverOutcomeTimeline\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryCarryOverConfidenceHandoff\(carryOverConfidenceHandoff\)/);
+});
+
+test('atlas military confidence handoff surfaces blocking next decisions and risk labels', () => {
+  assert.match(webAppSource, /renfort: sécuriser logistique/);
+  assert.match(webAppSource, /attente: confirmer renseignement/);
+  assert.match(webAppSource, /repli: éviter fenêtre météo/);
+  assert.match(webAppSource, /ordre: résoudre blocage/);
+  assert.match(webAppSource, /Confiance fragile/);
+  assert.match(webAppSource, /risque: dépendance/);
+});
+
+test('atlas military confidence handoff keeps fog-safe empty and accessible labels', () => {
+  assert.match(webAppSource, /Handoff confiance vide: aucun carry-over visible ou informations sous brouillard/);
+  assert.match(webAppSource, /Handoff confiance et risque des provinces contestées/);
+  assert.match(webAppSource, /data-atlas-confidence-handoff/);
+  assert.match(webAppSource, /décision bloquante \$\{row\.blockingDecision\}/);
+  assert.match(stylesSource, /\.atlas-military-confidence-handoff__panel/);
+  assert.match(stylesSource, /\.atlas-military-confidence-handoff-row--fragile circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1811,6 +1811,86 @@ function renderAtlasMilitaryCarryOverOutcomeTimeline(timeline) {
   `;
 }
 
+
+function getAtlasMilitaryCarryOverConfidence(item, timelineRow) {
+  if (!item || !timelineRow) return { level: 'fog-safe', label: 'Confiance brouillard', risk: 'données carry-over incomplètes' };
+  const hasBlockingDependency = (item.dependencies ?? []).some((dependency) => ['logistique', 'renseignement', 'météo'].includes(dependency));
+  if (item.kind === 'obligatoire' || timelineRow.impact === 'conflit non résolu') {
+    return {
+      level: hasBlockingDependency ? 'fragile' : 'basse',
+      label: hasBlockingDependency ? 'Confiance fragile' : 'Confiance basse',
+      risk: hasBlockingDependency ? `risque: dépendance ${item.dependencies.join('/')}` : 'risque: conflit militaire non résolu',
+    };
+  }
+  if (item.kind === 'opportuniste' || timelineRow.impact === 'ordre à revoir') {
+    return { level: 'moyenne', label: 'Confiance moyenne', risk: 'risque: fenêtre tactique à confirmer' };
+  }
+  return { level: 'haute', label: 'Confiance haute', risk: 'risque: simple surveillance' };
+}
+
+function getAtlasMilitaryBlockingHandoffDecision(item, confidence) {
+  if (!item) return 'attente: visibilité insuffisante';
+  if (item.kind === 'obligatoire' && item.dependencies?.includes('logistique')) return 'renfort: sécuriser logistique';
+  if (item.kind === 'obligatoire' && item.dependencies?.includes('renseignement')) return 'attente: confirmer renseignement';
+  if (item.kind === 'obligatoire' && item.dependencies?.includes('météo')) return 'repli: éviter fenêtre météo';
+  if (item.kind === 'obligatoire') return 'ordre: résoudre blocage';
+  if (item.kind === 'opportuniste' || confidence?.level === 'moyenne') return 'attente: revoir ordre';
+  return 'ordre: maintenir surveillance';
+}
+
+function buildAtlasMilitaryCarryOverConfidenceHandoff(carryOverQueue, outcomeTimeline) {
+  const items = carryOverQueue?.items ?? [];
+  const timelineByProvince = new Map((outcomeTimeline?.timelines ?? []).map((timeline) => [timeline.provinceLabel, timeline]));
+  if (!items.length || outcomeTimeline?.empty) {
+    return {
+      handoffs: [],
+      summary: 'Handoff confiance vide: aucun carry-over visible ou informations sous brouillard.',
+      empty: true,
+    };
+  }
+
+  const handoffs = items.slice(0, 3).map((item) => {
+    const timelineRow = timelineByProvince.get(item.provinceLabel) ?? null;
+    const confidence = getAtlasMilitaryCarryOverConfidence(item, timelineRow);
+    const blockingDecision = getAtlasMilitaryBlockingHandoffDecision(item, confidence);
+    return {
+      handoffId: `carry-over-confidence:${item.provinceLabel}`,
+      provinceLabel: item.provinceLabel,
+      confidence,
+      blockingDecision,
+      risk: confidence.risk,
+      detail: timelineRow?.impact ?? item.nextStep ?? 'détail masqué par brouillard',
+      tone: confidence.level === 'haute' ? 'high' : confidence.level === 'moyenne' ? 'medium' : confidence.level === 'fragile' ? 'fragile' : 'low',
+      priority: (item.priority ?? 0) + (confidence.level === 'fragile' ? 24 : confidence.level === 'basse' ? 18 : confidence.level === 'moyenne' ? 8 : 0),
+    };
+  })
+    .sort((left, right) => right.priority - left.priority || left.provinceLabel.localeCompare(right.provinceLabel));
+
+  return {
+    handoffs,
+    summary: `${handoffs.length} handoff${handoffs.length > 1 ? 's' : ''} confiance/risque prêt${handoffs.length > 1 ? 's' : ''} pour décision prochain tour.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryCarryOverConfidenceHandoff(handoff) {
+  const height = handoff.empty ? 7 : 6.5 + (handoff.handoffs.length * 4.8);
+  return `
+    <g class="atlas-military-confidence-handoff" aria-label="Handoff confiance et risque des provinces contestées: ${handoff.summary}">
+      <rect class="atlas-military-confidence-handoff__panel" x="82" y="66" width="15" height="${height}" rx="2.1"></rect>
+      <text class="atlas-military-confidence-handoff__title" x="83" y="68.8">Confiance</text>
+      ${handoff.empty ? `<text class="atlas-military-confidence-handoff__empty" x="83" y="72">${handoff.summary}</text>` : handoff.handoffs.map((row, index) => `
+        <g class="atlas-military-confidence-handoff-row atlas-military-confidence-handoff-row--${row.tone}" data-atlas-confidence-handoff="${row.handoffId}" aria-label="${row.provinceLabel}: ${row.confidence.label}; ${row.risk}; décision bloquante ${row.blockingDecision}">
+          <circle cx="83.6" cy="${71 + index * 4.8}" r="0.85"></circle>
+          <text class="atlas-military-confidence-handoff-row__province" x="85" y="${70.4 + index * 4.8}">${row.provinceLabel}</text>
+          <text class="atlas-military-confidence-handoff-row__decision" x="85" y="${71.9 + index * 4.8}">${row.blockingDecision}</text>
+          <text class="atlas-military-confidence-handoff-row__risk" x="85" y="${73.4 + index * 4.8}">${row.confidence.label} · ${row.risk}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryCommitmentConflictResolver(resolver) {
   const height = resolver.empty ? 8 : 8 + (resolver.recommendations.length * 5.2);
   return `
@@ -2798,6 +2878,7 @@ function renderAtlasMilitaryLayer(shell) {
   const postResolutionAudit = buildAtlasMilitaryPostResolutionOrderAudit(stagedCommitment, commitmentConflicts, commitmentCoverage, commitmentWarnings, commitmentResolver);
   const nextTurnCarryOverQueue = buildAtlasMilitaryNextTurnCarryOverQueue(postResolutionAudit, shell);
   const carryOverOutcomeTimeline = buildAtlasMilitaryCarryOverOutcomeTimeline(nextTurnCarryOverQueue);
+  const carryOverConfidenceHandoff = buildAtlasMilitaryCarryOverConfidenceHandoff(nextTurnCarryOverQueue, carryOverOutcomeTimeline);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -2833,6 +2914,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryPostResolutionOrderAudit(postResolutionAudit)}
       ${renderAtlasMilitaryNextTurnCarryOverQueue(nextTurnCarryOverQueue)}
       ${renderAtlasMilitaryCarryOverOutcomeTimeline(carryOverOutcomeTimeline)}
+      ${renderAtlasMilitaryCarryOverConfidenceHandoff(carryOverConfidenceHandoff)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -10999,6 +10999,7 @@ button { font: inherit; }
 .atlas-military-post-resolution-audit,
 .atlas-military-carry-over-queue,
 .atlas-military-outcome-timeline,
+.atlas-military-confidence-handoff,
 .atlas-military-warning-relief,
 .atlas-military-best-order,
 .atlas-military-fallback-order,
@@ -13162,3 +13163,39 @@ button { font: inherit; }
 }
 .economy-repayment-scenario__warning--danger { border-color: rgba(251, 113, 133, 0.42); }
 .economy-repayment-scenario__warning--costly { border-color: rgba(245, 158, 11, 0.34); }
+
+
+.atlas-military-confidence-handoff__panel {
+  fill: rgba(30, 27, 75, 0.78);
+  stroke: rgba(196, 181, 253, 0.44);
+  stroke-width: 0.3;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-confidence-handoff__title,
+.atlas-military-confidence-handoff-row text,
+.atlas-military-confidence-handoff__empty {
+  fill: #ede9fe;
+  font-size: 0.9px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.26;
+}
+.atlas-military-confidence-handoff-row circle {
+  fill: rgba(148, 163, 184, 0.78);
+  stroke: rgba(237, 233, 254, 0.78);
+  stroke-width: 0.16;
+}
+.atlas-military-confidence-handoff-row--high circle { fill: rgba(74, 222, 128, 0.82); }
+.atlas-military-confidence-handoff-row--medium circle { fill: rgba(251, 191, 36, 0.82); }
+.atlas-military-confidence-handoff-row--fragile circle,
+.atlas-military-confidence-handoff-row--low circle { fill: rgba(248, 113, 113, 0.88); }
+.atlas-military-confidence-handoff-row__decision {
+  fill: #fde68a;
+  font-size: 0.58px;
+}
+.atlas-military-confidence-handoff-row__risk,
+.atlas-military-confidence-handoff__empty {
+  fill: #c4b5fd;
+  font-size: 0.5px;
+}


### PR DESCRIPTION
Alpha: Implements #1300.

Summary:
- adds a confidence/risk handoff derived from visible carry-over outcomes and timeline entries
- highlights the next truly blocking decision: ordre, attente, repli, or renfort
- includes fog-safe empty copy and accessible SVG labels without replacing existing detail panels

Tests:
- node --test test/ui/war/webAtlasMilitaryCarryOverConfidenceHandoff.test.js
- node --check web/app.js
- npm test

Ready for Zeta review.