### PR TITLE
Alpha: Add MAP-A19 closure after-action comparison

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -31,3 +31,14 @@ test('atlas military next-best closure renders a primary recommendation and comp
   assert.match(stylesSource, /\.atlas-military-next-best-closure__panel/);
   assert.match(stylesSource, /\.atlas-military-next-best-closure-row\.is-alternative circle/);
 });
+
+test('atlas military compares attempted closure choices against the recommendation', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryClosureAfterActionComparison\(recommendation\)/);
+  assert.match(webAppSource, /Tenté \/ recommandé \/ risque/);
+  assert.match(webAppSource, /aucune action précédente visible/);
+  assert.match(webAppSource, /risque restant: capacité non réservée/);
+  assert.match(webAppSource, /data-atlas-closure-after-action/);
+  assert.match(webAppSource, /renderAtlasMilitaryClosureAfterActionComparison\(closureAfterActionComparison\)/);
+  assert.match(stylesSource, /\.atlas-military-closure-after-action__panel/);
+  assert.match(stylesSource, /\.atlas-military-closure-after-action-row\.is-alternative circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -1920,6 +1920,8 @@ function buildAtlasMilitaryBlockerResolutionChecklist(handoff) {
       provinceLabel: row.provinceLabel,
       blockerBadge: row.blockerBadge,
       checklist,
+      previousDecision: row.blockingDecision,
+      usefulAction: row.usefulAction,
       tone: row.blockerBadge.type,
       priority: row.priority ?? 0,
     };
@@ -1999,6 +2001,8 @@ function buildAtlasMilitaryNextBestClosureRecommendation(checklist) {
       orderState: item.checklist.orderState,
       reason: getAtlasMilitaryClosureReason(item),
       nextAction: item.checklist.immediateAction,
+      previousDecision: item.previousDecision,
+      usefulAction: item.usefulAction,
       waitState: item.checklist.waitingState,
       score: getAtlasMilitaryClosureImpactScore(item),
       promoted: item.blockerBadge.type !== 'unknown',
@@ -2036,6 +2040,65 @@ function renderAtlasMilitaryNextBestClosureRecommendation(recommendation) {
           <text class="atlas-military-next-best-closure-row__province" x="46" y="${90.5 + index * 4.4}">${index === 0 ? '1' : index + 1}. ${row.provinceLabel}</text>
           <text class="atlas-military-next-best-closure-row__reason" x="46" y="${92 + index * 4.4}">${row.reason}</text>
           <text class="atlas-military-next-best-closure-row__action" x="46" y="${93.4 + index * 4.4}">${row.nextAction}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
+function getAtlasMilitaryClosureRemainingRisk(row) {
+  if (row.blockerType === 'logistics') return 'risque restant: capacité non réservée';
+  if (row.blockerType === 'intel') return 'risque restant: brouillard avant engagement';
+  if (row.blockerType === 'climate') return 'risque restant: fenêtre météo instable';
+  if (row.blockerType === 'culture') return 'risque restant: adhésion locale fragile';
+  return 'risque restant: cause à vérifier';
+}
+
+function getAtlasMilitaryClosureAttemptLabel(row, index) {
+  if (row.previousDecision && row.previousDecision !== row.nextAction) return row.previousDecision;
+  if (index > 0) return `alternative récente: ${row.blockerLabel}`;
+  return 'aucune action précédente visible';
+}
+
+function buildAtlasMilitaryClosureAfterActionComparison(recommendation) {
+  const options = recommendation?.options ?? [];
+  if (!options.length || recommendation?.empty) {
+    return {
+      rows: [],
+      summary: 'Comparaison clôture indisponible: aucune recommandation visible.',
+      empty: true,
+    };
+  }
+
+  const rows = options.slice(0, 2).map((row, index) => ({
+    comparisonId: `closure-after-action:${row.provinceLabel}:${index}`,
+    provinceLabel: row.provinceLabel,
+    blockerType: row.blockerType,
+    attempted: getAtlasMilitaryClosureAttemptLabel(row, index),
+    recommended: row.nextAction,
+    remainingRisk: getAtlasMilitaryClosureRemainingRisk(row),
+    primary: index === 0,
+  }));
+
+  return {
+    rows,
+    summary: `${rows[0].provinceLabel}: tenté ${rows[0].attempted}; recommandé ${rows[0].recommended}; ${rows[0].remainingRisk}.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryClosureAfterActionComparison(comparison) {
+  const height = comparison.empty ? 6.8 : 5.8 + (comparison.rows.length * 4.1);
+  return `
+    <g class="atlas-military-closure-after-action" aria-label="Comparaison après action des choix de clôture: ${comparison.summary}">
+      <rect class="atlas-military-closure-after-action__panel" x="43" y="106" width="35" height="${height}" rx="2.1"></rect>
+      <text class="atlas-military-closure-after-action__title" x="44.2" y="108.5">Tenté / recommandé / risque</text>
+      ${comparison.empty ? `<text class="atlas-military-closure-after-action__empty" x="44.2" y="111.4">${comparison.summary}</text>` : comparison.rows.map((row, index) => `
+        <g class="atlas-military-closure-after-action-row atlas-military-closure-after-action-row--${row.blockerType} ${row.primary ? 'is-primary' : 'is-alternative'}" data-atlas-closure-after-action="${row.comparisonId}" aria-label="${row.provinceLabel}: tenté ${row.attempted}; recommandé ${row.recommended}; ${row.remainingRisk}">
+          <circle cx="44.8" cy="${111 + index * 4.1}" r="0.66"></circle>
+          <text class="atlas-military-closure-after-action-row__province" x="46" y="${110.5 + index * 4.1}">${row.primary ? 'Recommandé' : 'Alternative'} · ${row.provinceLabel}</text>
+          <text class="atlas-military-closure-after-action-row__attempt" x="46" y="${111.9 + index * 4.1}">tenté: ${row.attempted}</text>
+          <text class="atlas-military-closure-after-action-row__risk" x="46" y="${113.3 + index * 4.1}">reco: ${row.recommended} · ${row.remainingRisk}</text>
         </g>
       `).join('')}
     </g>
@@ -3101,6 +3164,7 @@ function renderAtlasMilitaryLayer(shell) {
   const carryOverConfidenceHandoff = buildAtlasMilitaryCarryOverConfidenceHandoff(nextTurnCarryOverQueue, carryOverOutcomeTimeline);
   const blockerResolutionChecklist = buildAtlasMilitaryBlockerResolutionChecklist(carryOverConfidenceHandoff);
   const nextBestClosureRecommendation = buildAtlasMilitaryNextBestClosureRecommendation(blockerResolutionChecklist);
+  const closureAfterActionComparison = buildAtlasMilitaryClosureAfterActionComparison(nextBestClosureRecommendation);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -3139,6 +3203,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryCarryOverConfidenceHandoff(carryOverConfidenceHandoff)}
       ${renderAtlasMilitaryBlockerResolutionChecklist(blockerResolutionChecklist)}
       ${renderAtlasMilitaryNextBestClosureRecommendation(nextBestClosureRecommendation)}
+      ${renderAtlasMilitaryClosureAfterActionComparison(closureAfterActionComparison)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13624,3 +13624,37 @@ button { font: inherit; }
 .atlas-military-next-best-closure-row--intel circle { fill: rgba(168, 85, 247, 0.82); }
 .atlas-military-next-best-closure-row--culture circle { fill: rgba(244, 114, 182, 0.82); }
 .atlas-military-next-best-closure-row--unknown circle { fill: rgba(148, 163, 184, 0.78); }
+
+.atlas-military-closure-after-action__panel {
+  fill: rgba(30, 41, 59, 0.78);
+  stroke: rgba(125, 211, 252, 0.4);
+  stroke-width: 0.28;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.42));
+}
+.atlas-military-closure-after-action__title,
+.atlas-military-closure-after-action-row text,
+.atlas-military-closure-after-action__empty {
+  fill: #e0f2fe;
+  font-size: 0.72px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.22;
+}
+.atlas-military-closure-after-action-row circle {
+  fill: rgba(125, 211, 252, 0.82);
+  stroke: rgba(240, 249, 255, 0.72);
+  stroke-width: 0.13;
+}
+.atlas-military-closure-after-action-row.is-alternative circle { fill: rgba(148, 163, 184, 0.74); }
+.atlas-military-closure-after-action-row__attempt,
+.atlas-military-closure-after-action-row__risk,
+.atlas-military-closure-after-action__empty {
+  fill: #bae6fd;
+  font-size: 0.46px;
+}
+.atlas-military-closure-after-action-row--logistics circle { fill: rgba(56, 189, 248, 0.84); }
+.atlas-military-closure-after-action-row--climate circle { fill: rgba(34, 197, 94, 0.82); }
+.atlas-military-closure-after-action-row--intel circle { fill: rgba(168, 85, 247, 0.82); }
+.atlas-military-closure-after-action-row--culture circle { fill: rgba(244, 114, 182, 0.82); }
+.atlas-military-closure-after-action-row--unknown circle { fill: rgba(148, 163, 184, 0.78); }


### PR DESCRIPTION
Alpha: Implements #1336.

Summary:
- adds a compact “Tenté / recommandé / risque” comparison after the MAP-A18 closure recommendation
- reuses visible closure recommendation data to explain why the recommended closure beats recent alternatives without adding hidden orders
- includes a sober fallback when no previous action is visible

Tests:
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- node --check web/app.js
- git diff --check
- npm test

Ready for Zeta review. Validation requested before merge.
