### PR TITLE
Gamma: Add cultural repetition safeguards

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -656,27 +656,77 @@ function normalizeCulturalPromptHistoryEntry(entry, index) {
   };
 }
 
+function tokenizePromptText(value) {
+  return normalizeText(value, '')
+    .toLowerCase()
+    .replace(/[’']/g, ' ')
+    .split(/[^a-zà-ÿ0-9]+/i)
+    .filter((token) => token.length > 3);
+}
+
+function findPromptHistoryRepeat(entry, historyEntries) {
+  const entryTokens = new Set(tokenizePromptText(`${entry.promptLabel} ${entry.clusterLabel}`));
+  return historyEntries
+    .map((historyEntry) => {
+      const historyTokens = tokenizePromptText(`${historyEntry.promptLabel} ${historyEntry.theme} ${historyEntry.clusterLabel}`);
+      const overlap = historyTokens.filter((token) => entryTokens.has(token)).length;
+      const exact = historyEntry.promptLabel === entry.promptLabel && historyEntry.clusterLabel === entry.clusterLabel;
+      const sameTerritory = historyEntry.clusterLabel === entry.clusterLabel;
+      const sameTheme = historyEntry.theme === entry.promptLabel || historyEntry.promptLabel === entry.promptLabel;
+      const repeatState = exact || (sameTerritory && sameTheme)
+        ? 'repeated'
+        : sameTerritory || overlap >= 2
+          ? 'near-repeat'
+          : 'new';
+
+      return { historyEntry, repeatState, overlap };
+    })
+    .filter((candidate) => candidate.repeatState !== 'new')
+    .sort((left, right) => {
+      const rank = { repeated: 2, 'near-repeat': 1 };
+      return (rank[right.repeatState] ?? 0) - (rank[left.repeatState] ?? 0) || right.overlap - left.overlap;
+    })[0] ?? null;
+}
+
+function buildPromptRotation(entry, repeatMatch, freshAlternative) {
+  if (!repeatMatch) {
+    return {
+      confirm: 'confirmer si le contexte narratif a changé',
+      defer: 'différer si aucun nouveau signal ne justifie ce prompt',
+      replace: freshAlternative ? `remplacer par ${freshAlternative.promptLabel}` : 'aucune alternative plus fraîche visible',
+    };
+  }
+
+  return {
+    confirm: repeatMatch.repeatState === 'repeated'
+      ? 'confirmer seulement si la répétition est intentionnelle'
+      : 'confirmer si la variante ajoute une nuance culturelle claire',
+    defer: 'différer pour éviter la fatigue de répétition',
+    replace: freshAlternative ? `remplacer par ${freshAlternative.promptLabel} (${freshAlternative.clusterLabel})` : 'remplacer par une alternative culturelle plus fraîche dès qu’un signal apparaît',
+  };
+}
+
 function buildCulturalPromptHistoryDrawer(promptChoiceComparison, promptHistory = [], regionId = 'province') {
   const historyEntries = promptHistory
     .map((entry, index) => normalizeCulturalPromptHistoryEntry(entry, index))
     .filter(Boolean)
     .sort((left, right) => (right.turn ?? 0) - (left.turn ?? 0))
     .slice(0, 5);
-  const currentEntries = promptChoiceComparison.entries.map((entry) => {
-    const repeatedMatch = historyEntries.find((historyEntry) =>
-      historyEntry.clusterLabel === entry.clusterLabel
-      || (historyEntry.promptLabel === entry.promptLabel && historyEntry.clusterLabel === entry.clusterLabel)
-      || (historyEntry.theme === entry.promptLabel && historyEntry.clusterLabel === entry.clusterLabel));
+  const repeatMatches = promptChoiceComparison.entries.map((entry) => findPromptHistoryRepeat(entry, historyEntries));
+  const currentEntries = promptChoiceComparison.entries.map((entry, index) => {
+    const repeatMatch = repeatMatches[index];
+    const freshAlternative = promptChoiceComparison.entries.find((candidate, candidateIndex) => candidateIndex !== index && !repeatMatches[candidateIndex]);
 
     return {
       promptId: entry.promptId,
       promptLabel: entry.promptLabel,
       clusterLabel: entry.clusterLabel,
       role: entry.role,
-      repeatState: repeatedMatch ? 'repeated' : 'new',
-      repeatReason: repeatedMatch
-        ? `ressemble à ${repeatedMatch.promptLabel} (${repeatedMatch.clusterLabel})${repeatedMatch.turn ? ` vu au tour ${repeatedMatch.turn}` : ''}`
+      repeatState: repeatMatch?.repeatState ?? 'new',
+      repeatReason: repeatMatch
+        ? `${repeatMatch.repeatState === 'repeated' ? 'répète' : 'quasi-équivalent à'} ${repeatMatch.historyEntry.promptLabel} (${repeatMatch.historyEntry.clusterLabel})${repeatMatch.historyEntry.turn ? ` vu au tour ${repeatMatch.historyEntry.turn}` : ''}`
         : 'aucune décision récente similaire dans la limite affichée',
+      rotation: buildPromptRotation(entry, repeatMatch, freshAlternative),
       narrativeImpact: entry.narrativeImpact,
     };
   });
@@ -704,13 +754,13 @@ function buildCulturalPromptHistoryDrawer(promptChoiceComparison, promptHistory 
       hasRepeat: false,
     };
     existing.entries.push(entry);
-    existing.hasRepeat = existing.hasRepeat || entry.repeatState === 'repeated';
+    existing.hasRepeat = existing.hasRepeat || entry.repeatState === 'repeated' || entry.repeatState === 'near-repeat';
     map.set(key, existing);
     return map;
   }, new Map()).values()].slice(0, 4);
 
   return {
-    state: groups.length === 0 ? 'quiet' : groups.some((group) => group.hasRepeat) ? 'repeat-warning' : 'ready',
+    state: groups.length === 0 ? 'quiet' : currentEntries.some((entry) => entry.repeatState === 'repeated') ? 'repeat-warning' : currentEntries.some((entry) => entry.repeatState === 'near-repeat') ? 'near-repeat' : 'ready',
     summary: groups.length === 0
       ? 'Aucun historique de prompt culturel à afficher.'
       : `${groups.length} groupe${groups.length > 1 ? 's' : ''} d’historique culturel limité${groups.length > 1 ? 's' : ''} à comparer.`,
@@ -718,6 +768,11 @@ function buildCulturalPromptHistoryDrawer(promptChoiceComparison, promptHistory 
     regionId,
     currentEntries,
     groups,
+    repetitionSafeguard: currentEntries.length === 0
+      ? 'Aucun prompt courant à protéger contre la répétition.'
+      : currentEntries.some((entry) => entry.repeatState !== 'new')
+        ? 'Rotation courte disponible: confirmer, différer ou remplacer les prompts répétés.'
+        : 'Aucune répétition récente détectée: garder les prompts frais en priorité.',
     emptyHint: historyEntries.length === 0
       ? 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.'
       : 'Historique limité aux décisions récentes pour garder le drawer lisible.',
@@ -950,6 +1005,7 @@ export function buildCultureTurnReportDeltas({
           regionId,
           currentEntries: [],
           groups: [],
+          repetitionSafeguard: 'Aucun prompt courant à protéger contre la répétition.',
           emptyHint: 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.',
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -257,6 +257,11 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
           role: 'best-safe',
           repeatState: 'new',
           repeatReason: 'aucune décision récente similaire dans la limite affichée',
+          rotation: {
+            confirm: 'confirmer si le contexte narratif a changé',
+            defer: 'différer si aucun nouveau signal ne justifie ce prompt',
+            replace: 'aucune alternative plus fraîche visible',
+          },
           narrativeImpact: 'Ouvrir le récit d’expansion garde expansion prudente lisible et transforme Compact d’Aurora en suivi narratif immédiat.',
         },
       ],
@@ -273,6 +278,11 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
               role: 'best-safe',
               repeatState: 'new',
               repeatReason: 'aucune décision récente similaire dans la limite affichée',
+              rotation: {
+                confirm: 'confirmer si le contexte narratif a changé',
+                defer: 'différer si aucun nouveau signal ne justifie ce prompt',
+                replace: 'aucune alternative plus fraîche visible',
+              },
               narrativeImpact: 'Ouvrir le récit d’expansion garde expansion prudente lisible et transforme Compact d’Aurora en suivi narratif immédiat.',
               source: 'current',
               theme: 'Ouvrir le récit d’expansion',
@@ -281,6 +291,7 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
           hasRepeat: false,
         },
       ],
+      repetitionSafeguard: 'Aucune répétition récente détectée: garder les prompts frais en priorité.',
       emptyHint: 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.',
     },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
@@ -343,6 +354,7 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         regionId: 'quiet-field',
         currentEntries: [],
         groups: [],
+        repetitionSafeguard: 'Aucun prompt courant à protéger contre la répétition.',
         emptyHint: 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.',
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
@@ -722,9 +734,12 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
   assert.equal(report.commitmentBundles.promptHistoryDrawer.displayLimit, 5);
   assert.deepEqual(report.commitmentBundles.promptHistoryDrawer.currentEntries.map((entry) => [entry.clusterLabel, entry.repeatState]), [
     ['Compact d’Aurora', 'repeated'],
-    ['Harbor Compact', 'new'],
+    ['Harbor Compact', 'near-repeat'],
     ['Ember Guild', 'new'],
   ]);
   assert.match(report.commitmentBundles.promptHistoryDrawer.currentEntries[0].repeatReason, /tour 7/);
+  assert.match(report.commitmentBundles.promptHistoryDrawer.currentEntries[0].rotation.defer, /fatigue/);
+  assert.match(report.commitmentBundles.promptHistoryDrawer.currentEntries[1].rotation.replace, /Ember Guild/);
+  assert.match(report.commitmentBundles.promptHistoryDrawer.repetitionSafeguard, /Rotation courte/);
   assert.equal(report.commitmentBundles.promptHistoryDrawer.groups[0].hasRepeat, true);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6254,12 +6254,14 @@ function renderCultureTurnReport(report) {
           <strong>${report.commitmentBundles?.promptHistoryDrawer?.summary ?? 'Aucun historique de prompt culturel à afficher.'}</strong>
         </summary>
         <small>${report.commitmentBundles?.promptHistoryDrawer?.emptyHint ?? 'Historique limité aux décisions récentes pour garder le drawer lisible.'} Limite: ${report.commitmentBundles?.promptHistoryDrawer?.displayLimit ?? 5} entrées.</small>
+        <small>${report.commitmentBundles?.promptHistoryDrawer?.repetitionSafeguard ?? 'Aucun prompt courant à protéger contre la répétition.'}</small>
         ${(report.commitmentBundles?.promptHistoryDrawer?.currentEntries ?? []).length > 0 ? `
           <div class="culture-turn-report__history-current">
             ${report.commitmentBundles.promptHistoryDrawer.currentEntries.map((entry) => `
               <span class="culture-turn-report__history-pill culture-turn-report__history-pill--${entry.repeatState}">
                 <b>${entry.promptLabel}</b>
-                <small>${entry.clusterLabel} · ${entry.repeatState === 'repeated' ? 'déjà proche' : 'nouveau'} · ${entry.repeatReason}</small>
+                <small>${entry.clusterLabel} · ${entry.repeatState === 'repeated' ? 'répété' : entry.repeatState === 'near-repeat' ? 'quasi équivalent' : 'nouveau'} · ${entry.repeatReason}</small>
+                <small>Rotation: confirmer — ${entry.rotation?.confirm ?? 'confirmer si utile'} · différer — ${entry.rotation?.defer ?? 'différer'} · remplacer — ${entry.rotation?.replace ?? 'aucune alternative'}</small>
               </span>
             `).join('')}
           </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1909,6 +1909,7 @@ button { font: inherit; }
 }
 .culture-turn-report__history-pill--repeated,
 .culture-turn-report__history-group--repeat { border-color: rgba(251, 191, 36, 0.44); }
+.culture-turn-report__history-pill--near-repeat { border-color: rgba(244, 114, 182, 0.38); }
 .culture-turn-report__history-pill--new { border-color: rgba(74, 222, 128, 0.24); }
 .hero-stats {
   display: grid;


### PR DESCRIPTION
Gamma: Implements MAP-G15 for #1302.\n\nSummary:\n- detects repeated and near-equivalent cultural prompts in the history drawer;\n- adds a short rotation for each current prompt: confirm, defer, or replace with a fresher cultural alternative;\n- preserves empty/low-data history states and keeps the drawer display-limited;\n- renders repetition safeguards without replacing MAP-G14 history grouping.\n\nChecks:\n- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js\n- node --check web/app.js\n- git diff --check\n- npm test