### PR TITLE
Delta: Add stabilization risk previews

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -3075,6 +3075,38 @@ function buildIntrigueEscalationOutcomeRecap({ locationId, locationName, intrigu
   };
 }
 
+function buildStabilizationRiskPreview({ action, blockedBy = null, exposureCost = '', fogRisk = '', reason = '' }) {
+  const riskText = `${blockedBy ?? ''} ${exposureCost} ${fogRisk} ${reason}`.toLowerCase();
+
+  if (blockedBy === 'insufficient-budget' || riskText.includes('budget')) {
+    return 'risque: dépasse budget visible';
+  }
+
+  if (blockedBy === 'over-exposure-risk' || riskText.includes('trop risqué') || riskText.includes('surexposition')) {
+    return 'risque: recrée du brouillard';
+  }
+
+  if (action === 'reverify') {
+    return riskText.includes('modéré')
+      ? 'risque: signal encore instable'
+      : 'risque: relance coûteuse';
+  }
+
+  if (action === 'observe') {
+    return riskText.includes('provenance')
+      ? 'risque: provenance incomplète'
+      : 'risque: laisse signal instable';
+  }
+
+  if (action === 'stabilize') {
+    return riskText.includes('partielles')
+      ? 'risque: confiance partielle'
+      : 'risque: aucun immédiat';
+  }
+
+  return 'risque: non calculable';
+}
+
 function buildPostRecapStabilizationChoices({ locationId, locationName, intrigueEscalationOutcomeRecap }) {
   if (intrigueEscalationOutcomeRecap.state === 'masked-outcome-recap') {
     return {
@@ -3089,6 +3121,11 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
         exposureCost: '0 exposition ajoutée',
         fogRisk: 'brouillard préservé',
         reason: 'La provenance reste insuffisante: maintenir la surveillance visible sans inférer de vérité cachée.',
+        riskPreview: buildStabilizationRiskPreview({
+          action: 'observe',
+          fogRisk: 'brouillard préservé',
+          reason: 'La provenance reste insuffisante: maintenir la surveillance visible sans inférer de vérité cachée.',
+        }),
       }],
       riskyChoices: intrigueEscalationOutcomeRecap.blockedChoices.map((choice) => ({
         action: 'reverify',
@@ -3097,6 +3134,13 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
         fogRisk: 'trop risqué sous brouillard',
         blockedBy: choice.blockedBy,
         reason: choice.safeReason,
+        riskPreview: buildStabilizationRiskPreview({
+          action: 'reverify',
+          blockedBy: choice.blockedBy,
+          exposureCost: choice.budgetEffect,
+          fogRisk: 'trop risqué sous brouillard',
+          reason: choice.safeReason,
+        }),
       })),
       summary: 'Posture post-récap: observer, car le brouillard masque encore la provenance sûre.',
       safeMapPolicy: 'Choix D17 limités aux effets visibles de posture, exposition et brouillard; aucune cible, cellule, relais, méthode ou vérité cachée n’est révélée.',
@@ -3135,6 +3179,16 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
           ? 'Les issues restent calmes: stabiliser et surveiller suffit pour ce tour.'
           : 'Stabiliser garde la priorité sous contrôle avant de rouvrir une vérification.',
       confidenceEffect: primaryChoice?.confidenceEffect ?? 'confiance stable avec données partielles préservées',
+      riskPreview: buildStabilizationRiskPreview({
+        action: 'stabilize',
+        exposureCost: '0 exposition ajoutée',
+        fogRisk: 'brouillard réduit sans nouvelle vérification',
+        reason: resolvedEnough
+          ? 'Le récap indique une résolution suffisante: stabiliser évite une boucle de recheck.'
+          : hasOnlyCalmOutcomes
+            ? 'Les issues restent calmes: stabiliser et surveiller suffit pour ce tour.'
+            : 'Stabiliser garde la priorité sous contrôle avant de rouvrir une vérification.',
+      }),
     },
     {
       action: 'observe',
@@ -3146,6 +3200,14 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
         ? 'Observer évite de payer une relance alors que budget ou provenance restent fragiles.'
         : 'Alternative prudente si le joueur veut confirmer la stabilité sans nouvelle escalade.',
       confidenceEffect: 'confiance maintenue sans déduire de cible cachée',
+      riskPreview: buildStabilizationRiskPreview({
+        action: 'observe',
+        exposureCost: '0-1 exposition visible',
+        fogRisk: 'brouillard conservé; signal à rafraîchir seulement s’il reste visible',
+        reason: shouldObserve
+          ? 'Observer évite de payer une relance alors que budget ou provenance restent fragiles.'
+          : 'Alternative prudente si le joueur veut confirmer la stabilité sans nouvelle escalade.',
+      }),
     },
   ];
 
@@ -3159,6 +3221,13 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
       blockedBy: firstBudgetBlock.blockedBy ?? 'over-exposure-risk',
       reason: 'Visible mais déconseillé: ne relancer qu’avec budget/provenance lisible.',
       confidenceEffect: firstBudgetBlock.confidenceEffect,
+      riskPreview: buildStabilizationRiskPreview({
+        action: 'reverify',
+        blockedBy: firstBudgetBlock.blockedBy ?? 'over-exposure-risk',
+        exposureCost: firstBudgetBlock.budgetEffect,
+        fogRisk: 'trop risqué: peut recréer du brouillard ou dépasser le budget visible',
+        reason: 'Visible mais déconseillé: ne relancer qu’avec budget/provenance lisible.',
+      }),
     }
     : activeChoices.length > 0 && !resolvedEnough
       ? {
@@ -3170,6 +3239,12 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
         blockedBy: null,
         reason: 'Option de reprise différée si l’observation montre encore une incertitude exploitable.',
         confidenceEffect: primaryChoice?.confidenceEffect,
+        riskPreview: buildStabilizationRiskPreview({
+          action: 'reverify',
+          exposureCost: primaryChoice?.budgetEffect ?? 'exposition modérée à revalider',
+          fogRisk: 'risque modéré: attendre un nouveau signal visible',
+          reason: 'Option de reprise différée si l’observation montre encore une incertitude exploitable.',
+        }),
       }
       : null;
 
@@ -3188,6 +3263,13 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
       fogRisk: 'risque trop élevé pour une relance immédiate',
       blockedBy: choice.blockedBy,
       reason: choice.safeReason,
+      riskPreview: buildStabilizationRiskPreview({
+        action: 'reverify',
+        blockedBy: choice.blockedBy,
+        exposureCost: choice.budgetEffect,
+        fogRisk: 'risque trop élevé pour une relance immédiate',
+        reason: choice.safeReason,
+      }),
     })),
     summary: recommendedPosture === 'stabilize'
       ? 'Posture post-récap: stabiliser ou surveiller, sans relancer une boucle de vérification.'

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2789,7 +2789,9 @@ test('buildIntrigueMapOverlay recommends post-recap stabilization choices withou
   assert.equal(stable.choices[0].action, 'stabilize');
   assert.equal(stable.choices[0].recommended, true);
   assert.match(stable.choices[0].reason, /évite une boucle de recheck/);
+  assert.equal(stable.choices[0].riskPreview, 'risque: aucun immédiat');
   assert.match(stable.choices[1].fogRisk, /brouillard conservé/);
+  assert.equal(stable.choices[1].riskPreview, 'risque: laisse signal instable');
   assert.equal(stable.choices[2].recommended, false);
 
   assert.equal(budget.state, 'observation-recommended');
@@ -2799,12 +2801,14 @@ test('buildIntrigueMapOverlay recommends post-recap stabilization choices withou
   assert.equal(budget.choices[1].recommended, true);
   assert.equal(budget.choices[2].action, 'reverify');
   assert.equal(budget.choices[2].blockedBy, 'insufficient-budget');
+  assert.equal(budget.choices[2].riskPreview, 'risque: dépasse budget visible');
   assert.match(budget.choices[2].fogRisk, /trop risqué/);
   assert.ok(budget.riskyChoices.every((choice) => choice.action === 'reverify'));
 
   assert.equal(masked.state, 'masked-stabilization-choices');
   assert.equal(masked.recommendedPosture, 'observe');
   assert.deepEqual(masked.choices.map((choice) => choice.action), ['observe']);
+  assert.equal(masked.choices[0].riskPreview, 'risque: provenance incomplète');
   assert.match(masked.choices[0].reason, /provenance reste insuffisante/);
   assert.match(masked.safeMapPolicy, /ne .*révélée/);
 });


### PR DESCRIPTION
Delta: Implements #1339.\n\nSummary:\n- Adds compact riskPreview text to each post-recap intrigue stabilization choice.\n- Covers stabilize, observe, and re-verify options with budget/fog/provenance risk hints.\n- Keeps the change presentation-only and fog-safe; no intrigue resolution behavior changes.\n\nValidation:\n- node --test test/ui/intrigue/buildIntrigueMapOverlay.test.js\n- node --check web/app.js\n- npm test\n- git diff --check\n\nZeta validation requested before merge.