### PR TITLE
Alpha: Add MAP-A16 cross-domain blocker badges

### DIFF
--- a/test/ui/war/webAtlasMilitaryCrossDomainBlockerBadges.test.js
+++ b/test/ui/war/webAtlasMilitaryCrossDomainBlockerBadges.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military handoff builds compact cross-domain blocker badges from visible dependencies', () => {
+  assert.match(webAppSource, /function getAtlasMilitaryCrossDomainBlockerBadge\(item\)/);
+  assert.match(webAppSource, /label: 'logistique\/capacité'/);
+  assert.match(webAppSource, /label: 'météo\/climat'/);
+  assert.match(webAppSource, /label: 'renseignement\/incertitude'/);
+  assert.match(webAppSource, /label: 'engagement culturel\/narratif'/);
+  assert.match(webAppSource, /label: 'blocage inconnu'/);
+});
+
+test('atlas military handoff reports useful military action only when blocker allows it', () => {
+  assert.match(webAppSource, /function getAtlasMilitaryUsefulActionAgainstBlocker\(item, blockerBadge, blockingDecision\)/);
+  assert.match(webAppSource, /renfort valide seulement après capacité confirmée/);
+  assert.match(webAppSource, /attendre fenêtre météo avant ordre exposé/);
+  assert.match(webAppSource, /vérifier visibilité avant engagement/);
+  assert.match(webAppSource, /ordre valide si récit local stabilisé/);
+  assert.match(webAppSource, /vérifier le bloqueur avant action/);
+});
+
+test('atlas military handoff keeps blocker badges accessible and styled', () => {
+  assert.match(webAppSource, /bloqueur \$\{row\.blockerBadge\.label\}/);
+  assert.match(webAppSource, /atlas-military-confidence-handoff-row__badge/);
+  assert.match(webAppSource, /dependencies\.push\('culture'\)/);
+  assert.match(webAppSource, /\['blocage inconnu'\]/);
+  assert.match(stylesSource, /\.atlas-military-confidence-handoff-row--logistics \.atlas-military-confidence-handoff-row__badge/);
+  assert.match(stylesSource, /\.atlas-military-confidence-handoff-row--unknown \.atlas-military-confidence-handoff-row__badge/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1689,7 +1689,8 @@ function getAtlasMilitaryCarryOverDependencies(row, shell) {
     : null;
   if (exposedCellule) dependencies.push('renseignement');
   if (province?.contested && (province.supplyLevel === 'strained' || row.status !== 'appliqué')) dependencies.push('météo');
-  return dependencies.length > 0 ? dependencies : ['aucune dépendance visible'];
+  if ((province?.loyalty ?? 100) <= 42) dependencies.push('culture');
+  return dependencies.length > 0 ? dependencies : ['blocage inconnu'];
 }
 
 function buildAtlasMilitaryNextTurnCarryOverQueue(postResolutionAudit, shell) {
@@ -1828,6 +1829,34 @@ function getAtlasMilitaryCarryOverConfidence(item, timelineRow) {
   return { level: 'haute', label: 'Confiance haute', risk: 'risque: simple surveillance' };
 }
 
+
+function getAtlasMilitaryCrossDomainBlockerBadge(item) {
+  const dependencies = item?.dependencies ?? [];
+  if (dependencies.includes('logistique')) {
+    return { type: 'logistics', label: 'logistique/capacité', action: 'renfort valide seulement après capacité confirmée' };
+  }
+  if (dependencies.includes('météo')) {
+    return { type: 'climate', label: 'météo/climat', action: 'attendre fenêtre météo avant ordre exposé' };
+  }
+  if (dependencies.includes('renseignement')) {
+    return { type: 'intel', label: 'renseignement/incertitude', action: 'vérifier visibilité avant engagement' };
+  }
+  if (dependencies.includes('culture')) {
+    return { type: 'culture', label: 'engagement culturel/narratif', action: 'ordre valide si récit local stabilisé' };
+  }
+  return { type: 'unknown', label: 'blocage inconnu', action: item?.kind === 'à surveiller' ? 'surveiller sans nouvel ordre' : 'vérifier le bloqueur avant action' };
+}
+
+function getAtlasMilitaryUsefulActionAgainstBlocker(item, blockerBadge, blockingDecision) {
+  if (!item) return 'attendre: données masquées';
+  if (blockerBadge.type === 'unknown') return blockerBadge.action;
+  if (item.kind !== 'obligatoire') return `action utile: ${blockingDecision}`;
+  if (blockerBadge.type === 'logistics' && blockingDecision.startsWith('renfort')) return blockerBadge.action;
+  if (blockerBadge.type === 'intel' || blockerBadge.type === 'climate') return blockerBadge.action;
+  if (blockerBadge.type === 'culture') return blockerBadge.action;
+  return `action utile: ${blockingDecision}`;
+}
+
 function getAtlasMilitaryBlockingHandoffDecision(item, confidence) {
   if (!item) return 'attente: visibilité insuffisante';
   if (item.kind === 'obligatoire' && item.dependencies?.includes('logistique')) return 'renfort: sécuriser logistique';
@@ -1853,11 +1882,15 @@ function buildAtlasMilitaryCarryOverConfidenceHandoff(carryOverQueue, outcomeTim
     const timelineRow = timelineByProvince.get(item.provinceLabel) ?? null;
     const confidence = getAtlasMilitaryCarryOverConfidence(item, timelineRow);
     const blockingDecision = getAtlasMilitaryBlockingHandoffDecision(item, confidence);
+    const blockerBadge = getAtlasMilitaryCrossDomainBlockerBadge(item);
+    const usefulAction = getAtlasMilitaryUsefulActionAgainstBlocker(item, blockerBadge, blockingDecision);
     return {
       handoffId: `carry-over-confidence:${item.provinceLabel}`,
       provinceLabel: item.provinceLabel,
       confidence,
       blockingDecision,
+      blockerBadge,
+      usefulAction,
       risk: confidence.risk,
       detail: timelineRow?.impact ?? item.nextStep ?? 'détail masqué par brouillard',
       tone: confidence.level === 'haute' ? 'high' : confidence.level === 'moyenne' ? 'medium' : confidence.level === 'fragile' ? 'fragile' : 'low',
@@ -1880,11 +1913,12 @@ function renderAtlasMilitaryCarryOverConfidenceHandoff(handoff) {
       <rect class="atlas-military-confidence-handoff__panel" x="82" y="66" width="15" height="${height}" rx="2.1"></rect>
       <text class="atlas-military-confidence-handoff__title" x="83" y="68.8">Confiance</text>
       ${handoff.empty ? `<text class="atlas-military-confidence-handoff__empty" x="83" y="72">${handoff.summary}</text>` : handoff.handoffs.map((row, index) => `
-        <g class="atlas-military-confidence-handoff-row atlas-military-confidence-handoff-row--${row.tone}" data-atlas-confidence-handoff="${row.handoffId}" aria-label="${row.provinceLabel}: ${row.confidence.label}; ${row.risk}; décision bloquante ${row.blockingDecision}">
+        <g class="atlas-military-confidence-handoff-row atlas-military-confidence-handoff-row--${row.tone} atlas-military-confidence-handoff-row--${row.blockerBadge.type}" data-atlas-confidence-handoff="${row.handoffId}" aria-label="${row.provinceLabel}: ${row.confidence.label}; bloqueur ${row.blockerBadge.label}; ${row.risk}; décision bloquante ${row.blockingDecision}; ${row.usefulAction}">
           <circle cx="83.6" cy="${71 + index * 4.8}" r="0.85"></circle>
-          <text class="atlas-military-confidence-handoff-row__province" x="85" y="${70.4 + index * 4.8}">${row.provinceLabel}</text>
-          <text class="atlas-military-confidence-handoff-row__decision" x="85" y="${71.9 + index * 4.8}">${row.blockingDecision}</text>
-          <text class="atlas-military-confidence-handoff-row__risk" x="85" y="${73.4 + index * 4.8}">${row.confidence.label} · ${row.risk}</text>
+          <rect class="atlas-military-confidence-handoff-row__badge" x="85" y="${69.1 + index * 4.8}" width="5.1" height="1.1" rx="0.35"></rect>
+          <text class="atlas-military-confidence-handoff-row__province" x="90.5" y="${70.1 + index * 4.8}">${row.provinceLabel}</text>
+          <text class="atlas-military-confidence-handoff-row__decision" x="85" y="${71.7 + index * 4.8}">${row.blockerBadge.label}</text>
+          <text class="atlas-military-confidence-handoff-row__risk" x="85" y="${73.2 + index * 4.8}">${row.usefulAction}</text>
         </g>
       `).join('')}
     </g>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13325,3 +13325,14 @@ button { font: inherit; }
 .economy-repayment-tradeoff__choice--minimale-sûre { border-color: rgba(74, 222, 128, 0.34); }
 .economy-repayment-tradeoff__choice--rapide-fragile { border-color: rgba(245, 158, 11, 0.34); }
 .economy-repayment-tradeoff__choice--à-éviter-si-surcharge-déplacée { border-color: rgba(251, 113, 133, 0.42); }
+
+.atlas-military-confidence-handoff-row__badge {
+  fill: rgba(148, 163, 184, 0.72);
+  stroke: rgba(237, 233, 254, 0.6);
+  stroke-width: 0.12;
+}
+.atlas-military-confidence-handoff-row--logistics .atlas-military-confidence-handoff-row__badge { fill: rgba(56, 189, 248, 0.82); }
+.atlas-military-confidence-handoff-row--climate .atlas-military-confidence-handoff-row__badge { fill: rgba(34, 197, 94, 0.78); }
+.atlas-military-confidence-handoff-row--intel .atlas-military-confidence-handoff-row__badge { fill: rgba(168, 85, 247, 0.8); }
+.atlas-military-confidence-handoff-row--culture .atlas-military-confidence-handoff-row__badge { fill: rgba(244, 114, 182, 0.8); }
+.atlas-military-confidence-handoff-row--unknown .atlas-military-confidence-handoff-row__badge { fill: rgba(148, 163, 184, 0.8); }


### PR DESCRIPTION
Alpha: Implements #1306.

Summary:
- adds compact cross-domain blocker badges to contested province confidence handoffs
- distinguishes logistique/capacité, météo/climat, renseignement/incertitude, engagement culturel/narratif, and unknown blockers
- keeps military next-action guidance conditional on whether the blocker still allows the action, with fog-safe accessible labels

Tests:
- node --test test/ui/war/webAtlasMilitaryCrossDomainBlockerBadges.test.js
- node --check web/app.js
- npm test

Ready for Zeta review.