### PR TITLE
Epsilon: Show climate threshold progress after readiness actions

### DIFF
--- a/test/ui/climate/webAtlasClimateThresholdProgressAfterReadinessAction.test.js
+++ b/test/ui/climate/webAtlasClimateThresholdProgressAfterReadinessAction.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas shows climate threshold progress after readiness actions', () => {
+  assert.match(webAppSource, /function buildAtlasClimateThresholdProgressAfterReadinessAction/);
+  assert.match(webAppSource, /function renderAtlasClimateThresholdProgressAfterReadinessAction/);
+  assert.match(webAppSource, /Progression seuil climat/);
+  assert.match(webAppSource, /Avant/);
+  assert.match(webAppSource, /Après/);
+  assert.match(webAppSource, /Manque encore/);
+  assert.match(webAppSource, /Prochain suivi carte/);
+  assert.match(webAppSource, /Compatibilité conséquences/);
+  assert.match(webAppSource, /threshold-reached/);
+  assert.match(webAppSource, /threshold-pending/);
+  assert.match(webAppSource, /buildAtlasClimateThresholdProgressAfterReadinessAction\(\s*atlasClimateNextReadinessThreshold,\s*atlasClimateReadinessConsequenceHints,\s*atlasClimateReadinessBoostRecommendations,\s*atlasClimatePostBoostDeadlineRiskPreview,\s*\)/);
+  assert.match(webAppSource, /renderAtlasClimateThresholdProgressAfterReadinessAction\(atlasClimateThresholdProgressAfterReadinessAction\)/);
+
+  assert.match(stylesSource, /\.map-world-climate-threshold-progress/);
+  assert.match(stylesSource, /\.map-world-climate-threshold-progress--threshold-reached/);
+  assert.match(stylesSource, /\.map-world-climate-threshold-progress--threshold-pending/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -10159,6 +10159,80 @@ function renderAtlasClimateNextReadinessThreshold(view) {
   `;
 }
 
+function buildAtlasClimateThresholdProgressAfterReadinessAction(nextThresholdView, consequenceView, boostView, postBoostView) {
+  if (!nextThresholdView || nextThresholdView.state === 'empty' || !nextThresholdView.recommendation) {
+    return {
+      state: 'empty',
+      progress: null,
+      summary: 'Aucune progression de seuil climat à comparer après action readiness.',
+    };
+  }
+
+  const recommendation = nextThresholdView.recommendation;
+  const hint = (consequenceView?.hints ?? []).find((candidate) => candidate.provinceId === recommendation.provinceId);
+  const boost = (boostView?.boosts ?? []).find((candidate) => candidate.provinceId === recommendation.provinceId);
+  const preview = (postBoostView?.previews ?? []).find((candidate) => candidate.provinceId === recommendation.provinceId);
+  const beforeGap = boost?.concreteReason ?? hint?.likelyMapEffect ?? recommendation.reason;
+  const reached = preview?.outcome === 'executable' || preview?.outcome === 'still-tight';
+  const stillMissing = preview?.outcome === 'still-tight'
+    ? 'Seuil atteint mais marge courte: rejouer la carte climat au prochain tour avant d’empiler un autre plan.'
+    : preview?.outcome === 'insufficient'
+      ? `${recommendation.threshold} non atteint: ${preview.postBoostSignal}`
+      : nextThresholdView.state === 'no-threshold-change'
+        ? `${recommendation.threshold} non atteint: ${recommendation.signal}.`
+        : 'Il manque une confirmation carte du bénéfice avant de masquer la conséquence readiness.';
+  const nextMapFollowUp = reached
+    ? (preview?.outcome === 'still-tight'
+      ? `Suivi carte suivant: surveiller ${recommendation.deadline} et relire la pression résiduelle avant nouvelle action.`
+      : `Suivi carte suivant: afficher ${recommendation.expectedBenefit} puis classer le prochain marqueur climat régional.`)
+    : `Encore manquant: ${stillMissing}`;
+  const afterGap = reached
+    ? (preview?.postBoostSignal ?? recommendation.expectedBenefit)
+    : stillMissing;
+
+  return {
+    state: reached ? 'threshold-reached' : 'threshold-pending',
+    progress: {
+      provinceId: recommendation.provinceId,
+      provinceLabel: recommendation.provinceLabel,
+      deadline: recommendation.deadline,
+      threshold: recommendation.threshold,
+      readinessAction: boost?.smallestBoost ?? recommendation.investment,
+      beforeGap,
+      afterGap,
+      missingLine: reached ? '' : stillMissing,
+      nextMapFollowUp,
+      consequenceCompatibility: hint?.followUpEffect ?? recommendation.expectedBenefit,
+    },
+    summary: reached
+      ? `${recommendation.provinceLabel}: l’action readiness franchit le seuil recommandé; proposer le suivi climat lisible sur la carte.`
+      : `${recommendation.provinceLabel}: l’action readiness réduit l’écart mais ne franchit pas encore le seuil recommandé.`,
+  };
+}
+
+function renderAtlasClimateThresholdProgressAfterReadinessAction(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty' || !view.progress) {
+    return '';
+  }
+
+  const progress = view.progress;
+  return `
+    <aside class="map-world-climate-threshold-progress map-world-climate-threshold-progress--${view.state}" aria-label="Progression vers le seuil climatique après action readiness">
+      <div class="map-world-climate-threshold-progress__header">
+        <strong>Progression seuil climat</strong>
+        <span>${view.state === 'threshold-reached' ? 'seuil atteint' : 'écart restant'}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>${progress.provinceLabel}</b> · ${progress.deadline} · ${progress.threshold}</small>
+      <small><b>Action readiness</b> · ${progress.readinessAction}</small>
+      <small><b>Avant</b> · ${progress.beforeGap}</small>
+      <small><b>Après</b> · ${progress.afterGap}</small>
+      ${progress.missingLine ? `<small><b>Manque encore</b> · ${progress.missingLine}</small>` : `<small><b>Prochain suivi carte</b> · ${progress.nextMapFollowUp}</small>`}
+      <small><b>Compatibilité conséquences</b> · ${progress.consequenceCompatibility}</small>
+    </aside>
+  `;
+}
+
 function buildAtlasClimateReadinessBoostReliefRanking(postBoostView) {
   if (!postBoostView || postBoostView.state === 'empty' || postBoostView.previews.length === 0) {
     return {
@@ -20588,6 +20662,12 @@ function render() {
     atlasClimateReadinessBoostRecommendations,
     atlasClimatePostBoostDeadlineRiskPreview,
   );
+  const atlasClimateThresholdProgressAfterReadinessAction = buildAtlasClimateThresholdProgressAfterReadinessAction(
+    atlasClimateNextReadinessThreshold,
+    atlasClimateReadinessConsequenceHints,
+    atlasClimateReadinessBoostRecommendations,
+    atlasClimatePostBoostDeadlineRiskPreview,
+  );
   const atlasClimateReadinessBoostReliefRanking = buildAtlasClimateReadinessBoostReliefRanking(atlasClimatePostBoostDeadlineRiskPreview);
   const atlasClimateMinimumViableBoostHint = buildAtlasClimateMinimumViableBoostHint(atlasClimateReadinessBoostReliefRanking);
   const atlasClimateMinimumBoostDeadlineMissWarning = buildAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumViableBoostHint);
@@ -20653,6 +20733,7 @@ function render() {
           ${renderAtlasClimatePostBoostDeadlineRiskPreview(atlasClimatePostBoostDeadlineRiskPreview)}
           ${renderAtlasClimateReadinessConsequenceHints(atlasClimateReadinessConsequenceHints)}
           ${renderAtlasClimateNextReadinessThreshold(atlasClimateNextReadinessThreshold)}
+          ${renderAtlasClimateThresholdProgressAfterReadinessAction(atlasClimateThresholdProgressAfterReadinessAction)}
           ${renderAtlasClimateReadinessBoostReliefRanking(atlasClimateReadinessBoostReliefRanking)}
           ${renderAtlasClimateMinimumViableBoostHint(atlasClimateMinimumViableBoostHint)}
           ${renderAtlasClimateMinimumBoostDeadlineMissWarning(atlasClimateMinimumBoostDeadlineMissWarning)}

--- a/web/styles.css
+++ b/web/styles.css
@@ -12444,6 +12444,39 @@ button { font: inherit; }
 .map-world-climate-next-threshold--no-threshold-change span,
 .map-world-climate-next-threshold--no-threshold-change small { color: #fee2e2; }
 
+.map-world-climate-threshold-progress {
+  display: grid;
+  gap: 6px;
+  max-width: 74ch;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.8), rgba(8, 145, 178, 0.18));
+  border: 1px solid rgba(103, 232, 249, 0.34);
+}
+.map-world-climate-threshold-progress--threshold-reached { border-color: rgba(110, 231, 183, 0.44); }
+.map-world-climate-threshold-progress--threshold-pending { border-color: rgba(251, 191, 36, 0.48); }
+.map-world-climate-threshold-progress__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-threshold-progress p,
+.map-world-climate-threshold-progress span,
+.map-world-climate-threshold-progress small {
+  color: #cffafe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-threshold-progress--threshold-reached p,
+.map-world-climate-threshold-progress--threshold-reached span,
+.map-world-climate-threshold-progress--threshold-reached small { color: #dcfce7; }
+.map-world-climate-threshold-progress--threshold-pending p,
+.map-world-climate-threshold-progress--threshold-pending span,
+.map-world-climate-threshold-progress--threshold-pending small { color: #fef3c7; }
+
 .atlas-cultural-border-zone__recommendation {
   fill: #ddd6fe;
   font-size: 0.86px;


### PR DESCRIPTION
Epsilon: PR prête pour #1370.

## Résumé
- Ajoute un encart carte “Progression seuil climat” après le prochain seuil readiness recommandé.
- Compare l’écart avant/après l’action readiness, indique ce qui manque encore si le seuil n’est pas franchi, ou propose le prochain suivi climat lisible sur la carte si le seuil est atteint.
- Réutilise les consequence hints / post-boost previews existants pour rester compatible avec les messages de conséquences.

## Tests
- node --test test/ui/climate/webAtlasClimateThresholdProgressAfterReadinessAction.test.js test/ui/climate/webAtlasClimateNextReadinessThreshold.test.js test/ui/climate/webAtlasClimateReadinessConsequenceHints.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?