### PR TITLE
Alpha: Add MAP-A17 blocker resolution checklist

### DIFF
--- a/test/ui/war/webAtlasMilitaryBlockerResolutionChecklist.test.js
+++ b/test/ui/war/webAtlasMilitaryBlockerResolutionChecklist.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military builds a fog-safe blocker resolution checklist from visible handoff badges', () => {
+  assert.match(webAppSource, /function getAtlasMilitaryBlockerResolutionChecklist\(blockerBadge, item, blockingDecision\)/);
+  assert.match(webAppSource, /function buildAtlasMilitaryBlockerResolutionChecklist\(handoff\)/);
+  assert.match(webAppSource, /Checklist de résolution vide: aucun bloqueur de province contestée visible/);
+  assert.match(webAppSource, /blockerResolutionChecklist = buildAtlasMilitaryBlockerResolutionChecklist\(carryOverConfidenceHandoff\)/);
+});
+
+test('atlas military checklist adapts action, prerequisite, and wait state by blocker type', () => {
+  assert.match(webAppSource, /réserver capacité de renfort/);
+  assert.match(webAppSource, /capacité logistique confirmée/);
+  assert.match(webAppSource, /mettre ordre en attente météo/);
+  assert.match(webAppSource, /fenêtre climat sûre/);
+  assert.match(webAppSource, /préparer vérification de visibilité/);
+  assert.match(webAppSource, /renseignement confirmé/);
+  assert.match(webAppSource, /aligner ordre avec engagement local/);
+  assert.match(webAppSource, /récit local stabilisé/);
+  assert.match(webAppSource, /remplacer par vérification/);
+  assert.match(webAppSource, /bloqueur principal identifié/);
+});
+
+test('atlas military checklist exposes order state and accessible SVG hooks', () => {
+  assert.match(webAppSource, /ordre préparé/);
+  assert.match(webAppSource, /ordre différé/);
+  assert.match(webAppSource, /vérification requise/);
+  assert.match(webAppSource, /data-atlas-blocker-checklist/);
+  assert.match(webAppSource, /aria-label="\$\{row\.provinceLabel\}: \$\{row\.blockerBadge\.label\}; action immédiate/);
+  assert.match(webAppSource, /renderAtlasMilitaryBlockerResolutionChecklist\(blockerResolutionChecklist\)/);
+  assert.match(stylesSource, /\.atlas-military-blocker-checklist__panel/);
+  assert.match(stylesSource, /\.atlas-military-blocker-checklist-row--unknown \.atlas-military-blocker-checklist-row__badge/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1857,6 +1857,99 @@ function getAtlasMilitaryUsefulActionAgainstBlocker(item, blockerBadge, blocking
   return `action utile: ${blockingDecision}`;
 }
 
+
+function getAtlasMilitaryBlockerResolutionChecklist(blockerBadge, item, blockingDecision) {
+  const orderState = blockerBadge.type === 'unknown'
+    ? 'vérification requise'
+    : item?.kind === 'obligatoire' && ['climate', 'intel'].includes(blockerBadge.type)
+      ? 'ordre différé'
+      : item?.kind === 'à surveiller'
+        ? 'ordre en veille'
+        : 'ordre préparé';
+  const checklistByType = {
+    logistics: {
+      immediateAction: 'réserver capacité de renfort',
+      missingPrerequisite: 'capacité logistique confirmée',
+      waitingState: 'attendre couloir ravitaillement visible',
+    },
+    climate: {
+      immediateAction: 'mettre ordre en attente météo',
+      missingPrerequisite: 'fenêtre climat sûre',
+      waitingState: 'attendre signal météo stable',
+    },
+    intel: {
+      immediateAction: 'préparer vérification de visibilité',
+      missingPrerequisite: 'renseignement confirmé',
+      waitingState: 'attendre levée incertitude',
+    },
+    culture: {
+      immediateAction: 'aligner ordre avec engagement local',
+      missingPrerequisite: 'récit local stabilisé',
+      waitingState: 'attendre apaisement narratif visible',
+    },
+    unknown: {
+      immediateAction: 'remplacer par vérification',
+      missingPrerequisite: 'bloqueur principal identifié',
+      waitingState: 'attendre cause visible fog-safe',
+    },
+  };
+  const checklist = checklistByType[blockerBadge.type] ?? checklistByType.unknown;
+  return {
+    orderState,
+    immediateAction: checklist.immediateAction,
+    missingPrerequisite: checklist.missingPrerequisite,
+    waitingState: checklist.waitingState,
+    militaryInstruction: orderState === 'ordre préparé' ? blockingDecision : `${orderState}: ${checklist.waitingState}`,
+  };
+}
+
+function buildAtlasMilitaryBlockerResolutionChecklist(handoff) {
+  const handoffs = handoff?.handoffs ?? [];
+  if (!handoffs.length || handoff?.empty) {
+    return {
+      items: [],
+      summary: 'Checklist de résolution vide: aucun bloqueur de province contestée visible.',
+      empty: true,
+    };
+  }
+
+  const items = handoffs.slice(0, 3).map((row) => {
+    const checklist = getAtlasMilitaryBlockerResolutionChecklist(row.blockerBadge, { kind: row.kind }, row.blockingDecision);
+    return {
+      checklistId: `blocker-resolution:${row.provinceLabel}`,
+      provinceLabel: row.provinceLabel,
+      blockerBadge: row.blockerBadge,
+      checklist,
+      tone: row.blockerBadge.type,
+      priority: row.priority ?? 0,
+    };
+  });
+
+  return {
+    items,
+    summary: `${items.length} checklist${items.length > 1 ? 's' : ''} de résolution fog-safe prête${items.length > 1 ? 's' : ''}.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryBlockerResolutionChecklist(checklist) {
+  const height = checklist.empty ? 7 : 6.5 + (checklist.items.length * 5.2);
+  return `
+    <g class="atlas-military-blocker-checklist" aria-label="Checklist de résolution des bloqueurs de provinces contestées: ${checklist.summary}">
+      <rect class="atlas-military-blocker-checklist__panel" x="64" y="84" width="33" height="${height}" rx="2.1"></rect>
+      <text class="atlas-military-blocker-checklist__title" x="65.5" y="86.8">Checklist bloqueur</text>
+      ${checklist.empty ? `<text class="atlas-military-blocker-checklist__empty" x="65.5" y="90">${checklist.summary}</text>` : checklist.items.map((row, index) => `
+        <g class="atlas-military-blocker-checklist-row atlas-military-blocker-checklist-row--${row.tone}" data-atlas-blocker-checklist="${row.checklistId}" aria-label="${row.provinceLabel}: ${row.blockerBadge.label}; action immédiate ${row.checklist.immediateAction}; prérequis manquant ${row.checklist.missingPrerequisite}; état d'attente ${row.checklist.waitingState}; ordre militaire ${row.checklist.orderState}">
+          <rect class="atlas-military-blocker-checklist-row__badge" x="65.5" y="${88.4 + index * 5.2}" width="4.8" height="3.5" rx="0.8"></rect>
+          <text class="atlas-military-blocker-checklist-row__province" x="71" y="${89.3 + index * 5.2}">${row.provinceLabel} · ${row.checklist.orderState}</text>
+          <text class="atlas-military-blocker-checklist-row__action" x="71" y="${90.8 + index * 5.2}">immédiat: ${row.checklist.immediateAction}</text>
+          <text class="atlas-military-blocker-checklist-row__wait" x="71" y="${92.3 + index * 5.2}">attente: ${row.checklist.waitingState}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function getAtlasMilitaryBlockingHandoffDecision(item, confidence) {
   if (!item) return 'attente: visibilité insuffisante';
   if (item.kind === 'obligatoire' && item.dependencies?.includes('logistique')) return 'renfort: sécuriser logistique';
@@ -1887,6 +1980,7 @@ function buildAtlasMilitaryCarryOverConfidenceHandoff(carryOverQueue, outcomeTim
     return {
       handoffId: `carry-over-confidence:${item.provinceLabel}`,
       provinceLabel: item.provinceLabel,
+      kind: item.kind,
       confidence,
       blockingDecision,
       blockerBadge,
@@ -2913,6 +3007,7 @@ function renderAtlasMilitaryLayer(shell) {
   const nextTurnCarryOverQueue = buildAtlasMilitaryNextTurnCarryOverQueue(postResolutionAudit, shell);
   const carryOverOutcomeTimeline = buildAtlasMilitaryCarryOverOutcomeTimeline(nextTurnCarryOverQueue);
   const carryOverConfidenceHandoff = buildAtlasMilitaryCarryOverConfidenceHandoff(nextTurnCarryOverQueue, carryOverOutcomeTimeline);
+  const blockerResolutionChecklist = buildAtlasMilitaryBlockerResolutionChecklist(carryOverConfidenceHandoff);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -2949,6 +3044,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryNextTurnCarryOverQueue(nextTurnCarryOverQueue)}
       ${renderAtlasMilitaryCarryOverOutcomeTimeline(carryOverOutcomeTimeline)}
       ${renderAtlasMilitaryCarryOverConfidenceHandoff(carryOverConfidenceHandoff)}
+      ${renderAtlasMilitaryBlockerResolutionChecklist(blockerResolutionChecklist)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13375,3 +13375,36 @@ button { font: inherit; }
 .economy-repayment-outcome--résolution-avec-surcharge-secondaire { border-color: rgba(245, 158, 11, 0.38); }
 .economy-repayment-outcome--résolution-partielle,
 .economy-repayment-outcome--données-partielles { border-color: rgba(251, 113, 133, 0.38); }
+
+.atlas-military-blocker-checklist__panel {
+  fill: rgba(15, 23, 42, 0.78);
+  stroke: rgba(251, 191, 36, 0.42);
+  stroke-width: 0.3;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-blocker-checklist__title,
+.atlas-military-blocker-checklist-row text,
+.atlas-military-blocker-checklist__empty {
+  fill: #fef3c7;
+  font-size: 0.82px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.24;
+}
+.atlas-military-blocker-checklist-row__badge {
+  fill: rgba(148, 163, 184, 0.72);
+  stroke: rgba(254, 243, 199, 0.62);
+  stroke-width: 0.12;
+}
+.atlas-military-blocker-checklist-row__action,
+.atlas-military-blocker-checklist-row__wait,
+.atlas-military-blocker-checklist__empty {
+  fill: #fde68a;
+  font-size: 0.52px;
+}
+.atlas-military-blocker-checklist-row--logistics .atlas-military-blocker-checklist-row__badge { fill: rgba(56, 189, 248, 0.82); }
+.atlas-military-blocker-checklist-row--climate .atlas-military-blocker-checklist-row__badge { fill: rgba(34, 197, 94, 0.78); }
+.atlas-military-blocker-checklist-row--intel .atlas-military-blocker-checklist-row__badge { fill: rgba(168, 85, 247, 0.8); }
+.atlas-military-blocker-checklist-row--culture .atlas-military-blocker-checklist-row__badge { fill: rgba(244, 114, 182, 0.8); }
+.atlas-military-blocker-checklist-row--unknown .atlas-military-blocker-checklist-row__badge { fill: rgba(148, 163, 184, 0.8); }


### PR DESCRIPTION
Alpha: Implements #1316.

Summary:
- adds a compact blocker resolution checklist for contested province handoffs
- adapts immediate action, missing prerequisite, waiting state, and order status for logistics/capacity, weather/climate, intel/uncertainty, cultural/narrative, and unknown blockers
- keeps content derived from visible handoff badges so it remains fog-safe and accessible

Tests:
- node --test test/ui/war/webAtlasMilitaryBlockerResolutionChecklist.test.js
- node --check web/app.js
- git diff --check
- npm test

Ready for Zeta review.