### PR TITLE
Gamma: Add cultural freshness filter

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -779,6 +779,57 @@ function buildCulturalPromptHistoryDrawer(promptChoiceComparison, promptHistory 
   };
 }
 
+function buildCulturalPromptFreshnessFilter(promptChoiceComparison, promptHistoryDrawer) {
+  const freshnessEntries = promptChoiceComparison.entries
+    .map((entry) => {
+      const historyEntry = promptHistoryDrawer.currentEntries.find((candidate) => candidate.promptId === entry.promptId);
+      const freshnessState = historyEntry?.repeatState === 'repeated'
+        ? 'seen'
+        : historyEntry?.repeatState === 'near-repeat'
+          ? 'defer'
+          : 'fresh';
+      const explanation = freshnessState === 'fresh'
+        ? 'recommandation fraîche: aucun choix récent similaire dans l’historique lisible'
+        : freshnessState === 'seen'
+          ? `déjà vue: ${historyEntry.repeatReason}`
+          : `à différer: ${historyEntry.repeatReason}`;
+      const score = (freshnessState === 'fresh' ? 3 : freshnessState === 'defer' ? 2 : 1)
+        + (entry.role === 'best-safe' ? 2 : entry.role === 'risky-useful' ? 1 : 0);
+
+      return {
+        freshnessId: `${entry.promptId}:freshness`,
+        promptId: entry.promptId,
+        promptLabel: entry.promptLabel,
+        clusterLabel: entry.clusterLabel,
+        role: entry.role,
+        freshnessState,
+        score,
+        explanation,
+        rotation: historyEntry?.rotation ?? null,
+      };
+    })
+    .sort((left, right) => right.score - left.score || left.clusterLabel.localeCompare(right.clusterLabel));
+  const preferred = freshnessEntries.find((entry) => entry.freshnessState === 'fresh') ?? freshnessEntries[0] ?? null;
+
+  return {
+    state: freshnessEntries.length === 0
+      ? 'quiet'
+      : preferred?.freshnessState === 'fresh'
+        ? 'fresh'
+        : preferred?.freshnessState === 'defer'
+          ? 'mixed'
+          : 'stale',
+    summary: freshnessEntries.length === 0
+      ? 'Aucun filtre de fraîcheur culturel actif.'
+      : `${freshnessEntries.length} recommandation${freshnessEntries.length > 1 ? 's' : ''} culturelle${freshnessEntries.length > 1 ? 's' : ''} classée${freshnessEntries.length > 1 ? 's' : ''} par fraîcheur.`,
+    preferredPromptId: preferred?.promptId ?? null,
+    entries: freshnessEntries,
+    fallback: promptHistoryDrawer.groups.length < 2
+      ? 'Historique court ou ambigu: conserver le classement stable et expliquer la fraîcheur sans masquer les prompts.'
+      : 'Historique suffisant: favoriser les alternatives non répétitives avant les prompts déjà vus.',
+  };
+}
+
 function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = [], promptHistory = [], regionId = 'province') {
   const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
   const trajectories = ['apaisement', 'consolidation', 'enquête', 'expansion', 'attente'];
@@ -881,6 +932,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
   const followUpPrompts = buildCulturalFollowUpPrompts(bundles, incompatibilities);
   const promptChoiceComparison = buildCulturalPromptChoiceComparison(followUpPrompts, bundles, timingWindows);
   const promptHistoryDrawer = buildCulturalPromptHistoryDrawer(promptChoiceComparison, promptHistory, regionId);
+  const promptFreshnessFilter = buildCulturalPromptFreshnessFilter(promptChoiceComparison, promptHistoryDrawer);
 
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
@@ -896,6 +948,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
     followUpPrompts,
     promptChoiceComparison,
     promptHistoryDrawer,
+    promptFreshnessFilter,
     dependencyExplanation: bundles.length === 0
       ? 'Aucune dépendance entre marqueurs culturels.'
       : bundles
@@ -1007,6 +1060,13 @@ export function buildCultureTurnReportDeltas({
           groups: [],
           repetitionSafeguard: 'Aucun prompt courant à protéger contre la répétition.',
           emptyHint: 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.',
+        },
+        promptFreshnessFilter: {
+          state: 'quiet',
+          summary: 'Aucun filtre de fraîcheur culturel actif.',
+          preferredPromptId: null,
+          entries: [],
+          fallback: 'Historique court ou ambigu: conserver le classement stable et expliquer la fraîcheur sans masquer les prompts.',
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
       },

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -294,6 +294,29 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       repetitionSafeguard: 'Aucune répétition récente détectée: garder les prompts frais en priorité.',
       emptyHint: 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.',
     },
+    promptFreshnessFilter: {
+      state: 'fresh',
+      summary: '1 recommandation culturelle classée par fraîcheur.',
+      preferredPromptId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+      entries: [
+        {
+          freshnessId: 'culture-commitment:expansion:timing:river-gate:follow-up:freshness',
+          promptId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+          promptLabel: 'Ouvrir le récit d’expansion',
+          clusterLabel: 'Compact d’Aurora',
+          role: 'best-safe',
+          freshnessState: 'fresh',
+          score: 5,
+          explanation: 'recommandation fraîche: aucun choix récent similaire dans l’historique lisible',
+          rotation: {
+            confirm: 'confirmer si le contexte narratif a changé',
+            defer: 'différer si aucun nouveau signal ne justifie ce prompt',
+            replace: 'aucune alternative plus fraîche visible',
+          },
+        },
+      ],
+      fallback: 'Historique court ou ambigu: conserver le classement stable et expliquer la fraîcheur sans masquer les prompts.',
+    },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
 });
@@ -356,6 +379,13 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         groups: [],
         repetitionSafeguard: 'Aucun prompt courant à protéger contre la répétition.',
         emptyHint: 'Historique léger: comparer seulement les prompts actuels et commencer à mémoriser les décisions.',
+      },
+      promptFreshnessFilter: {
+        state: 'quiet',
+        summary: 'Aucun filtre de fraîcheur culturel actif.',
+        preferredPromptId: null,
+        entries: [],
+        fallback: 'Historique court ou ambigu: conserver le classement stable et expliquer la fraîcheur sans masquer les prompts.',
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },
@@ -742,4 +772,12 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
   assert.match(report.commitmentBundles.promptHistoryDrawer.currentEntries[1].rotation.replace, /Ember Guild/);
   assert.match(report.commitmentBundles.promptHistoryDrawer.repetitionSafeguard, /Rotation courte/);
   assert.equal(report.commitmentBundles.promptHistoryDrawer.groups[0].hasRepeat, true);
+  assert.equal(report.commitmentBundles.promptFreshnessFilter.state, 'fresh');
+  assert.deepEqual(report.commitmentBundles.promptFreshnessFilter.entries.map((entry) => [entry.clusterLabel, entry.freshnessState]), [
+    ['Ember Guild', 'fresh'],
+    ['Harbor Compact', 'defer'],
+    ['Compact d’Aurora', 'seen'],
+  ]);
+  assert.match(report.commitmentBundles.promptFreshnessFilter.entries[0].explanation, /fraîche/);
+  assert.match(report.commitmentBundles.promptFreshnessFilter.fallback, /Historique suffisant|Historique court/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6330,6 +6330,22 @@ function renderCultureTurnReport(report) {
           </div>
         ` : '<small>État vide: aucun prompt compatible, risqué ou à attendre à comparer.</small>'}
       </div>
+      <div class="culture-turn-report__freshness culture-turn-report__freshness--${report.commitmentBundles?.promptFreshnessFilter?.state ?? 'quiet'}" aria-label="Filtre de fraîcheur des recommandations culturelles">
+        <span>Fraîcheur culturelle</span>
+        <strong>${report.commitmentBundles?.promptFreshnessFilter?.summary ?? 'Aucun filtre de fraîcheur culturel actif.'}</strong>
+        <small>${report.commitmentBundles?.promptFreshnessFilter?.fallback ?? 'Historique court ou ambigu: conserver le classement stable et expliquer la fraîcheur sans masquer les prompts.'}</small>
+        ${(report.commitmentBundles?.promptFreshnessFilter?.entries ?? []).length > 0 ? `
+          <div class="culture-turn-report__freshness-list">
+            ${report.commitmentBundles.promptFreshnessFilter.entries.map((entry) => `
+              <article class="culture-turn-report__freshness-entry culture-turn-report__freshness-entry--${entry.freshnessState}" data-culture-freshness="${entry.freshnessId}">
+                <b>${entry.promptLabel}</b>
+                <em>${entry.clusterLabel} · ${entry.freshnessState === 'fresh' ? 'frais' : entry.freshnessState === 'defer' ? 'à différer' : 'déjà vu'}</em>
+                <small>${entry.explanation}</small>
+              </article>
+            `).join('')}
+          </div>
+        ` : '<small>État vide: aucune recommandation culturelle à classer par fraîcheur.</small>'}
+      </div>
       <details class="culture-turn-report__history culture-turn-report__history--${report.commitmentBundles?.promptHistoryDrawer?.state ?? 'quiet'}" aria-label="Historique des prompts culturels de carte">
         <summary>
           <span>Historique culturel</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1860,6 +1860,48 @@ button { font: inherit; }
 .culture-turn-report__choice-entry--best-safe { border-color: rgba(74, 222, 128, 0.34); }
 .culture-turn-report__choice-entry--risky-useful { border-color: rgba(251, 191, 36, 0.44); }
 .culture-turn-report__choice-entry--wait { border-color: rgba(148, 163, 184, 0.26); }
+.culture-turn-report__freshness {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid rgba(45, 212, 191, 0.12);
+}
+.culture-turn-report__freshness > span {
+  color: #5eead4;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__freshness > strong {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.culture-turn-report__freshness > small { color: var(--muted); }
+.culture-turn-report__freshness-list {
+  display: grid;
+  gap: 6px;
+}
+.culture-turn-report__freshness-entry {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(20, 83, 45, 0.18);
+  border: 1px solid rgba(45, 212, 191, 0.18);
+}
+.culture-turn-report__freshness-entry b { color: #ccfbf1; }
+.culture-turn-report__freshness-entry em {
+  color: #5eead4;
+  font-style: normal;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.culture-turn-report__freshness-entry small { color: var(--muted); }
+.culture-turn-report__freshness-entry--fresh { border-color: rgba(45, 212, 191, 0.36); }
+.culture-turn-report__freshness-entry--defer { border-color: rgba(251, 191, 36, 0.4); }
+.culture-turn-report__freshness-entry--seen { border-color: rgba(148, 163, 184, 0.26); }
 .culture-turn-report__history {
   display: grid;
   gap: 7px;


### PR DESCRIPTION
Gamma: Implements MAP-G16 for #1308.\n\nSummary:\n- ranks cultural prompt recommendations by freshness before repetition fatigue hits;\n- favors non-repetitive alternatives when multiple prompts are available for related territory/theme choices;\n- explains in one line whether each recommendation is fresh, already seen, or should be deferred;\n- keeps stable fallback behavior for short or ambiguous history.\n\nChecks:\n- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js\n- node --check web/app.js\n- git diff --check\n- npm test