### PR TITLE
Beta: Add recovery momentum forecast

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2680,6 +2680,62 @@ function buildNextRecoveryActionSummary(outcomeRecaps, warningGroups) {
   };
 }
 
+function buildRecoveryMomentumForecast(outcomeRecaps, nextRecoveryActionSummary) {
+  if (outcomeRecaps.length === 0) {
+    return {
+      id: 'logistics-recovery-momentum-forecast',
+      status: 'stable',
+      title: 'Momentum prochain tour',
+      headline: 'stable',
+      summary: 'Signaux insuffisants pour conclure: garder la reprise en observation jusqu’au prochain recap.',
+      confidence: 'faible',
+      linkedOutcomeRecapId: null,
+    };
+  }
+
+  const selected = outcomeRecaps.find((recap) => recap.id === nextRecoveryActionSummary?.linkedOutcomeRecapId)
+    ?? outcomeRecaps[0];
+  const totalCapacityFreed = outcomeRecaps.reduce((total, recap) => total + Math.max(0, recap.capacityFreed), 0);
+  const fragileRecaps = outcomeRecaps.filter((recap) => recap.secondaryOverload || recap.status !== 'résolution nette');
+  const unresolvedRecaps = outcomeRecaps.filter((recap) => recap.status === 'résolution partielle' || recap.status === 'données partielles');
+  const hasConcreteRecovery = totalCapacityFreed > 0 && unresolvedRecaps.length === 0 && fragileRecaps.length === 0;
+  const isFragile = unresolvedRecaps.length > 0 || Boolean(nextRecoveryActionSummary?.overloadWarning) || fragileRecaps.length > 0;
+
+  if (hasConcreteRecovery) {
+    return {
+      id: 'logistics-recovery-momentum-forecast',
+      status: 'en reprise',
+      title: 'Momentum prochain tour',
+      headline: 'en reprise',
+      summary: `${totalCapacityFreed} capacité libérée sans goulot secondaire: la trajectoire économique devrait repartir au prochain tour.`,
+      confidence: selected.probableDelay === 'ce tour' ? 'haute' : 'moyenne',
+      linkedOutcomeRecapId: selected.id,
+    };
+  }
+
+  if (isFragile) {
+    return {
+      id: 'logistics-recovery-momentum-forecast',
+      status: 'fragile',
+      title: 'Momentum prochain tour',
+      headline: 'fragile',
+      summary: `${selected.capacityFreed} capacité peut revenir, mais ${selected.displacedRisk}; surveiller la dette avant d’enchaîner.`,
+      confidence: unresolvedRecaps.length > 0 ? 'moyenne' : 'haute',
+      linkedOutcomeRecapId: selected.id,
+    };
+  }
+
+  return {
+    id: 'logistics-recovery-momentum-forecast',
+    status: 'stable',
+    title: 'Momentum prochain tour',
+    headline: 'stable',
+    summary: 'La reprise garde une marge lisible, mais les recaps ne montrent pas encore d’accélération nette.',
+    confidence: 'moyenne',
+    linkedOutcomeRecapId: selected.id,
+  };
+}
+
 function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymentPriorities, logisticsFeatures = []) {
   const candidates = repaymentPriorities.priorities.slice(0, 3);
   const scenarios = candidates.map((priority) => {
@@ -2712,6 +2768,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
   const tradeOffComparisons = buildRepaymentTradeOffComparisons(scenarios, warningGroups);
   const outcomeRecaps = buildRepaymentOutcomeRecaps(tradeOffComparisons);
   const nextRecoveryActionSummary = buildNextRecoveryActionSummary(outcomeRecaps, warningGroups);
+  const recoveryMomentumForecast = buildRecoveryMomentumForecast(outcomeRecaps, nextRecoveryActionSummary);
 
   return {
     id: 'logistics-recovery-repayment-scenarios',
@@ -2730,6 +2787,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
     outcomeRecaps,
     topOutcomeRecapId: outcomeRecaps[0]?.id ?? null,
     nextRecoveryActionSummary,
+    recoveryMomentumForecast,
     legend: [
       { key: 'partial', label: 'Partiel: débloque une portion', tone: 'warning' },
       { key: 'complete', label: 'Complet: sécurise la reprise', tone: 'positive' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1692,6 +1692,16 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.primaryAction, /sans déplacer la surcharge/);
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.alternativeAction, /Alternative prudente/);
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.nextRecoveryActionSummary.overloadWarning, /recréer un bottleneck/);
+  assert.deepEqual({
+    status: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryMomentumForecast.status,
+    headline: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryMomentumForecast.headline,
+    linkedOutcomeRecapId: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryMomentumForecast.linkedOutcomeRecapId,
+  }, {
+    status: 'fragile',
+    headline: 'fragile',
+    linkedOutcomeRecapId: 'outcome-recap:stock:stock:recovery-repayment:route-coast:complete',
+  });
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryMomentumForecast.summary, /surveiller la dette/);
 
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -36,6 +36,9 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(webAppSource, /nextRecoveryActionSummary/);
   assert.match(webAppSource, /economy-next-recovery-action/);
   assert.match(webAppSource, /nextRecoveryActionSummary\.affectedDestinations/);
+  assert.match(webAppSource, /recoveryMomentumForecast/);
+  assert.match(webAppSource, /economy-recovery-momentum/);
+  assert.match(webAppSource, /recoveryMomentumForecast\.confidence/);
   assert.match(webAppSource, /economy-repayment-outcomes/);
   assert.match(webAppSource, /recap\.secondaryOverload/);
 
@@ -78,4 +81,7 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(stylesSource, /\.economy-next-recovery-action--action-concrète/);
   assert.match(stylesSource, /\.economy-next-recovery-action--à-arbitrer/);
   assert.match(stylesSource, /\.economy-next-recovery-action--surveiller/);
+  assert.match(stylesSource, /\.economy-recovery-momentum--en-reprise/);
+  assert.match(stylesSource, /\.economy-recovery-momentum--stable/);
+  assert.match(stylesSource, /\.economy-recovery-momentum--fragile/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -19079,6 +19079,14 @@ function renderEconomyRecoveryRepaymentScenarios(economyView) {
           ${view.nextRecoveryActionSummary.overloadWarning ? `<b>${view.nextRecoveryActionSummary.overloadWarning}</b>` : ''}
         </article>
       ` : ''}
+      ${view.recoveryMomentumForecast ? `
+        <article class="economy-recovery-momentum economy-recovery-momentum--${view.recoveryMomentumForecast.status.replaceAll(' ', '-')}">
+          <span>${view.recoveryMomentumForecast.title}</span>
+          <strong>${view.recoveryMomentumForecast.headline}</strong>
+          <p>${view.recoveryMomentumForecast.summary}</p>
+          <small>Confiance ${view.recoveryMomentumForecast.confidence}</small>
+        </article>
+      ` : ''}
       ${view.tradeOffComparisons?.length ? `
         <div class="economy-repayment-tradeoffs" aria-label="Comparaison des options de résolution de goulot">
           ${view.tradeOffComparisons.map((comparison) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13588,6 +13588,34 @@ button { font: inherit; }
 .economy-next-recovery-action--action-concrète { border-color: rgba(74, 222, 128, 0.34); }
 .economy-next-recovery-action--à-arbitrer { border-color: rgba(245, 158, 11, 0.38); }
 .economy-next-recovery-action--surveiller { border-color: rgba(148, 163, 184, 0.24); }
+.economy-recovery-momentum {
+  display: grid;
+  gap: 5px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+.economy-recovery-momentum span {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.economy-recovery-momentum strong {
+  color: #f8fafc;
+  font-size: 15px;
+}
+.economy-recovery-momentum p,
+.economy-recovery-momentum small {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.economy-recovery-momentum--en-reprise { border-color: rgba(74, 222, 128, 0.38); }
+.economy-recovery-momentum--stable { border-color: rgba(125, 211, 252, 0.3); }
+.economy-recovery-momentum--fragile { border-color: rgba(251, 191, 36, 0.42); }
 
 .atlas-military-next-best-closure__panel {
   fill: rgba(20, 83, 45, 0.76);


### PR DESCRIPTION
Beta: Closes #1337.

## Summary
- add a next-turn recovery momentum forecast after the next recovery action summary
- classify the trajectory as en reprise, stable, or fragile from existing outcome recap and overload signals
- include concise explanation, confidence, and a safe fallback when signals are insufficient

## Tests
- node --test test/ui/economy/buildEconomyMapOverlay.test.js test/ui/economy/webEconomyRecoveryDebtLedger.test.js
- node --check web/app.js
- git diff --check
- npm test