### PR TITLE
Gamma: Preview cultural bundle fallout

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1110,6 +1110,65 @@ function buildCulturalBundleCleanupPrompts(groups, commitmentFollowThroughRemind
   });
 }
 
+function buildCulturalBundleFalloutPreview(cleanupPrompts) {
+  const falloutCandidates = cleanupPrompts
+    .map((prompt) => {
+      const consequenceType = prompt.state === 'obsolete'
+        ? 'opportunity-lost'
+        : prompt.state === 'risk-persists'
+          ? 'tension'
+          : prompt.state === 'review'
+            ? 'consolidation-delay'
+            : 'none';
+      const severity = consequenceType === 'opportunity-lost'
+        ? 3
+        : consequenceType === 'tension'
+          ? 2
+          : consequenceType === 'consolidation-delay'
+            ? 1
+            : 0;
+      const consequence = consequenceType === 'opportunity-lost'
+        ? `${prompt.clusterLabel}: opportunité fraîche masquée si le bundle obsolète reste visible.`
+        : consequenceType === 'tension'
+          ? `${prompt.clusterLabel}: tension culturelle maintenue si le nettoyage est ignoré.`
+          : consequenceType === 'consolidation-delay'
+            ? `${prompt.clusterLabel}: consolidation retardée d’un tour si le bundle n’est pas réévalué.`
+            : `${prompt.clusterLabel}: aucun fallout immédiat détecté.`;
+
+      return {
+        falloutId: `${prompt.cleanupId}:fallout-preview`,
+        bundleId: prompt.bundleId,
+        clusterLabel: prompt.clusterLabel,
+        cleanupState: prompt.state,
+        consequenceType,
+        consequence,
+        severity,
+        exceedsThreshold: severity >= 2,
+        minimalCleanupAction: severity >= 2 ? prompt.action : null,
+      };
+    })
+    .sort((left, right) => right.severity - left.severity || left.clusterLabel.localeCompare(right.clusterLabel));
+  const priority = falloutCandidates.find((candidate) => candidate.severity > 0) ?? null;
+
+  return {
+    state: !priority
+      ? 'quiet'
+      : priority.exceedsThreshold
+        ? 'action-needed'
+        : 'watch',
+    summary: !priority
+      ? 'Aucun fallout culturel si les bundles restent en place ce tour.'
+      : `${priority.consequence}${priority.exceedsThreshold ? ` Cleanup minimal: ${priority.minimalCleanupAction}.` : ''}`,
+    priorityBundleId: priority?.bundleId ?? null,
+    affectedCulture: priority?.clusterLabel ?? null,
+    consequenceType: priority?.consequenceType ?? 'none',
+    consequence: priority?.consequence ?? 'Aucun fallout immédiat détecté.',
+    severity: priority?.severity ?? 0,
+    minimalCleanupAction: priority?.minimalCleanupAction ?? null,
+    entries: falloutCandidates,
+  };
+}
+
 function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder) {
   const groups = promptHistoryDrawer.groups.map((group) => {
     const currentEntries = group.entries.filter((entry) => entry.source === 'current');
@@ -1172,6 +1231,7 @@ function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptH
   const cleanupSummary = cleanupPrompts.length === 0
     ? 'Aucun prompt de nettoyage culturel à proposer.'
     : `${cleanupPrompts.length} prompt${cleanupPrompts.length > 1 ? 's' : ''} de nettoyage: ${cleanupPrompts.map((prompt) => `${prompt.clusterLabel} → ${prompt.action}`).join(' | ')}.`;
+  const falloutPreview = buildCulturalBundleFalloutPreview(cleanupPrompts);
 
   return {
     state: groups.length === 0
@@ -1188,6 +1248,7 @@ function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptH
     groups,
     cleanupPrompts,
     cleanupSummary,
+    falloutPreview,
     detailMode: groups.length === 0
       ? 'Aucun détail individuel à ouvrir.'
       : 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
@@ -1479,6 +1540,17 @@ export function buildCultureTurnReportDeltas({
           groups: [],
           cleanupPrompts: [],
           cleanupSummary: 'Aucun prompt de nettoyage culturel à proposer.',
+          falloutPreview: {
+            state: 'quiet',
+            summary: 'Aucun fallout culturel si les bundles restent en place ce tour.',
+            priorityBundleId: null,
+            affectedCulture: null,
+            consequenceType: 'none',
+            consequence: 'Aucun fallout immédiat détecté.',
+            severity: 0,
+            minimalCleanupAction: null,
+            entries: [],
+          },
           detailMode: 'Aucun détail individuel à ouvrir.',
         },
         dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -417,6 +417,29 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
         },
       ],
       cleanupSummary: '1 prompt de nettoyage: Compact d’Aurora → conserver: risque culturel encore actif.',
+      falloutPreview: {
+        state: 'action-needed',
+        summary: 'Compact d’Aurora: tension culturelle maintenue si le nettoyage est ignoré. Cleanup minimal: conserver: risque culturel encore actif.',
+        priorityBundleId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle',
+        affectedCulture: 'Compact d’Aurora',
+        consequenceType: 'tension',
+        consequence: 'Compact d’Aurora: tension culturelle maintenue si le nettoyage est ignoré.',
+        severity: 2,
+        minimalCleanupAction: 'conserver: risque culturel encore actif',
+        entries: [
+          {
+            falloutId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle:cleanup-prompt:fallout-preview',
+            bundleId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle',
+            clusterLabel: 'Compact d’Aurora',
+            cleanupState: 'risk-persists',
+            consequenceType: 'tension',
+            consequence: 'Compact d’Aurora: tension culturelle maintenue si le nettoyage est ignoré.',
+            severity: 2,
+            exceedsThreshold: true,
+            minimalCleanupAction: 'conserver: risque culturel encore actif',
+          },
+        ],
+      },
       detailMode: 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
     },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
@@ -504,6 +527,11 @@ test('buildCultureTurnReportDeltas marks stale cultural follow-through reminders
   assert.match(report.commitmentBundles.followThroughBundlePlan.cleanupPrompts[0].reason, /opportunités fraîches/);
   assert.equal(report.commitmentBundles.followThroughBundlePlan.cleanupPrompts[0].replacesPromptLabel, 'Ouvrir le récit d’expansion');
   assert.match(report.commitmentBundles.followThroughBundlePlan.cleanupPrompts[0].safeguard, /Rotation courte|Aucune répétition/);
+  assert.equal(report.commitmentBundles.followThroughBundlePlan.falloutPreview.state, 'action-needed');
+  assert.equal(report.commitmentBundles.followThroughBundlePlan.falloutPreview.affectedCulture, 'Compact d’Aurora');
+  assert.equal(report.commitmentBundles.followThroughBundlePlan.falloutPreview.consequenceType, 'opportunity-lost');
+  assert.match(report.commitmentBundles.followThroughBundlePlan.falloutPreview.consequence, /opportunité fraîche masquée/);
+  assert.equal(report.commitmentBundles.followThroughBundlePlan.falloutPreview.minimalCleanupAction, 'remplacer par Ouvrir le récit d’expansion');
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -611,6 +639,17 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         groups: [],
         cleanupPrompts: [],
         cleanupSummary: 'Aucun prompt de nettoyage culturel à proposer.',
+        falloutPreview: {
+          state: 'quiet',
+          summary: 'Aucun fallout culturel si les bundles restent en place ce tour.',
+          priorityBundleId: null,
+          affectedCulture: null,
+          consequenceType: 'none',
+          consequence: 'Aucun fallout immédiat détecté.',
+          severity: 0,
+          minimalCleanupAction: null,
+          entries: [],
+        },
         detailMode: 'Aucun détail individuel à ouvrir.',
       },
       dependencyExplanation: 'Aucune dépendance entre marqueurs culturels.',

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -161,6 +161,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /safetyJustification\.state === 'no-safe-justification'/);
   assert.match(webAppSource, /risque retiré:/);
   assert.match(webAppSource, /atlas-cultural-border-zone__risk-relief/);
+  assert.match(webAppSource, /culture-turn-report__fallout-preview/);
+  assert.match(webAppSource, /Fallout si ignoré/);
+  assert.match(webAppSource, /falloutPreview/);
+  assert.match(webAppSource, /Cleanup minimal:/);
   assert.match(webAppSource, /culture-turn-report__cleanup-prompts/);
   assert.match(webAppSource, /Prompts de nettoyage des bundles culturels/);
   assert.match(webAppSource, /cleanupPrompts/);
@@ -237,6 +241,9 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__safest-support/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__support-justification/);
   assert.match(stylesSource, /\.atlas-cultural-consolidation-action__risk-relief/);
+  assert.match(stylesSource, /\.culture-turn-report__fallout-preview/);
+  assert.match(stylesSource, /\.culture-turn-report__fallout-preview--action-needed/);
+  assert.match(stylesSource, /\.culture-turn-report__fallout-preview--watch/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompts/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--obsolete/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--resolved/);

--- a/web/app.js
+++ b/web/app.js
@@ -6879,6 +6879,12 @@ function renderCultureTurnReport(report) {
             `).join('')}
           </div>
         ` : `<small>${report.commitmentBundles?.followThroughBundlePlan?.detailMode ?? 'Aucun détail individuel à ouvrir.'}</small>`}
+        <div class="culture-turn-report__fallout-preview culture-turn-report__fallout-preview--${report.commitmentBundles?.followThroughBundlePlan?.falloutPreview?.state ?? 'quiet'}" aria-label="Fallout culturel si les bundles obsolètes restent visibles">
+          <span>Fallout si ignoré</span>
+          <strong>${report.commitmentBundles?.followThroughBundlePlan?.falloutPreview?.summary ?? 'Aucun fallout culturel si les bundles restent en place ce tour.'}</strong>
+          <small>Conséquence: ${report.commitmentBundles?.followThroughBundlePlan?.falloutPreview?.consequence ?? 'Aucun fallout immédiat détecté.'}</small>
+          ${report.commitmentBundles?.followThroughBundlePlan?.falloutPreview?.minimalCleanupAction ? `<small>Cleanup minimal: ${report.commitmentBundles.followThroughBundlePlan.falloutPreview.minimalCleanupAction}</small>` : ''}
+        </div>
         <div class="culture-turn-report__cleanup-prompts" aria-label="Prompts de nettoyage des bundles culturels">
           <strong>${report.commitmentBundles?.followThroughBundlePlan?.cleanupSummary ?? 'Aucun prompt de nettoyage culturel à proposer.'}</strong>
           ${(report.commitmentBundles?.followThroughBundlePlan?.cleanupPrompts ?? []).length > 0 ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -2051,6 +2051,25 @@ button { font: inherit; }
   background: rgba(15, 23, 42, 0.35);
 }
 .culture-turn-report__follow-through-plan-detail b { color: #f8fafc; }
+.culture-turn-report__fallout-preview {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.32);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+.culture-turn-report__fallout-preview span {
+  color: #bae6fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__fallout-preview strong { color: #f8fafc; font-size: 11px; }
+.culture-turn-report__fallout-preview small { color: var(--muted); }
+.culture-turn-report__fallout-preview--action-needed { border-color: rgba(248, 113, 113, 0.45); }
+.culture-turn-report__fallout-preview--watch { border-color: rgba(251, 191, 36, 0.38); }
+.culture-turn-report__fallout-preview--quiet { border-color: rgba(74, 222, 128, 0.24); }
 .culture-turn-report__cleanup-prompts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Gamma: Fixes #1378.

Résumé:
- ajoute une prévisualisation compacte du fallout culturel si un bundle obsolète reste visible;
- priorise le bundle/culture affecté et classe la conséquence en tension, opportunité perdue ou retard de consolidation;
- affiche le cleanup minimal quand le fallout dépasse le seuil raisonnable;
- conserve l’alignement avec les prompts de cleanup MAP-G22.

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?