### PR TITLE
Alpha: Add relapse prevention commit checklist

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -66,3 +66,21 @@ test('atlas military adds safe-wait windows to post-closure relapse risks', () =
   assert.match(webAppSource, /row\.dominantFactor/);
   assert.match(stylesSource, /\.atlas-military-post-closure-watchlist-row__window/);
 });
+
+// MAP-A22: keep this source-level contract compact because the atlas demo data is
+// assembled inside web/app.js rather than exported as a unit-testable builder.
+test('atlas military renders a relapse prevention checklist before committing province orders', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryRelapsePreventionCommitChecklist\(watchlist\)/);
+  assert.match(webAppSource, /function renderAtlasMilitaryRelapsePreventionCommitChecklist\(checklist\)/);
+  assert.match(webAppSource, /Checklist prévention rechute avant confirmation d'ordre/);
+  assert.match(webAppSource, /Check avant ordre/);
+  assert.match(webAppSource, /Safe to commit: aucune rechute provinciale significative détectée/);
+  assert.match(webAppSource, /Prévenir rechute/);
+  assert.match(webAppSource, /risque restant \$\{row\.remainingRisk\}; prérequis/);
+  assert.match(webAppSource, /raison d'attendre: \$\{row\.nextCheck\}/);
+  assert.match(webAppSource, /visibleRows = \(watchlist\?\.items \?\? \[\]\)\.slice\(0, 4\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryRelapsePreventionCommitChecklist\(relapsePreventionCommitChecklist\)/);
+  assert.match(stylesSource, /\.atlas-military-relapse-commit-checklist__panel/);
+  assert.match(stylesSource, /\.atlas-military-relapse-commit-checklist-row--fragile circle/);
+  assert.match(stylesSource, /\.atlas-military-relapse-commit-checklist-row--safe circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2193,6 +2193,54 @@ function buildAtlasMilitaryPostClosureRelapseWatchlist(comparison, recommendatio
   };
 }
 
+function buildAtlasMilitaryRelapseCommitPoint(row) {
+  if (row.statusKey === 'stable') {
+    return {
+      tone: 'safe',
+      label: 'Safe to commit',
+      detail: `${row.provinceLabel}: aucun signal de rechute significatif; ${row.safeWaitWindow}.`,
+    };
+  }
+
+  if (row.statusKey === 'fragile') {
+    return {
+      tone: 'fragile',
+      label: 'Prévenir rechute',
+      detail: `${row.provinceLabel}: risque restant ${row.remainingRisk}; prérequis ${row.dominantFactor.replace('facteur: ', '')}.`,
+    };
+  }
+
+  return {
+    tone: 'watch',
+    label: 'Attendre signal',
+    detail: `${row.provinceLabel}: ${row.reason}; raison d'attendre: ${row.nextCheck}.`,
+  };
+}
+
+function buildAtlasMilitaryRelapsePreventionCommitChecklist(watchlist) {
+  const visibleRows = (watchlist?.items ?? []).slice(0, 4);
+  if (!visibleRows.length || watchlist?.empty) {
+    return {
+      points: [],
+      summary: 'Safe to commit: aucune rechute provinciale significative détectée.',
+      empty: true,
+      safeToCommit: true,
+    };
+  }
+
+  const points = visibleRows.map(buildAtlasMilitaryRelapseCommitPoint);
+  const significantRelapseCount = points.filter((point) => point.tone === 'fragile' || point.tone === 'watch').length;
+
+  return {
+    points,
+    summary: significantRelapseCount === 0
+      ? 'Safe to commit: aucune rechute provinciale significative détectée.'
+      : `${significantRelapseCount} point${significantRelapseCount > 1 ? 's' : ''} à vérifier avant confirmation d'ordre.`,
+    empty: false,
+    safeToCommit: significantRelapseCount === 0,
+  };
+}
+
 function renderAtlasMilitaryPostClosureRelapseWatchlist(watchlist) {
   const height = watchlist.empty ? 6.8 : 5.8 + (watchlist.items.length * 5.1);
   return `
@@ -2206,6 +2254,23 @@ function renderAtlasMilitaryPostClosureRelapseWatchlist(watchlist) {
           <text class="atlas-military-post-closure-watchlist-row__window" x="46" y="${126.45 + index * 5.1}">${row.safeWaitWindow}</text>
           <text class="atlas-military-post-closure-watchlist-row__factor" x="46" y="${127.8 + index * 5.1}">${row.dominantFactor}</text>
           <text class="atlas-military-post-closure-watchlist-row__check" x="46" y="${129.15 + index * 5.1}">${row.nextCheck}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
+function renderAtlasMilitaryRelapsePreventionCommitChecklist(checklist) {
+  const height = checklist.empty ? 6.2 : 5.4 + (checklist.points.length * 3.65);
+  return `
+    <g class="atlas-military-relapse-commit-checklist atlas-military-relapse-commit-checklist--${checklist.safeToCommit ? 'safe' : 'active'}" aria-label="Checklist prévention rechute avant confirmation d'ordre: ${checklist.summary}">
+      <rect class="atlas-military-relapse-commit-checklist__panel" x="43" y="139" width="35" height="${height}" rx="2.1"></rect>
+      <text class="atlas-military-relapse-commit-checklist__title" x="44.2" y="141.4">Check avant ordre</text>
+      ${checklist.empty ? `<text class="atlas-military-relapse-commit-checklist__empty" x="44.2" y="144.1">${checklist.summary}</text>` : checklist.points.map((point, index) => `
+        <g class="atlas-military-relapse-commit-checklist-row atlas-military-relapse-commit-checklist-row--${point.tone}" aria-label="${point.label}: ${point.detail}">
+          <circle cx="44.8" cy="${143.5 + index * 3.65}" r="0.58"></circle>
+          <text class="atlas-military-relapse-commit-checklist-row__label" x="46" y="${143.1 + index * 3.65}">${point.label}</text>
+          <text class="atlas-military-relapse-commit-checklist-row__detail" x="46" y="${144.45 + index * 3.65}">${point.detail}</text>
         </g>
       `).join('')}
     </g>
@@ -3273,6 +3338,7 @@ function renderAtlasMilitaryLayer(shell) {
   const nextBestClosureRecommendation = buildAtlasMilitaryNextBestClosureRecommendation(blockerResolutionChecklist);
   const closureAfterActionComparison = buildAtlasMilitaryClosureAfterActionComparison(nextBestClosureRecommendation);
   const postClosureRelapseWatchlist = buildAtlasMilitaryPostClosureRelapseWatchlist(closureAfterActionComparison, nextBestClosureRecommendation);
+  const relapsePreventionCommitChecklist = buildAtlasMilitaryRelapsePreventionCommitChecklist(postClosureRelapseWatchlist);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -3313,6 +3379,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryNextBestClosureRecommendation(nextBestClosureRecommendation)}
       ${renderAtlasMilitaryClosureAfterActionComparison(closureAfterActionComparison)}
       ${renderAtlasMilitaryPostClosureRelapseWatchlist(postClosureRelapseWatchlist)}
+      ${renderAtlasMilitaryRelapsePreventionCommitChecklist(relapsePreventionCommitChecklist)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -13917,3 +13917,34 @@ button { font: inherit; }
 .atlas-military-post-closure-watchlist-row--climate circle { stroke: rgba(134, 239, 172, 0.78); }
 .atlas-military-post-closure-watchlist-row--intel circle { stroke: rgba(216, 180, 254, 0.78); }
 .atlas-military-post-closure-watchlist-row--culture circle { stroke: rgba(251, 207, 232, 0.78); }
+
+.atlas-military-relapse-commit-checklist__panel {
+  fill: rgba(15, 23, 42, 0.76);
+  stroke: rgba(147, 197, 253, 0.42);
+  stroke-width: 0.26;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.42));
+}
+.atlas-military-relapse-commit-checklist__title,
+.atlas-military-relapse-commit-checklist-row text,
+.atlas-military-relapse-commit-checklist__empty {
+  fill: #dbeafe;
+  font-size: 0.68px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.2;
+}
+.atlas-military-relapse-commit-checklist-row circle {
+  fill: rgba(96, 165, 250, 0.82);
+  stroke: rgba(239, 246, 255, 0.72);
+  stroke-width: 0.12;
+}
+.atlas-military-relapse-commit-checklist-row__detail,
+.atlas-military-relapse-commit-checklist__empty {
+  fill: #bfdbfe;
+  font-size: 0.43px;
+}
+.atlas-military-relapse-commit-checklist-row--safe circle { fill: rgba(74, 222, 128, 0.84); }
+.atlas-military-relapse-commit-checklist-row--fragile circle { fill: rgba(251, 191, 36, 0.88); }
+.atlas-military-relapse-commit-checklist-row--watch circle { fill: rgba(96, 165, 250, 0.84); }
+.atlas-military-relapse-commit-checklist-row--fragile .atlas-military-relapse-commit-checklist-row__detail { fill: #fed7aa; }


### PR DESCRIPTION
Alpha: Implements #1366.\n\nSummary:\n- Adds a compact pre-order relapse prevention checklist from the post-closure watchlist.\n- Surfaces fragile, watch, and safe-to-commit states with remaining risk, missing prerequisite/factor, and wait/act rationale.\n- Keeps the atlas panel bounded to 2-4 visible points and styles fragile/stable scenarios.\n\nValidation:\n- npm test