### PR TITLE
Alpha: Add MAP-A18 next-best closure recommendation

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas military builds next-best closure recommendations from visible blocker checklists', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryNextBestClosureRecommendation\(checklist\)/);
+  assert.match(webAppSource, /function getAtlasMilitaryClosureImpactScore\(item\)/);
+  assert.match(webAppSource, /impact tactique direct \+ capacité/);
+  assert.match(webAppSource, /réduit incertitude avant engagement/);
+  assert.match(webAppSource, /évite retard météo critique/);
+  assert.match(webAppSource, /stabilise engagement local/);
+});
+
+test('atlas military next-best closure avoids false signals for unresolved unknown or idle blockers', () => {
+  assert.match(webAppSource, /Prochaine fermeture indécise: aucun blocker actionnable visible/);
+  assert.match(webAppSource, /Prochaine fermeture indécise: données visibles insuffisantes, aucune promotion sûre/);
+  assert.match(webAppSource, /item\.checklist\.orderState !== 'ordre en veille'/);
+  assert.match(webAppSource, /item\.promoted \|\| items\.length === 1/);
+  assert.match(webAppSource, /blockerBadge\.type !== 'unknown'/);
+});
+
+test('atlas military next-best closure renders a primary recommendation and compact alternatives', () => {
+  assert.match(webAppSource, /renderAtlasMilitaryNextBestClosureRecommendation\(nextBestClosureRecommendation\)/);
+  assert.match(webAppSource, /data-atlas-next-best-closure/);
+  assert.match(webAppSource, /Recommandation principale/);
+  assert.match(webAppSource, /Alternative/);
+  assert.match(webAppSource, /action minimale \$\{row\.nextAction\}/);
+  assert.match(stylesSource, /\.atlas-military-next-best-closure__panel/);
+  assert.match(stylesSource, /\.atlas-military-next-best-closure-row\.is-alternative circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1950,6 +1950,98 @@ function renderAtlasMilitaryBlockerResolutionChecklist(checklist) {
   `;
 }
 
+
+function getAtlasMilitaryClosureImpactScore(item) {
+  const blockerImpact = {
+    logistics: 32,
+    intel: 26,
+    climate: 22,
+    culture: 18,
+    unknown: 4,
+  };
+  const orderImpact = item.checklist.orderState === 'ordre préparé'
+    ? 18
+    : item.checklist.orderState === 'ordre différé'
+      ? 12
+      : item.checklist.orderState === 'vérification requise'
+        ? 6
+        : 0;
+  const delayRisk = item.checklist.waitingState.includes('attendre') ? 10 : 4;
+  return (item.priority ?? 0) + (blockerImpact[item.blockerBadge.type] ?? 0) + orderImpact + delayRisk;
+}
+
+function getAtlasMilitaryClosureReason(item) {
+  if (item.blockerBadge.type === 'logistics') return 'impact tactique direct + capacité';
+  if (item.blockerBadge.type === 'intel') return 'réduit incertitude avant engagement';
+  if (item.blockerBadge.type === 'climate') return 'évite retard météo critique';
+  if (item.blockerBadge.type === 'culture') return 'stabilise engagement local';
+  return 'données insuffisantes: vérifier sans ordre caché';
+}
+
+function buildAtlasMilitaryNextBestClosureRecommendation(checklist) {
+  const items = checklist?.items ?? [];
+  if (!items.length || checklist?.empty) {
+    return {
+      options: [],
+      primary: null,
+      summary: 'Prochaine fermeture indécise: aucun blocker actionnable visible.',
+      empty: true,
+    };
+  }
+
+  const options = items
+    .filter((item) => item.checklist.orderState !== 'ordre en veille')
+    .map((item) => ({
+      closureId: `next-best-closure:${item.provinceLabel}`,
+      provinceLabel: item.provinceLabel,
+      blockerLabel: item.blockerBadge.label,
+      blockerType: item.blockerBadge.type,
+      orderState: item.checklist.orderState,
+      reason: getAtlasMilitaryClosureReason(item),
+      nextAction: item.checklist.immediateAction,
+      waitState: item.checklist.waitingState,
+      score: getAtlasMilitaryClosureImpactScore(item),
+      promoted: item.blockerBadge.type !== 'unknown',
+    }))
+    .filter((item) => item.promoted || items.length === 1)
+    .sort((left, right) => right.score - left.score || left.provinceLabel.localeCompare(right.provinceLabel))
+    .slice(0, 3);
+
+  if (!options.length) {
+    return {
+      options: [],
+      primary: null,
+      summary: 'Prochaine fermeture indécise: données visibles insuffisantes, aucune promotion sûre.',
+      empty: true,
+    };
+  }
+
+  return {
+    options,
+    primary: options[0],
+    summary: `${options[0].provinceLabel}: fermer ${options[0].blockerLabel} en premier (${options[0].reason}).`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryNextBestClosureRecommendation(recommendation) {
+  const height = recommendation.empty ? 7 : 6 + (recommendation.options.length * 4.4);
+  return `
+    <g class="atlas-military-next-best-closure" aria-label="Prochaine fermeture recommandée pour blockers de provinces contestées: ${recommendation.summary}">
+      <rect class="atlas-military-next-best-closure__panel" x="43" y="86" width="20" height="${height}" rx="2.1"></rect>
+      <text class="atlas-military-next-best-closure__title" x="44.2" y="88.6">À fermer</text>
+      ${recommendation.empty ? `<text class="atlas-military-next-best-closure__empty" x="44.2" y="91.8">${recommendation.summary}</text>` : recommendation.options.map((row, index) => `
+        <g class="atlas-military-next-best-closure-row atlas-military-next-best-closure-row--${row.blockerType} ${index === 0 ? 'is-primary' : 'is-alternative'}" data-atlas-next-best-closure="${row.closureId}" aria-label="${index === 0 ? 'Recommandation principale' : 'Alternative'} ${row.provinceLabel}: fermer ${row.blockerLabel}; raison ${row.reason}; action minimale ${row.nextAction}; état ${row.orderState}">
+          <circle cx="44.7" cy="${91 + index * 4.4}" r="0.72"></circle>
+          <text class="atlas-military-next-best-closure-row__province" x="46" y="${90.5 + index * 4.4}">${index === 0 ? '1' : index + 1}. ${row.provinceLabel}</text>
+          <text class="atlas-military-next-best-closure-row__reason" x="46" y="${92 + index * 4.4}">${row.reason}</text>
+          <text class="atlas-military-next-best-closure-row__action" x="46" y="${93.4 + index * 4.4}">${row.nextAction}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function getAtlasMilitaryBlockingHandoffDecision(item, confidence) {
   if (!item) return 'attente: visibilité insuffisante';
   if (item.kind === 'obligatoire' && item.dependencies?.includes('logistique')) return 'renfort: sécuriser logistique';
@@ -3008,6 +3100,7 @@ function renderAtlasMilitaryLayer(shell) {
   const carryOverOutcomeTimeline = buildAtlasMilitaryCarryOverOutcomeTimeline(nextTurnCarryOverQueue);
   const carryOverConfidenceHandoff = buildAtlasMilitaryCarryOverConfidenceHandoff(nextTurnCarryOverQueue, carryOverOutcomeTimeline);
   const blockerResolutionChecklist = buildAtlasMilitaryBlockerResolutionChecklist(carryOverConfidenceHandoff);
+  const nextBestClosureRecommendation = buildAtlasMilitaryNextBestClosureRecommendation(blockerResolutionChecklist);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -3045,6 +3138,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryCarryOverOutcomeTimeline(carryOverOutcomeTimeline)}
       ${renderAtlasMilitaryCarryOverConfidenceHandoff(carryOverConfidenceHandoff)}
       ${renderAtlasMilitaryBlockerResolutionChecklist(blockerResolutionChecklist)}
+      ${renderAtlasMilitaryNextBestClosureRecommendation(nextBestClosureRecommendation)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13479,3 +13479,39 @@ button { font: inherit; }
 .atlas-military-blocker-checklist-row--intel .atlas-military-blocker-checklist-row__badge { fill: rgba(168, 85, 247, 0.8); }
 .atlas-military-blocker-checklist-row--culture .atlas-military-blocker-checklist-row__badge { fill: rgba(244, 114, 182, 0.8); }
 .atlas-military-blocker-checklist-row--unknown .atlas-military-blocker-checklist-row__badge { fill: rgba(148, 163, 184, 0.8); }
+
+.atlas-military-next-best-closure__panel {
+  fill: rgba(20, 83, 45, 0.76);
+  stroke: rgba(134, 239, 172, 0.42);
+  stroke-width: 0.3;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.45));
+}
+.atlas-military-next-best-closure__title,
+.atlas-military-next-best-closure-row text,
+.atlas-military-next-best-closure__empty {
+  fill: #dcfce7;
+  font-size: 0.82px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.24;
+}
+.atlas-military-next-best-closure-row circle {
+  fill: rgba(134, 239, 172, 0.82);
+  stroke: rgba(240, 253, 244, 0.7);
+  stroke-width: 0.14;
+}
+.atlas-military-next-best-closure-row.is-alternative circle {
+  fill: rgba(148, 163, 184, 0.75);
+}
+.atlas-military-next-best-closure-row__reason,
+.atlas-military-next-best-closure-row__action,
+.atlas-military-next-best-closure__empty {
+  fill: #bbf7d0;
+  font-size: 0.48px;
+}
+.atlas-military-next-best-closure-row--logistics circle { fill: rgba(56, 189, 248, 0.84); }
+.atlas-military-next-best-closure-row--climate circle { fill: rgba(34, 197, 94, 0.82); }
+.atlas-military-next-best-closure-row--intel circle { fill: rgba(168, 85, 247, 0.82); }
+.atlas-military-next-best-closure-row--culture circle { fill: rgba(244, 114, 182, 0.82); }
+.atlas-military-next-best-closure-row--unknown circle { fill: rgba(148, 163, 184, 0.78); }


### PR DESCRIPTION
Alpha: Implements #1326.

Summary:
- adds a compact next-best closure recommendation for contested province blockers
- ranks up to three visible options by tactical impact, cross-domain dependency, and delay risk
- avoids promoting hidden/idle blockers and keeps empty/indecisive states explicit

Tests:
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- node --check web/app.js
- git diff --check
- npm test

Ready for Zeta review.