### PR TITLE
Beta: Group repayment capacity bottlenecks

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2375,6 +2375,7 @@ function buildRepaymentSideEffectWarning(priority, debtEntry, routeFeature, opti
       source,
       text: `${source}: ${option.remainingBlocked} capacité reste bloquée après ${option.label.toLowerCase()}.`,
       nextArbitrage: `Arbitrer ${priority.nextAction} avant de lancer un second remboursement.`,
+      bottleneckKey: `${source}:${debtEntry?.debtResources?.join('+') || routeFeature?.bottleneckResourceId || priority.targetId}`,
     };
   }
 
@@ -2384,6 +2385,7 @@ function buildRepaymentSideEffectWarning(priority, debtEntry, routeFeature, opti
       source,
       text: `${source}: ${option.label.toLowerCase()} consomme ${option.capacityConsumed} capacité de reprise ce tour.`,
       nextArbitrage: 'Confirmer que cette capacité ne manque pas à une route ou ville concurrente.',
+      bottleneckKey: `${source}:${debtEntry?.debtResources?.join('+') || routeFeature?.bottleneckResourceId || priority.targetId}`,
     };
   }
 
@@ -2419,6 +2421,95 @@ function buildRepaymentScenarioOption(priority, debtEntry, routeFeature, mode) {
   };
 }
 
+
+function rankRepaymentWarningOption(option) {
+  const severityRank = option.sideEffectWarning?.severity === 'danger' ? 2 : option.sideEffectWarning ? 1 : 0;
+  return severityRank * 1000 + option.remainingBlocked * 100 + option.capacityConsumed;
+}
+
+function buildRepaymentBottleneckWarningGroups(scenarios) {
+  const groupsByKey = new Map();
+
+  for (const scenario of scenarios) {
+    for (const option of scenario.options) {
+      const warning = option.sideEffectWarning;
+
+      if (!warning) {
+        continue;
+      }
+
+      const key = warning.bottleneckKey ?? `${warning.source}:${scenario.targetId}`;
+      const existing = groupsByKey.get(key) ?? {
+        key,
+        source: warning.source,
+        severity: 'costly',
+        scenarios: [],
+        optionCount: 0,
+        maxRemainingBlocked: 0,
+        totalCapacityConsumed: 0,
+        bestOption: null,
+      };
+
+      existing.severity = existing.severity === 'danger' || warning.severity === 'danger' ? 'danger' : 'costly';
+      existing.optionCount += 1;
+      existing.maxRemainingBlocked = Math.max(existing.maxRemainingBlocked, option.remainingBlocked);
+      existing.totalCapacityConsumed += option.capacityConsumed;
+
+      if (!existing.scenarios.some((entry) => entry.scenarioId === scenario.id)) {
+        existing.scenarios.push({
+          scenarioId: scenario.id,
+          label: scenario.label,
+          corridor: scenario.corridor,
+          targetId: scenario.targetId,
+        });
+      }
+
+      const candidate = {
+        scenarioId: scenario.id,
+        optionId: option.id,
+        label: `${scenario.label} · ${option.label}`,
+        decision: option.label,
+        remainingBlocked: option.remainingBlocked,
+        capacityConsumed: option.capacityConsumed,
+        nextArbitrage: warning.nextArbitrage,
+      };
+
+      if (!existing.bestOption || rankRepaymentWarningOption(option) < rankRepaymentWarningOption(existing.bestOption)) {
+        existing.bestOption = { ...option, ...candidate };
+      }
+
+      groupsByKey.set(key, existing);
+    }
+  }
+
+  return [...groupsByKey.values()]
+    .map((group) => ({
+      key: group.key,
+      source: group.source,
+      severity: group.severity,
+      scenarioCount: group.scenarios.length,
+      optionCount: group.optionCount,
+      maxRemainingBlocked: group.maxRemainingBlocked,
+      totalCapacityConsumed: group.totalCapacityConsumed,
+      bestDecision: group.bestOption ? {
+        scenarioId: group.bestOption.scenarioId,
+        optionId: group.bestOption.optionId,
+        label: group.bestOption.label,
+        decision: group.bestOption.decision,
+        remainingBlocked: group.bestOption.remainingBlocked,
+        capacityConsumed: group.bestOption.capacityConsumed,
+        nextArbitrage: group.bestOption.nextArbitrage,
+      } : null,
+      quickRead: group.bestOption
+        ? `${group.source}: ${group.bestOption.label} réduit le risque avec ${group.bestOption.remainingBlocked} capacité encore bloquée.`
+        : `${group.source}: arbitrage requis avant remboursement.`,
+      details: group.scenarios,
+    }))
+    .sort((left, right) => Number(right.severity === 'danger') - Number(left.severity === 'danger')
+      || right.maxRemainingBlocked - left.maxRemainingBlocked
+      || left.source.localeCompare(right.source));
+}
+
 function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymentPriorities, logisticsFeatures = []) {
   const candidates = repaymentPriorities.priorities.slice(0, 3);
   const scenarios = candidates.map((priority) => {
@@ -2447,6 +2538,8 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
     };
   });
 
+  const warningGroups = buildRepaymentBottleneckWarningGroups(scenarios);
+
   return {
     id: 'logistics-recovery-repayment-scenarios',
     title: 'Scénarios remboursement dettes prioritaires',
@@ -2457,6 +2550,8 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
     topScenarioId: scenarios[0]?.id ?? null,
     minimalViableAction: scenarios[0]?.minimalViableAction ?? 'continuer la surveillance',
     warningCount: scenarios.reduce((count, scenario) => count + scenario.sideEffectWarningCount, 0),
+    warningGroups,
+    topWarningGroupKey: warningGroups[0]?.key ?? null,
     legend: [
       { key: 'partial', label: 'Partiel: débloque une portion', tone: 'warning' },
       { key: 'complete', label: 'Complet: sécurise la reprise', tone: 'positive' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1609,6 +1609,27 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
   ]);
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.scenarios[0].options[0].sideEffectWarning.text, /capacité reste bloquée/);
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.scenarios[0].options[1].sideEffectWarning.nextArbitrage, /route ou ville concurrente/);
+  assert.deepEqual(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.warningGroups.map((group) => ({
+    key: group.key,
+    source: group.source,
+    severity: group.severity,
+    scenarioCount: group.scenarioCount,
+    optionCount: group.optionCount,
+    bestDecision: group.bestDecision.decision,
+    remainingBlocked: group.bestDecision.remainingBlocked,
+  })), [
+    {
+      key: 'stock:stock',
+      source: 'stock',
+      severity: 'danger',
+      scenarioCount: 1,
+      optionCount: 2,
+      bestDecision: 'Remboursement complet',
+      remainingBlocked: 0,
+    },
+  ]);
+  assert.equal(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.topWarningGroupKey, 'stock:stock');
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.warningGroups[0].quickRead, /réduit le risque/);
 
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -30,6 +30,9 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(webAppSource, /option\.remainingBlocked/);
   assert.match(webAppSource, /scenario\.minimalViableAction/);
   assert.match(webAppSource, /sideEffectWarning/);
+  assert.match(webAppSource, /warningGroups/);
+  assert.match(webAppSource, /economy-repayment-bottlenecks/);
+  assert.match(webAppSource, /group\.bestDecision\?\.nextArbitrage/);
   assert.match(webAppSource, /economy-repayment-scenario__warning/);
   assert.match(webAppSource, /option\.sideEffectWarning\.nextArbitrage/);
   assert.match(webAppSource, /renderEconomyRecoveryRepaymentScenarios\(economyView\)/);
@@ -48,4 +51,6 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(stylesSource, /\.economy-repayment-scenario__option--positive/);
   assert.match(stylesSource, /\.economy-repayment-scenario__warning--danger/);
   assert.match(stylesSource, /\.economy-repayment-scenario__warning--costly/);
+  assert.match(stylesSource, /\.economy-repayment-bottleneck--danger/);
+  assert.match(stylesSource, /\.economy-repayment-bottleneck--costly/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -18529,6 +18529,23 @@ function renderEconomyRecoveryRepaymentScenarios(economyView) {
         <strong>${view.title}</strong>
       </div>
       <p>${view.summary}</p>
+      ${view.warningGroups?.length ? `
+        <div class="economy-repayment-bottlenecks" aria-label="Goulots de remboursement groupés">
+          ${view.warningGroups.map((group) => `
+            <details class="economy-repayment-bottleneck economy-repayment-bottleneck--${group.severity}" ${group.key === view.topWarningGroupKey ? 'open' : ''}>
+              <summary>
+                <span>${group.source}</span>
+                <strong>${group.quickRead}</strong>
+              </summary>
+              <p>${group.bestDecision?.nextArbitrage ?? 'Arbitrage à confirmer avant remboursement.'}</p>
+              <small>${group.scenarioCount} scénario(s), ${group.optionCount} option(s), ${group.maxRemainingBlocked} capacité max encore bloquée.</small>
+              <ul>
+                ${group.details.map((detail) => `<li>${detail.label} · ${detail.corridor}</li>`).join('')}
+              </ul>
+            </details>
+          `).join('')}
+        </div>
+      ` : ''}
       <div class="economy-repayment-scenarios__list">
         ${view.scenarios.map((scenario) => `
           <article class="economy-repayment-scenario">

--- a/web/styles.css
+++ b/web/styles.css
@@ -13200,3 +13200,38 @@ button { font: inherit; }
   fill: #c4b5fd;
   font-size: 0.5px;
 }
+.economy-repayment-bottlenecks {
+  display: grid;
+  gap: 8px;
+}
+.economy-repayment-bottleneck {
+  padding: 9px;
+  border-radius: 13px;
+  background: rgba(15, 23, 42, 0.42);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.economy-repayment-bottleneck summary {
+  cursor: pointer;
+  display: grid;
+  gap: 3px;
+}
+.economy-repayment-bottleneck summary span {
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.economy-repayment-bottleneck summary strong { color: #f8fafc; }
+.economy-repayment-bottleneck p,
+.economy-repayment-bottleneck small,
+.economy-repayment-bottleneck li {
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.economy-repayment-bottleneck ul {
+  margin: 6px 0 0;
+  padding-left: 16px;
+}
+.economy-repayment-bottleneck--danger { border-color: rgba(251, 113, 133, 0.42); }
+.economy-repayment-bottleneck--costly { border-color: rgba(245, 158, 11, 0.34); }


### PR DESCRIPTION
Beta: Closes #1301.\n\n## Summary\n- group repayment side-effect warnings by shared bottleneck source/key\n- choose the fastest risk-reducing repayment option that avoids unnecessary overload when possible\n- add compact map-readable bottleneck summaries with expandable details\n\n## Tests\n- node --test test/ui/economy/buildEconomyMapOverlay.test.js test/ui/economy/webEconomyRecoveryDebtLedger.test.js\n- node --check web/app.js\n- npm test\n- git diff --check