### PR TITLE
Gamma: Add cultural follow-through reminders

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -956,7 +956,56 @@ function buildCulturalRotationCommitmentSummary(recommendationRotationPreview, p
   };
 }
 
-function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = [], promptHistory = [], regionId = 'province') {
+
+function buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary, promptHistoryDrawer, turn = 1) {
+  const recentCommitment = promptHistoryDrawer.groups
+    .flatMap((group) => group.entries)
+    .filter((entry) => entry.source === 'history')
+    .filter((entry) => ['chosen', 'committed', 'confirmed', 'accepted'].includes(entry.choiceState))
+    .sort((left, right) => (right.turn ?? 0) - (left.turn ?? 0))[0] ?? null;
+  const selected = rotationCommitmentSummary.entries.find((entry) => entry.promptId === rotationCommitmentSummary.selectedPromptId)
+    ?? rotationCommitmentSummary.entries[0]
+    ?? null;
+
+  if (!recentCommitment) {
+    return {
+      state: 'fallback',
+      reminderId: 'culture-commitment:follow-through:fallback',
+      summary: 'Aucun engagement culturel récent traçable: afficher le prochain choix recommandé sans inventer de promesse passée.',
+      sourcePromptLabel: null,
+      clusterLabel: selected?.clusterLabel ?? null,
+      lastTurn: null,
+      nextCheck: selected
+        ? `Vérifier si ${selected.clusterLabel} peut encore suivre ${selected.promptLabel}.`
+        : 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.',
+      expectedAction: selected?.hasUnresolvedDependencies
+        ? selected.dependencyWarning
+        : 'attendre un engagement culturel explicite avant de rappeler une promesse',
+    };
+  }
+
+  const followTurn = recentCommitment.turn ? recentCommitment.turn + 1 : turn;
+  const matchingCurrent = rotationCommitmentSummary.entries.find((entry) => entry.clusterLabel === recentCommitment.clusterLabel)
+    ?? selected;
+  const hasDependency = matchingCurrent?.hasUnresolvedDependencies === true;
+
+  return {
+    state: hasDependency ? 'watch' : 'ready',
+    reminderId: `${recentCommitment.historyId}:follow-through-reminder`,
+    summary: `${recentCommitment.clusterLabel}: engagement à suivre au tour ${followTurn} — ${recentCommitment.outcome}.`,
+    sourcePromptLabel: recentCommitment.promptLabel,
+    clusterLabel: recentCommitment.clusterLabel,
+    lastTurn: recentCommitment.turn ?? null,
+    nextCheck: hasDependency
+      ? `Lever la dépendance avant de prolonger ${recentCommitment.promptLabel}.`
+      : `Confirmer que ${recentCommitment.promptLabel} produit encore un signal culturel visible.`,
+    expectedAction: matchingCurrent
+      ? `${matchingCurrent.duration}; ${matchingCurrent.repeatPolicy}`
+      : 'réévaluer le suivi culturel sans répéter tout l’historique',
+  };
+}
+
+function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = [], promptHistory = [], regionId = 'province', turn = 1) {
   const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
   const trajectories = ['apaisement', 'consolidation', 'enquête', 'expansion', 'attente'];
   const bundles = trajectories
@@ -1061,6 +1110,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
   const promptFreshnessFilter = buildCulturalPromptFreshnessFilter(promptChoiceComparison, promptHistoryDrawer);
   const recommendationRotationPreview = buildCulturalRecommendationRotationPreview(promptFreshnessFilter, promptHistoryDrawer);
   const rotationCommitmentSummary = buildCulturalRotationCommitmentSummary(recommendationRotationPreview, promptChoiceComparison, bundles, incompatibilities);
+  const commitmentFollowThroughReminder = buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary, promptHistoryDrawer, turn);
 
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
@@ -1079,6 +1129,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
     promptFreshnessFilter,
     recommendationRotationPreview,
     rotationCommitmentSummary,
+    commitmentFollowThroughReminder,
     dependencyExplanation: bundles.length === 0
       ? 'Aucune dépendance entre marqueurs culturels.'
       : bundles
@@ -1125,7 +1176,7 @@ export function buildCultureTurnReportDeltas({
   });
   const stabilizationRecommendations = buildCultureStabilizationRecommendations(momentumLayer);
   const recommendationCoherence = buildCultureRecommendationCoherenceSummary(stabilizationRecommendations, activeRecommendations);
-  const commitmentBundles = buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations, promptHistory, regionId);
+  const commitmentBundles = buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations, promptHistory, regionId, turn);
   const deltas = dedupeAndSort([
     ...buildTimelineDeltas(localTimeline, regionId),
     ...buildMarkerDeltas(selectedMarker, regionId),
@@ -1209,6 +1260,16 @@ export function buildCultureTurnReportDeltas({
           summary: 'Aucun résumé d’engagement culturel disponible.',
           selectedPromptId: null,
           entries: [],
+        },
+        commitmentFollowThroughReminder: {
+          state: 'fallback',
+          reminderId: 'culture-commitment:follow-through:fallback',
+          summary: 'Aucun engagement culturel récent traçable: afficher le prochain choix recommandé sans inventer de promesse passée.',
+          sourcePromptLabel: null,
+          clusterLabel: null,
+          lastTurn: null,
+          nextCheck: 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.',
+          expectedAction: 'attendre un engagement culturel explicite avant de rappeler une promesse',
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
       },

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -356,6 +356,16 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
         },
       ],
     },
+    commitmentFollowThroughReminder: {
+      state: 'fallback',
+      reminderId: 'culture-commitment:follow-through:fallback',
+      summary: 'Aucun engagement culturel récent traçable: afficher le prochain choix recommandé sans inventer de promesse passée.',
+      sourcePromptLabel: null,
+      clusterLabel: 'Compact d’Aurora',
+      lastTurn: null,
+      nextCheck: 'Vérifier si Compact d’Aurora peut encore suivre Ouvrir le récit d’expansion.',
+      expectedAction: 'attendre un engagement culturel explicite avant de rappeler une promesse',
+    },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
 });
@@ -437,6 +447,16 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         summary: 'Aucun résumé d’engagement culturel disponible.',
         selectedPromptId: null,
         entries: [],
+      },
+      commitmentFollowThroughReminder: {
+        state: 'fallback',
+        reminderId: 'culture-commitment:follow-through:fallback',
+        summary: 'Aucun engagement culturel récent traçable: afficher le prochain choix recommandé sans inventer de promesse passée.',
+        sourcePromptLabel: null,
+        clusterLabel: null,
+        lastTurn: null,
+        nextCheck: 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.',
+        expectedAction: 'attendre un engagement culturel explicite avant de rappeler une promesse',
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },
@@ -849,4 +869,8 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
   assert.match(report.commitmentBundles.rotationCommitmentSummary.entries[0].benefit, /verrouille/);
   assert.match(report.commitmentBundles.rotationCommitmentSummary.entries[0].opportunityCost, /narratif\/recherche/);
   assert.match(report.commitmentBundles.rotationCommitmentSummary.entries[1].repeatPolicy, /dépriorisé/);
+  assert.equal(report.commitmentBundles.commitmentFollowThroughReminder.state, 'watch');
+  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.summary, /engagement à suivre au tour 8/);
+  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.nextCheck, /dépendance/);
+  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.expectedAction, /dépriorisé/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6605,6 +6605,12 @@ function renderCultureTurnReport(report) {
           </div>
         ` : '<small>État vide: aucune recommandation culturelle sélectionnable à résumer.</small>'}
       </div>
+      <div class="culture-turn-report__follow-through culture-turn-report__follow-through--${report.commitmentBundles?.commitmentFollowThroughReminder?.state ?? 'fallback'}" aria-label="Rappel d’engagement culturel à suivre">
+        <span>Engagement à suivre</span>
+        <strong>${report.commitmentBundles?.commitmentFollowThroughReminder?.summary ?? 'Aucun engagement culturel récent traçable: afficher le prochain choix recommandé sans inventer de promesse passée.'}</strong>
+        <small>Prochaine vérification: ${report.commitmentBundles?.commitmentFollowThroughReminder?.nextCheck ?? 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.'}</small>
+        <small>Action attendue: ${report.commitmentBundles?.commitmentFollowThroughReminder?.expectedAction ?? 'attendre un engagement culturel explicite avant de rappeler une promesse'}</small>
+      </div>
       <details class="culture-turn-report__history culture-turn-report__history--${report.commitmentBundles?.promptHistoryDrawer?.state ?? 'quiet'}" aria-label="Historique des prompts culturels de carte">
         <summary>
           <span>Historique culturel</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1988,6 +1988,29 @@ button { font: inherit; }
 .culture-turn-report__commitment-entry--deferred-freshness { border-color: rgba(251, 191, 36, 0.42); }
 .culture-turn-report__commitment-entry--excluded-context { border-color: rgba(148, 163, 184, 0.26); }
 .culture-turn-report__commitment-entry--caution { box-shadow: inset 3px 0 0 rgba(251, 191, 36, 0.55); }
+.culture-turn-report__follow-through {
+  display: grid;
+  gap: 5px;
+  margin-top: 10px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.28);
+  border: 1px solid rgba(250, 204, 21, 0.18);
+}
+.culture-turn-report__follow-through > span {
+  color: #fde68a;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__follow-through > strong {
+  color: #f8fafc;
+  font-size: 12px;
+}
+.culture-turn-report__follow-through small { color: var(--muted); }
+.culture-turn-report__follow-through--ready { border-color: rgba(74, 222, 128, 0.3); }
+.culture-turn-report__follow-through--watch { border-color: rgba(251, 191, 36, 0.42); }
+.culture-turn-report__follow-through--fallback { border-color: rgba(148, 163, 184, 0.24); }
 .culture-turn-report__history {
   display: grid;
   gap: 7px;


### PR DESCRIPTION
Gamma: Résumé

- Ajoute un rappel “engagement à suivre” dérivé de l’historique récent des prompts culturels choisis.
- Affiche la prochaine vérification/action attendue sans nouveau système persistant, avec fallback quand aucun engagement récent n’est traçable.
- Rend le rappel dans le rapport web avec états ready/watch/fallback.

Tests

- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check
- npm test (723 passing)

Fixes loo469/historia#1338