### PR TITLE
Delta: Compare intrigue stabilization timing

### DIFF
--- a/src/ui/intrigue/buildIntrigueMapOverlay.js
+++ b/src/ui/intrigue/buildIntrigueMapOverlay.js
@@ -3187,8 +3187,98 @@ function buildStabilizationWaitCostHint({ recommendedPosture, resolvedEnough = f
   };
 }
 
+function buildStabilizationTimingComparison({ recommendedPosture, waitCostHint, firstBudgetBlock = null, masked = false }) {
+  if (masked || waitCostHint.state === 'insufficient-information') {
+    return {
+      state: 'short-wait-recommended',
+      recommendedTiming: 'short-wait',
+      waitRecommended: true,
+      urgency: 'temper',
+      dominantReason: 'information-manquante',
+      label: 'Attendre court réduit le risque',
+      actNow: {
+        outcome: 'Stabiliser maintenant resterait trop opaque.',
+        risk: 'peut figer une lecture sans provenance sûre',
+      },
+      shortWait: {
+        outcome: 'Attendre un signal fog-safe rend la stabilisation plus fiable.',
+        risk: 'signal peut périmer si aucun indice ne revient',
+      },
+      summary: 'Temporiser est recommandé: l’information manquante domine le coût d’opportunité visible.',
+    };
+  }
+
+  if (recommendedPosture !== 'stabilize') {
+    const exposureDriven = firstBudgetBlock?.blockedBy === 'insufficient-budget' || waitCostHint.waitCostLevel === 'high';
+
+    return {
+      state: 'short-wait-recommended',
+      recommendedTiming: 'short-wait',
+      waitRecommended: true,
+      urgency: 'temper',
+      dominantReason: exposureDriven ? 'exposition' : 'coût-opportunité',
+      label: exposureDriven ? 'Attendre court baisse l’exposition' : 'Attendre court clarifie le coût',
+      actNow: {
+        outcome: 'Agir maintenant risque de payer une relance trop chère.',
+        risk: exposureDriven ? 'exposition/budget visible défavorable' : 'gain visible trop faible',
+      },
+      shortWait: {
+        outcome: 'Attendre un tour peut rouvrir une fenêtre moins coûteuse.',
+        risk: 'priorité surveillée sans révéler de cible cachée',
+      },
+      summary: exposureDriven
+        ? 'Temporiser est meilleur maintenant: l’exposition domine la décision visible.'
+        : 'Temporiser est meilleur maintenant: le coût d’opportunité dépasse le gain immédiat.',
+    };
+  }
+
+  if (waitCostHint.state === 'immediate-risk') {
+    return {
+      state: 'act-now-urgent',
+      recommendedTiming: 'act-now',
+      waitRecommended: false,
+      urgency: 'urgent',
+      dominantReason: 'fenêtre-adverse',
+      label: 'Agir maintenant évite une dégradation rapide',
+      actNow: {
+        outcome: 'Stabiliser verrouille la fenêtre sûre visible.',
+        risk: '0 exposition ajoutée',
+      },
+      shortWait: {
+        outcome: 'Attendre peut laisser la fenêtre adverse se refermer.',
+        risk: 'priorité instable et recheck plus coûteux',
+      },
+      summary: 'Choix urgent: la fenêtre visible se dégrade plus vite que le bénéfice d’attendre.',
+    };
+  }
+
+  return {
+    state: 'act-now-preferred',
+    recommendedTiming: 'act-now',
+    waitRecommended: false,
+    urgency: 'watch',
+    dominantReason: 'coût-opportunité',
+    label: 'Agir maintenant évite une dette de suivi',
+    actNow: {
+      outcome: 'Stabiliser maintenant clôt la boucle sans nouvelle exposition.',
+      risk: 'risque immédiat faible',
+    },
+    shortWait: {
+      outcome: 'Attendre reste possible mais rend le suivi moins net.',
+      risk: 'signal vieilli ou re-vérification plus chère',
+    },
+    summary: 'Agir maintenant reste préférable: l’attente est tolérée, pas recommandée.',
+  };
+}
+
+
 function buildPostRecapStabilizationChoices({ locationId, locationName, intrigueEscalationOutcomeRecap }) {
   if (intrigueEscalationOutcomeRecap.state === 'masked-outcome-recap') {
+    const waitCostHint = buildStabilizationWaitCostHint({
+      recommendedPosture: 'observe',
+      masked: true,
+    });
+
     return {
       state: 'masked-stabilization-choices',
       locationId,
@@ -3222,8 +3312,10 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
           reason: choice.safeReason,
         }),
       })),
-      waitCostHint: buildStabilizationWaitCostHint({
+      waitCostHint,
+      timingComparison: buildStabilizationTimingComparison({
         recommendedPosture: 'observe',
+        waitCostHint,
         masked: true,
       }),
       summary: 'Posture post-récap: observer, car le brouillard masque encore la provenance sûre.',
@@ -3332,6 +3424,15 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
       }
       : null;
 
+  const waitCostHint = buildStabilizationWaitCostHint({
+    recommendedPosture,
+    resolvedEnough,
+    hasOnlyCalmOutcomes,
+    shouldObserve,
+    firstBudgetBlock,
+    primaryChoice,
+  });
+
   return {
     state: recommendedPosture === 'stabilize'
       ? 'stabilization-recommended'
@@ -3355,13 +3456,11 @@ function buildPostRecapStabilizationChoices({ locationId, locationName, intrigue
         reason: choice.safeReason,
       }),
     })),
-    waitCostHint: buildStabilizationWaitCostHint({
+    waitCostHint,
+    timingComparison: buildStabilizationTimingComparison({
       recommendedPosture,
-      resolvedEnough,
-      hasOnlyCalmOutcomes,
-      shouldObserve,
+      waitCostHint,
       firstBudgetBlock,
-      primaryChoice,
     }),
     summary: recommendedPosture === 'stabilize'
       ? 'Posture post-récap: stabiliser ou surveiller, sans relancer une boucle de vérification.'

--- a/test/ui/intrigue/buildIntrigueMapOverlay.test.js
+++ b/test/ui/intrigue/buildIntrigueMapOverlay.test.js
@@ -2797,6 +2797,10 @@ test('buildIntrigueMapOverlay recommends post-recap stabilization choices withou
   assert.equal(stable.waitCostHint.waitCostLevel, 'medium');
   assert.match(stable.waitCostHint.latentRisk, /re-vérification ultérieure/);
   assert.ok(stable.waitCostHint.worsensIfWaiting.includes('fraîcheur du signal'));
+  assert.equal(stable.timingComparison.state, 'act-now-preferred');
+  assert.equal(stable.timingComparison.recommendedTiming, 'act-now');
+  assert.equal(stable.timingComparison.waitRecommended, false);
+  assert.equal(stable.timingComparison.dominantReason, 'coût-opportunité');
 
   assert.equal(budget.state, 'observation-recommended');
   assert.equal(budget.recommendedPosture, 'observe');
@@ -2811,6 +2815,11 @@ test('buildIntrigueMapOverlay recommends post-recap stabilization choices withou
   assert.equal(budget.waitCostHint.state, 'immediate-risk');
   assert.equal(budget.waitCostHint.waitCostLevel, 'high');
   assert.match(budget.waitCostHint.immediateRisk, /Budget\/provenance fragiles/);
+  assert.equal(budget.timingComparison.state, 'short-wait-recommended');
+  assert.equal(budget.timingComparison.recommendedTiming, 'short-wait');
+  assert.equal(budget.timingComparison.waitRecommended, true);
+  assert.equal(budget.timingComparison.dominantReason, 'exposition');
+  assert.match(budget.timingComparison.shortWait.outcome, /fenêtre moins coûteuse/);
 
   assert.equal(masked.state, 'masked-stabilization-choices');
   assert.equal(masked.recommendedPosture, 'observe');
@@ -2820,5 +2829,9 @@ test('buildIntrigueMapOverlay recommends post-recap stabilization choices withou
   assert.equal(masked.waitCostHint.state, 'insufficient-information');
   assert.equal(masked.waitCostHint.waitCostLevel, 'unknown');
   assert.match(masked.waitCostHint.summary, /Attendre reste plus sûr/);
+  assert.equal(masked.timingComparison.state, 'short-wait-recommended');
+  assert.equal(masked.timingComparison.dominantReason, 'information-manquante');
+  assert.equal(masked.timingComparison.waitRecommended, true);
+  assert.match(masked.timingComparison.actNow.risk, /provenance sûre/);
   assert.match(masked.safeMapPolicy, /ne .*révélée/);
 });


### PR DESCRIPTION
Delta: ## Summary
- Add a compact act-now vs short-wait timing comparison for post-recap intrigue stabilization choices.
- Surface dominant reasons such as missing information, exposure, adverse window, and opportunity cost.
- Mark short-wait recommended states separately from act-now preferred/urgent states while preserving fog-safe copy.

## Tests
- npm test -- test/ui/intrigue/buildIntrigueMapOverlay.test.js
- npm test

Closes #1359
