### PR TITLE
Beta: Add next recovery action summary

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2628,6 +2628,58 @@ function buildRepaymentOutcomeRecaps(tradeOffComparisons) {
   });
 }
 
+
+function buildNextRecoveryActionSummary(outcomeRecaps, warningGroups) {
+  if (outcomeRecaps.length === 0) {
+    return {
+      id: 'logistics-next-recovery-action-summary',
+      status: 'surveiller',
+      title: 'Prochaine action de récupération',
+      summary: 'Aucun goulot critique ne demande une action immédiate avec les données disponibles.',
+      primaryAction: 'attendre / surveiller les prochains recaps de récupération',
+      alternativeAction: 'conserver la capacité de reprise tant qu’aucune dette prioritaire n’est confirmée',
+      affectedDestinations: [],
+      linkedOutcomeRecapId: null,
+      linkedWarningGroupKey: null,
+      overloadWarning: null,
+    };
+  }
+
+  const ranked = [...outcomeRecaps].sort((left, right) => Number(left.secondaryOverload) - Number(right.secondaryOverload)
+    || Number(left.status !== 'résolution nette') - Number(right.status !== 'résolution nette')
+    || right.capacityFreed - left.capacityFreed
+    || String(left.warningGroupKey).localeCompare(String(right.warningGroupKey)));
+  const selected = ranked[0];
+  const warningGroup = warningGroups.find((group) => group.key === selected.warningGroupKey) ?? null;
+  const affectedDestinations = warningGroup?.details.map((detail) => ({
+    targetId: detail.targetId,
+    label: detail.label,
+    corridor: detail.corridor,
+  })) ?? [];
+  const overCapacity = selected.secondaryOverload || selected.status === 'résolution partielle';
+
+  return {
+    id: 'logistics-next-recovery-action-summary',
+    status: overCapacity ? 'à arbitrer' : 'action concrète',
+    title: 'Prochaine action de récupération',
+    summary: `${selected.summary} Destinations affectées: ${affectedDestinations.length || 'aucune donnée détaillée'}.`,
+    primaryAction: overCapacity
+      ? `Sécuriser ${selected.warningGroupKey} sans déplacer la surcharge: ${selected.displacedRisk}.`
+      : `Appliquer l’option liée à ${selected.warningGroupKey}: ${selected.capacityFreed} capacité libérée, délai ${selected.probableDelay}.`,
+    alternativeAction: selected.secondaryOverload
+      ? 'Alternative prudente: différer le remboursement complet et réserver de la capacité pour la route ou ville concurrente.'
+      : selected.status === 'résolution partielle'
+        ? 'Alternative prudente: attendre un renfort de capacité avant de pousser la reprise suivante.'
+        : 'Alternative prudente: surveiller un tour si la capacité libérée est nécessaire ailleurs.',
+    affectedDestinations,
+    linkedOutcomeRecapId: selected.id,
+    linkedWarningGroupKey: selected.warningGroupKey,
+    overloadWarning: overCapacity
+      ? 'Cette action peut dépasser la capacité disponible ou recréer un bottleneck secondaire.'
+      : null,
+  };
+}
+
 function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymentPriorities, logisticsFeatures = []) {
   const candidates = repaymentPriorities.priorities.slice(0, 3);
   const scenarios = candidates.map((priority) => {
@@ -2659,6 +2711,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
   const warningGroups = buildRepaymentBottleneckWarningGroups(scenarios);
   const tradeOffComparisons = buildRepaymentTradeOffComparisons(scenarios, warningGroups);
   const outcomeRecaps = buildRepaymentOutcomeRecaps(tradeOffComparisons);
+  const nextRecoveryActionSummary = buildNextRecoveryActionSummary(outcomeRecaps, warningGroups);
 
   return {
     id: 'logistics-recovery-repayment-scenarios',
@@ -2676,6 +2729,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
     topTradeOffComparisonId: tradeOffComparisons[0]?.id ?? null,
     outcomeRecaps,
     topOutcomeRecapId: outcomeRecaps[0]?.id ?? null,
+    nextRecoveryActionSummary,
     legend: [
       { key: 'partial', label: 'Partiel: débloque une portion', tone: 'warning' },
       { key: 'complete', label: 'Complet: sécurise la reprise', tone: 'positive' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1678,6 +1678,20 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
   ]);
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.outcomeRecaps[0].summary, /dette restante aucun goulot critique restant/);
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.outcomeRecaps[0].displacedRisk, /déplacer la surcharge/);
+  assert.deepEqual({
+    status: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.status,
+    linkedOutcomeRecapId: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.linkedOutcomeRecapId,
+    linkedWarningGroupKey: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.linkedWarningGroupKey,
+    affectedDestinations: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.affectedDestinations.map((destination) => destination.targetId),
+  }, {
+    status: 'à arbitrer',
+    linkedOutcomeRecapId: 'outcome-recap:stock:stock:recovery-repayment:route-coast:complete',
+    linkedWarningGroupKey: 'stock:stock',
+    affectedDestinations: ['route-coast'],
+  });
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.primaryAction, /sans déplacer la surcharge/);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.alternativeAction, /Alternative prudente/);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.overloadWarning, /recréer un bottleneck/);
 
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -33,6 +33,9 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(webAppSource, /warningGroups/);
   assert.match(webAppSource, /tradeOffComparisons/);
   assert.match(webAppSource, /outcomeRecaps/);
+  assert.match(webAppSource, /nextRecoveryActionSummary/);
+  assert.match(webAppSource, /economy-next-recovery-action/);
+  assert.match(webAppSource, /nextRecoveryActionSummary\.affectedDestinations/);
   assert.match(webAppSource, /economy-repayment-outcomes/);
   assert.match(webAppSource, /recap\.secondaryOverload/);
   assert.match(webAppSource, /economy-repayment-tradeoffs/);
@@ -63,4 +66,7 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(stylesSource, /\.economy-repayment-tradeoff__choice--rapide-fragile/);
   assert.match(stylesSource, /\.economy-repayment-outcome--résolution-avec-surcharge-secondaire/);
   assert.match(stylesSource, /\.economy-repayment-outcome--données-partielles/);
+  assert.match(stylesSource, /\.economy-next-recovery-action--action-concrète/);
+  assert.match(stylesSource, /\.economy-next-recovery-action--à-arbitrer/);
+  assert.match(stylesSource, /\.economy-next-recovery-action--surveiller/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -18820,6 +18820,22 @@ function renderEconomyRecoveryRepaymentScenarios(economyView) {
         <strong>${view.title}</strong>
       </div>
       <p>${view.summary}</p>
+      ${view.nextRecoveryActionSummary ? `
+        <article class="economy-next-recovery-action economy-next-recovery-action--${view.nextRecoveryActionSummary.status.replaceAll(' ', '-')}">
+          <div>
+            <span>${view.nextRecoveryActionSummary.status}</span>
+            <strong>${view.nextRecoveryActionSummary.primaryAction}</strong>
+          </div>
+          <p>${view.nextRecoveryActionSummary.summary}</p>
+          <small>${view.nextRecoveryActionSummary.alternativeAction}</small>
+          ${view.nextRecoveryActionSummary.affectedDestinations.length ? `
+            <ul>
+              ${view.nextRecoveryActionSummary.affectedDestinations.map((destination) => `<li>${destination.label} · ${destination.corridor}</li>`).join('')}
+            </ul>
+          ` : ''}
+          ${view.nextRecoveryActionSummary.overloadWarning ? `<b>${view.nextRecoveryActionSummary.overloadWarning}</b>` : ''}
+        </article>
+      ` : ''}
       ${view.outcomeRecaps?.length ? `
         <div class="economy-repayment-outcomes" aria-label="Récapitulatif résultat après résolution de goulot">
           ${view.outcomeRecaps.map((recap) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13479,3 +13479,42 @@ button { font: inherit; }
 .atlas-military-blocker-checklist-row--intel .atlas-military-blocker-checklist-row__badge { fill: rgba(168, 85, 247, 0.8); }
 .atlas-military-blocker-checklist-row--culture .atlas-military-blocker-checklist-row__badge { fill: rgba(244, 114, 182, 0.8); }
 .atlas-military-blocker-checklist-row--unknown .atlas-military-blocker-checklist-row__badge { fill: rgba(148, 163, 184, 0.8); }
+.economy-next-recovery-action {
+  display: grid;
+  gap: 7px;
+  padding: 11px;
+  border-radius: 15px;
+  background: rgba(12, 74, 110, 0.3);
+  border: 1px solid rgba(125, 211, 252, 0.2);
+}
+.economy-next-recovery-action div {
+  display: grid;
+  gap: 3px;
+}
+.economy-next-recovery-action span {
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.economy-next-recovery-action strong { color: #f8fafc; }
+.economy-next-recovery-action p,
+.economy-next-recovery-action small,
+.economy-next-recovery-action li {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.economy-next-recovery-action ul {
+  margin: 0;
+  padding-left: 16px;
+}
+.economy-next-recovery-action b {
+  justify-self: start;
+  color: #fecaca;
+  font-size: 11px;
+}
+.economy-next-recovery-action--action-concrète { border-color: rgba(74, 222, 128, 0.34); }
+.economy-next-recovery-action--à-arbitrer { border-color: rgba(245, 158, 11, 0.38); }
+.economy-next-recovery-action--surveiller { border-color: rgba(148, 163, 184, 0.24); }


### PR DESCRIPTION
Beta: Closes #1327.\n\n## Summary\n- add a next recovery action summary after bottleneck outcome recaps\n- choose a concrete action or justified watch state based on freed capacity, remaining debt, and displaced-risk signals\n- show a prudent alternative and grouped affected destinations without duplicating ledger rows\n\n## Tests\n- node --test test/ui/economy/buildEconomyMapOverlay.test.js test/ui/economy/webEconomyRecoveryDebtLedger.test.js\n- node --check web/app.js\n- npm test\n- git diff --check