### PR TITLE
Delta: Flag intrigue timing recommendation changes

### DIFF
--- a/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
+++ b/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
@@ -26,6 +26,80 @@ function getResponseTone(response) {
   return 'masked';
 }
 
+const TIMING_LABELS = {
+  'act-now': 'agir maintenant',
+  'short-wait': 'attendre',
+};
+
+const TIMING_CAUSE_LABELS = {
+  exposition: 'exposition',
+  'information-manquante': 'nouvelle information',
+  'coût-opportunité': 'dette de chaleur',
+  'fenêtre-adverse': 'confiance',
+};
+
+function normalizeTimingRecommendation(value) {
+  if (value === 'act-now' || value === 'agir-maintenant' || value === 'agir maintenant') {
+    return 'act-now';
+  }
+
+  if (value === 'short-wait' || value === 'wait' || value === 'attendre' || value === 'attendre-court') {
+    return 'short-wait';
+  }
+
+  return null;
+}
+
+function getEntryForProvince(province, intrigueView) {
+  const provinceId = province?.provinceId;
+  return (intrigueView?.map?.entries ?? []).find((entry) => entry.locationId === provinceId) ?? null;
+}
+
+function getTimingChangeCause(timingComparison) {
+  const dominantReason = timingComparison?.dominantReason ?? null;
+
+  if (TIMING_CAUSE_LABELS[dominantReason]) {
+    return TIMING_CAUSE_LABELS[dominantReason];
+  }
+
+  if (/exposition|budget/i.test(`${timingComparison?.actNow?.risk ?? ''} ${timingComparison?.shortWait?.risk ?? ''}`)) {
+    return 'exposition';
+  }
+
+  if (/confiance|provenance|information/i.test(`${timingComparison?.summary ?? ''} ${timingComparison?.shortWait?.outcome ?? ''}`)) {
+    return 'nouvelle information';
+  }
+
+  if (/chaleur|coût|cout|dette/i.test(`${timingComparison?.summary ?? ''} ${timingComparison?.actNow?.outcome ?? ''}`)) {
+    return 'dette de chaleur';
+  }
+
+  return 'confiance';
+}
+
+function buildTimingRecommendationChange({ previousTimingRecommendation, currentTimingComparison }) {
+  const previous = normalizeTimingRecommendation(previousTimingRecommendation);
+  const current = normalizeTimingRecommendation(currentTimingComparison?.recommendedTiming);
+
+  if (!previous || !current || previous === current) {
+    return null;
+  }
+
+  const direction = `${TIMING_LABELS[previous]} → ${TIMING_LABELS[current]}`;
+  const cause = getTimingChangeCause(currentTimingComparison);
+
+  return {
+    previousTiming: previous,
+    currentTiming: current,
+    direction,
+    cause,
+    tone: current === 'act-now' ? 'worse' : 'watch',
+    label: 'Timing recommandé modifié',
+    detail: `${direction}: cause visible ${cause}.`,
+    fogSafe: true,
+  };
+}
+
 function buildResponseDeltas(response, fallbackSummary) {
   if (!response) {
     return [];
@@ -95,6 +169,7 @@ export function buildIntrigueTurnReportDeltas(province, intrigueView, options = 
   }
 
   const drillDown = findSelectedDrillDown(province, intrigueView);
+  const entry = getEntryForProvince(province, intrigueView);
 
   if (!drillDown) {
     return {
@@ -109,7 +184,27 @@ export function buildIntrigueTurnReportDeltas(province, intrigueView, options = 
     ?? drillDown.quickResponses?.find((candidate) => candidate.code === drillDown.recommendedResponseCode)
     ?? drillDown.quickResponses?.[0]
     ?? null;
-  const deltas = buildResponseDeltas(response, drillDown.responseAftermath?.summary)
+  const timingComparison = drillDown.postRecapStabilizationChoices?.timingComparison
+    ?? entry?.postRecapStabilizationChoices?.timingComparison
+    ?? null;
+  const timingRecommendationChange = buildTimingRecommendationChange({
+    previousTimingRecommendation: normalizedOptions.previousTimingRecommendation
+      ?? drillDown.previousTimingRecommendation
+      ?? entry?.previousTimingRecommendation
+      ?? entry?.lastTurn?.timingRecommendation
+      ?? null,
+    currentTimingComparison: timingComparison,
+  });
+  const deltas = [
+    ...buildResponseDeltas(response, drillDown.responseAftermath?.summary),
+    ...(timingRecommendationChange ? [{
+      type: 'timing',
+      tone: timingRecommendationChange.tone,
+      label: timingRecommendationChange.label,
+      detail: timingRecommendationChange.detail,
+      score: 110,
+    }] : []),
+  ]
     .sort((left, right) => right.score - left.score || left.label.localeCompare(right.label))
     .slice(0, 4);
   const worseCount = deltas.filter((delta) => delta.tone === 'worse').length;
@@ -126,5 +221,6 @@ export function buildIntrigueTurnReportDeltas(province, intrigueView, options = 
     previousAction: `Action Delta résolue: ${actionLabel} sur ${drillDown.locationName}.`,
     deltas,
     retaliationRisk: drillDown.responseAftermath?.retaliationRisk ?? 'inconnu',
+    timingRecommendationChange,
   };
 }

--- a/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
@@ -60,6 +60,36 @@ test('buildIntrigueTurnReportDeltas marks aggravated and exposed aftermath clear
   assert.ok(report.deltas.some((delta) => delta.label === 'Réseau exposé'));
 });
 
+test('buildIntrigueTurnReportDeltas flags changed timing recommendations fog-safely', () => {
+  const view = buildIntrigueView();
+  view.selectedProvince.drillDown.postRecapStabilizationChoices = {
+    timingComparison: {
+      recommendedTiming: 'short-wait',
+      dominantReason: 'exposition',
+      actNow: { risk: 'exposition visible défavorable' },
+      shortWait: { outcome: 'Attendre un tour peut rouvrir une fenêtre moins coûteuse.' },
+      summary: 'Temporiser est meilleur maintenant: l’exposition domine la décision visible.',
+    },
+  };
+
+  const report = buildIntrigueTurnReportDeltas(province, view, {
+    previousActionCode: 'contenir',
+    previousTimingRecommendation: 'act-now',
+  });
+
+  assert.deepEqual(report.timingRecommendationChange, {
+    previousTiming: 'act-now',
+    currentTiming: 'short-wait',
+    direction: 'agir maintenant → attendre',
+    cause: 'exposition',
+    tone: 'watch',
+    label: 'Timing recommandé modifié',
+    detail: 'agir maintenant → attendre: cause visible exposition.',
+    fogSafe: true,
+  });
+  assert.ok(report.deltas.some((delta) => delta.type === 'timing' && delta.detail === 'agir maintenant → attendre: cause visible exposition.'));
+});
+
 test('buildIntrigueTurnReportDeltas keeps unknown intelligence discreet', () => {
   assert.deepEqual(buildIntrigueTurnReportDeltas(province, null), {
     tone: 'masked',

--- a/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
@@ -9,5 +9,7 @@ test('playable map wires intrigue aftermath deltas into selected province turn r
   assert.match(webAppSource, /function renderIntrigueTurnReportDeltas/);
   assert.match(webAppSource, /Rapport intrigue dernier tour/);
   assert.match(webAppSource, /Risque représailles/);
+  assert.match(webAppSource, /previousTimingRecommendation/);
+  assert.match(webAppSource, /Changement de recommandation de timing intrigue/);
   assert.match(webAppSource, /renderIntrigueTurnReportDeltas\(province, intrigueView\)/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -7741,6 +7741,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
 function renderIntrigueTurnReportDeltas(province, intrigueView) {
   const report = buildIntrigueTurnReportDeltas(province, intrigueView, {
     previousActionCode: intrigueView?.selectedProvince?.drillDown?.recommendedResponseCode ?? null,
+    previousTimingRecommendation: intrigueView?.selectedProvince?.previousTimingRecommendation ?? null,
   });
 
   return `
@@ -7752,6 +7753,12 @@ function renderIntrigueTurnReportDeltas(province, intrigueView) {
       <p>${report.summary}</p>
       ${report.previousAction ? `<small>${report.previousAction}</small>` : ''}
       ${report.retaliationRisk ? `<small>Risque représailles: ${report.retaliationRisk}</small>` : ''}
+      ${report.timingRecommendationChange ? `
+        <div class="province-intrigue-turn-report__timing-change province-intrigue-turn-report__timing-change--${report.timingRecommendationChange.tone}" aria-label="Changement de recommandation de timing intrigue">
+          <b>${report.timingRecommendationChange.direction}</b>
+          <span>Cause visible: ${report.timingRecommendationChange.cause}</span>
+        </div>
+      ` : ''}
       ${report.deltas.length > 0 ? `
         <ul class="province-intrigue-turn-report__list">
           ${report.deltas.map((delta) => `
@@ -17859,6 +17866,7 @@ function getIntrigueViewModel() {
       sleeperCellCount: selectedEntry.metrics.sleeperCellCount,
       activeOperationCount: selectedOperations.length,
       drillDown: selectedEntry.drillDown,
+      previousTimingRecommendation: selectedEntry.previousTimingRecommendation ?? selectedEntry.lastTurn?.timingRecommendation ?? null,
       fogHint: selectedFogHint,
       responseChoices: selectedResponseChoices,
       reasons: selectedRiskReasons.length > 0 ? selectedRiskReasons : ['Aucun signal Delta notable'],

--- a/web/styles.css
+++ b/web/styles.css
@@ -9501,6 +9501,18 @@ button { font: inherit; }
   margin: 6px 0 0;
   color: var(--muted);
 }
+.province-intrigue-turn-report__timing-change {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.28);
+  border: 1px solid rgba(250, 204, 21, 0.24);
+}
+.province-intrigue-turn-report__timing-change--worse { border-color: rgba(248, 113, 113, 0.34); }
+.province-intrigue-turn-report__timing-change span { color: var(--muted); }
 .province-intrigue-turn-report__list {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Résout #1369.

Résumé:
- Ajoute un delta fog-safe quand la recommandation de timing intrigue bascule entre « agir maintenant » et « attendre ».
- Expose une cause courte limitée aux signaux visibles: exposition, confiance, dette de chaleur ou nouvelle information.
- Affiche la bascule dans le rapport intrigue sélectionné sans révéler cible, cellule, relais ou vérité cachée.

Tests:
- node --test test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?