### PR TITLE
Gamma: Add cultural bundle cleanup prompts

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1058,6 +1058,58 @@ function buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary,
 }
 
 
+function buildCulturalBundleCleanupPrompts(groups, commitmentFollowThroughReminder, promptHistoryDrawer) {
+  const repetitionSafeguard = promptHistoryDrawer.repetitionSafeguard;
+
+  return groups.map((group) => {
+    const currentEntries = group.details.filter((entry) => entry.source === 'current');
+    const historyEntries = group.details.filter((entry) => entry.source === 'history');
+    const hasCurrentFollowUp = currentEntries.length > 0;
+    const replacementEntry = currentEntries[0]
+      ?? groups.find((candidate) => candidate.bundleId !== group.bundleId)?.details.find((entry) => entry.source === 'current')
+      ?? null;
+    const reminderTargetsGroup = commitmentFollowThroughReminder.clusterLabel === group.clusterLabel;
+    const isStaleReminder = reminderTargetsGroup && commitmentFollowThroughReminder.agePriority?.stale === true;
+    const resolvedWithoutCurrentAction = !hasCurrentFollowUp && historyEntries.length > 0 && !isStaleReminder;
+    const riskPersists = group.state === 'urgent'
+      || group.state === 'ready'
+      || (group.state === 'context' && hasCurrentFollowUp)
+      || (reminderTargetsGroup && commitmentFollowThroughReminder.agePriority?.priority >= 3 && !isStaleReminder);
+    const cleanupState = isStaleReminder || group.state === 'stale'
+      ? 'obsolete'
+      : riskPersists
+        ? 'risk-persists'
+        : resolvedWithoutCurrentAction || group.state === 'context'
+          ? 'resolved'
+          : 'review';
+    const action = cleanupState === 'obsolete'
+      ? (replacementEntry ? `remplacer par ${replacementEntry.promptLabel}` : 'archiver le bundle obsolète')
+      : cleanupState === 'resolved'
+        ? 'archiver le bundle résolu'
+        : cleanupState === 'risk-persists'
+          ? 'conserver: risque culturel encore actif'
+          : 'revoir au prochain tour avant archivage';
+    const reason = cleanupState === 'obsolete'
+      ? `${group.clusterLabel}: ${commitmentFollowThroughReminder.agePriority?.relevance ?? 'ancien suivi dépassé par le contexte récent'}.`
+      : cleanupState === 'resolved'
+        ? `${group.clusterLabel}: aucun suivi courant immédiat; l’historique suffit comme trace lisible.`
+        : cleanupState === 'risk-persists'
+          ? `${group.clusterLabel}: ${group.avoidedLoss}; ${commitmentFollowThroughReminder.nextCheck}`
+          : `${group.clusterLabel}: état à surveiller sans relancer toute la répétition.`;
+
+    return {
+      cleanupId: `${group.bundleId}:cleanup-prompt`,
+      bundleId: group.bundleId,
+      clusterLabel: group.clusterLabel,
+      state: cleanupState,
+      action,
+      reason,
+      safeguard: repetitionSafeguard,
+      replacesPromptLabel: cleanupState === 'obsolete' ? replacementEntry?.promptLabel ?? null : null,
+    };
+  });
+}
+
 function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder) {
   const groups = promptHistoryDrawer.groups.map((group) => {
     const currentEntries = group.entries.filter((entry) => entry.source === 'current');
@@ -1116,6 +1168,10 @@ function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptH
     };
   }).sort((left, right) => right.unlockScore - left.unlockScore || right.detailCount - left.detailCount || left.clusterLabel.localeCompare(right.clusterLabel));
   const top = groups[0] ?? null;
+  const cleanupPrompts = buildCulturalBundleCleanupPrompts(groups, commitmentFollowThroughReminder, promptHistoryDrawer);
+  const cleanupSummary = cleanupPrompts.length === 0
+    ? 'Aucun prompt de nettoyage culturel à proposer.'
+    : `${cleanupPrompts.length} prompt${cleanupPrompts.length > 1 ? 's' : ''} de nettoyage: ${cleanupPrompts.map((prompt) => `${prompt.clusterLabel} → ${prompt.action}`).join(' | ')}.`;
 
   return {
     state: groups.length === 0
@@ -1130,6 +1186,8 @@ function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptH
       : `${groups.length} plan${groups.length > 1 ? 's' : ''} de suivi culturel groupé${groups.length > 1 ? 's' : ''}; premier: ${top.clusterLabel}.`,
     bestBundleId: top?.bundleId ?? null,
     groups,
+    cleanupPrompts,
+    cleanupSummary,
     detailMode: groups.length === 0
       ? 'Aucun détail individuel à ouvrir.'
       : 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
@@ -1419,6 +1477,8 @@ export function buildCultureTurnReportDeltas({
           summary: 'Aucun plan de suivi culturel groupé.',
           bestBundleId: null,
           groups: [],
+          cleanupPrompts: [],
+          cleanupSummary: 'Aucun prompt de nettoyage culturel à proposer.',
           detailMode: 'Aucun détail individuel à ouvrir.',
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -404,6 +404,19 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
           ],
         },
       ],
+      cleanupPrompts: [
+        {
+          cleanupId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle:cleanup-prompt',
+          bundleId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle',
+          clusterLabel: 'Compact d’Aurora',
+          state: 'risk-persists',
+          action: 'conserver: risque culturel encore actif',
+          reason: 'Compact d’Aurora: expansion prudente: verrouille le bénéfice culturel principal autour de Compact d’Aurora; Vérifier si Compact d’Aurora peut encore suivre Ouvrir le récit d’expansion.',
+          safeguard: 'Aucune répétition récente détectée: garder les prompts frais en priorité.',
+          replacesPromptLabel: null,
+        },
+      ],
+      cleanupSummary: '1 prompt de nettoyage: Compact d’Aurora → conserver: risque culturel encore actif.',
       detailMode: 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
     },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
@@ -480,6 +493,17 @@ test('buildCultureTurnReportDeltas marks stale cultural follow-through reminders
   assert.equal(report.commitmentBundles.followThroughBundlePlan.groups[0].clusterLabel, 'Compact d’Aurora');
   assert.match(report.commitmentBundles.followThroughBundlePlan.groups[0].groupingReason, /Même enjeu culturel|Même thème/);
   assert.match(report.commitmentBundles.followThroughBundlePlan.groups[0].avoidedLoss, /opportunité fraîche/);
+  assert.deepEqual(report.commitmentBundles.followThroughBundlePlan.cleanupPrompts.map((prompt) => [
+    prompt.clusterLabel,
+    prompt.state,
+    prompt.action,
+  ]), [
+    ['Compact d’Aurora', 'obsolete', 'remplacer par Ouvrir le récit d’expansion'],
+    ['Harbor Compact', 'risk-persists', 'conserver: risque culturel encore actif'],
+  ]);
+  assert.match(report.commitmentBundles.followThroughBundlePlan.cleanupPrompts[0].reason, /opportunités fraîches/);
+  assert.equal(report.commitmentBundles.followThroughBundlePlan.cleanupPrompts[0].replacesPromptLabel, 'Ouvrir le récit d’expansion');
+  assert.match(report.commitmentBundles.followThroughBundlePlan.cleanupPrompts[0].safeguard, /Rotation courte|Aucune répétition/);
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -585,6 +609,8 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         summary: 'Aucun plan de suivi culturel groupé.',
         bestBundleId: null,
         groups: [],
+        cleanupPrompts: [],
+        cleanupSummary: 'Aucun prompt de nettoyage culturel à proposer.',
         detailMode: 'Aucun détail individuel à ouvrir.',
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -161,6 +161,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /safetyJustification\.state === 'no-safe-justification'/);
   assert.match(webAppSource, /risque retiré:/);
   assert.match(webAppSource, /atlas-cultural-border-zone__risk-relief/);
+  assert.match(webAppSource, /culture-turn-report__cleanup-prompts/);
+  assert.match(webAppSource, /Prompts de nettoyage des bundles culturels/);
+  assert.match(webAppSource, /cleanupPrompts/);
+  assert.match(webAppSource, /Safeguard:/);
   assert.match(stylesSource, /\.atlas-culture-layer/);
   assert.match(stylesSource, /\.atlas-culture-zone--dominant/);
   assert.match(stylesSource, /\.atlas-discovery-site path/);
@@ -233,4 +237,8 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__safest-support/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__support-justification/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__risk-relief/);
+  assert.match(stylesSource, /\.culture-turn-report__cleanup-prompts/);
+  assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--obsolete/);
+  assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--resolved/);
+  assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--risk-persists/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -6879,6 +6879,21 @@ function renderCultureTurnReport(report) {
             `).join('')}
           </div>
         ` : `<small>${report.commitmentBundles?.followThroughBundlePlan?.detailMode ?? 'Aucun détail individuel à ouvrir.'}</small>`}
+        <div class="culture-turn-report__cleanup-prompts" aria-label="Prompts de nettoyage des bundles culturels">
+          <strong>${report.commitmentBundles?.followThroughBundlePlan?.cleanupSummary ?? 'Aucun prompt de nettoyage culturel à proposer.'}</strong>
+          ${(report.commitmentBundles?.followThroughBundlePlan?.cleanupPrompts ?? []).length > 0 ? `
+            <div class="culture-turn-report__cleanup-prompt-list">
+              ${report.commitmentBundles.followThroughBundlePlan.cleanupPrompts.map((prompt) => `
+                <span class="culture-turn-report__cleanup-prompt culture-turn-report__cleanup-prompt--${prompt.state}">
+                  <b>${prompt.clusterLabel}</b>
+                  <small>${prompt.action}${prompt.replacesPromptLabel ? ` · remplace: ${prompt.replacesPromptLabel}` : ''}</small>
+                  <small>${prompt.reason}</small>
+                  <small>Safeguard: ${prompt.safeguard}</small>
+                </span>
+              `).join('')}
+            </div>
+          ` : ''}
+        </div>
       </div>
       <details class="culture-turn-report__history culture-turn-report__history--${report.commitmentBundles?.promptHistoryDrawer?.state ?? 'quiet'}" aria-label="Historique des prompts culturels de carte">
         <summary>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2051,6 +2051,27 @@ button { font: inherit; }
   background: rgba(15, 23, 42, 0.35);
 }
 .culture-turn-report__follow-through-plan-detail b { color: #f8fafc; }
+.culture-turn-report__cleanup-prompts {
+  display: grid;
+  gap: 6px;
+  padding-top: 7px;
+  border-top: 1px solid rgba(14, 165, 233, 0.12);
+}
+.culture-turn-report__cleanup-prompts > strong { color: #e0f2fe; font-size: 11px; }
+.culture-turn-report__cleanup-prompt-list { display: grid; gap: 5px; }
+.culture-turn-report__cleanup-prompt {
+  display: grid;
+  gap: 2px;
+  padding: 6px 7px;
+  border-radius: 9px;
+  background: rgba(2, 6, 23, 0.24);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+.culture-turn-report__cleanup-prompt b { color: #f8fafc; }
+.culture-turn-report__cleanup-prompt small { color: var(--muted); }
+.culture-turn-report__cleanup-prompt--obsolete { border-color: rgba(248, 113, 113, 0.42); }
+.culture-turn-report__cleanup-prompt--resolved { border-color: rgba(74, 222, 128, 0.3); }
+.culture-turn-report__cleanup-prompt--risk-persists { border-color: rgba(251, 191, 36, 0.42); }
 .culture-turn-report__history {
   display: grid;
   gap: 7px;


### PR DESCRIPTION
Gamma: Fixes #1368.

Résumé:
- ajoute des prompts de nettoyage aux plans de suivi culturel groupés;
- classe les bundles en obsolète, résolu, risque persistant ou revue;
- propose une action lisible: archiver, remplacer par un suivi plus frais, ou conserver si le risque persiste;
- affiche la raison de nettoyage et le safeguard anti-répétition dans le rapport UI.

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?