### PR TITLE
Gamma: Add cultural commitment summary

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -889,6 +889,73 @@ function buildCulturalRecommendationRotationPreview(promptFreshnessFilter, promp
   };
 }
 
+function buildCulturalRotationCommitmentSummary(recommendationRotationPreview, promptChoiceComparison, bundles, incompatibilities) {
+  const entries = recommendationRotationPreview.entries.map((entry) => {
+    const comparison = promptChoiceComparison.entries.find((candidate) => candidate.promptId === entry.promptId);
+    const bundle = bundles.find((candidate) => entry.promptId.startsWith(candidate.bundleId)) ?? null;
+    const unresolvedDependencies = incompatibilities.filter((dependency) => (
+      comparison?.recommendationIds ?? []
+    ).some((recommendationId) => dependency.recommendationIds.includes(recommendationId)));
+    const duration = entry.rotationState === 'available-now'
+      ? '1 à 2 tours de suivi culturel'
+      : entry.rotationState === 'review-soon'
+        ? 'à réévaluer au prochain tour de carte'
+        : entry.rotationState === 'deferred-freshness'
+          ? 'différer jusqu’à un nouveau signal culturel'
+          : 'aucune durée fiable tant que le contexte manque';
+    const benefit = bundle
+      ? `${bundle.label}: verrouille le bénéfice culturel principal autour de ${entry.clusterLabel}`
+      : `${entry.promptLabel}: clarifie le prochain choix culturel visible`;
+    const opportunityCost = entry.rotationState === 'available-now'
+      ? 'coût narratif/recherche modéré: les autres thèmes restent en file de rotation'
+      : entry.rotationState === 'review-soon'
+        ? 'coût d’opportunité: retarder évite de répéter un thème déjà vu'
+        : entry.rotationState === 'deferred-freshness'
+          ? 'coût d’opportunité faible: attendre protège la fraîcheur et laisse une alternative progresser'
+          : 'coût d’opportunité incertain: garder les ressources de recherche ouvertes';
+    const dependencyWarning = unresolvedDependencies.length > 0
+      ? `${unresolvedDependencies.length} dépendance${unresolvedDependencies.length > 1 ? 's' : ''} non résolue${unresolvedDependencies.length > 1 ? 's' : ''}: ${unresolvedDependencies.map((dependency) => dependency.reason).join(' | ')}`
+      : entry.rotationState === 'available-now'
+        ? 'aucune dépendance bloquante visible avant engagement'
+        : 'pas de blocage dur: décision légitime si le contexte narratif le justifie';
+
+    return {
+      summaryId: `${entry.promptId}:commitment-summary`,
+      promptId: entry.promptId,
+      promptLabel: entry.promptLabel,
+      clusterLabel: entry.clusterLabel,
+      rotationState: entry.rotationState,
+      duration,
+      benefit,
+      opportunityCost,
+      dependencyWarning,
+      hasUnresolvedDependencies: unresolvedDependencies.length > 0,
+      repeatPolicy: entry.rotationState === 'available-now'
+        ? 'non répété récemment: peut rester prioritaire'
+        : 'répétition récente ou contexte faible: garder dépriorisé et expliqué',
+      alternativeLabel: entry.alternativeLabel,
+    };
+  });
+  const selected = entries.find((entry) => entry.rotationState === 'available-now') ?? entries[0] ?? null;
+
+  return {
+    state: entries.length === 0
+      ? 'quiet'
+      : entries.some((entry) => entry.hasUnresolvedDependencies && entry.rotationState === 'available-now')
+        ? 'caution'
+        : selected?.rotationState === 'available-now'
+          ? 'ready'
+          : 'defer',
+    summary: entries.length === 0
+      ? 'Aucun résumé d’engagement culturel disponible.'
+      : selected
+        ? `${selected.promptLabel}: ${selected.duration}; ${selected.benefit}.`
+        : 'Résumé d’engagement culturel en attente.',
+    selectedPromptId: selected?.promptId ?? null,
+    entries,
+  };
+}
+
 function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = [], promptHistory = [], regionId = 'province') {
   const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
   const trajectories = ['apaisement', 'consolidation', 'enquête', 'expansion', 'attente'];
@@ -993,6 +1060,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
   const promptHistoryDrawer = buildCulturalPromptHistoryDrawer(promptChoiceComparison, promptHistory, regionId);
   const promptFreshnessFilter = buildCulturalPromptFreshnessFilter(promptChoiceComparison, promptHistoryDrawer);
   const recommendationRotationPreview = buildCulturalRecommendationRotationPreview(promptFreshnessFilter, promptHistoryDrawer);
+  const rotationCommitmentSummary = buildCulturalRotationCommitmentSummary(recommendationRotationPreview, promptChoiceComparison, bundles, incompatibilities);
 
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
@@ -1010,6 +1078,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
     promptHistoryDrawer,
     promptFreshnessFilter,
     recommendationRotationPreview,
+    rotationCommitmentSummary,
     dependencyExplanation: bundles.length === 0
       ? 'Aucune dépendance entre marqueurs culturels.'
       : bundles
@@ -1134,6 +1203,12 @@ export function buildCultureTurnReportDeltas({
           summary: 'Aucun aperçu de rotation culturelle disponible.',
           entries: [],
           fallback: 'Fallback stable: historique court ou ambigu, conserver les prompts visibles sans forcer la rotation.',
+        },
+        rotationCommitmentSummary: {
+          state: 'quiet',
+          summary: 'Aucun résumé d’engagement culturel disponible.',
+          selectedPromptId: null,
+          entries: [],
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
       },

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -335,6 +335,27 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       ],
       fallback: 'Fallback stable: historique court ou ambigu, conserver les prompts visibles sans forcer la rotation.',
     },
+    rotationCommitmentSummary: {
+      state: 'ready',
+      summary: 'Ouvrir le récit d’expansion: 1 à 2 tours de suivi culturel; expansion prudente: verrouille le bénéfice culturel principal autour de Compact d’Aurora.',
+      selectedPromptId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+      entries: [
+        {
+          summaryId: 'culture-commitment:expansion:timing:river-gate:follow-up:commitment-summary',
+          promptId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+          promptLabel: 'Ouvrir le récit d’expansion',
+          clusterLabel: 'Compact d’Aurora',
+          rotationState: 'available-now',
+          duration: '1 à 2 tours de suivi culturel',
+          benefit: 'expansion prudente: verrouille le bénéfice culturel principal autour de Compact d’Aurora',
+          opportunityCost: 'coût narratif/recherche modéré: les autres thèmes restent en file de rotation',
+          dependencyWarning: 'aucune dépendance bloquante visible avant engagement',
+          hasUnresolvedDependencies: false,
+          repeatPolicy: 'non répété récemment: peut rester prioritaire',
+          alternativeLabel: null,
+        },
+      ],
+    },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
 });
@@ -410,6 +431,12 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         summary: 'Aucun aperçu de rotation culturelle disponible.',
         entries: [],
         fallback: 'Fallback stable: historique court ou ambigu, conserver les prompts visibles sans forcer la rotation.',
+      },
+      rotationCommitmentSummary: {
+        state: 'quiet',
+        summary: 'Aucun résumé d’engagement culturel disponible.',
+        selectedPromptId: null,
+        entries: [],
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },
@@ -812,4 +839,14 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
   ]);
   assert.match(report.commitmentBundles.recommendationRotationPreview.entries[1].alternativeLabel, /Préparer|Ouvrir|Renforcer|Observer/);
   assert.match(report.commitmentBundles.recommendationRotationPreview.fallback, /alternative fraîche|Fallback stable/);
+  assert.equal(report.commitmentBundles.rotationCommitmentSummary.state, 'caution');
+  assert.deepEqual(report.commitmentBundles.rotationCommitmentSummary.entries.map((entry) => [entry.clusterLabel, entry.rotationState, entry.hasUnresolvedDependencies]), [
+    ['Ember Guild', 'available-now', true],
+    ['Harbor Compact', 'deferred-freshness', true],
+    ['Compact d’Aurora', 'review-soon', true],
+  ]);
+  assert.match(report.commitmentBundles.rotationCommitmentSummary.entries[0].duration, /1 à 2 tours/);
+  assert.match(report.commitmentBundles.rotationCommitmentSummary.entries[0].benefit, /verrouille/);
+  assert.match(report.commitmentBundles.rotationCommitmentSummary.entries[0].opportunityCost, /narratif\/recherche/);
+  assert.match(report.commitmentBundles.rotationCommitmentSummary.entries[1].repeatPolicy, /dépriorisé/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6493,6 +6493,24 @@ function renderCultureTurnReport(report) {
           </div>
         ` : '<small>État vide: aucune recommandation culturelle à planifier.</small>'}
       </div>
+      <div class="culture-turn-report__commitment-summary culture-turn-report__commitment-summary--${report.commitmentBundles?.rotationCommitmentSummary?.state ?? 'quiet'}" aria-label="Résumé d’engagement culturel avant validation">
+        <span>Engagement culturel</span>
+        <strong>${report.commitmentBundles?.rotationCommitmentSummary?.summary ?? 'Aucun résumé d’engagement culturel disponible.'}</strong>
+        ${(report.commitmentBundles?.rotationCommitmentSummary?.entries ?? []).length > 0 ? `
+          <div class="culture-turn-report__commitment-list">
+            ${report.commitmentBundles.rotationCommitmentSummary.entries.map((entry) => `
+              <article class="culture-turn-report__commitment-entry culture-turn-report__commitment-entry--${entry.rotationState} ${entry.hasUnresolvedDependencies ? 'culture-turn-report__commitment-entry--caution' : ''}" data-culture-commitment="${entry.summaryId}">
+                <b>${entry.promptLabel}</b>
+                <em>${entry.duration}</em>
+                <small>Bénéfice: ${entry.benefit}</small>
+                <small>Coût: ${entry.opportunityCost}</small>
+                <small>${entry.dependencyWarning}</small>
+                <small>${entry.repeatPolicy}${entry.alternativeLabel ? ` · Alternative: ${entry.alternativeLabel}` : ''}</small>
+              </article>
+            `).join('')}
+          </div>
+        ` : '<small>État vide: aucune recommandation culturelle sélectionnable à résumer.</small>'}
+      </div>
       <details class="culture-turn-report__history culture-turn-report__history--${report.commitmentBundles?.promptHistoryDrawer?.state ?? 'quiet'}" aria-label="Historique des prompts culturels de carte">
         <summary>
           <span>Historique culturel</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1945,6 +1945,49 @@ button { font: inherit; }
 .culture-turn-report__rotation-entry--review-soon { border-color: rgba(96, 165, 250, 0.34); }
 .culture-turn-report__rotation-entry--deferred-freshness { border-color: rgba(251, 191, 36, 0.4); }
 .culture-turn-report__rotation-entry--excluded-context { border-color: rgba(148, 163, 184, 0.26); }
+.culture-turn-report__commitment-summary {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid rgba(250, 204, 21, 0.14);
+}
+.culture-turn-report__commitment-summary > span {
+  color: #fde68a;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__commitment-summary > strong {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.culture-turn-report__commitment-list {
+  display: grid;
+  gap: 6px;
+}
+.culture-turn-report__commitment-entry {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(113, 63, 18, 0.16);
+  border: 1px solid rgba(250, 204, 21, 0.18);
+}
+.culture-turn-report__commitment-entry b { color: #fef3c7; }
+.culture-turn-report__commitment-entry em {
+  color: #fde68a;
+  font-style: normal;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.culture-turn-report__commitment-entry small { color: var(--muted); }
+.culture-turn-report__commitment-entry--available-now { border-color: rgba(74, 222, 128, 0.3); }
+.culture-turn-report__commitment-entry--review-soon { border-color: rgba(96, 165, 250, 0.32); }
+.culture-turn-report__commitment-entry--deferred-freshness { border-color: rgba(251, 191, 36, 0.42); }
+.culture-turn-report__commitment-entry--excluded-context { border-color: rgba(148, 163, 184, 0.26); }
+.culture-turn-report__commitment-entry--caution { box-shadow: inset 3px 0 0 rgba(251, 191, 36, 0.55); }
 .culture-turn-report__history {
   display: grid;
   gap: 7px;


### PR DESCRIPTION
Gamma: Résumé

- Ajoute un résumé compact d’engagement culturel pour la recommandation de rotation sélectionnée.
- Affiche durée attendue, bénéfice principal, coût d’opportunité et avertissements de dépendances non résolues.
- Rend le bloc dans le rapport web avec états ready/caution/defer/quiet.

Tests

- npm test -- test/ui/culture/buildCultureTurnReportDeltas.test.js

Fixes loo469/historia#1328