### PR TITLE
Delta: Add intrigue escalation outcome recaps

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -2958,6 +2958,123 @@ function buildIntrigueEscalationPrompts({ locationId, locationName, intrigueRech
   };
 }
 
+function buildIntrigueEscalationOutcomeRecap({ locationId, locationName, intrigueEscalationPrompts }) {
+  if (intrigueEscalationPrompts.state === 'masked-escalation') {
+    return {
+      state: 'masked-outcome-recap',
+      locationId,
+      locationName,
+      choices: [],
+      blockedChoices: intrigueEscalationPrompts.blockedPrompts.map((prompt) => ({
+        action: prompt.action,
+        label: prompt.label,
+        expectedEffect: 'Aucun effet appliqué: garder la carte en attente de provenance visible.',
+        priorityEffect: 'priorité non modifiée',
+        ageEffect: 'âge non interprété',
+        budgetEffect: 'budget préservé',
+        confidenceEffect: 'confiance inchangée',
+        blockedBy: 'unknown-provenance',
+        safeReason: prompt.reason,
+      })),
+      summary: 'Récap masqué: aucune issue d’escalade n’est évaluée tant que la provenance reste insuffisante.',
+      safeMapPolicy: 'Récap D16 limité aux effets visibles sur priorité, âge, budget et confiance; aucune cible, cellule, relais, cause ou vérité cachée n’est révélée.',
+    };
+  }
+
+  const choices = intrigueEscalationPrompts.prompts.map((prompt) => {
+    if (prompt.action === 'verify-now') {
+      return {
+        promptId: prompt.promptId,
+        action: prompt.action,
+        label: prompt.label,
+        expectedEffect: 'Résout ou réduit l’incertitude prioritaire si le contrôle visible confirme assez de signal.',
+        priorityEffect: 'priorité baisse après résolution; reste haute si le signal demeure ambigu',
+        ageEffect: 'âge remis à zéro pour le prochain suivi visible',
+        budgetEffect: prompt.exposureCostCue,
+        confidenceEffect: 'confiance attendue en hausse prudente, sans confirmer de vérité cachée',
+        blockedBy: null,
+        safeReason: prompt.reason,
+      };
+    }
+    if (prompt.action === 'delegate-light-observation') {
+      return {
+        promptId: prompt.promptId,
+        action: prompt.action,
+        label: prompt.label,
+        expectedEffect: 'Peut rafraîchir l’incertitude sans convertir le panneau en rapport complet.',
+        priorityEffect: 'priorité surveillée; escalade directe évitée tant que le signal ne se durcit pas',
+        ageEffect: 'âge ralenti par observation légère, pas supprimé',
+        budgetEffect: prompt.exposureCostCue,
+        confidenceEffect: 'confiance légèrement clarifiée ou maintenue si les données restent partielles',
+        blockedBy: null,
+        safeReason: prompt.reason,
+      };
+    }
+    if (prompt.action === 'wait-for-budget') {
+      return {
+        promptId: prompt.promptId,
+        action: prompt.action,
+        label: prompt.label,
+        expectedEffect: 'Retarde la décision pour éviter une surexposition visible.',
+        priorityEffect: 'priorité conservée mais non aggravée par une action coûteuse',
+        ageEffect: 'âge continue de monter jusqu’à récupération de budget',
+        budgetEffect: prompt.exposureCostCue,
+        confidenceEffect: 'confiance inchangée; aucune conclusion cachée inférée',
+        blockedBy: 'insufficient-budget',
+        safeReason: prompt.reason,
+      };
+    }
+    return {
+      promptId: prompt.promptId,
+      action: prompt.action,
+      label: prompt.label,
+      expectedEffect: 'Maintient l’incertitude au calme avec surveillance minimale.',
+      priorityEffect: 'priorité stable',
+      ageEffect: 'âge observé sans escalade',
+      budgetEffect: prompt.exposureCostCue,
+      confidenceEffect: 'confiance stable avec données partielles préservées',
+      blockedBy: prompt.originFallback?.includes('Origine non datée') ? 'unknown-origin' : null,
+      safeReason: prompt.reason,
+    };
+  });
+
+  const blockedChoices = intrigueEscalationPrompts.blockedPrompts.map((prompt) => ({
+    action: prompt.action,
+    label: prompt.label,
+    expectedEffect: 'Abandon provisoire: évite de payer une relance dont le risque visible dépasse le gain probable.',
+    priorityEffect: 'priorité mise en pause jusqu’à nouveau signal visible',
+    ageEffect: 'âge gelé comme dette de suivi, pas comme preuve',
+    budgetEffect: prompt.exposureCostCue,
+    confidenceEffect: 'confiance non augmentée; aucune vérité cachée déduite',
+    blockedBy: /exposition|trop élevée|éviter|avoid/i.test(`${prompt.reason} ${prompt.exposureCostCue}`)
+      ? 'over-exposure-risk'
+      : 'unknown-provenance',
+    safeReason: prompt.reason,
+  }));
+  const blockedBudgetCount = choices.filter((choice) => choice.blockedBy === 'insufficient-budget').length;
+  const activeChoiceCount = choices.filter((choice) => !choice.blockedBy).length;
+
+  return {
+    state: blockedBudgetCount > 0
+      ? 'budget-blocked-outcomes'
+      : activeChoiceCount > 0
+        ? 'outcomes-available'
+        : blockedChoices.length > 0
+          ? 'blocked-outcomes-only'
+          : 'calm-outcomes',
+    locationId,
+    locationName,
+    choices,
+    blockedChoices,
+    summary: blockedBudgetCount > 0
+      ? 'Certaines issues restent bloquées par budget: attendre évite une surexposition sans révéler de secret.'
+      : activeChoiceCount > 0
+        ? 'Issues d’escalade résumées par priorité, âge, budget et confiance visibles.'
+        : 'Aucune issue active: conserver les états calmes ou les données partielles.',
+    safeMapPolicy: 'Récap D16 dérivé uniquement des prompts D15 visibles; il ne révèle jamais cible, cellule, relais, cause, méthode ou vérité cachée.',
+  };
+}
+
 function buildSafeMapMasking({ presenceLevel, riskLevel, sabotageRiskScore, exposedCellCount, locationOperations }) {
   const activeRisk = riskLevel === 'high' || locationOperations.some((operation) => operation.phase === 'execution');
   const decayingRisk = !activeRisk && sabotageRiskScore > 0;
@@ -3166,6 +3283,11 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
         locationName,
         intrigueRecheckQueue,
       });
+      const intrigueEscalationOutcomeRecap = buildIntrigueEscalationOutcomeRecap({
+        locationId,
+        locationName,
+        intrigueEscalationPrompts,
+      });
       const safeMapSignals = normalizedOptions.includeSuspicionPlayback || normalizedOptions.safeMapMode
         ? {
           suspicionHeatDecayPlayback,
@@ -3183,6 +3305,7 @@ export function buildIntrigueMapOverlay(cellules, operations = [], options = {})
           verificationOutcomeRecap,
           intrigueRecheckQueue,
           intrigueEscalationPrompts,
+          intrigueEscalationOutcomeRecap,
         }
         : {};
 

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2631,3 +2631,90 @@ test('buildIntrigueMapOverlay proposes fog-safe escalation prompts for ageing in
   assert.equal(masked.blockedPrompts[0].action, 'do-not-escalate');
   assert.match(masked.summary, /attendre une provenance visible/);
 });
+
+test('buildIntrigueMapOverlay recaps fog-safe outcomes for escalation prompt choices', () => {
+  const overlay = buildIntrigueMapOverlay([
+    new Cellule({
+      id: 'cell-outcome-now',
+      factionId: 'shadow-league',
+      codename: 'Outcome Now',
+      locationId: 'outcome-now',
+      memberIds: ['ag-1'],
+      assetIds: ['asset-1'],
+      exposure: 92,
+    }),
+    new Cellule({
+      id: 'cell-outcome-budget',
+      factionId: 'shadow-league',
+      codename: 'Outcome Budget',
+      locationId: 'outcome-budget',
+      memberIds: ['ag-2'],
+      assetIds: ['asset-2'],
+      exposure: 99,
+    }),
+    new Cellule({
+      id: 'cell-outcome-masked',
+      factionId: 'shadow-league',
+      codename: 'Outcome Masked',
+      locationId: 'outcome-masked',
+      memberIds: ['ag-3'],
+      assetIds: ['asset-3'],
+      exposure: 0,
+    }),
+  ], [
+    new OperationClandestine({
+      id: 'op-outcome-now',
+      celluleId: 'cell-outcome-now',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Escalation outcome recap',
+      theaterId: 'outcome-now',
+      assignedAgentIds: ['ag-1'],
+      requiredAssetIds: ['asset-1'],
+      detectionRisk: 92,
+      progress: 80,
+      heat: 86,
+      phase: 'execution',
+    }),
+    new OperationClandestine({
+      id: 'op-outcome-budget',
+      celluleId: 'cell-outcome-budget',
+      targetFactionId: 'sun-empire',
+      type: 'sabotage',
+      objective: 'Blocked budget outcome recap',
+      theaterId: 'outcome-budget',
+      assignedAgentIds: ['ag-2'],
+      requiredAssetIds: ['asset-2'],
+      detectionRisk: 99,
+      progress: 94,
+      heat: 99,
+      phase: 'execution',
+    }),
+  ], { safeMapMode: true });
+  const byLocation = new Map(overlay.map((entry) => [entry.locationId, entry.intrigueEscalationOutcomeRecap]));
+  const active = byLocation.get('outcome-now');
+  const budget = byLocation.get('outcome-budget');
+  const masked = byLocation.get('outcome-masked');
+
+  assert.equal(active.state, 'budget-blocked-outcomes');
+  assert.equal(active.choices[0].action, 'verify-now');
+  assert.match(active.choices[0].expectedEffect, /Résout ou réduit l’incertitude/);
+  assert.match(active.choices[0].priorityEffect, /priorité baisse/);
+  assert.match(active.choices[0].ageEffect, /remis à zéro/);
+  assert.match(active.choices[0].budgetEffect, /budget restant 4/);
+  assert.match(active.choices[0].confidenceEffect, /sans confirmer de vérité cachée/);
+  assert.equal(active.choices[1].action, 'wait-for-budget');
+  assert.equal(active.choices[1].blockedBy, 'insufficient-budget');
+  assert.match(active.blockedChoices[0].expectedEffect, /Abandon provisoire/);
+  assert.equal(active.blockedChoices[0].blockedBy, 'over-exposure-risk');
+  assert.match(active.safeMapPolicy, /ne révèle jamais cible, cellule, relais, cause, méthode ou vérité cachée/);
+
+  assert.equal(budget.state, 'budget-blocked-outcomes');
+  assert.ok(budget.choices.some((choice) => choice.blockedBy === 'insufficient-budget'));
+  assert.match(budget.summary, /bloquées par budget/);
+
+  assert.equal(masked.state, 'masked-outcome-recap');
+  assert.deepEqual(masked.choices, []);
+  assert.equal(masked.blockedChoices[0].blockedBy, 'unknown-provenance');
+  assert.match(masked.summary, /provenance reste insuffisante/);
+});


### PR DESCRIPTION
Delta: Implements #1319.

Summary:
- adds fog-safe outcome recaps for each ageing intrigue escalation prompt choice;
- summarizes expected effects on priority, uncertainty age, exposure budget, and confidence for verify-now, light observation, wait, calm hold, and provisional abandon choices;
- flags blocked outcomes for insufficient budget, unknown provenance/origin, and over-exposure risk without exposing hidden targets, cells, relays, causes, methods, or secret truth;
- preserves calm and partial-data states instead of turning the panel into a full espionage report.

Validation:
- node --check src/ui/intrigue/buildIntrigueMapOverlay.js
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test (716 passing)
- node --check web/app.js
- git diff --check

Closes #1319