### PR TITLE
Epsilon: Add climate readiness gap indicators

### DIFF
--- a/test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
+++ b/test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
@@ -37,6 +37,13 @@ test('atlas renders compatibility bundles for climate rebound follow-up queues',
   assert.match(webAppSource, /Risque majeur évité/);
   assert.match(webAppSource, /Coût réserve\/tempo/);
   assert.match(webAppSource, /Follow-ups en attente/);
+  assert.match(webAppSource, /Manque principal/);
+  assert.match(webAppSource, /buildReadinessGapIndicator/);
+  assert.match(webAppSource, /manque délai/);
+  assert.match(webAppSource, /manque ressource/);
+  assert.match(webAppSource, /manque région/);
+  assert.match(webAppSource, /manque soutien/);
+  assert.match(webAppSource, /manque à confirmer/);
   assert.match(webAppSource, /immediate-action/);
   assert.match(webAppSource, /safe-wait/);
   assert.match(webAppSource, /minimal-prep/);
@@ -47,4 +54,9 @@ test('atlas renders compatibility bundles for climate rebound follow-up queues',
   assert.match(stylesSource, /\.map-world-climate-follow-up-compat__item--ambitious-fragile/);
   assert.match(stylesSource, /\.map-world-climate-follow-up-readiness-recap/);
   assert.match(stylesSource, /\.map-world-climate-next-follow-up/);
+  assert.match(stylesSource, /\.map-world-climate-next-follow-up__gap--resource/);
+  assert.match(stylesSource, /\.map-world-climate-next-follow-up__gap--delay/);
+  assert.match(stylesSource, /\.map-world-climate-next-follow-up__gap--region/);
+  assert.match(stylesSource, /\.map-world-climate-next-follow-up__gap--support/);
+  assert.match(stylesSource, /\.map-world-climate-next-follow-up__gap--fallback/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -11813,6 +11813,8 @@ function buildAtlasNextClimateFollowUpAction(readinessRecapView, compatibilityVi
 
   const cooldownBlocked = selectedRecap.linkedCooldownState === 'soon-safe' || selectedRecap.linkedCooldownState === 'still-risky';
   const reservePressure = /réserve|ressource|mitigation/i.test(`${selectedRecap.safeAction} ${selectedRecap.avoidAction} ${selectedRecap.residualRisk}`);
+  const regionalPressure = /région|regional|fragile|catastrophe|mythe/i.test(`${selectedRecap.state} ${selectedRecap.reason} ${selectedRecap.residualRisk}`);
+  const supportPressure = /readiness|mitigation|soutien|relais/i.test(`${selectedRecap.safeAction} ${selectedRecap.reason}`);
   const residualRisk = selectedRecap.residualRisk;
   const avoidedRisk = selectedRecap.linkedRiskDelta === 'worsening-probable'
     ? 'rebond catastrophique ou régional immédiat'
@@ -11843,6 +11845,47 @@ function buildAtlasNextClimateFollowUpAction(readinessRecapView, compatibilityVi
     return 'moins prioritaire que le bundle minimal sélectionné';
   };
   const selectedIds = new Set(selectedBundle?.itemIds ?? []);
+  const buildReadinessGapIndicator = () => {
+    if (cooldownBlocked) {
+      return {
+        type: 'delay',
+        label: 'manque délai',
+        gapReduced: 'réduit l’écart de timing avant le prochain engagement sûr',
+        actionHint: 'attendre le cooling-off puis relire le delta avant action',
+      };
+    }
+    if (reservePressure) {
+      return {
+        type: 'resource',
+        label: 'manque ressource',
+        gapReduced: 'réduit l’écart de réserve ou mitigation nécessaire',
+        actionHint: 'verrouiller seulement la réserve minimale affichée',
+      };
+    }
+    if (regionalPressure) {
+      return {
+        type: 'region',
+        label: 'manque région',
+        gapReduced: 'réduit l’écart de fragilité régionale avant propagation',
+        actionHint: 'confirmer la région exposée avant d’élargir le bundle',
+      };
+    }
+    if (supportPressure) {
+      return {
+        type: 'support',
+        label: 'manque soutien',
+        gapReduced: 'réduit l’écart de soutien readiness avant exécution',
+        actionHint: 'garder un relais ou une mitigation courte attachée à l’action',
+      };
+    }
+    return {
+      type: 'fallback',
+      label: 'manque à confirmer',
+      gapReduced: 'réduit un écart encore non qualifié par les signaux actuels',
+      actionHint: 'rester sur l’action courte et surveiller le prochain signal climat',
+    };
+  };
+  const readinessGap = buildReadinessGapIndicator();
   const pendingIncompatible = [
     ...(compatibilityView.pendingIfMinimal ?? []).map((item) => ({
       label: item.label,
@@ -11867,6 +11910,7 @@ function buildAtlasNextClimateFollowUpAction(readinessRecapView, compatibilityVi
       cost,
       residualRisk,
       cooldownState: selectedRecap.linkedCooldownState,
+      readinessGap,
       reserveImpact: reservePressure ? 'réserve sollicitée: limiter au strict nécessaire' : 'réserve préservée',
       rationale: mode === 'immediate-action'
         ? 'readiness prête: l’action peut devenir le choix principal sans violer le cooldown'
@@ -11898,6 +11942,7 @@ function renderAtlasNextClimateFollowUpAction(view) {
       <small><b>${view.recommendation.label}</b> · ${view.recommendation.action}</small>
       <small><b>Risque majeur évité</b> · ${view.recommendation.avoidedRisk}; ${view.recommendation.residualRisk}</small>
       <small><b>Coût réserve/tempo</b> · ${view.recommendation.cost}; ${view.recommendation.reserveImpact}</small>
+      <small class="map-world-climate-next-follow-up__gap map-world-climate-next-follow-up__gap--${view.recommendation.readinessGap.type}"><b>Manque principal</b> · ${view.recommendation.readinessGap.label}: ${view.recommendation.readinessGap.gapReduced}. ${view.recommendation.readinessGap.actionHint}</small>
       <small><b>Pourquoi ce choix</b> · ${view.recommendation.rationale}</small>
       <small><b>Follow-ups en attente</b> · ${view.pendingIncompatible.length > 0 ? view.pendingIncompatible.map((item) => `${item.label}: ${item.reason}`).join(' | ') : 'aucun follow-up incompatible à masquer'}</small>
     </aside>

--- a/web/styles.css
+++ b/web/styles.css
@@ -12868,6 +12868,17 @@ button { font: inherit; }
   line-height: 1.35;
   margin: 0;
 }
+.map-world-climate-next-follow-up__gap {
+  padding: 5px 7px;
+  border-radius: 10px;
+  background: rgba(8, 47, 73, 0.52);
+  border: 1px solid rgba(125, 211, 252, 0.2);
+}
+.map-world-climate-next-follow-up__gap--resource { border-color: rgba(74, 222, 128, 0.34); }
+.map-world-climate-next-follow-up__gap--delay { border-color: rgba(251, 191, 36, 0.42); }
+.map-world-climate-next-follow-up__gap--region { border-color: rgba(248, 113, 113, 0.4); }
+.map-world-climate-next-follow-up__gap--support { border-color: rgba(196, 181, 253, 0.38); }
+.map-world-climate-next-follow-up__gap--fallback { border-color: rgba(148, 163, 184, 0.28); }
 .map-world-climate-next-follow-up--immediate-action { border-color: rgba(74, 222, 128, 0.42); }
 .map-world-climate-next-follow-up--safe-wait { border-color: rgba(251, 191, 36, 0.48); }
 .map-world-climate-next-follow-up--minimal-prep { border-color: rgba(56, 189, 248, 0.42); }


### PR DESCRIPTION
Epsilon: Implements #1340.

## Summary
- adds a compact “Manque principal” indicator to the next climate follow-up action
- derives resource, delay, region, support, or fallback gaps from existing readiness/cooldown signals
- shows which gap the next action reduces and a short action hint
- styles gap badges and extends the existing climate follow-up regression check

## Validation
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
- npm test

Zeta: ready for review. Please validate before any merge.