### PR TITLE
Delta: Add ageing intrigue escalation prompts

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2863,6 +2863,101 @@ function buildIntrigueRecheckQueue({ locationId, locationName, verificationOutco
   };
 }
 
+function buildIntrigueEscalationPrompts({ locationId, locationName, intrigueRecheckQueue }) {
+  if (intrigueRecheckQueue.state === 'masked-recheck-queue') {
+    return {
+      state: 'masked-escalation',
+      locationId,
+      locationName,
+      prompts: [],
+      blockedPrompts: intrigueRecheckQueue.blockedRechecks.map((block) => ({
+        action: 'do-not-escalate',
+        label: 'Ne pas escalader',
+        reason: block.reason,
+        triggerCondition: block.triggerCondition,
+      })),
+      summary: 'Escalade masquée: attendre une provenance visible avant toute relance.',
+      safeMapPolicy: 'Prompts D15 bornés au statut visible; aucune cible, cellule, relais, cause ou vérité cachée n’est révélée.',
+    };
+  }
+
+  const prompts = intrigueRecheckQueue.entries.map((entry) => {
+    const ageState = entry.ageIndicator?.state ?? 'fresh';
+    const hasBudget = entry.status !== 'wait-for-budget' && entry.budgetRemaining >= 3;
+    if (ageState === 'urgent' && hasBudget) {
+      return {
+        promptId: `${entry.queueId}:escalate`,
+        action: 'verify-now',
+        label: 'Vérifier maintenant',
+        urgency: 'urgent',
+        reason: 'Attendre devient plus risqué que consommer une vérification prudente.',
+        exposureCostCue: `Exposition probable ${entry.recommendedCheck?.exposureBand ?? 'modérée'}, budget restant ${entry.budgetRemaining}.`,
+        triggerCondition: entry.triggerCondition,
+        provenanceLink: entry.provenanceLink,
+        originFallback: entry.ageIndicator.fallback,
+      };
+    }
+    if (ageState === 'watch') {
+      const enoughForObservation = entry.budgetRemaining >= 5;
+      return {
+        promptId: `${entry.queueId}:observe`,
+        action: enoughForObservation ? 'delegate-light-observation' : 'wait-for-budget',
+        label: enoughForObservation ? 'Observation légère' : 'Budget insuffisant',
+        urgency: enoughForObservation ? 'watch' : 'budget-insufficient',
+        reason: enoughForObservation
+          ? 'Déléguer une observation légère sans élargir la couverture ni confirmer de vérité cachée.'
+          : 'Ne pas escalader tant que le budget visible ne couvre pas une relance prudente.',
+        exposureCostCue: enoughForObservation
+          ? `Exposition probable basse à ${entry.recommendedCheck?.exposureBand ?? 'modérée'}, budget restant ${entry.budgetRemaining}.`
+          : `Budget restant ${entry.budgetRemaining}: relance différée pour éviter une exposition excessive.`,
+        triggerCondition: entry.triggerCondition,
+        provenanceLink: entry.provenanceLink,
+        originFallback: entry.ageIndicator.fallback,
+      };
+    }
+    return {
+      promptId: `${entry.queueId}:calm`,
+      action: 'hold-calm',
+      label: 'Calme',
+      urgency: 'fresh',
+      reason: 'Incertitude encore fraîche: surveiller sans escalade immédiate.',
+      exposureCostCue: `Aucune exposition supplémentaire recommandée, budget restant ${entry.budgetRemaining}.`,
+      triggerCondition: entry.triggerCondition,
+      provenanceLink: entry.provenanceLink,
+      originFallback: entry.ageIndicator?.fallback ?? 'Origine non datée: conserver un état calme par défaut.',
+    };
+  });
+  const blockedPrompts = intrigueRecheckQueue.blockedRechecks.map((block) => ({
+    action: 'abandon-provisionally',
+    label: 'Abandon provisoire',
+    reason: block.reason,
+    exposureCostCue: `Relance ${block.exposureBand ?? 'évitable'}: exposition trop élevée ou non justifiée par la provenance visible.`,
+    triggerCondition: block.triggerCondition,
+  }));
+  const urgentCount = prompts.filter((prompt) => prompt.urgency === 'urgent').length;
+  const blockedByBudgetCount = prompts.filter((prompt) => prompt.urgency === 'budget-insufficient').length;
+
+  return {
+    state: urgentCount > 0
+      ? 'escalation-needed'
+      : blockedByBudgetCount > 0
+        ? 'budget-limited'
+        : prompts.length > 0
+          ? 'calm-or-watch'
+          : 'no-escalation-needed',
+    locationId,
+    locationName,
+    prompts,
+    blockedPrompts,
+    summary: urgentCount > 0
+      ? `${urgentCount} incertitude(s) vieillissante(s): vérifier maintenant devient plus sûr que continuer d’attendre.`
+      : blockedByBudgetCount > 0
+        ? 'Escalade retenue: budget visible insuffisant pour vérifier sans surexposition.'
+        : 'Aucune escalade urgente: surveillance prudente ou maintien au calme.',
+    safeMapPolicy: 'Prompts D15 dérivés uniquement de l’âge visible, du budget restant et de la provenance; ils ne révèlent jamais cible, cellule, relais, cause ou vérité cachée.',
+  };
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -3066,6 +3161,11 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         intelligenceProvenancePanel,
         exposureBudgetForPriorityVerifications,
       });
+      const intrigueEscalationPrompts = buildIntrigueEscalationPrompts({
+        locationId,
+        locationName,
+        intrigueRecheckQueue,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -3082,6 +3182,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           verificationConflictResolver,
           verificationOutcomeRecap,
           intrigueRecheckQueue,
+          intrigueEscalationPrompts,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2547,3 +2547,87 @@ test('buildIntrigueMapOverlay marks ageing priority for fog-safe recheck queue u
   assert.match(urgentQueue.entries[1].ageIndicator.reliabilityCue, /attendre un créneau sûr/);
   assert.match(urgentQueue.entries[1].ageIndicator.fallback, /vieillissement affiché comme surveillance prudente/);
 });
+
+test('buildIntrigueMapOverlay proposes fog-safe escalation prompts for ageing intrigue uncertainties', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-escalate-now',
+      factionId: 'shadow-league',
+      codename: 'Escalate',
+      locationId: 'escalate-now',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 92,
+    }),
+    new Cellule({
+      id: 'cell-escalate-budget',
+      factionId: 'shadow-league',
+      codename: 'Budget Hold',
+      locationId: 'escalate-budget',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 99,
+    }),
+    new Cellule({
+      id: 'cell-escalate-masked',
+      factionId: 'shadow-league',
+      codename: 'Masked Escalation',
+      locationId: 'escalate-masked',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-escalate-now',
+      celluleId: 'cell-escalate-now',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Age into escalation',
+      theaterId: 'escalate-now',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 92,
+      progress: 80,
+      heat: 86,
+      phase: 'execution',
+    }),
+    new OperationClandestine({
+      id: 'op-escalate-budget',
+      celluleId: 'cell-escalate-budget',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Drain recheck budget',
+      theaterId: 'escalate-budget',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 99,
+      progress: 94,
+      heat: 99,
+      phase: 'execution',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.intrigueEscalationPrompts]));
+  const urgent = byLocation.get('escalate-now');
+  const budget = byLocation.get('escalate-budget');
+  const masked = byLocation.get('escalate-masked');
+
+  assert.equal(urgent.state, 'escalation-needed');
+  assert.equal(urgent.prompts[0].action, 'verify-now');
+  assert.equal(urgent.prompts[0].label, 'Vérifier maintenant');
+  assert.match(urgent.prompts[0].reason, /Attendre devient plus risqué/);
+  assert.match(urgent.prompts[0].exposureCostCue, /budget restant 4/);
+  assert.match(urgent.prompts[0].originFallback, /Origine non datée/);
+  assert.equal(urgent.blockedPrompts[0].action, 'abandon-provisionally');
+  assert.match(urgent.safeMapPolicy, /ne révèlent jamais cible, cellule, relais, cause ou vérité cachée/);
+
+  assert.equal(budget.state, 'escalation-needed');
+  assert.equal(urgent.prompts[1].action, 'wait-for-budget');
+  assert.equal(urgent.prompts[1].label, 'Budget insuffisant');
+  assert.match(urgent.prompts[1].exposureCostCue, /relance différée/);
+
+  assert.equal(masked.state, 'masked-escalation');
+  assert.deepEqual(masked.prompts, []);
+  assert.equal(masked.blockedPrompts[0].action, 'do-not-escalate');
+  assert.match(masked.summary, /attendre une provenance visible/);
+});


### PR DESCRIPTION
Delta: Implements #1309.

Summary:
- adds fog-safe escalation prompts derived from ageing intrigue recheck queues;
- proposes verify-now, delegate-light-observation, wait-for-budget, calm hold, or provisional abandon actions from visible age/budget/provenance signals;
- explains likely exposure cost without exposing hidden targets, cells, relays, causes, methods, or secret truth;
- covers calm, budget-insufficient, masked/origin-unknown fallback states.

Validation:
- node --check src/ui/intrigue/buildIntrigueMapOverlay.js
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test (712 passing)
- node --check web/app.js
- git diff --check

Closes #1309