### PR TITLE
Beta: Add recovery relapse risk alerts

### DIFF
--- a/src/ui/economy/buildEconomyMapOverlay.js
+++ b/src/ui/economy/buildEconomyMapOverlay.js
@@ -2736,6 +2736,81 @@ function buildRecoveryMomentumForecast(outcomeRecaps, nextRecoveryActionSummary)
   };
 }
 
+function buildRecoveryRelapseRiskAlerts(recoveryMomentumForecast, outcomeRecaps, warningGroups) {
+  if (!recoveryMomentumForecast || recoveryMomentumForecast.status !== 'fragile') {
+    return {
+      id: 'logistics-recovery-relapse-risk-alerts',
+      status: 'solide',
+      title: 'Risque de rechute prochain tour',
+      summary: 'Aucune alerte de rechute prioritaire: la récupération reste lisible pour le prochain tour.',
+      alertGroups: [],
+      topAlertKey: null,
+    };
+  }
+
+  const groupedAlerts = new Map();
+  outcomeRecaps
+    .filter((recap) => recap.secondaryOverload || recap.status !== 'résolution nette')
+    .forEach((recap) => {
+      const warningGroup = warningGroups.find((group) => group.key === recap.warningGroupKey) ?? null;
+      const factor = recap.secondaryOverload
+        ? 'capacité partagée peut redéplacer la surcharge'
+        : recap.status === 'résolution partielle'
+          ? 'dette résiduelle peut rebloquer la route'
+          : 'signal incomplet à confirmer';
+      const key = recap.secondaryOverload ? `shared-capacity:${recap.warningGroupKey}` : `residual-debt:${recap.warningGroupKey}`;
+      const existing = groupedAlerts.get(key) ?? {
+        key,
+        severity: recap.secondaryOverload ? 'à risque' : 'fragile',
+        factor,
+        action: recap.secondaryOverload
+          ? 'réserver une marge de capacité avant de relancer une récupération concurrente'
+          : 'rembourser la dette résiduelle avant d’enchaîner la reprise',
+        warningGroupKey: recap.warningGroupKey,
+        linkedOutcomeRecapIds: [],
+        targets: [],
+      };
+
+      existing.linkedOutcomeRecapIds.push(recap.id);
+      warningGroup?.details.forEach((detail) => {
+        if (!existing.targets.some((target) => target.targetId === detail.targetId)) {
+          existing.targets.push({
+            targetId: detail.targetId,
+            label: detail.label,
+            corridor: detail.corridor,
+          });
+        }
+      });
+      groupedAlerts.set(key, existing);
+    });
+
+  const alertGroups = [...groupedAlerts.values()].sort((left, right) => Number(right.severity === 'à risque') - Number(left.severity === 'à risque')
+    || right.linkedOutcomeRecapIds.length - left.linkedOutcomeRecapIds.length
+    || left.key.localeCompare(right.key));
+
+  if (alertGroups.length === 0) {
+    return {
+      id: 'logistics-recovery-relapse-risk-alerts',
+      status: 'à surveiller',
+      title: 'Risque de rechute prochain tour',
+      summary: 'Momentum fragile sans facteur isolé: confirmer les signaux de reprise avant le prochain arbitrage.',
+      alertGroups: [],
+      topAlertKey: null,
+    };
+  }
+
+  const topAlert = alertGroups[0];
+
+  return {
+    id: 'logistics-recovery-relapse-risk-alerts',
+    status: topAlert.severity,
+    title: 'Risque de rechute prochain tour',
+    summary: `${alertGroups.length} facteur(s) groupé(s); principal risque: ${topAlert.factor}.`,
+    alertGroups,
+    topAlertKey: topAlert.key,
+  };
+}
+
 function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymentPriorities, logisticsFeatures = []) {
   const candidates = repaymentPriorities.priorities.slice(0, 3);
   const scenarios = candidates.map((priority) => {
@@ -2769,6 +2844,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
   const outcomeRecaps = buildRepaymentOutcomeRecaps(tradeOffComparisons);
   const nextRecoveryActionSummary = buildNextRecoveryActionSummary(outcomeRecaps, warningGroups);
   const recoveryMomentumForecast = buildRecoveryMomentumForecast(outcomeRecaps, nextRecoveryActionSummary);
+  const recoveryRelapseRiskAlerts = buildRecoveryRelapseRiskAlerts(recoveryMomentumForecast, outcomeRecaps, warningGroups);
 
   return {
     id: 'logistics-recovery-repayment-scenarios',
@@ -2788,6 +2864,7 @@ function buildRecoveryDebtRepaymentScenarioPreviews(recoveryDebtLedger, repaymen
     topOutcomeRecapId: outcomeRecaps[0]?.id ?? null,
     nextRecoveryActionSummary,
     recoveryMomentumForecast,
+    recoveryRelapseRiskAlerts,
     legend: [
       { key: 'partial', label: 'Partiel: débloque une portion', tone: 'warning' },
       { key: 'complete', label: 'Complet: sécurise la reprise', tone: 'positive' },

--- a/test/ui/economy/buildEconomyMapOverlay.test.js
+++ b/test/ui/economy/buildEconomyMapOverlay.test.js
@@ -1702,6 +1702,19 @@ test('buildEconomyMapOverlay exposes city resource and logistics map layers', ()
     linkedOutcomeRecapId: 'outcome-recap:stock:stock:recovery-repayment:route-coast:complete',
   });
   assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryMomentumForecast.summary, /surveiller la dette/);
+  assert.deepEqual({
+    status: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryRelapseRiskAlerts.status,
+    topAlertKey: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryRelapseRiskAlerts.topAlertKey,
+    alertCount: overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryRelapseRiskAlerts.alertGroups.length,
+  }, {
+    status: 'à risque',
+    topAlertKey: 'shared-capacity:stock:stock',
+    alertCount: 1,
+  });
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryRelapseRiskAlerts.summary, /principal risque/);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryRelapseRiskAlerts.alertGroups[0].factor, /capacité partagée/);
+  assert.match(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryRelapseRiskAlerts.alertGroups[0].action, /réserver une marge/);
+  assert.deepEqual(overlay.layers.logistics.recoveryDebtRepaymentScenarioPreviews.recoveryRelapseRiskAlerts.alertGroups[0].targets.map((target) => target.targetId), ['route-coast']);
 
   assert.deepEqual(overlay.layers.logistics.recoveryMarkers.map((marker) => ({
     targetType: marker.targetType,

--- a/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
+++ b/test/ui/economy/webEconomyRecoveryDebtLedger.test.js
@@ -39,6 +39,11 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(webAppSource, /recoveryMomentumForecast/);
   assert.match(webAppSource, /economy-recovery-momentum/);
   assert.match(webAppSource, /recoveryMomentumForecast\.confidence/);
+  assert.match(webAppSource, /recoveryRelapseRiskAlerts/);
+  assert.match(webAppSource, /economy-recovery-relapse/);
+  assert.match(webAppSource, /Alertes risque de rechute de récupération/);
+  assert.match(webAppSource, /group\.factor/);
+  assert.match(webAppSource, /group\.action/);
   assert.match(webAppSource, /economy-repayment-outcomes/);
   assert.match(webAppSource, /recap\.secondaryOverload/);
 
@@ -84,4 +89,6 @@ test('playable economy overlay renders logistics recovery debt ledger', () => {
   assert.match(stylesSource, /\.economy-recovery-momentum--en-reprise/);
   assert.match(stylesSource, /\.economy-recovery-momentum--stable/);
   assert.match(stylesSource, /\.economy-recovery-momentum--fragile/);
+  assert.match(stylesSource, /\.economy-recovery-relapse--à-risque/);
+  assert.match(stylesSource, /\.economy-recovery-relapse__group--fragile/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -19203,6 +19203,23 @@ function renderEconomyRecoveryRepaymentScenarios(economyView) {
           <small>Confiance ${view.recoveryMomentumForecast.confidence}</small>
         </article>
       ` : ''}
+      ${view.recoveryRelapseRiskAlerts?.alertGroups?.length ? `
+        <aside class="economy-recovery-relapse economy-recovery-relapse--${view.recoveryRelapseRiskAlerts.status.replaceAll(' ', '-')}" aria-label="Alertes risque de rechute de récupération">
+          <div>
+            <span>${view.recoveryRelapseRiskAlerts.title}</span>
+            <strong>${view.recoveryRelapseRiskAlerts.summary}</strong>
+          </div>
+          <ul>
+            ${view.recoveryRelapseRiskAlerts.alertGroups.map((group) => `
+              <li class="economy-recovery-relapse__group economy-recovery-relapse__group--${group.severity.replaceAll(' ', '-')}">
+                <b>${group.factor}</b>
+                <span>${group.action}</span>
+                <small>${group.targets.length ? group.targets.map((target) => `${target.label} · ${target.corridor}`).join(' · ') : group.warningGroupKey}</small>
+              </li>
+            `).join('')}
+          </ul>
+        </aside>
+      ` : ''}
       ${view.tradeOffComparisons?.length ? `
         <div class="economy-repayment-tradeoffs" aria-label="Comparaison des options de résolution de goulot">
           ${view.tradeOffComparisons.map((comparison) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13650,6 +13650,50 @@ button { font: inherit; }
 .economy-recovery-momentum--en-reprise { border-color: rgba(74, 222, 128, 0.38); }
 .economy-recovery-momentum--stable { border-color: rgba(125, 211, 252, 0.3); }
 .economy-recovery-momentum--fragile { border-color: rgba(251, 191, 36, 0.42); }
+.economy-recovery-relapse {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(69, 26, 3, 0.24);
+  border: 1px solid rgba(251, 191, 36, 0.26);
+}
+.economy-recovery-relapse div {
+  display: grid;
+  gap: 3px;
+}
+.economy-recovery-relapse span:first-child {
+  color: #fde68a;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.economy-recovery-relapse strong,
+.economy-recovery-relapse b { color: #fef3c7; }
+.economy-recovery-relapse ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.economy-recovery-relapse__group {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.28);
+}
+.economy-recovery-relapse__group span,
+.economy-recovery-relapse__group small {
+  color: #cbd5e1;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.economy-recovery-relapse--à-risque,
+.economy-recovery-relapse__group--à-risque { border-color: rgba(251, 113, 133, 0.38); }
+.economy-recovery-relapse--fragile,
+.economy-recovery-relapse__group--fragile { border-color: rgba(251, 191, 36, 0.36); }
 
 .atlas-military-next-best-closure__panel {
   fill: rgba(20, 83, 45, 0.76);


### PR DESCRIPTION
Beta: Closes #1347.

## Summary
- add grouped recovery relapse-risk alerts after fragile momentum forecasts
- identify shared-capacity and residual-debt factors from existing outcome recap and warning-group signals
- render one compact alert group with concrete arbitration/action copy instead of duplicating MAP-B18/MAP-B19 recaps

## Tests
- node --test test/ui/economy/buildEconomyMapOverlay.test.js test/ui/economy/webEconomyRecoveryDebtLedger.test.js
- node --check web/app.js
- git diff --check
- npm test