### PR TITLE
Beta: Add bottleneck outcome recaps

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2580,6 +2580,54 @@ function buildRepaymentTradeOffComparisons(scenarios, warningGroups) {
   });
 }
 
+
+function buildRepaymentOutcomeRecap(choice, comparison) {
+  if (!choice) {
+    return {
+      id: `outcome-recap:${comparison.id}:none`,
+      warningGroupKey: comparison.warningGroupKey,
+      selectedOptionId: null,
+      status: 'données partielles',
+      capacityFreed: 0,
+      remainingDebt: null,
+      probableDelay: 'à confirmer',
+      displacedRisk: 'aucune option sélectionnable avec les données actuelles',
+      summary: `${comparison.source}: résultat impossible à estimer sans option comparable.`,
+      secondaryOverload: false,
+    };
+  }
+
+  const secondaryOverload = choice.overloadShiftRisk.includes('déplacer la surcharge');
+  const resolvesBottleneck = choice.residualRisk === 'aucun goulot critique restant';
+
+  return {
+    id: `outcome-recap:${comparison.warningGroupKey}:${choice.optionId}`,
+    warningGroupKey: comparison.warningGroupKey,
+    selectedOptionId: choice.id,
+    linkedComparisonId: comparison.id,
+    status: resolvesBottleneck && !secondaryOverload ? 'résolution nette' : resolvesBottleneck ? 'résolution avec surcharge secondaire' : 'résolution partielle',
+    capacityFreed: choice.capacityFreed,
+    remainingDebt: choice.residualRisk,
+    probableDelay: choice.delay,
+    displacedRisk: choice.overloadShiftRisk,
+    summary: resolvesBottleneck
+      ? `${choice.label}: libère ${choice.capacityFreed} capacité; dette restante ${choice.residualRisk}; délai ${choice.delay}.`
+      : `${choice.label}: libère ${choice.capacityFreed} capacité mais conserve ${choice.residualRisk}; délai ${choice.delay}.`,
+    secondaryOverload,
+  };
+}
+
+function buildRepaymentOutcomeRecaps(tradeOffComparisons) {
+  return tradeOffComparisons.map((comparison) => {
+    const selected = comparison.choices.find((choice) => choice.id === comparison.minimalSafeOptionId)
+      ?? comparison.choices.find((choice) => choice.id === comparison.fastFragileOptionId)
+      ?? comparison.choices[0]
+      ?? null;
+
+    return buildRepaymentOutcomeRecap(selected, comparison);
+  });
+}
+
 function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymentPriorities, logisticsFeatures = []) {
   const candidates = repaymentPriorities.priorities.slice(0, 3);
   const scenarios = candidates.map((priority) => {
@@ -2610,6 +2658,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
 
   const warningGroups = buildRepaymentBottleneckWarningGroups(scenarios);
   const tradeOffComparisons = buildRepaymentTradeOffComparisons(scenarios, warningGroups);
+  const outcomeRecaps = buildRepaymentOutcomeRecaps(tradeOffComparisons);
 
   return {
     id: 'logistics-recovery-repayment-scenarios',
@@ -2625,6 +2674,8 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
     topWarningGroupKey: warningGroups[0]?.key ?? null,
     tradeOffComparisons,
     topTradeOffComparisonId: tradeOffComparisons[0]?.id ?? null,
+    outcomeRecaps,
+    topOutcomeRecapId: outcomeRecaps[0]?.id ?? null,
     legend: [
       { key: 'partial', label: 'Partiel: débloque une portion', tone: 'warning' },
       { key: 'complete', label: 'Complet: sécurise la reprise', tone: 'positive' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1656,6 +1656,28 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
     { role: 'minimale sûre', cost: 2, delay: 'ce tour', residualRisk: 'aucun goulot critique restant' },
   ]);
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.tradeOffComparisons[0].choices[1].overloadShiftRisk, /déplacer la surcharge/);
+  assert.equal(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.topOutcomeRecapId, 'outcome-recap:stock:stock:recovery-repayment:route-coast:complete');
+  assert.deepEqual(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.outcomeRecaps.map((recap) => ({
+    warningGroupKey: recap.warningGroupKey,
+    selectedOptionId: recap.selectedOptionId,
+    status: recap.status,
+    capacityFreed: recap.capacityFreed,
+    remainingDebt: recap.remainingDebt,
+    probableDelay: recap.probableDelay,
+    secondaryOverload: recap.secondaryOverload,
+  })), [
+    {
+      warningGroupKey: 'stock:stock',
+      selectedOptionId: 'tradeoff:stock:stock:recovery-repayment:route-coast:complete',
+      status: 'résolution avec surcharge secondaire',
+      capacityFreed: 2,
+      remainingDebt: 'aucun goulot critique restant',
+      probableDelay: 'ce tour',
+      secondaryOverload: true,
+    },
+  ]);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.outcomeRecaps[0].summary, /dette restante aucun goulot critique restant/);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.outcomeRecaps[0].displacedRisk, /déplacer la surcharge/);
 
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -32,6 +32,9 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(webAppSource, /sideEffectWarning/);
   assert.match(webAppSource, /warningGroups/);
   assert.match(webAppSource, /tradeOffComparisons/);
+  assert.match(webAppSource, /outcomeRecaps/);
+  assert.match(webAppSource, /economy-repayment-outcomes/);
+  assert.match(webAppSource, /recap\.secondaryOverload/);
   assert.match(webAppSource, /economy-repayment-tradeoffs/);
   assert.match(webAppSource, /choice\.overloadShiftRisk/);
   assert.match(webAppSource, /economy-repayment-bottlenecks/);
@@ -58,4 +61,6 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(stylesSource, /\.economy-repayment-bottleneck--costly/);
   assert.match(stylesSource, /\.economy-repayment-tradeoff__choice--minimale-sûre/);
   assert.match(stylesSource, /\.economy-repayment-tradeoff__choice--rapide-fragile/);
+  assert.match(stylesSource, /\.economy-repayment-outcome--résolution-avec-surcharge-secondaire/);
+  assert.match(stylesSource, /\.economy-repayment-outcome--données-partielles/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -18619,6 +18619,21 @@ function renderEconomyRecoveryRepaymentScenarios(economyView) {
         <strong>${view.title}</strong>
       </div>
       <p>${view.summary}</p>
+      ${view.outcomeRecaps?.length ? `
+        <div class="economy-repayment-outcomes" aria-label="Récapitulatif résultat après résolution de goulot">
+          ${view.outcomeRecaps.map((recap) => `
+            <article class="economy-repayment-outcome economy-repayment-outcome--${recap.status.replaceAll(' ', '-')}">
+              <div>
+                <span>${recap.status}</span>
+                <strong>${recap.summary}</strong>
+              </div>
+              <small>Capacité libérée ${recap.capacityFreed} · dette restante ${recap.remainingDebt ?? 'inconnue'} · délai ${recap.probableDelay}</small>
+              <p>${recap.displacedRisk}</p>
+              ${recap.secondaryOverload ? '<b>Surcharge secondaire possible</b>' : ''}
+            </article>
+          `).join('')}
+        </div>
+      ` : ''}
       ${view.tradeOffComparisons?.length ? `
         <div class="economy-repayment-tradeoffs" aria-label="Comparaison des options de résolution de goulot">
           ${view.tradeOffComparisons.map((comparison) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13336,3 +13336,42 @@ button { font: inherit; }
 .atlas-military-confidence-handoff-row--intel .atlas-military-confidence-handoff-row__badge { fill: rgba(168, 85, 247, 0.8); }
 .atlas-military-confidence-handoff-row--culture .atlas-military-confidence-handoff-row__badge { fill: rgba(244, 114, 182, 0.8); }
 .atlas-military-confidence-handoff-row--unknown .atlas-military-confidence-handoff-row__badge { fill: rgba(148, 163, 184, 0.8); }
+.economy-repayment-outcomes {
+  display: grid;
+  gap: 8px;
+}
+.economy-repayment-outcome {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.46);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+.economy-repayment-outcome div {
+  display: grid;
+  gap: 3px;
+}
+.economy-repayment-outcome span {
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.economy-repayment-outcome strong { color: #f8fafc; }
+.economy-repayment-outcome small,
+.economy-repayment-outcome p {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.economy-repayment-outcome b {
+  justify-self: start;
+  color: #fecaca;
+  font-size: 11px;
+}
+.economy-repayment-outcome--résolution-nette { border-color: rgba(74, 222, 128, 0.34); }
+.economy-repayment-outcome--résolution-avec-surcharge-secondaire { border-color: rgba(245, 158, 11, 0.38); }
+.economy-repayment-outcome--résolution-partielle,
+.economy-repayment-outcome--données-partielles { border-color: rgba(251, 113, 133, 0.38); }


### PR DESCRIPTION
Beta: Closes #1317.\n\n## Summary\n- add compact outcome recaps after repayment trade-off comparisons\n- summarize freed capacity, remaining debt, probable delay, and displaced risk for the selected option\n- clearly flag recaps that resolve a bottleneck while creating a secondary overload\n\n## Tests\n- node --test test/ui/economy/buildEconomyMapOverlay.test.js test/ui/economy/webEconomyRecoveryDebtLedger.test.js\n- node --check web/app.js\n- npm test\n- git diff --check