### PR TITLE
Gamma: Add cultural rotation preview

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -830,6 +830,65 @@ function buildCulturalPromptFreshnessFilter(promptChoiceComparison, promptHistor
   };
 }
 
+function buildCulturalRecommendationRotationPreview(promptFreshnessFilter, promptHistoryDrawer) {
+  const entries = promptFreshnessFilter.entries.map((entry) => {
+    const historyEntry = promptHistoryDrawer.currentEntries.find((candidate) => candidate.promptId === entry.promptId);
+    const alternative = promptFreshnessFilter.entries.find((candidate) => candidate.promptId !== entry.promptId && candidate.freshnessState === 'fresh') ?? null;
+    const rotationState = entry.freshnessState === 'fresh'
+      ? 'available-now'
+      : entry.freshnessState === 'defer'
+        ? 'deferred-freshness'
+        : alternative
+          ? 'review-soon'
+          : 'excluded-context';
+    const factor = entry.freshnessState === 'fresh'
+      ? 'compatibilité'
+      : entry.freshnessState === 'defer'
+        ? 'historique récent'
+        : alternative
+          ? 'thème'
+          : 'contexte manquant';
+    const factorExplanation = rotationState === 'available-now'
+      ? `${entry.clusterLabel}: compatible maintenant et sans répétition récente.`
+      : rotationState === 'deferred-freshness'
+        ? `${entry.clusterLabel}: historique récent trop proche, à revoir après rotation.`
+        : rotationState === 'review-soon'
+          ? `${entry.clusterLabel}: déjà vu, mais le thème peut revenir après une alternative fraîche.`
+          : `${entry.clusterLabel}: écarté faute d’alternative fraîche ou de contexte distinct.`;
+
+    return {
+      previewId: `${entry.promptId}:rotation-preview`,
+      promptId: entry.promptId,
+      promptLabel: entry.promptLabel,
+      clusterLabel: entry.clusterLabel,
+      rotationState,
+      factor,
+      factorExplanation,
+      alternativePromptId: entry.freshnessState === 'fresh' ? null : alternative?.promptId ?? null,
+      alternativeLabel: entry.freshnessState === 'fresh' ? null : alternative?.promptLabel ?? historyEntry?.rotation?.replace ?? 'aucune alternative fraîche visible',
+    };
+  });
+
+  return {
+    state: entries.length === 0
+      ? 'quiet'
+      : entries.some((entry) => entry.rotationState === 'available-now')
+        ? 'ready'
+        : entries.some((entry) => entry.rotationState === 'review-soon' || entry.rotationState === 'deferred-freshness')
+          ? 'scheduled'
+          : 'blocked',
+    summary: entries.length === 0
+      ? 'Aucun aperçu de rotation culturelle disponible.'
+      : `${entries.length} recommandation${entries.length > 1 ? 's' : ''} culturelle${entries.length > 1 ? 's' : ''} planifiée${entries.length > 1 ? 's' : ''} pour rotation.`,
+    entries,
+    fallback: entries.length === 0 || promptHistoryDrawer.groups.length < 2
+      ? 'Fallback stable: historique court ou ambigu, conserver les prompts visibles sans forcer la rotation.'
+      : entries.some((entry) => entry.alternativePromptId)
+        ? 'Rotation lisible: proposer une alternative fraîche avant de réintroduire les prompts différés.'
+        : 'Fallback stable: aucune alternative fraîche sûre, garder le classement actuel et réévaluer au prochain tour.',
+  };
+}
+
 function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = [], promptHistory = [], regionId = 'province') {
   const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
   const trajectories = ['apaisement', 'consolidation', 'enquête', 'expansion', 'attente'];
@@ -933,6 +992,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
   const promptChoiceComparison = buildCulturalPromptChoiceComparison(followUpPrompts, bundles, timingWindows);
   const promptHistoryDrawer = buildCulturalPromptHistoryDrawer(promptChoiceComparison, promptHistory, regionId);
   const promptFreshnessFilter = buildCulturalPromptFreshnessFilter(promptChoiceComparison, promptHistoryDrawer);
+  const recommendationRotationPreview = buildCulturalRecommendationRotationPreview(promptFreshnessFilter, promptHistoryDrawer);
 
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
@@ -949,6 +1009,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
     promptChoiceComparison,
     promptHistoryDrawer,
     promptFreshnessFilter,
+    recommendationRotationPreview,
     dependencyExplanation: bundles.length === 0
       ? 'Aucune dépendance entre marqueurs culturels.'
       : bundles
@@ -1067,6 +1128,12 @@ export function buildCultureTurnReportDeltas({
           preferredPromptId: null,
           entries: [],
           fallback: 'Historique court ou ambigu: conserver le classement stable et expliquer la fraîcheur sans masquer les prompts.',
+        },
+        recommendationRotationPreview: {
+          state: 'quiet',
+          summary: 'Aucun aperçu de rotation culturelle disponible.',
+          entries: [],
+          fallback: 'Fallback stable: historique court ou ambigu, conserver les prompts visibles sans forcer la rotation.',
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
       },

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -317,6 +317,24 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       ],
       fallback: 'Historique court ou ambigu: conserver le classement stable et expliquer la fraîcheur sans masquer les prompts.',
     },
+    recommendationRotationPreview: {
+      state: 'ready',
+      summary: '1 recommandation culturelle planifiée pour rotation.',
+      entries: [
+        {
+          previewId: 'culture-commitment:expansion:timing:river-gate:follow-up:rotation-preview',
+          promptId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+          promptLabel: 'Ouvrir le récit d’expansion',
+          clusterLabel: 'Compact d’Aurora',
+          rotationState: 'available-now',
+          factor: 'compatibilité',
+          factorExplanation: 'Compact d’Aurora: compatible maintenant et sans répétition récente.',
+          alternativePromptId: null,
+          alternativeLabel: null,
+        },
+      ],
+      fallback: 'Fallback stable: historique court ou ambigu, conserver les prompts visibles sans forcer la rotation.',
+    },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
 });
@@ -386,6 +404,12 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         preferredPromptId: null,
         entries: [],
         fallback: 'Historique court ou ambigu: conserver le classement stable et expliquer la fraîcheur sans masquer les prompts.',
+      },
+      recommendationRotationPreview: {
+        state: 'quiet',
+        summary: 'Aucun aperçu de rotation culturelle disponible.',
+        entries: [],
+        fallback: 'Fallback stable: historique court ou ambigu, conserver les prompts visibles sans forcer la rotation.',
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },
@@ -780,4 +804,12 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
   ]);
   assert.match(report.commitmentBundles.promptFreshnessFilter.entries[0].explanation, /fraîche/);
   assert.match(report.commitmentBundles.promptFreshnessFilter.fallback, /Historique suffisant|Historique court/);
+  assert.equal(report.commitmentBundles.recommendationRotationPreview.state, 'ready');
+  assert.deepEqual(report.commitmentBundles.recommendationRotationPreview.entries.map((entry) => [entry.clusterLabel, entry.rotationState, entry.factor]), [
+    ['Ember Guild', 'available-now', 'compatibilité'],
+    ['Harbor Compact', 'deferred-freshness', 'historique récent'],
+    ['Compact d’Aurora', 'review-soon', 'thème'],
+  ]);
+  assert.match(report.commitmentBundles.recommendationRotationPreview.entries[1].alternativeLabel, /Préparer|Ouvrir|Renforcer|Observer/);
+  assert.match(report.commitmentBundles.recommendationRotationPreview.fallback, /alternative fraîche|Fallback stable/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6380,6 +6380,23 @@ function renderCultureTurnReport(report) {
           </div>
         ` : '<small>État vide: aucune recommandation culturelle à classer par fraîcheur.</small>'}
       </div>
+      <div class="culture-turn-report__rotation-preview culture-turn-report__rotation-preview--${report.commitmentBundles?.recommendationRotationPreview?.state ?? 'quiet'}" aria-label="Aperçu de rotation des recommandations culturelles">
+        <span>Rotation prochaine</span>
+        <strong>${report.commitmentBundles?.recommendationRotationPreview?.summary ?? 'Aucun aperçu de rotation culturelle disponible.'}</strong>
+        <small>${report.commitmentBundles?.recommendationRotationPreview?.fallback ?? 'Fallback stable: historique court ou ambigu, conserver les prompts visibles sans forcer la rotation.'}</small>
+        ${(report.commitmentBundles?.recommendationRotationPreview?.entries ?? []).length > 0 ? `
+          <div class="culture-turn-report__rotation-list">
+            ${report.commitmentBundles.recommendationRotationPreview.entries.map((entry) => `
+              <article class="culture-turn-report__rotation-entry culture-turn-report__rotation-entry--${entry.rotationState}" data-culture-rotation="${entry.previewId}">
+                <b>${entry.promptLabel}</b>
+                <em>${entry.rotationState === 'available-now' ? 'disponible maintenant' : entry.rotationState === 'review-soon' ? 'à revoir bientôt' : entry.rotationState === 'deferred-freshness' ? 'différée pour fraîcheur' : 'écartée faute de contexte'}</em>
+                <small>${entry.factor}: ${entry.factorExplanation}</small>
+                ${entry.alternativeLabel ? `<small>Alternative fraîche: ${entry.alternativeLabel}</small>` : ''}
+              </article>
+            `).join('')}
+          </div>
+        ` : '<small>État vide: aucune recommandation culturelle à planifier.</small>'}
+      </div>
       <details class="culture-turn-report__history culture-turn-report__history--${report.commitmentBundles?.promptHistoryDrawer?.state ?? 'quiet'}" aria-label="Historique des prompts culturels de carte">
         <summary>
           <span>Historique culturel</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1902,6 +1902,49 @@ button { font: inherit; }
 .culture-turn-report__freshness-entry--fresh { border-color: rgba(45, 212, 191, 0.36); }
 .culture-turn-report__freshness-entry--defer { border-color: rgba(251, 191, 36, 0.4); }
 .culture-turn-report__freshness-entry--seen { border-color: rgba(148, 163, 184, 0.26); }
+.culture-turn-report__rotation-preview {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid rgba(129, 140, 248, 0.14);
+}
+.culture-turn-report__rotation-preview > span {
+  color: #c4b5fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__rotation-preview > strong {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.culture-turn-report__rotation-preview > small { color: var(--muted); }
+.culture-turn-report__rotation-list {
+  display: grid;
+  gap: 6px;
+}
+.culture-turn-report__rotation-entry {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(49, 46, 129, 0.18);
+  border: 1px solid rgba(196, 181, 253, 0.18);
+}
+.culture-turn-report__rotation-entry b { color: #ede9fe; }
+.culture-turn-report__rotation-entry em {
+  color: #c4b5fd;
+  font-style: normal;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.culture-turn-report__rotation-entry small { color: var(--muted); }
+.culture-turn-report__rotation-entry--available-now { border-color: rgba(74, 222, 128, 0.34); }
+.culture-turn-report__rotation-entry--review-soon { border-color: rgba(96, 165, 250, 0.34); }
+.culture-turn-report__rotation-entry--deferred-freshness { border-color: rgba(251, 191, 36, 0.4); }
+.culture-turn-report__rotation-entry--excluded-context { border-color: rgba(148, 163, 184, 0.26); }
 .culture-turn-report__history {
   display: grid;
   gap: 7px;


### PR DESCRIPTION
Gamma: Implements MAP-G17 for #1318.\n\nSummary:\n- adds a cultural recommendation rotation preview after the freshness filter;\n- classifies prompts as available now, review soon, deferred for freshness, or excluded for missing context;\n- explains the main rotation factor in one line;\n- exposes fresh alternatives for deferred/seen recommendations when available;\n- keeps stable fallback copy for short, ambiguous, or alternative-free history.\n\nChecks:\n- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js\n- node --check web/app.js\n- git diff --check\n- npm test