### PR TITLE
Epsilon: Add climate readiness consequence hints

### DIFF
--- a/test/ui/climate/webAtlasClimateReadinessConsequenceHints.test.js
+++ b/test/ui/climate/webAtlasClimateReadinessConsequenceHints.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas shows compact map consequence hints for climate readiness gaps', () => {
+  assert.match(webAppSource, /function buildAtlasClimateReadinessConsequenceHints/);
+  assert.match(webAppSource, /function renderAtlasClimateReadinessConsequenceHints/);
+  assert.match(webAppSource, /slice\(0, 3\)/);
+  assert.match(webAppSource, /Conséquence probable carte/);
+  assert.match(webAppSource, /Action de suivi/);
+  assert.match(webAppSource, /Effet sur risque/);
+  assert.match(webAppSource, /réduit le risque/);
+  assert.match(webAppSource, /reporte le risque/);
+  assert.match(webAppSource, /ne change pas vraiment le risque/);
+  assert.match(webAppSource, /capacité mitigation régionale/);
+  assert.match(webAppSource, /corridor régional partagé/);
+  assert.match(webAppSource, /fenêtre saisonnière/);
+  assert.match(webAppSource, /atlasClimateReadinessConsequenceHints = buildAtlasClimateReadinessConsequenceHints/);
+  assert.match(webAppSource, /renderAtlasClimateReadinessConsequenceHints\(atlasClimateReadinessConsequenceHints\)/);
+
+  assert.match(stylesSource, /\.map-world-climate-readiness-consequences/);
+  assert.match(stylesSource, /\.map-world-climate-readiness-consequences__item--insufficient/);
+  assert.match(stylesSource, /\.map-world-climate-readiness-consequences__item--too-late/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9718,6 +9718,75 @@ function buildAtlasClimatePostBoostDeadlineRiskPreview(boostView) {
   };
 }
 
+
+function buildAtlasClimateReadinessConsequenceHints(gapView, boostView, postBoostView) {
+  if (!gapView || gapView.state !== 'warning' || gapView.gaps.length === 0) {
+    return {
+      state: 'empty',
+      hints: [],
+      summary: 'Aucune conséquence readiness climat prioritaire à afficher.',
+    };
+  }
+
+  const boostsByProvince = new Map((boostView?.boosts ?? []).map((boost) => [boost.provinceId, boost]));
+  const postBoostByProvince = new Map((postBoostView?.previews ?? []).map((preview) => [preview.provinceId, preview]));
+  const consequenceByGapType = {
+    capacité: {
+      threatenedSystem: 'capacité mitigation régionale',
+      likelyMapEffect: 'front climatique élargi: une province voisine garde sa cascade active faute d’équipe disponible.',
+    },
+    'dépendance régionale': {
+      threatenedSystem: 'corridor régional partagé',
+      likelyMapEffect: 'effet domino carte: le hub protégé reste dépendant d’un voisin non sécurisé.',
+    },
+    délai: {
+      threatenedSystem: 'fenêtre saisonnière',
+      likelyMapEffect: 'deadline ratée: la province bascule en marqueur critique au prochain tour météo.',
+    },
+    ressource: {
+      threatenedSystem: 'stock logistique climat',
+      likelyMapEffect: 'mitigation partielle: le risque reste visible malgré l’action principale.',
+    },
+  };
+
+  const hints = gapView.gaps
+    .slice(0, 3)
+    .map((gap) => {
+      const boost = boostsByProvince.get(gap.provinceId);
+      const postBoost = postBoostByProvince.get(gap.provinceId);
+      const consequence = consequenceByGapType[gap.gapType] ?? consequenceByGapType.ressource;
+      const followUpEffect = postBoost?.outcome === 'executable'
+        ? 'réduit le risque: le boost rend la fenêtre jouable sans créer de nouvelle queue.'
+        : postBoost?.outcome === 'still-tight'
+          ? 'reporte le risque: le boost gagne du temps mais impose une relecture au prochain tour.'
+          : 'ne change pas vraiment le risque: il faut arbitrer plus qu’un boost minimal.';
+      const priorityReason = gap.status === 'too-late'
+        ? 'priorité maximale car la carte risque déjà de montrer une deadline manquée.'
+        : gap.status === 'insufficient'
+          ? 'priorité haute car la province manque de capacité avant exposition.'
+          : 'priorité de veille car la fenêtre tient seulement si l’action part maintenant.';
+
+      return {
+        provinceId: gap.provinceId,
+        provinceLabel: gap.provinceLabel,
+        status: gap.status,
+        gapType: gap.gapType,
+        deadline: gap.deadline,
+        threatenedSystem: consequence.threatenedSystem,
+        likelyMapEffect: consequence.likelyMapEffect,
+        followUpAction: boost?.smallestBoost ?? 'Confirmer ressource et timing avant validation.',
+        followUpEffect,
+        priorityReason,
+      };
+    });
+
+  return {
+    state: hints.length > 0 ? 'warning' : 'empty',
+    hints,
+    summary: `${hints.length} conséquence${hints.length > 1 ? 's' : ''} carte prioritaire${hints.length > 1 ? 's' : ''}: seules les menaces readiness les plus utiles sont affichées.`,
+  };
+}
+
 function renderAtlasClimatePostBoostDeadlineRiskPreview(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -9737,6 +9806,35 @@ function renderAtlasClimatePostBoostDeadlineRiskPreview(view) {
             <span>${preview.deadline} · ${preview.label}</span>
             <small><b>Boost appliqué</b> · ${preview.appliedBoost}</small>
             <small><b>Pression résiduelle</b> · ${preview.postBoostSignal}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
+
+function renderAtlasClimateReadinessConsequenceHints(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state !== 'warning') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-readiness-consequences map-world-climate-readiness-consequences--${view.state}" aria-label="Conséquences carte des écarts de readiness climat">
+      <div class="map-world-climate-readiness-consequences__header">
+        <strong>Conséquences readiness</strong>
+        <span>${view.hints.length} menace${view.hints.length > 1 ? 's' : ''} priorisée${view.hints.length > 1 ? 's' : ''}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-readiness-consequences__list">
+        ${view.hints.map((hint) => `
+          <li class="map-world-climate-readiness-consequences__item map-world-climate-readiness-consequences__item--${hint.status}">
+            <b>${hint.provinceLabel}</b>
+            <span>${hint.deadline} · ${hint.threatenedSystem}</span>
+            <small><b>Conséquence probable carte</b> · ${hint.likelyMapEffect}</small>
+            <small><b>Action de suivi</b> · ${hint.followUpAction}</small>
+            <small><b>Effet sur risque</b> · ${hint.followUpEffect}</small>
+            <small><b>Pourquoi priorisé</b> · ${hint.priorityReason}</small>
           </li>
         `).join('')}
       </ol>
@@ -20145,6 +20243,11 @@ function render() {
   const atlasClimateUnderReadyExecutionGaps = buildAtlasClimateUnderReadyExecutionGaps(atlasClimateMitigationReadiness);
   const atlasClimateReadinessBoostRecommendations = buildAtlasClimateReadinessBoostRecommendations(atlasClimateUnderReadyExecutionGaps);
   const atlasClimatePostBoostDeadlineRiskPreview = buildAtlasClimatePostBoostDeadlineRiskPreview(atlasClimateReadinessBoostRecommendations);
+  const atlasClimateReadinessConsequenceHints = buildAtlasClimateReadinessConsequenceHints(
+    atlasClimateUnderReadyExecutionGaps,
+    atlasClimateReadinessBoostRecommendations,
+    atlasClimatePostBoostDeadlineRiskPreview,
+  );
   const atlasClimateReadinessBoostReliefRanking = buildAtlasClimateReadinessBoostReliefRanking(atlasClimatePostBoostDeadlineRiskPreview);
   const atlasClimateMinimumViableBoostHint = buildAtlasClimateMinimumViableBoostHint(atlasClimateReadinessBoostReliefRanking);
   const atlasClimateMinimumBoostDeadlineMissWarning = buildAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumViableBoostHint);
@@ -20208,6 +20311,7 @@ function render() {
           ${renderAtlasClimateUnderReadyExecutionGaps(atlasClimateUnderReadyExecutionGaps)}
           ${renderAtlasClimateReadinessBoostRecommendations(atlasClimateReadinessBoostRecommendations)}
           ${renderAtlasClimatePostBoostDeadlineRiskPreview(atlasClimatePostBoostDeadlineRiskPreview)}
+          ${renderAtlasClimateReadinessConsequenceHints(atlasClimateReadinessConsequenceHints)}
           ${renderAtlasClimateReadinessBoostReliefRanking(atlasClimateReadinessBoostReliefRanking)}
           ${renderAtlasClimateMinimumViableBoostHint(atlasClimateMinimumViableBoostHint)}
           ${renderAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumBoostDeadlineMissWarning)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -12317,6 +12317,48 @@ button { font: inherit; }
 .map-world-climate-readiness-boosts__item--insufficient,
 .map-world-climate-readiness-boosts__item--too-late { border-color: rgba(248, 113, 113, 0.5); }
 
+.map-world-climate-readiness-consequences {
+  display: grid;
+  gap: 8px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 11px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.78), rgba(14, 116, 144, 0.2));
+  border: 1px solid rgba(125, 211, 252, 0.36);
+}
+.map-world-climate-readiness-consequences__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-readiness-consequences p,
+.map-world-climate-readiness-consequences span,
+.map-world-climate-readiness-consequences small {
+  color: #cffafe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-readiness-consequences__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-readiness-consequences__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(125, 211, 252, 0.28);
+}
+.map-world-climate-readiness-consequences__item--just-in-time { border-color: rgba(251, 191, 36, 0.42); }
+.map-world-climate-readiness-consequences__item--insufficient { border-color: rgba(251, 146, 60, 0.48); }
+.map-world-climate-readiness-consequences__item--too-late { border-color: rgba(248, 113, 113, 0.54); }
+
 .atlas-cultural-border-zone__recommendation {
   fill: #ddd6fe;
   font-size: 0.86px;


### PR DESCRIPTION
Epsilon: ## Summary

Adds compact climate-readiness consequence hints that connect the top under-ready climate gaps to concrete map threats and explain whether the recommended follow-up reduces, defers, or fails to change the risk.

## Changes

- Added an atlas consequence-hint view derived from existing readiness gaps, boost recommendations, and post-boost deadline previews.
- Rendered up to three prioritized province/system consequences without adding new queue state or duplicating existing MAP-E17/MAP-E18 panels.
- Added dedicated compact styling and a regression test for wiring/copy/states.

## Testing

- `node --test test/ui/climate/webAtlasClimateReadinessConsequenceHints.test.js test/ui/climate/webAtlasClimateReadinessBoostRecommendations.test.js test/ui/climate/webAtlasClimateMinimumBoostDeadlineMissWarning.test.js`
- `node --check web/app.js`
- `git diff --check`
- `npm test`

Fixes loo469/historia#1350
