### PR TITLE
Beta: Rank logistics recovery levers

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -509,6 +509,74 @@ function buildRecoveryPriorityActions(routeChoices) {
 }
 
 
+function buildRecoveryLeverRanking(routeChoices, priorityActions, hasBlocker) {
+  if (!hasBlocker || priorityActions.length === 0) {
+    return {
+      levers: [],
+      summary: hasBlocker
+        ? 'Aucun levier recovery utile: coûts ou risques évités trop incertains.'
+        : 'Aucun levier recovery à classer: logistique stable ou signaux insuffisants.',
+      empty: true,
+    };
+  }
+
+  const optionByRouteId = new Map(routeChoices.map((option) => [option.routeId, option]));
+  const candidates = priorityActions
+    .map((action) => {
+      const option = optionByRouteId.get(action.routeId) ?? null;
+      const choice = option?.recoveryChoices.find((candidate) => candidate.choiceId === action.choiceId) ?? null;
+      const criticalAvoided = Math.max(
+        action.shortagesAvoided,
+        choice?.downstreamShortages.filter((shortage) => shortage.status === 'aggravée' || shortage.status === 'déplacée').length ?? 0,
+      );
+      const capacityKey = `${action.resource}:${choice?.blocker ?? option?.cost ?? action.cost}`;
+      const avoidedRisk = criticalAvoided > 0
+        ? `${criticalAvoided} pénurie${criticalAvoided > 1 ? 's' : ''}/goulot${criticalAvoided > 1 ? 's' : ''} évité${criticalAvoided > 1 ? 's' : ''}`
+        : choice?.bottleneck?.tone === 'high'
+          ? `${choice.bottleneck.label} neutralisé avant rechute`
+          : `${action.downstreamStatus} contenu avant prochain tour`;
+
+      return {
+        leverId: `lever:${action.actionId}`,
+        label: action.action,
+        route: action.route,
+        resource: action.resource,
+        tone: action.tone,
+        primaryCost: action.cost,
+        avoidedRisk,
+        tradeoff: action.tradeoff,
+        blocker: choice?.blocker ?? 'capacité à confirmer',
+        capacityKey,
+        priorityScore: action.impactScore + criticalAvoided * 16,
+      };
+    })
+    .sort((left, right) => right.priorityScore - left.priorityScore || left.label.localeCompare(right.label))
+    .slice(0, 3);
+
+  const capacityCounts = candidates.reduce((counts, lever) => counts.set(lever.capacityKey, (counts.get(lever.capacityKey) ?? 0) + 1), new Map());
+  const levers = candidates.map((lever, index, ordered) => {
+    const conflict = ordered.find((candidate, candidateIndex) => candidateIndex !== index && candidate.capacityKey === lever.capacityKey) ?? null;
+    return {
+      ...lever,
+      rank: index + 1,
+      recommended: index === 0,
+      mutualBlocker: conflict
+        ? `Partage ${lever.resource}/${lever.blocker} avec ${conflict.label}: choisir l’un retarde l’autre.`
+        : (capacityCounts.get(lever.capacityKey) ?? 0) > 1
+          ? `Même capacité consommée par un autre levier ${lever.resource}.`
+          : 'Pas de blocage mutuel majeur détecté.',
+    };
+  });
+
+  return {
+    levers,
+    summary: levers.length > 0
+      ? `${levers[0].label} d’abord: coût ${levers[0].primaryCost}, risque évité ${levers[0].avoidedRisk}.`
+      : 'Aucun levier recovery utile: coûts ou risques évités trop incertains.',
+    empty: levers.length === 0,
+  };
+}
+
 function buildSelectedActionImpactPreview(priorityAction, routeChoices) {
   if (!priorityAction) {
     return {
@@ -604,7 +672,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const queuedLogisticsActions = Array.isArray(normalizedOptions.queuedLogisticsActions) ? normalizedOptions.queuedLogisticsActions : [];
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', selectedActionPreview: buildSelectedActionImpactPreview(null, []), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -639,6 +707,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       downstreamSummary: 'Aucune pénurie aval claire détectée.',
       priorityActions: [],
       prioritySummary: 'Aucune action logistique prioritaire disponible.',
+      recoveryLeverRanking: buildRecoveryLeverRanking([], [], false),
       selectedActionPreview: buildSelectedActionImpactPreview(null, []),
       primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions),
       status: 'stable',
@@ -651,6 +720,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const hasBlocker = routeChoices.some((choice) => choice.tone === 'high' || choice.tone === 'medium');
   const priorityActions = buildRecoveryPriorityActions(routeChoices);
   const recommendedPriority = priorityActions[0] ?? null;
+  const recoveryLeverRanking = buildRecoveryLeverRanking(routeChoices, priorityActions, hasBlocker);
   const selectedActionPreview = buildSelectedActionImpactPreview(recommendedPriority, routeChoices);
   const primaryLogisticsAction = buildPrimaryLogisticsQueueAction(recommendedPriority, selectedActionPreview, queuedLogisticsActions);
 
@@ -669,6 +739,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
     prioritySummary: recommendedPriority
       ? `${recommendedPriority.action} recommandée: ${recommendedPriority.reason} (${recommendedPriority.tradeoff}, ${recommendedPriority.delay}).`
       : 'Aucune action logistique prioritaire disponible.',
+    recoveryLeverRanking,
     selectedActionPreview,
     primaryLogisticsAction,
     status: hasBlocker ? recommended.tone : 'stable',

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -79,6 +79,11 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.ok(['aggravée', 'déplacée', 'résolue', 'inconnue'].includes(preview.downstreamStatus));
   assert.ok(preview.priorityActions.length >= 2);
   assert.equal(preview.priorityActions[0].recommended, true);
+  assert.equal(preview.recoveryLeverRanking.empty, false);
+  assert.ok(preview.recoveryLeverRanking.levers.length >= 2);
+  assert.equal(preview.recoveryLeverRanking.levers[0].recommended, true);
+  assert.match(preview.recoveryLeverRanking.summary, /coût|risque évité/i);
+  assert.ok(preview.recoveryLeverRanking.levers.every((lever) => lever.primaryCost.length > 0 && lever.avoidedRisk.length > 0 && lever.mutualBlocker.length > 0));
   assert.ok(preview.selectedActionPreview.badges.length <= 3);
   assert.match(preview.prioritySummary, /recommandée/);
   assert.ok(preview.priorityActions.some((action) => /rapide mais limitée|plus lente mais structurante|équilibrée/.test(action.tradeoff)));
@@ -143,6 +148,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.downstreamSummary, /Aucune pénurie aval/);
   assert.deepEqual(preview.priorityActions, []);
   assert.match(preview.prioritySummary, /Aucune action logistique prioritaire/);
+  assert.equal(preview.recoveryLeverRanking.empty, true);
+  assert.deepEqual(preview.recoveryLeverRanking.levers, []);
   assert.equal(preview.selectedActionPreview.status, 'empty');
   assert.deepEqual(preview.selectedActionPreview.badges, []);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
@@ -186,6 +193,7 @@ test('buildProvinceLogisticsChoicePreview exposes stable local route causes', ()
   assert.match(preview.options[0].recoveryChoices[0].bottleneck.detail, /Aucun ralentisseur/);
   assert.ok(preview.priorityActions.length >= 1);
   assert.equal(preview.priorityActions[0].recommended, true);
+  assert.equal(preview.recoveryLeverRanking.empty, true);
   assert.equal(preview.options[0].recoveryChoices[0].downstreamShortages[0].status, 'résolue');
   assert.match(preview.options[0].recoveryChoices[0].downstreamShortages[0].detail, /aucune pénurie aval/i);
 });

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -58,6 +58,12 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Priorité aval/);
   assert.match(webAppSource, /preview\.priorityActions/);
   assert.match(webAppSource, /action\.tradeoff/);
+  assert.match(webAppSource, /province-logistics-recovery-lever-ranking/);
+  assert.match(webAppSource, /Leviers recovery/);
+  assert.match(webAppSource, /preview\.recoveryLeverRanking/);
+  assert.match(webAppSource, /lever\.primaryCost/);
+  assert.match(webAppSource, /lever\.avoidedRisk/);
+  assert.match(webAppSource, /lever\.mutualBlocker/);
   assert.match(webAppSource, /province-logistics-impact-preview/);
   assert.match(webAppSource, /Impact si engagé/);
   assert.match(webAppSource, /selectedActionPreview/);

--- a/web/app.js
+++ b/web/app.js
@@ -7563,6 +7563,23 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
           `).join('')}
         </div>
       ` : ''}
+      ${preview.recoveryLeverRanking && !preview.recoveryLeverRanking.empty ? `
+        <div class="province-logistics-recovery-lever-ranking" aria-label="Classement compact des leviers recovery logistique">
+          <div class="province-logistics-recovery-lever-ranking__header">
+            <b>Leviers recovery</b>
+            <span>${preview.recoveryLeverRanking.summary}</span>
+          </div>
+          <ol>
+            ${preview.recoveryLeverRanking.levers.map((lever) => `
+              <li class="province-logistics-recovery-lever province-logistics-recovery-lever--${lever.tone} ${lever.recommended ? 'is-recommended' : ''}">
+                <strong>#${lever.rank} ${lever.label}</strong>
+                <span>Coût: ${lever.primaryCost} · Risque évité: ${lever.avoidedRisk}</span>
+                <small>${lever.tradeoff} · ${lever.mutualBlocker}</small>
+              </li>
+            `).join('')}
+          </ol>
+        </div>
+      ` : ''}
       <div class="province-logistics-queue-action province-logistics-queue-action--${preview.primaryLogisticsAction.status}" aria-label="Engager une action logistique depuis la carte">
         <div>
           <b>Action carte</b>


### PR DESCRIPTION
Beta: PR pour #1357.

J’ai ajouté un classement compact des leviers recovery logistique directement dans l’aperçu province:
- top 2-3 leviers issus des actions prioritaires existantes;
- coût principal + risque/goulot évité pour chaque levier;
- signal de blocage mutuel quand deux leviers partagent la même ressource/capacité;
- état silencieux quand aucune fragilité logistique utile n’est présente.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?