### PR TITLE
Beta: Add bottleneck repayment trade-off comparison

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2510,6 +2510,76 @@ function buildRepaymentBottleneckWarningGroups(scenarios) {
       || left.source.localeCompare(right.source));
 }
 
+
+function classifyRepaymentTradeOffOption(option) {
+  if (option.remainingBlocked === 0 && option.sideEffectWarning?.severity !== 'danger') {
+    return 'minimale sûre';
+  }
+
+  if (option.remainingBlocked > 0 && option.capacityConsumed <= Math.max(1, option.remainingBlocked)) {
+    return 'rapide fragile';
+  }
+
+  if (option.sideEffectWarning?.severity === 'costly') {
+    return 'à vérifier';
+  }
+
+  return 'à éviter si surcharge déplacée';
+}
+
+function buildRepaymentTradeOffComparisons(scenarios, warningGroups) {
+  return warningGroups.map((group) => {
+    const options = scenarios.flatMap((scenario) => scenario.options
+      .filter((option) => option.sideEffectWarning?.bottleneckKey === group.key)
+      .map((option) => ({ scenario, option })));
+    const ranked = [...options].sort((left, right) => left.option.remainingBlocked - right.option.remainingBlocked
+      || left.option.capacityConsumed - right.option.capacityConsumed
+      || left.scenario.rank - right.scenario.rank);
+    const minimalSafe = ranked.find(({ option }) => option.remainingBlocked === 0 && option.sideEffectWarning?.severity !== 'danger') ?? ranked[0] ?? null;
+    const fastFragile = [...options].sort((left, right) => left.option.capacityConsumed - right.option.capacityConsumed
+      || left.option.remainingBlocked - right.option.remainingBlocked
+      || left.scenario.rank - right.scenario.rank)
+      .find(({ option }) => option.remainingBlocked > 0) ?? options[0] ?? null;
+    const avoid = [...options].sort((left, right) => Number(right.option.sideEffectWarning?.severity === 'danger') - Number(left.option.sideEffectWarning?.severity === 'danger')
+      || right.option.remainingBlocked - left.option.remainingBlocked
+      || right.option.capacityConsumed - left.option.capacityConsumed)[0] ?? null;
+
+    const choices = options.map(({ scenario, option }) => ({
+      id: `tradeoff:${group.key}:${option.id}`,
+      scenarioId: scenario.id,
+      optionId: option.id,
+      label: `${scenario.label} · ${option.label}`,
+      role: classifyRepaymentTradeOffOption(option),
+      cost: option.capacityConsumed,
+      capacityFreed: Math.max(0, (scenario.options.find((candidate) => candidate.mode === 'complete')?.capacityConsumed ?? option.capacityConsumed) - option.remainingBlocked),
+      delay: option.remainingBlocked === 0 ? 'ce tour' : 'ce tour + reprise suivante',
+      residualRisk: option.remainingBlocked === 0 ? 'aucun goulot critique restant' : `${option.remainingBlocked} capacité encore bloquée`,
+      overloadShiftRisk: option.sideEffectWarning?.severity === 'costly'
+        ? 'risque de déplacer la surcharge vers une route ou ville concurrente'
+        : option.sideEffectWarning?.severity === 'danger'
+          ? 'risque persistant sur le goulot partagé'
+          : 'pas de surcharge déplacée signalée',
+      warningGroupKey: group.key,
+    }));
+
+    return {
+      id: `tradeoff-comparison:${group.key}`,
+      warningGroupKey: group.key,
+      source: group.source,
+      summary: choices.length === 0
+        ? `${group.source}: aucune option comparable pour ce goulot.`
+        : `${group.source}: ${choices.length} option(s) comparées pour résoudre le goulot partagé.`,
+      minimalSafeOptionId: minimalSafe ? `tradeoff:${group.key}:${minimalSafe.option.id}` : null,
+      fastFragileOptionId: fastFragile ? `tradeoff:${group.key}:${fastFragile.option.id}` : null,
+      avoidOptionId: avoid ? `tradeoff:${group.key}:${avoid.option.id}` : null,
+      recommendation: minimalSafe
+        ? `${minimalSafe.scenario.label}: ${minimalSafe.option.label} est l'option minimale sûre.`
+        : 'Surveiller le goulot: aucune option sûre n’est disponible avec les données actuelles.',
+      choices,
+    };
+  });
+}
+
 function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymentPriorities, logisticsFeatures = []) {
   const candidates = repaymentPriorities.priorities.slice(0, 3);
   const scenarios = candidates.map((priority) => {
@@ -2539,6 +2609,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
   });
 
   const warningGroups = buildRepaymentBottleneckWarningGroups(scenarios);
+  const tradeOffComparisons = buildRepaymentTradeOffComparisons(scenarios, warningGroups);
 
   return {
     id: 'logistics-recovery-repayment-scenarios',
@@ -2552,6 +2623,8 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
     warningCount: scenarios.reduce((count, scenario) => count + scenario.sideEffectWarningCount, 0),
     warningGroups,
     topWarningGroupKey: warningGroups[0]?.key ?? null,
+    tradeOffComparisons,
+    topTradeOffComparisonId: tradeOffComparisons[0]?.id ?? null,
     legend: [
       { key: 'partial', label: 'Partiel: débloque une portion', tone: 'warning' },
       { key: 'complete', label: 'Complet: sécurise la reprise', tone: 'positive' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1630,6 +1630,32 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
   ]);
   assert.equal(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.topWarningGroupKey, 'stock:stock');
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.warningGroups[0].quickRead, /réduit le risque/);
+  assert.equal(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.topTradeOffComparisonId, 'tradeoff-comparison:stock:stock');
+  assert.deepEqual(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.tradeOffComparisons.map((comparison) => ({
+    id: comparison.id,
+    warningGroupKey: comparison.warningGroupKey,
+    minimalSafeOptionId: comparison.minimalSafeOptionId,
+    fastFragileOptionId: comparison.fastFragileOptionId,
+    avoidOptionId: comparison.avoidOptionId,
+  })), [
+    {
+      id: 'tradeoff-comparison:stock:stock',
+      warningGroupKey: 'stock:stock',
+      minimalSafeOptionId: 'tradeoff:stock:stock:recovery-repayment:route-coast:complete',
+      fastFragileOptionId: 'tradeoff:stock:stock:recovery-repayment:route-coast:partial',
+      avoidOptionId: 'tradeoff:stock:stock:recovery-repayment:route-coast:partial',
+    },
+  ]);
+  assert.deepEqual(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.tradeOffComparisons[0].choices.map((choice) => ({
+    role: choice.role,
+    cost: choice.cost,
+    delay: choice.delay,
+    residualRisk: choice.residualRisk,
+  })), [
+    { role: 'rapide fragile', cost: 1, delay: 'ce tour + reprise suivante', residualRisk: '1 capacité encore bloquée' },
+    { role: 'minimale sûre', cost: 2, delay: 'ce tour', residualRisk: 'aucun goulot critique restant' },
+  ]);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.tradeOffComparisons[0].choices[1].overloadShiftRisk, /déplacer la surcharge/);
 
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -31,6 +31,9 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(webAppSource, /scenario\.minimalViableAction/);
   assert.match(webAppSource, /sideEffectWarning/);
   assert.match(webAppSource, /warningGroups/);
+  assert.match(webAppSource, /tradeOffComparisons/);
+  assert.match(webAppSource, /economy-repayment-tradeoffs/);
+  assert.match(webAppSource, /choice\.overloadShiftRisk/);
   assert.match(webAppSource, /economy-repayment-bottlenecks/);
   assert.match(webAppSource, /group\.bestDecision\?\.nextArbitrage/);
   assert.match(webAppSource, /economy-repayment-scenario__warning/);
@@ -53,4 +56,6 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(stylesSource, /\.economy-repayment-scenario__warning--costly/);
   assert.match(stylesSource, /\.economy-repayment-bottleneck--danger/);
   assert.match(stylesSource, /\.economy-repayment-bottleneck--costly/);
+  assert.match(stylesSource, /\.economy-repayment-tradeoff__choice--minimale-sûre/);
+  assert.match(stylesSource, /\.economy-repayment-tradeoff__choice--rapide-fragile/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -18529,6 +18529,29 @@ function renderEconomyRecoveryRepaymentScenarios(economyView) {
         <strong>${view.title}</strong>
       </div>
       <p>${view.summary}</p>
+      ${view.tradeOffComparisons?.length ? `
+        <div class="economy-repayment-tradeoffs" aria-label="Comparaison des options de résolution de goulot">
+          ${view.tradeOffComparisons.map((comparison) => `
+            <details class="economy-repayment-tradeoff" ${comparison.id === view.topTradeOffComparisonId ? 'open' : ''}>
+              <summary>
+                <span>${comparison.source}</span>
+                <strong>${comparison.recommendation}</strong>
+              </summary>
+              <div class="economy-repayment-tradeoff__choices">
+                ${comparison.choices.map((choice) => `
+                  <article class="economy-repayment-tradeoff__choice economy-repayment-tradeoff__choice--${choice.role.replaceAll(' ', '-')}">
+                    <b>${choice.role}</b>
+                    <strong>${choice.label}</strong>
+                    <small>Coût ${choice.cost} · libère ${choice.capacityFreed} · délai ${choice.delay}</small>
+                    <p>${choice.residualRisk}</p>
+                    <span>${choice.overloadShiftRisk}</span>
+                  </article>
+                `).join('')}
+              </div>
+            </details>
+          `).join('')}
+        </div>
+      ` : ''}
       ${view.warningGroups?.length ? `
         <div class="economy-repayment-bottlenecks" aria-label="Goulots de remboursement groupés">
           ${view.warningGroups.map((group) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13235,3 +13235,51 @@ button { font: inherit; }
 }
 .economy-repayment-bottleneck--danger { border-color: rgba(251, 113, 133, 0.42); }
 .economy-repayment-bottleneck--costly { border-color: rgba(245, 158, 11, 0.34); }
+.economy-repayment-tradeoffs {
+  display: grid;
+  gap: 8px;
+}
+.economy-repayment-tradeoff {
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(8, 47, 73, 0.28);
+  border: 1px solid rgba(125, 211, 252, 0.18);
+}
+.economy-repayment-tradeoff summary {
+  cursor: pointer;
+  display: grid;
+  gap: 3px;
+}
+.economy-repayment-tradeoff summary span,
+.economy-repayment-tradeoff__choice b {
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.economy-repayment-tradeoff summary strong,
+.economy-repayment-tradeoff__choice strong { color: #f8fafc; }
+.economy-repayment-tradeoff__choices {
+  display: grid;
+  gap: 7px;
+  margin-top: 8px;
+}
+.economy-repayment-tradeoff__choice {
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border-radius: 11px;
+  background: rgba(2, 6, 23, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.economy-repayment-tradeoff__choice small,
+.economy-repayment-tradeoff__choice p,
+.economy-repayment-tradeoff__choice span {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.economy-repayment-tradeoff__choice--minimale-sûre { border-color: rgba(74, 222, 128, 0.34); }
+.economy-repayment-tradeoff__choice--rapide-fragile { border-color: rgba(245, 158, 11, 0.34); }
+.economy-repayment-tradeoff__choice--à-éviter-si-surcharge-déplacée { border-color: rgba(251, 113, 133, 0.42); }


### PR DESCRIPTION
Beta: Closes #1307.\n\n## Summary\n- add trade-off comparisons for options attached to the same repayment bottleneck group\n- mark minimal safe, fast-but-fragile, and avoid/overload-shift choices\n- surface cost, capacity freed, delay, residual risk, and overload displacement risk without duplicating the ledger\n\n## Tests\n- node --test test/ui/economy/buildEconomyMapOverlay.test.js test/ui/economy/webEconomyRecoveryDebtLedger.test.js\n- node --check web/app.js\n- npm test\n- git diff --check