### PR TITLE
Epsilon: Recommend next climate readiness threshold

### DIFF
--- a/test/ui/climate/webAtlasClimateNextReadinessThreshold.test.js
+++ b/test/ui/climate/webAtlasClimateNextReadinessThreshold.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas recommends the next climate readiness threshold from map hints', () => {
+  assert.match(webAppSource, /function buildAtlasClimateNextReadinessThreshold/);
+  assert.match(webAppSource, /function renderAtlasClimateNextReadinessThreshold/);
+  assert.match(webAppSource, /seuil capacité \+1 équipe prête/);
+  assert.match(webAppSource, /seuil coordination régionale confirmée/);
+  assert.match(webAppSource, /seuil délai: jalon avancé avant saison critique/);
+  assert.match(webAppSource, /catastrophe évitée/);
+  assert.match(webAppSource, /délai gagné/);
+  assert.match(webAppSource, /région protégée/);
+  assert.match(webAppSource, /mythe stabilisé/);
+  assert.match(webAppSource, /petit investissement sans effet de seuil immédiat/);
+  assert.match(webAppSource, /Sans effet immédiat/);
+  assert.match(webAppSource, /buildAtlasClimateNextReadinessThreshold\(\s*atlasClimateReadinessConsequenceHints/);
+  assert.match(webAppSource, /renderAtlasClimateNextReadinessThreshold\(atlasClimateNextReadinessThreshold\)/);
+
+  assert.match(stylesSource, /\.map-world-climate-next-threshold/);
+  assert.match(stylesSource, /\.map-world-climate-next-threshold--threshold-tight/);
+  assert.match(stylesSource, /\.map-world-climate-next-threshold--no-threshold-change/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -9924,6 +9924,93 @@ function renderAtlasClimateReadinessConsequenceHints(view) {
   `;
 }
 
+function buildAtlasClimateNextReadinessThreshold(consequenceView, boostView, postBoostView) {
+  if (!consequenceView || consequenceView.state !== 'warning' || consequenceView.hints.length === 0) {
+    return {
+      state: 'empty',
+      recommendation: null,
+      noEffectSignals: [],
+      summary: 'Aucun prochain seuil readiness climat à recommander depuis la carte.',
+    };
+  }
+
+  const boostsByProvince = new Map((boostView?.boosts ?? []).map((boost) => [boost.provinceId, boost]));
+  const postBoostByProvince = new Map((postBoostView?.previews ?? []).map((preview) => [preview.provinceId, preview]));
+  const thresholdBySystem = {
+    'capacité mitigation régionale': 'seuil capacité +1 équipe prête',
+    'corridor régional partagé': 'seuil coordination régionale confirmée',
+    'fenêtre saisonnière': 'seuil délai: jalon avancé avant saison critique',
+    'stock logistique climat': 'seuil réserve climat verrouillée',
+  };
+  const benefitBySystem = {
+    'capacité mitigation régionale': 'catastrophe évitée: cascade voisine contenue avant saturation de carte.',
+    'corridor régional partagé': 'région protégée: le corridor partagé cesse de propager le risque.',
+    'fenêtre saisonnière': 'délai gagné: une fenêtre d’action redevient lisible avant la saison critique.',
+    'stock logistique climat': 'mythe stabilisé: le récit de crise ne s’aggrave pas faute de ressource visible.',
+  };
+  const outcomeWeight = { executable: 3, 'still-tight': 2, insufficient: 1 };
+  const recommendations = consequenceView.hints
+    .map((hint) => {
+      const boost = boostsByProvince.get(hint.provinceId);
+      const preview = postBoostByProvince.get(hint.provinceId);
+      const outcome = preview?.outcome ?? 'insufficient';
+      const noImmediateThresholdChange = outcome === 'insufficient';
+      return {
+        provinceId: hint.provinceId,
+        provinceLabel: hint.provinceLabel,
+        status: hint.status,
+        deadline: hint.deadline,
+        threshold: thresholdBySystem[hint.threatenedSystem] ?? 'seuil readiness minimal confirmé',
+        expectedBenefit: benefitBySystem[hint.threatenedSystem] ?? hint.likelyMapEffect,
+        investment: boost?.smallestBoost ?? hint.followUpAction,
+        outcome,
+        noImmediateThresholdChange,
+        signal: noImmediateThresholdChange
+          ? 'petit investissement sans effet de seuil immédiat'
+          : outcome === 'still-tight'
+            ? 'seuil franchi mais marge courte'
+            : 'seuil franchi avec bénéfice lisible',
+        reason: hint.priorityReason,
+      };
+    })
+    .sort((left, right) => outcomeWeight[right.outcome] - outcomeWeight[left.outcome] || (left.noImmediateThresholdChange ? 1 : 0) - (right.noImmediateThresholdChange ? 1 : 0) || left.deadline.localeCompare(right.deadline));
+
+  const recommendation = recommendations.find((candidate) => !candidate.noImmediateThresholdChange) ?? recommendations[0];
+  const noEffectSignals = recommendations
+    .filter((candidate) => candidate.noImmediateThresholdChange)
+    .slice(0, 2);
+
+  return {
+    state: recommendation.noImmediateThresholdChange ? 'no-threshold-change' : recommendation.outcome === 'still-tight' ? 'threshold-tight' : 'threshold-ready',
+    recommendation,
+    noEffectSignals,
+    summary: recommendation.noImmediateThresholdChange
+      ? `${recommendation.provinceLabel}: aucun petit investissement ne change un seuil immédiatement; escalader avant de promettre un bénéfice carte.`
+      : `${recommendation.provinceLabel}: prochain seuil recommandé (${recommendation.threshold}) avec bénéfice carte immédiat.`,
+  };
+}
+
+function renderAtlasClimateNextReadinessThreshold(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty' || !view.recommendation) {
+    return '';
+  }
+
+  const recommendation = view.recommendation;
+  return `
+    <aside class="map-world-climate-next-threshold map-world-climate-next-threshold--${view.state}" aria-label="Prochain seuil de préparation climatique recommandé">
+      <div class="map-world-climate-next-threshold__header">
+        <strong>Prochain seuil readiness</strong>
+        <span>${recommendation.signal}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>${recommendation.provinceLabel}</b> · ${recommendation.deadline} · ${recommendation.threshold}</small>
+      <small><b>Bénéfice attendu</b> · ${recommendation.expectedBenefit}</small>
+      <small><b>Investissement lisible</b> · ${recommendation.investment}</small>
+      ${view.noEffectSignals.length > 0 ? `<small><b>Sans effet immédiat</b> · ${view.noEffectSignals.map((signal) => `${signal.provinceLabel}: ${signal.threshold}`).join(' | ')}</small>` : ''}
+    </aside>
+  `;
+}
+
 function buildAtlasClimateReadinessBoostReliefRanking(postBoostView) {
   if (!postBoostView || postBoostView.state === 'empty' || postBoostView.previews.length === 0) {
     return {
@@ -20347,6 +20434,11 @@ function render() {
     atlasClimateReadinessBoostRecommendations,
     atlasClimatePostBoostDeadlineRiskPreview,
   );
+  const atlasClimateNextReadinessThreshold = buildAtlasClimateNextReadinessThreshold(
+    atlasClimateReadinessConsequenceHints,
+    atlasClimateReadinessBoostRecommendations,
+    atlasClimatePostBoostDeadlineRiskPreview,
+  );
   const atlasClimateReadinessBoostReliefRanking = buildAtlasClimateReadinessBoostReliefRanking(atlasClimatePostBoostDeadlineRiskPreview);
   const atlasClimateMinimumViableBoostHint = buildAtlasClimateMinimumViableBoostHint(atlasClimateReadinessBoostReliefRanking);
   const atlasClimateMinimumBoostDeadlineMissWarning = buildAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumViableBoostHint);
@@ -20411,6 +20503,7 @@ function render() {
           ${renderAtlasClimateReadinessBoostRecommendations(atlasClimateReadinessBoostRecommendations)}
           ${renderAtlasClimatePostBoostDeadlineRiskPreview(atlasClimatePostBoostDeadlineRiskPreview)}
           ${renderAtlasClimateReadinessConsequenceHints(atlasClimateReadinessConsequenceHints)}
+          ${renderAtlasClimateNextReadinessThreshold(atlasClimateNextReadinessThreshold)}
           ${renderAtlasClimateReadinessBoostReliefRanking(atlasClimateReadinessBoostReliefRanking)}
           ${renderAtlasClimateMinimumViableBoostHint(atlasClimateMinimumViableBoostHint)}
           ${renderAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumBoostDeadlineMissWarning)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -12360,6 +12360,39 @@ button { font: inherit; }
 .map-world-climate-readiness-consequences__item--insufficient { border-color: rgba(251, 146, 60, 0.48); }
 .map-world-climate-readiness-consequences__item--too-late { border-color: rgba(248, 113, 113, 0.54); }
 
+.map-world-climate-next-threshold {
+  display: grid;
+  gap: 6px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.78), rgba(21, 128, 61, 0.18));
+  border: 1px solid rgba(110, 231, 183, 0.34);
+}
+.map-world-climate-next-threshold--threshold-tight { border-color: rgba(251, 191, 36, 0.46); }
+.map-world-climate-next-threshold--no-threshold-change { border-color: rgba(248, 113, 113, 0.52); }
+.map-world-climate-next-threshold__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-next-threshold p,
+.map-world-climate-next-threshold span,
+.map-world-climate-next-threshold small {
+  color: #dcfce7;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-next-threshold--threshold-tight p,
+.map-world-climate-next-threshold--threshold-tight span,
+.map-world-climate-next-threshold--threshold-tight small { color: #fef3c7; }
+.map-world-climate-next-threshold--no-threshold-change p,
+.map-world-climate-next-threshold--no-threshold-change span,
+.map-world-climate-next-threshold--no-threshold-change small { color: #fee2e2; }
+
 .atlas-cultural-border-zone__recommendation {
   fill: #ddd6fe;
   font-size: 0.86px;


### PR DESCRIPTION
Epsilon: ## Summary

Adds a compact next-threshold recommendation for visible climate readiness gaps so the player can see which climate effort should come next and what map benefit it unlocks.

## Changes

- Derives the next climate readiness threshold from existing consequence hints, boost recommendations, and post-boost deadline previews.
- Shows expected benefits such as catastrophe avoided, delay gained, region protected, or myth stabilized.
- Calls out small investments that do not immediately change any readiness threshold.
- Keeps the information inside the existing climate map recap stack with compact styling.

## Testing

- `node --test test/ui/climate/webAtlasClimateNextReadinessThreshold.test.js test/ui/climate/webAtlasClimateReadinessConsequenceHints.test.js test/ui/climate/webAtlasClimateReadinessBoostReliefRanking.test.js`
- `node --check web/app.js`
- `git diff --check`
- `npm test`

Fixes loo469/historia#1360
