### PR TITLE
Gamma: Add cultural follow-through ageing priority

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -957,6 +957,47 @@ function buildCulturalRotationCommitmentSummary(recommendationRotationPreview, p
 }
 
 
+function buildCulturalFollowThroughAgePriority(recentCommitment, matchingCurrent, selected, turn = 1) {
+  if (!recentCommitment) {
+    return {
+      state: selected ? 'next-choice' : 'none',
+      label: selected ? 'nouvelle priorité' : 'aucun engagement actif',
+      ageTurns: 0,
+      priority: selected ? 1 : 0,
+      relevance: selected ? 'orienter le prochain choix sans masquer les nouvelles opportunités' : 'aucune promesse culturelle active à vieillir',
+      almostExpired: false,
+      stale: false,
+    };
+  }
+
+  const ageTurns = Math.max(0, Number.isFinite(recentCommitment.turn) ? turn - recentCommitment.turn : 1);
+  const currentStillRelevant = matchingCurrent && matchingCurrent.clusterLabel === recentCommitment.clusterLabel;
+  const rotationState = matchingCurrent?.rotationState ?? 'missing';
+  const almostExpired = ageTurns >= 2 || rotationState === 'deferred-freshness' || rotationState === 'review-soon';
+  const stale = ageTurns >= 3 || rotationState === 'excluded-context' || !currentStillRelevant;
+  const priority = stale
+    ? 1
+    : almostExpired
+      ? 3
+      : matchingCurrent?.rotationState === 'available-now'
+        ? 4
+        : 2;
+
+  return {
+    state: stale ? 'stale' : almostExpired ? 'expiring' : 'current',
+    label: stale ? 'pertinence perdue' : almostExpired ? 'presque périmé' : 'suivi actif',
+    ageTurns,
+    priority,
+    relevance: stale
+      ? 'ne pas laisser cet ancien rappel masquer les opportunités fraîches'
+      : almostExpired
+        ? 'valider maintenant ou remplacer par une opportunité plus fraîche'
+        : 'suivi encore utile si un signal visible confirme la promesse',
+    almostExpired,
+    stale,
+  };
+}
+
 function buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary, promptHistoryDrawer, turn = 1) {
   const recentCommitment = promptHistoryDrawer.groups
     .flatMap((group) => group.entries)
@@ -968,6 +1009,8 @@ function buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary,
     ?? null;
 
   if (!recentCommitment) {
+    const agePriority = buildCulturalFollowThroughAgePriority(null, null, selected, turn);
+
     return {
       state: 'fallback',
       reminderId: 'culture-commitment:follow-through:fallback',
@@ -975,6 +1018,8 @@ function buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary,
       sourcePromptLabel: null,
       clusterLabel: selected?.clusterLabel ?? null,
       lastTurn: null,
+      agePriority,
+      priorityLabel: `${agePriority.label} · priorité ${agePriority.priority}/4`,
       nextCheck: selected
         ? `Vérifier si ${selected.clusterLabel} peut encore suivre ${selected.promptLabel}.`
         : 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.',
@@ -988,20 +1033,27 @@ function buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary,
   const matchingCurrent = rotationCommitmentSummary.entries.find((entry) => entry.clusterLabel === recentCommitment.clusterLabel)
     ?? selected;
   const hasDependency = matchingCurrent?.hasUnresolvedDependencies === true;
+  const agePriority = buildCulturalFollowThroughAgePriority(recentCommitment, matchingCurrent, selected, turn);
 
   return {
-    state: hasDependency ? 'watch' : 'ready',
+    state: agePriority.stale ? 'stale' : hasDependency || agePriority.almostExpired ? 'watch' : 'ready',
     reminderId: `${recentCommitment.historyId}:follow-through-reminder`,
     summary: `${recentCommitment.clusterLabel}: engagement à suivre au tour ${followTurn} — ${recentCommitment.outcome}.`,
     sourcePromptLabel: recentCommitment.promptLabel,
     clusterLabel: recentCommitment.clusterLabel,
     lastTurn: recentCommitment.turn ?? null,
-    nextCheck: hasDependency
-      ? `Lever la dépendance avant de prolonger ${recentCommitment.promptLabel}.`
-      : `Confirmer que ${recentCommitment.promptLabel} produit encore un signal culturel visible.`,
+    agePriority,
+    priorityLabel: `${agePriority.label} · ${agePriority.ageTurns} tour${agePriority.ageTurns > 1 ? 's' : ''} · priorité ${agePriority.priority}/4`,
+    nextCheck: agePriority.stale
+      ? `Remplacer ou reconfirmer ${recentCommitment.promptLabel}: le rappel a perdu sa pertinence.`
+      : agePriority.almostExpired
+        ? `Décider ce tour si ${recentCommitment.promptLabel} mérite encore une action.`
+        : hasDependency
+          ? `Lever la dépendance avant de prolonger ${recentCommitment.promptLabel}.`
+          : `Confirmer que ${recentCommitment.promptLabel} produit encore un signal culturel visible.`,
     expectedAction: matchingCurrent
-      ? `${matchingCurrent.duration}; ${matchingCurrent.repeatPolicy}`
-      : 'réévaluer le suivi culturel sans répéter tout l’historique',
+      ? `${matchingCurrent.duration}; ${matchingCurrent.repeatPolicy}; ${agePriority.relevance}`
+      : `réévaluer le suivi culturel sans répéter tout l’historique; ${agePriority.relevance}`,
   };
 }
 
@@ -1268,6 +1320,16 @@ export function buildCultureTurnReportDeltas({
           sourcePromptLabel: null,
           clusterLabel: null,
           lastTurn: null,
+          agePriority: {
+            state: 'none',
+            label: 'aucun engagement actif',
+            ageTurns: 0,
+            priority: 0,
+            relevance: 'aucune promesse culturelle active à vieillir',
+            almostExpired: false,
+            stale: false,
+          },
+          priorityLabel: 'aucun engagement actif · priorité 0/4',
           nextCheck: 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.',
           expectedAction: 'attendre un engagement culturel explicite avant de rappeler une promesse',
         },

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -363,11 +363,89 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       sourcePromptLabel: null,
       clusterLabel: 'Compact d’Aurora',
       lastTurn: null,
+      agePriority: {
+        state: 'next-choice',
+        label: 'nouvelle priorité',
+        ageTurns: 0,
+        priority: 1,
+        relevance: 'orienter le prochain choix sans masquer les nouvelles opportunités',
+        almostExpired: false,
+        stale: false,
+      },
+      priorityLabel: 'nouvelle priorité · priorité 1/4',
       nextCheck: 'Vérifier si Compact d’Aurora peut encore suivre Ouvrir le récit d’expansion.',
       expectedAction: 'attendre un engagement culturel explicite avant de rappeler une promesse',
     },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
+});
+
+
+test('buildCultureTurnReportDeltas marks stale cultural follow-through reminders behind fresher opportunities', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 12,
+    selectedRegionId: 'harbor',
+    selectedMarker: {
+      overlayId: 'harbor:culture-aurora',
+      regionId: 'harbor',
+      cultureName: 'Harbor Compact',
+      influenceTier: 'strong',
+      influenceScore: 78,
+      discoveries: ['harbor-forum'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'amplifier',
+        consequencePreview: {
+          confidence: 'high',
+          opportunity: 'forum portuaire prêt',
+          summary: 'amplifier: forum portuaire prêt.',
+          visibleMarkerIds: ['harbor:culture-aurora:event:forum'],
+        },
+      },
+    },
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'chosen',
+        outcome: 'forum ancien à confirmer',
+      },
+    ],
+    activeRecommendations: [
+      {
+        recommendationId: 'harbor:momentum:surge:stabilization',
+        regionId: 'harbor',
+        cultureName: 'Harbor Compact',
+        action: 'amplifier',
+        tone: 'opportunity',
+        level: 'surging',
+        discoveryId: 'harbor-forum',
+        confidence: 'high',
+        supportKey: 'amplifier',
+        markerIds: ['harbor-marker'],
+        rank: 1,
+      },
+    ],
+  });
+
+  assert.equal(report.commitmentBundles.commitmentFollowThroughReminder.state, 'stale');
+  assert.deepEqual(report.commitmentBundles.commitmentFollowThroughReminder.agePriority, {
+    state: 'stale',
+    label: 'pertinence perdue',
+    ageTurns: 4,
+    priority: 1,
+    relevance: 'ne pas laisser cet ancien rappel masquer les opportunités fraîches',
+    almostExpired: true,
+    stale: true,
+  });
+  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.nextCheck, /Remplacer ou reconfirmer/);
+  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.expectedAction, /opportunités fraîches/);
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -455,6 +533,16 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         sourcePromptLabel: null,
         clusterLabel: null,
         lastTurn: null,
+        agePriority: {
+          state: 'none',
+          label: 'aucun engagement actif',
+          ageTurns: 0,
+          priority: 0,
+          relevance: 'aucune promesse culturelle active à vieillir',
+          almostExpired: false,
+          stale: false,
+        },
+        priorityLabel: 'aucun engagement actif · priorité 0/4',
         nextCheck: 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.',
         expectedAction: 'attendre un engagement culturel explicite avant de rappeler une promesse',
       },
@@ -709,6 +797,7 @@ test('buildCultureTurnReportDeltas summarizes coherence tensions between active 
 
 test('buildCultureTurnReportDeltas groups compatible and incompatible cultural commitment bundles', () => {
   const report = buildCultureTurnReportDeltas({
+    turn: 8,
     selectedRegionId: 'river-gate',
     selectedMarker: {
       overlayId: 'river-gate:culture-aurora',
@@ -871,6 +960,16 @@ test('buildCultureTurnReportDeltas groups compatible and incompatible cultural c
   assert.match(report.commitmentBundles.rotationCommitmentSummary.entries[1].repeatPolicy, /dépriorisé/);
   assert.equal(report.commitmentBundles.commitmentFollowThroughReminder.state, 'watch');
   assert.match(report.commitmentBundles.commitmentFollowThroughReminder.summary, /engagement à suivre au tour 8/);
-  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.nextCheck, /dépendance/);
-  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.expectedAction, /dépriorisé/);
+  assert.deepEqual(report.commitmentBundles.commitmentFollowThroughReminder.agePriority, {
+    state: 'expiring',
+    label: 'presque périmé',
+    ageTurns: 1,
+    priority: 3,
+    relevance: 'valider maintenant ou remplacer par une opportunité plus fraîche',
+    almostExpired: true,
+    stale: false,
+  });
+  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.priorityLabel, /presque périmé · 1 tour · priorité 3\/4/);
+  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.nextCheck, /Décider ce tour/);
+  assert.match(report.commitmentBundles.commitmentFollowThroughReminder.expectedAction, /opportunité plus fraîche/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6673,6 +6673,7 @@ function renderCultureTurnReport(report) {
       <div class="culture-turn-report__follow-through culture-turn-report__follow-through--${report.commitmentBundles?.commitmentFollowThroughReminder?.state ?? 'fallback'}" aria-label="Rappel d’engagement culturel à suivre">
         <span>Engagement à suivre</span>
         <strong>${report.commitmentBundles?.commitmentFollowThroughReminder?.summary ?? 'Aucun engagement culturel récent traçable: afficher le prochain choix recommandé sans inventer de promesse passée.'}</strong>
+        <small>Âge/priorité: ${report.commitmentBundles?.commitmentFollowThroughReminder?.priorityLabel ?? 'aucun engagement actif · priorité 0/4'}</small>
         <small>Prochaine vérification: ${report.commitmentBundles?.commitmentFollowThroughReminder?.nextCheck ?? 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.'}</small>
         <small>Action attendue: ${report.commitmentBundles?.commitmentFollowThroughReminder?.expectedAction ?? 'attendre un engagement culturel explicite avant de rappeler une promesse'}</small>
       </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2010,6 +2010,7 @@ button { font: inherit; }
 .culture-turn-report__follow-through small { color: var(--muted); }
 .culture-turn-report__follow-through--ready { border-color: rgba(74, 222, 128, 0.3); }
 .culture-turn-report__follow-through--watch { border-color: rgba(251, 191, 36, 0.42); }
+.culture-turn-report__follow-through--stale { border-color: rgba(248, 113, 113, 0.45); }
 .culture-turn-report__follow-through--fallback { border-color: rgba(148, 163, 184, 0.24); }
 .culture-turn-report__history {
   display: grid;


### PR DESCRIPTION
Gamma: Fixes #1348.

Résumé:
- ajoute un score âge/priorité aux rappels d'engagement culturel à suivre;
- signale les rappels presque périmés ou devenus moins pertinents;
- garde la rotation/fraîcheur existante comme critère pour ne pas masquer les opportunités nouvelles;
- affiche l'âge/priorité dans le rapport culturel.

Tests:
- npm test
- node --check web/app.js
- git diff --check

Zeta, peux-tu valider avant tout merge ?