### PR TITLE
Alpha: Add post-closure relapse watchlist

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -42,3 +42,15 @@ test('atlas military compares attempted closure choices against the recommendati
   assert.match(stylesSource, /\.atlas-military-closure-after-action__panel/);
   assert.match(stylesSource, /\.atlas-military-closure-after-action-row\.is-alternative circle/);
 });
+
+test('atlas military renders a post-closure relapse watchlist from visible closure risks', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryPostClosureRelapseWatchlist\(comparison, recommendation\)/);
+  assert.match(webAppSource, /Watchlist post-clôture des rechutes provinciales/);
+  assert.match(webAppSource, /À recontrôler/);
+  assert.match(webAppSource, /capacité à confirmer au tour suivant/);
+  assert.match(webAppSource, /fenêtre météo peut rouvrir le front/);
+  assert.match(webAppSource, /data-atlas-post-closure-watch/);
+  assert.match(webAppSource, /renderAtlasMilitaryPostClosureRelapseWatchlist\(postClosureRelapseWatchlist\)/);
+  assert.match(stylesSource, /\.atlas-military-post-closure-watchlist__panel/);
+  assert.match(stylesSource, /\.atlas-military-post-closure-watchlist-row--fragile circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2105,6 +2105,85 @@ function renderAtlasMilitaryClosureAfterActionComparison(comparison) {
   `;
 }
 
+
+function getAtlasMilitaryRelapseWatchStatus(row, index) {
+  if (row.blockerType === 'unknown') return 'à surveiller';
+  if (row.primary && index === 0 && !row.remainingRisk.includes('fragile')) return 'stable';
+  if (row.blockerType === 'climate' || row.blockerType === 'culture') return 'fragile';
+  return 'à surveiller';
+}
+
+function getAtlasMilitaryRelapseWatchReason(row) {
+  if (row.blockerType === 'logistics') return 'capacité à confirmer au tour suivant';
+  if (row.blockerType === 'intel') return 'brouillard à lever avant reprise';
+  if (row.blockerType === 'climate') return 'fenêtre météo peut rouvrir le front';
+  if (row.blockerType === 'culture') return 'adhésion locale encore sensible';
+  return 'cause visible insuffisante: contrôle léger';
+}
+
+function buildAtlasMilitaryPostClosureRelapseWatchlist(comparison, recommendation) {
+  const comparisonRows = comparison?.rows ?? [];
+  const recommendationOptions = recommendation?.options ?? [];
+  if ((!comparisonRows.length || comparison?.empty) && (!recommendationOptions.length || recommendation?.empty)) {
+    return {
+      items: [],
+      summary: 'Surveillance post-clôture indisponible: aucune province fermée visible.',
+      empty: true,
+    };
+  }
+
+  const mergedRows = [...comparisonRows];
+  recommendationOptions.forEach((option) => {
+    if (mergedRows.some((row) => row.provinceLabel === option.provinceLabel)) return;
+    mergedRows.push({
+      provinceLabel: option.provinceLabel,
+      blockerType: option.blockerType,
+      attempted: option.previousDecision || option.nextAction,
+      recommended: option.nextAction,
+      remainingRisk: getAtlasMilitaryClosureRemainingRisk(option),
+      primary: false,
+    });
+  });
+
+  const items = mergedRows.slice(0, 3).map((row, index) => {
+    const status = getAtlasMilitaryRelapseWatchStatus(row, index);
+    return {
+      watchId: `post-closure-relapse:${row.provinceLabel}:${index}`,
+      provinceLabel: row.provinceLabel,
+      blockerType: row.blockerType,
+      status,
+      statusKey: status === 'stable' ? 'stable' : status === 'fragile' ? 'fragile' : 'surveiller',
+      reason: getAtlasMilitaryRelapseWatchReason(row),
+      nextCheck: status === 'stable' ? 'recontrôle léger' : status === 'fragile' ? 'priorité prochain tour' : 'vérifier signal visible',
+      remainingRisk: row.remainingRisk,
+    };
+  });
+
+  return {
+    items,
+    summary: `${items.length} province${items.length > 1 ? 's' : ''} à recontrôler après clôture: ${items.map((item) => `${item.provinceLabel} ${item.status}`).join(', ')}.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryPostClosureRelapseWatchlist(watchlist) {
+  const height = watchlist.empty ? 6.8 : 5.6 + (watchlist.items.length * 4.05);
+  return `
+    <g class="atlas-military-post-closure-watchlist" aria-label="Watchlist post-clôture des rechutes provinciales: ${watchlist.summary}">
+      <rect class="atlas-military-post-closure-watchlist__panel" x="43" y="121" width="35" height="${height}" rx="2.1"></rect>
+      <text class="atlas-military-post-closure-watchlist__title" x="44.2" y="123.4">À recontrôler</text>
+      ${watchlist.empty ? `<text class="atlas-military-post-closure-watchlist__empty" x="44.2" y="126.2">${watchlist.summary}</text>` : watchlist.items.map((row, index) => `
+        <g class="atlas-military-post-closure-watchlist-row atlas-military-post-closure-watchlist-row--${row.blockerType} atlas-military-post-closure-watchlist-row--${row.statusKey}" data-atlas-post-closure-watch="${row.watchId}" aria-label="${row.provinceLabel}: ${row.status}; raison ${row.reason}; prochain contrôle ${row.nextCheck}; ${row.remainingRisk}">
+          <circle cx="44.8" cy="${125.7 + index * 4.05}" r="0.64"></circle>
+          <text class="atlas-military-post-closure-watchlist-row__province" x="46" y="${125.1 + index * 4.05}">${row.provinceLabel} · ${row.status}</text>
+          <text class="atlas-military-post-closure-watchlist-row__reason" x="46" y="${126.45 + index * 4.05}">${row.reason}</text>
+          <text class="atlas-military-post-closure-watchlist-row__check" x="46" y="${127.8 + index * 4.05}">${row.nextCheck}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function getAtlasMilitaryBlockingHandoffDecision(item, confidence) {
   if (!item) return 'attente: visibilité insuffisante';
   if (item.kind === 'obligatoire' && item.dependencies?.includes('logistique')) return 'renfort: sécuriser logistique';
@@ -3165,6 +3244,7 @@ function renderAtlasMilitaryLayer(shell) {
   const blockerResolutionChecklist = buildAtlasMilitaryBlockerResolutionChecklist(carryOverConfidenceHandoff);
   const nextBestClosureRecommendation = buildAtlasMilitaryNextBestClosureRecommendation(blockerResolutionChecklist);
   const closureAfterActionComparison = buildAtlasMilitaryClosureAfterActionComparison(nextBestClosureRecommendation);
+  const postClosureRelapseWatchlist = buildAtlasMilitaryPostClosureRelapseWatchlist(closureAfterActionComparison, nextBestClosureRecommendation);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -3204,6 +3284,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryBlockerResolutionChecklist(blockerResolutionChecklist)}
       ${renderAtlasMilitaryNextBestClosureRecommendation(nextBestClosureRecommendation)}
       ${renderAtlasMilitaryClosureAfterActionComparison(closureAfterActionComparison)}
+      ${renderAtlasMilitaryPostClosureRelapseWatchlist(postClosureRelapseWatchlist)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13720,3 +13720,38 @@ button { font: inherit; }
 .atlas-military-closure-after-action-row--intel circle { fill: rgba(168, 85, 247, 0.82); }
 .atlas-military-closure-after-action-row--culture circle { fill: rgba(244, 114, 182, 0.82); }
 .atlas-military-closure-after-action-row--unknown circle { fill: rgba(148, 163, 184, 0.78); }
+
+.atlas-military-post-closure-watchlist__panel {
+  fill: rgba(69, 26, 3, 0.78);
+  stroke: rgba(251, 191, 36, 0.42);
+  stroke-width: 0.28;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.42));
+}
+.atlas-military-post-closure-watchlist__title,
+.atlas-military-post-closure-watchlist-row text,
+.atlas-military-post-closure-watchlist__empty {
+  fill: #fef3c7;
+  font-size: 0.72px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.22;
+}
+.atlas-military-post-closure-watchlist-row circle {
+  fill: rgba(251, 191, 36, 0.82);
+  stroke: rgba(255, 251, 235, 0.72);
+  stroke-width: 0.13;
+}
+.atlas-military-post-closure-watchlist-row__reason,
+.atlas-military-post-closure-watchlist-row__check,
+.atlas-military-post-closure-watchlist__empty {
+  fill: #fde68a;
+  font-size: 0.46px;
+}
+.atlas-military-post-closure-watchlist-row--stable circle { fill: rgba(74, 222, 128, 0.82); }
+.atlas-military-post-closure-watchlist-row--fragile circle { fill: rgba(251, 191, 36, 0.86); }
+.atlas-military-post-closure-watchlist-row--surveiller circle { fill: rgba(96, 165, 250, 0.82); }
+.atlas-military-post-closure-watchlist-row--logistics circle { stroke: rgba(125, 211, 252, 0.78); }
+.atlas-military-post-closure-watchlist-row--climate circle { stroke: rgba(134, 239, 172, 0.78); }
+.atlas-military-post-closure-watchlist-row--intel circle { stroke: rgba(216, 180, 254, 0.78); }
+.atlas-military-post-closure-watchlist-row--culture circle { stroke: rgba(251, 207, 232, 0.78); }


### PR DESCRIPTION
Alpha: Implements #1346.\n\nSummary:\n- Adds a compact post-closure relapse watchlist after the closure after-action comparison.\n- Highlights up to three provinces/fronts to recheck next turn with stable/fragile/watch statuses and fog-safe reasons.\n- Reuses visible closure recommendation/comparison signals; no new simulation state.\n\nValidation:\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- node --check web/app.js\n- git diff --check\n- npm test