### PR TITLE
Gamma: Group cultural follow-through plans

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1057,6 +1057,85 @@ function buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary,
   };
 }
 
+
+function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder) {
+  const groups = promptHistoryDrawer.groups.map((group) => {
+    const currentEntries = group.entries.filter((entry) => entry.source === 'current');
+    const historyEntries = group.entries.filter((entry) => entry.source === 'history');
+    const matchingCommitment = rotationCommitmentSummary.entries.find((entry) => entry.clusterLabel === group.clusterLabel)
+      ?? null;
+    const isReminderGroup = commitmentFollowThroughReminder.clusterLabel === group.clusterLabel;
+    const agePriority = isReminderGroup ? commitmentFollowThroughReminder.agePriority : null;
+    const unlockScore = (agePriority?.priority ?? 0)
+      + (matchingCommitment && !matchingCommitment.hasUnresolvedDependencies ? 2 : 0)
+      + currentEntries.length
+      + Math.min(historyEntries.length, 2);
+    const firstDetail = currentEntries[0] ?? historyEntries[0] ?? null;
+
+    return {
+      bundleId: `${group.groupId}:follow-through-bundle`,
+      clusterLabel: group.clusterLabel,
+      theme: group.theme,
+      state: agePriority?.stale
+        ? 'stale'
+        : agePriority?.almostExpired
+          ? 'urgent'
+          : matchingCommitment?.rotationState === 'available-now'
+            ? 'ready'
+            : historyEntries.length > 0
+              ? 'watch'
+              : 'context',
+      summary: `${group.clusterLabel}: ${group.entries.length} suivi${group.entries.length > 1 ? 's' : ''} regroupé${group.entries.length > 1 ? 's' : ''} sur ${group.theme}.`,
+      groupingReason: historyEntries.length > 0 && currentEntries.length > 0
+        ? 'Même région et même thème: comparer la promesse récente avec le suivi proposé.'
+        : historyEntries.length > 1
+          ? 'Même thème récurrent: traiter ensemble avant de relancer une action.'
+          : currentEntries.length > 1
+            ? 'Même enjeu actif: choisir un premier suivi au lieu de lire chaque alerte.'
+            : 'Même enjeu culturel: garder le contexte visible sans grossir la file.',
+      unlockScore,
+      bestFirstFollowUp: matchingCommitment
+        ? `${matchingCommitment.promptLabel} — ${matchingCommitment.hasUnresolvedDependencies ? matchingCommitment.dependencyWarning : matchingCommitment.benefit}`
+        : firstDetail
+          ? `${firstDetail.promptLabel} — ${firstDetail.outcome ?? firstDetail.repeatReason ?? 'contexte à confirmer'}`
+          : 'Aucun premier suivi disponible.',
+      avoidedLoss: agePriority?.stale
+        ? 'évite de laisser un ancien suivi masquer une opportunité fraîche'
+        : agePriority?.almostExpired
+          ? 'évite de perdre la fenêtre avant le prochain tour'
+          : matchingCommitment?.benefit ?? 'préserve le contexte culturel groupé',
+      detailCount: group.entries.length,
+      details: group.entries.map((entry) => ({
+        detailId: entry.promptId ?? entry.historyId,
+        source: entry.source,
+        promptLabel: entry.promptLabel,
+        clusterLabel: entry.clusterLabel,
+        state: entry.source === 'history' ? entry.choiceState : entry.role,
+        note: entry.source === 'history' ? entry.outcome : entry.repeatReason,
+      })),
+    };
+  }).sort((left, right) => right.unlockScore - left.unlockScore || right.detailCount - left.detailCount || left.clusterLabel.localeCompare(right.clusterLabel));
+  const top = groups[0] ?? null;
+
+  return {
+    state: groups.length === 0
+      ? 'quiet'
+      : groups.some((group) => group.state === 'urgent' || group.state === 'stale')
+        ? 'actionable'
+        : groups.some((group) => group.state === 'ready')
+          ? 'ready'
+          : 'watch',
+    summary: groups.length === 0
+      ? 'Aucun plan de suivi culturel groupé.'
+      : `${groups.length} plan${groups.length > 1 ? 's' : ''} de suivi culturel groupé${groups.length > 1 ? 's' : ''}; premier: ${top.clusterLabel}.`,
+    bestBundleId: top?.bundleId ?? null,
+    groups,
+    detailMode: groups.length === 0
+      ? 'Aucun détail individuel à ouvrir.'
+      : 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
+  };
+}
+
 function buildCulturalCommitmentBundles(stabilizationRecommendations, activeRecommendations = [], promptHistory = [], regionId = 'province', turn = 1) {
   const recommendations = collectNormalizedRecommendations(stabilizationRecommendations, activeRecommendations);
   const trajectories = ['apaisement', 'consolidation', 'enquête', 'expansion', 'attente'];
@@ -1163,6 +1242,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
   const recommendationRotationPreview = buildCulturalRecommendationRotationPreview(promptFreshnessFilter, promptHistoryDrawer);
   const rotationCommitmentSummary = buildCulturalRotationCommitmentSummary(recommendationRotationPreview, promptChoiceComparison, bundles, incompatibilities);
   const commitmentFollowThroughReminder = buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary, promptHistoryDrawer, turn);
+  const followThroughBundlePlan = buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder);
 
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',
@@ -1182,6 +1262,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
     recommendationRotationPreview,
     rotationCommitmentSummary,
     commitmentFollowThroughReminder,
+    followThroughBundlePlan,
     dependencyExplanation: bundles.length === 0
       ? 'Aucune dépendance entre marqueurs culturels.'
       : bundles
@@ -1332,6 +1413,13 @@ export function buildCultureTurnReportDeltas({
           priorityLabel: 'aucun engagement actif · priorité 0/4',
           nextCheck: 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.',
           expectedAction: 'attendre un engagement culturel explicite avant de rappeler une promesse',
+        },
+        followThroughBundlePlan: {
+          state: 'quiet',
+          summary: 'Aucun plan de suivi culturel groupé.',
+          bestBundleId: null,
+          groups: [],
+          detailMode: 'Aucun détail individuel à ouvrir.',
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
       },

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -376,6 +376,36 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       nextCheck: 'Vérifier si Compact d’Aurora peut encore suivre Ouvrir le récit d’expansion.',
       expectedAction: 'attendre un engagement culturel explicite avant de rappeler une promesse',
     },
+    followThroughBundlePlan: {
+      state: 'ready',
+      summary: '1 plan de suivi culturel groupé; premier: Compact d’Aurora.',
+      bestBundleId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle',
+      groups: [
+        {
+          bundleId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle',
+          clusterLabel: 'Compact d’Aurora',
+          theme: 'Ouvrir le récit d’expansion',
+          state: 'ready',
+          summary: 'Compact d’Aurora: 1 suivi regroupé sur Ouvrir le récit d’expansion.',
+          groupingReason: 'Même enjeu culturel: garder le contexte visible sans grossir la file.',
+          unlockScore: 4,
+          bestFirstFollowUp: 'Ouvrir le récit d’expansion — expansion prudente: verrouille le bénéfice culturel principal autour de Compact d’Aurora',
+          avoidedLoss: 'expansion prudente: verrouille le bénéfice culturel principal autour de Compact d’Aurora',
+          detailCount: 1,
+          details: [
+            {
+              detailId: 'culture-commitment:expansion:timing:river-gate:follow-up',
+              source: 'current',
+              promptLabel: 'Ouvrir le récit d’expansion',
+              clusterLabel: 'Compact d’Aurora',
+              state: 'best-safe',
+              note: 'aucune décision récente similaire dans la limite affichée',
+            },
+          ],
+        },
+      ],
+      detailMode: 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
+    },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
   });
 });
@@ -446,6 +476,10 @@ test('buildCultureTurnReportDeltas marks stale cultural follow-through reminders
   });
   assert.match(report.commitmentBundles.commitmentFollowThroughReminder.nextCheck, /Remplacer ou reconfirmer/);
   assert.match(report.commitmentBundles.commitmentFollowThroughReminder.expectedAction, /opportunités fraîches/);
+  assert.equal(report.commitmentBundles.followThroughBundlePlan.state, 'actionable');
+  assert.equal(report.commitmentBundles.followThroughBundlePlan.groups[0].clusterLabel, 'Compact d’Aurora');
+  assert.match(report.commitmentBundles.followThroughBundlePlan.groups[0].groupingReason, /Même enjeu culturel|Même thème/);
+  assert.match(report.commitmentBundles.followThroughBundlePlan.groups[0].avoidedLoss, /opportunité fraîche/);
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -545,6 +579,13 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         priorityLabel: 'aucun engagement actif · priorité 0/4',
         nextCheck: 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.',
         expectedAction: 'attendre un engagement culturel explicite avant de rappeler une promesse',
+      },
+      followThroughBundlePlan: {
+        state: 'quiet',
+        summary: 'Aucun plan de suivi culturel groupé.',
+        bestBundleId: null,
+        groups: [],
+        detailMode: 'Aucun détail individuel à ouvrir.',
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',
     },

--- a/web/app.js
+++ b/web/app.js
@@ -6786,6 +6786,33 @@ function renderCultureTurnReport(report) {
         <small>Prochaine vérification: ${report.commitmentBundles?.commitmentFollowThroughReminder?.nextCheck ?? 'Continuer à surveiller les signaux culturels visibles avant d’annoncer un suivi.'}</small>
         <small>Action attendue: ${report.commitmentBundles?.commitmentFollowThroughReminder?.expectedAction ?? 'attendre un engagement culturel explicite avant de rappeler une promesse'}</small>
       </div>
+      <div class="culture-turn-report__follow-through-plan culture-turn-report__follow-through-plan--${report.commitmentBundles?.followThroughBundlePlan?.state ?? 'quiet'}" aria-label="Plans de suivi culturel groupés">
+        <span>Plans de suivi groupés</span>
+        <strong>${report.commitmentBundles?.followThroughBundlePlan?.summary ?? 'Aucun plan de suivi culturel groupé.'}</strong>
+        ${(report.commitmentBundles?.followThroughBundlePlan?.groups ?? []).length > 0 ? `
+          <div class="culture-turn-report__follow-through-plan-list">
+            ${report.commitmentBundles.followThroughBundlePlan.groups.map((group) => `
+              <details class="culture-turn-report__follow-through-plan-group culture-turn-report__follow-through-plan-group--${group.state}" ${group.bundleId === report.commitmentBundles.followThroughBundlePlan.bestBundleId ? 'open' : ''}>
+                <summary>
+                  <b>${group.clusterLabel}</b>
+                  <em>${group.state === 'urgent' ? 'à traiter' : group.state === 'stale' ? 'à remplacer' : group.state === 'ready' ? 'prêt' : 'à surveiller'} · score ${group.unlockScore}</em>
+                </summary>
+                <small>${group.groupingReason}</small>
+                <small>Premier suivi: ${group.bestFirstFollowUp}</small>
+                <small>Perte évitée: ${group.avoidedLoss}</small>
+                <div class="culture-turn-report__follow-through-plan-details">
+                  ${group.details.map((detail) => `
+                    <span class="culture-turn-report__follow-through-plan-detail culture-turn-report__follow-through-plan-detail--${detail.source}">
+                      <b>${detail.promptLabel}</b>
+                      <small>${detail.source === 'history' ? 'historique' : 'courant'} · ${detail.state} · ${detail.note}</small>
+                    </span>
+                  `).join('')}
+                </div>
+              </details>
+            `).join('')}
+          </div>
+        ` : `<small>${report.commitmentBundles?.followThroughBundlePlan?.detailMode ?? 'Aucun détail individuel à ouvrir.'}</small>`}
+      </div>
       <details class="culture-turn-report__history culture-turn-report__history--${report.commitmentBundles?.promptHistoryDrawer?.state ?? 'quiet'}" aria-label="Historique des prompts culturels de carte">
         <summary>
           <span>Historique culturel</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2012,6 +2012,45 @@ button { font: inherit; }
 .culture-turn-report__follow-through--watch { border-color: rgba(251, 191, 36, 0.42); }
 .culture-turn-report__follow-through--stale { border-color: rgba(248, 113, 113, 0.45); }
 .culture-turn-report__follow-through--fallback { border-color: rgba(148, 163, 184, 0.24); }
+.culture-turn-report__follow-through-plan {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding: 8px 9px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.3);
+  border: 1px solid rgba(125, 211, 252, 0.2);
+}
+.culture-turn-report__follow-through-plan > span {
+  color: #bae6fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__follow-through-plan > strong { color: #f8fafc; font-size: 12px; }
+.culture-turn-report__follow-through-plan-list { display: grid; gap: 6px; }
+.culture-turn-report__follow-through-plan-group {
+  padding: 7px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(2, 6, 23, 0.22);
+}
+.culture-turn-report__follow-through-plan-group summary { cursor: pointer; }
+.culture-turn-report__follow-through-plan-group summary b { color: #e0f2fe; }
+.culture-turn-report__follow-through-plan-group summary em { color: var(--muted); margin-left: 6px; }
+.culture-turn-report__follow-through-plan-group small { display: block; color: var(--muted); margin-top: 4px; }
+.culture-turn-report__follow-through-plan-group--ready { border-color: rgba(74, 222, 128, 0.32); }
+.culture-turn-report__follow-through-plan-group--urgent { border-color: rgba(251, 191, 36, 0.45); }
+.culture-turn-report__follow-through-plan-group--stale { border-color: rgba(248, 113, 113, 0.42); }
+.culture-turn-report__follow-through-plan-details { display: grid; gap: 4px; margin-top: 6px; }
+.culture-turn-report__follow-through-plan-detail {
+  display: grid;
+  gap: 2px;
+  padding: 5px 6px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.35);
+}
+.culture-turn-report__follow-through-plan-detail b { color: #f8fafc; }
 .culture-turn-report__history {
   display: grid;
   gap: 7px;


### PR DESCRIPTION
Gamma: Fixes #1358.

Résumé:
- ajoute un plan de suivi culturel groupé par région/thème;
- calcule un premier suivi recommandé avec score de déblocage/perte évitée;
- explique en une phrase pourquoi les suivis sont regroupés;
- conserve les suivis individuels dans des détails ouvrables.

Tests:
- npm test
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check

Zeta, peux-tu valider avant tout merge ?