### PR TITLE
Beta: Show capacity cost behind top logistics lever

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -525,16 +525,25 @@ function buildRecoveryLeverRanking(routeChoices, priorityActions, hasBlocker) {
     .map((action) => {
       const option = optionByRouteId.get(action.routeId) ?? null;
       const choice = option?.recoveryChoices.find((candidate) => candidate.choiceId === action.choiceId) ?? null;
+      const unresolvedDebt = choice?.downstreamShortages.find((shortage) => shortage.status === 'aggravée' || shortage.status === 'déplacée' || shortage.status === 'inconnue') ?? null;
       const criticalAvoided = Math.max(
         action.shortagesAvoided,
         choice?.downstreamShortages.filter((shortage) => shortage.status === 'aggravée' || shortage.status === 'déplacée').length ?? 0,
       );
       const capacityKey = `${action.resource}:${choice?.blocker ?? option?.cost ?? action.cost}`;
+      const capacityCostDetail = option
+        ? `${action.cost} sur ${action.route} vers ${option.affectedCity}, délai ${action.delay}; capacité requise: ${choice?.blocker ?? action.resource}.`
+        : `${action.cost}, délai ${action.delay}; capacité requise: ${choice?.blocker ?? action.resource}.`;
       const avoidedRisk = criticalAvoided > 0
         ? `${criticalAvoided} pénurie${criticalAvoided > 1 ? 's' : ''}/goulot${criticalAvoided > 1 ? 's' : ''} évité${criticalAvoided > 1 ? 's' : ''}`
         : choice?.bottleneck?.tone === 'high'
           ? `${choice.bottleneck.label} neutralisé avant rechute`
           : `${action.downstreamStatus} contenu avant prochain tour`;
+      const debtWatch = unresolvedDebt
+        ? `Dette à surveiller: ${unresolvedDebt.target} (${unresolvedDebt.status}) après ${action.route}.`
+        : choice?.bottleneck?.tone === 'high'
+          ? `Dette à surveiller: ${choice.bottleneck.label} peut rester active sur ${action.route}.`
+          : 'Dette aval résiduelle faible après ce levier.';
 
       return {
         leverId: `lever:${action.actionId}`,
@@ -543,7 +552,9 @@ function buildRecoveryLeverRanking(routeChoices, priorityActions, hasBlocker) {
         resource: action.resource,
         tone: action.tone,
         primaryCost: action.cost,
+        capacityCostDetail,
         avoidedRisk,
+        debtWatch,
         tradeoff: action.tradeoff,
         blocker: choice?.blocker ?? 'capacité à confirmer',
         capacityKey,
@@ -556,10 +567,14 @@ function buildRecoveryLeverRanking(routeChoices, priorityActions, hasBlocker) {
   const capacityCounts = candidates.reduce((counts, lever) => counts.set(lever.capacityKey, (counts.get(lever.capacityKey) ?? 0) + 1), new Map());
   const levers = candidates.map((lever, index, ordered) => {
     const conflict = ordered.find((candidate, candidateIndex) => candidateIndex !== index && candidate.capacityKey === lever.capacityKey) ?? null;
+    const nextLever = ordered[index + 1] ?? null;
     return {
       ...lever,
       rank: index + 1,
       recommended: index === 0,
+      capacityComparison: nextLever
+        ? `${nextLever.label} demande ${nextLever.primaryCost}; ${lever.label} garde le meilleur ratio capacité/risque.`
+        : 'Aucun second levier assez utile pour comparer le coût de capacité.',
       mutualBlocker: conflict
         ? `Partage ${lever.resource}/${lever.blocker} avec ${conflict.label}: choisir l’un retarde l’autre.`
         : (capacityCounts.get(lever.capacityKey) ?? 0) > 1

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -83,7 +83,10 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.ok(preview.recoveryLeverRanking.levers.length >= 2);
   assert.equal(preview.recoveryLeverRanking.levers[0].recommended, true);
   assert.match(preview.recoveryLeverRanking.summary, /coût|risque évité/i);
-  assert.ok(preview.recoveryLeverRanking.levers.every((lever) => lever.primaryCost.length > 0 && lever.avoidedRisk.length > 0 && lever.mutualBlocker.length > 0));
+  assert.match(preview.recoveryLeverRanking.levers[0].capacityCostDetail, /capacité requise|délai|Ember Line|River Gate/);
+  assert.match(preview.recoveryLeverRanking.levers[0].capacityComparison, /demande|second levier|ratio capacité\/risque/);
+  assert.match(preview.recoveryLeverRanking.levers[0].debtWatch, /Dette|résiduelle/);
+  assert.ok(preview.recoveryLeverRanking.levers.every((lever) => lever.primaryCost.length > 0 && lever.capacityCostDetail.length > 0 && lever.avoidedRisk.length > 0 && lever.mutualBlocker.length > 0));
   assert.ok(preview.selectedActionPreview.badges.length <= 3);
   assert.match(preview.prioritySummary, /recommandée/);
   assert.ok(preview.priorityActions.some((action) => /rapide mais limitée|plus lente mais structurante|équilibrée/.test(action.tradeoff)));

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -62,6 +62,10 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Leviers recovery/);
   assert.match(webAppSource, /preview\.recoveryLeverRanking/);
   assert.match(webAppSource, /lever\.primaryCost/);
+  assert.match(webAppSource, /lever\.capacityCostDetail/);
+  assert.match(webAppSource, /lever\.capacityComparison/);
+  assert.match(webAppSource, /lever\.debtWatch/);
+  assert.match(webAppSource, /Capacité:/);
   assert.match(webAppSource, /lever\.avoidedRisk/);
   assert.match(webAppSource, /lever\.mutualBlocker/);
   assert.match(webAppSource, /province-logistics-impact-preview/);

--- a/web/app.js
+++ b/web/app.js
@@ -7629,6 +7629,8 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               <li class="province-logistics-recovery-lever province-logistics-recovery-lever--${lever.tone} ${lever.recommended ? 'is-recommended' : ''}">
                 <strong>#${lever.rank} ${lever.label}</strong>
                 <span>Coût: ${lever.primaryCost} · Risque évité: ${lever.avoidedRisk}</span>
+                ${lever.recommended ? `<span>Capacité: ${lever.capacityCostDetail}</span>` : ''}
+                ${lever.recommended ? `<small>${lever.capacityComparison} · ${lever.debtWatch}</small>` : ''}
                 <small>${lever.tradeoff} · ${lever.mutualBlocker}</small>
               </li>
             `).join('')}


### PR DESCRIPTION
Beta: Implements #1367.

Summary:
- Adds compact capacity cost detail to the recommended logistics recovery lever.
- Compares the top lever with the second option when available.
- Flags residual downstream logistics debt to watch after the recommended lever.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
