### PR TITLE
Alpha: Preview neighboring front shifts

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -84,3 +84,22 @@ test('atlas military renders a relapse prevention checklist before committing pr
   assert.match(stylesSource, /\.atlas-military-relapse-commit-checklist-row--fragile circle/);
   assert.match(stylesSource, /\.atlas-military-relapse-commit-checklist-row--safe circle/);
 });
+
+// MAP-A23: preview the immediate neighbouring-front effects without expanding the
+// A22 checklist panel.
+test('atlas military previews neighboring front shifts after committing province orders', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryNeighborFrontShiftPreview\(recommendation, checklist, features\)/);
+  assert.match(webAppSource, /function renderAtlasMilitaryNeighborFrontShiftPreview\(preview\)/);
+  assert.match(webAppSource, /Prévisualisation des fronts voisins après engagement/);
+  assert.match(webAppSource, /Voisins après ordre/);
+  assert.match(webAppSource, /candidateRoutes = \(features\?\.routes \?\? \[\]\)/);
+  assert.match(webAppSource, /fallbackRoutes\.slice\(0, 3\)/);
+  assert.match(webAppSource, /label: 'soulage'/);
+  assert.match(webAppSource, /label: 'neutre'/);
+  assert.match(webAppSource, /label: 'rechute probable'/);
+  assert.match(webAppSource, /pression voisine élevée après engagement/);
+  assert.match(webAppSource, /renderAtlasMilitaryNeighborFrontShiftPreview\(neighborFrontShiftPreview\)/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-front-shift__panel/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-front-shift-row--soulage circle/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-front-shift-row--rechute circle/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2277,6 +2277,107 @@ function renderAtlasMilitaryRelapsePreventionCommitChecklist(checklist) {
   `;
 }
 
+
+function getAtlasMilitaryNeighborFrontShiftEffect(route, focusPoint, checklist) {
+  if (focusPoint?.tone === 'fragile' && (route.contested || route.pressure >= 58)) {
+    return {
+      tone: 'fragilise',
+      label: 'fragilise',
+      reason: 'pression voisine élevée après engagement',
+    };
+  }
+
+  if (route.pressure >= 74) {
+    return {
+      tone: 'rechute',
+      label: 'rechute probable',
+      reason: 'front voisin déjà sous tension critique',
+    };
+  }
+
+  if (checklist.safeToCommit && route.pressure < 64) {
+    return {
+      tone: 'soulage',
+      label: 'soulage',
+      reason: 'ordre principal absorbe la pression locale',
+    };
+  }
+
+  return {
+    tone: 'neutre',
+    label: 'neutre',
+    reason: 'changement voisin sous seuil de rechute',
+  };
+}
+
+function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, features) {
+  const focus = recommendation?.primary ?? null;
+  const focusProvince = focus?.provinceLabel ?? checklist?.points?.[0]?.detail?.split(':')?.[0] ?? null;
+  if (!focusProvince) {
+    return {
+      focusProvince: null,
+      focusOrder: 'ordre contesté non sélectionné',
+      shifts: [],
+      summary: 'Prévision voisins indisponible: aucun ordre de province en focus.',
+      empty: true,
+    };
+  }
+
+  const focusPoint = (checklist?.points ?? []).find((point) => point.detail.startsWith(`${focusProvince}:`)) ?? checklist?.points?.[0] ?? null;
+  const candidateRoutes = (features?.routes ?? [])
+    .filter((route) => route.sourceLabel === focusProvince || route.targetLabel === focusProvince);
+  const fallbackRoutes = candidateRoutes.length ? candidateRoutes : (features?.routes ?? []);
+  const shifts = fallbackRoutes.slice(0, 3).map((route, index) => {
+    const neighborLabel = route.sourceLabel === focusProvince ? route.targetLabel : route.sourceLabel;
+    const effect = getAtlasMilitaryNeighborFrontShiftEffect(route, focusPoint, checklist ?? { safeToCommit: false });
+    return {
+      shiftId: `neighbor-front-shift:${focusProvince}:${neighborLabel}:${index}`,
+      neighborLabel,
+      routeLabel: `${route.sourceLabel} ↔ ${route.targetLabel}`,
+      pressure: route.pressure,
+      effect: effect.label,
+      tone: effect.tone,
+      reason: effect.reason,
+    };
+  });
+
+  if (!shifts.length) {
+    return {
+      focusProvince,
+      focusOrder: focus?.nextAction ?? 'ordre contesté recommandé',
+      shifts: [],
+      summary: `${focusProvince}: aucun front voisin lisible après engagement.`,
+      empty: true,
+    };
+  }
+
+  return {
+    focusProvince,
+    focusOrder: focus?.nextAction ?? 'ordre contesté recommandé',
+    shifts,
+    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}.`,
+    empty: false,
+  };
+}
+
+function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
+  const height = preview.empty ? 6.1 : 5.6 + (preview.shifts.length * 3.45);
+  return `
+    <g class="atlas-military-neighbor-front-shift atlas-military-neighbor-front-shift--${preview.empty ? 'empty' : 'active'}" aria-label="Prévisualisation des fronts voisins après engagement: ${preview.summary}">
+      <rect class="atlas-military-neighbor-front-shift__panel" x="43" y="157" width="35" height="${height}" rx="2.1"></rect>
+      <text class="atlas-military-neighbor-front-shift__title" x="44.2" y="159.4">Voisins après ordre</text>
+      <text class="atlas-military-neighbor-front-shift__focus" x="44.2" y="160.75">${preview.focusProvince ?? 'Aucun focus'} · ${preview.focusOrder}</text>
+      ${preview.empty ? `<text class="atlas-military-neighbor-front-shift__empty" x="44.2" y="162.2">${preview.summary}</text>` : preview.shifts.map((shift, index) => `
+        <g class="atlas-military-neighbor-front-shift-row atlas-military-neighbor-front-shift-row--${shift.tone}" data-atlas-neighbor-front-shift="${shift.shiftId}" aria-label="${shift.routeLabel}: ${shift.effect}; ${shift.reason}; pression ${shift.pressure}">
+          <circle cx="44.8" cy="${162.45 + index * 3.45}" r="0.58"></circle>
+          <text class="atlas-military-neighbor-front-shift-row__label" x="46" y="${162.05 + index * 3.45}">${shift.neighborLabel} · ${shift.effect}</text>
+          <text class="atlas-military-neighbor-front-shift-row__reason" x="46" y="${163.38 + index * 3.45}">${shift.reason}</text>
+        </g>
+      `).join('')}
+    </g>
+  `;
+}
+
 function getAtlasMilitaryBlockingHandoffDecision(item, confidence) {
   if (!item) return 'attente: visibilité insuffisante';
   if (item.kind === 'obligatoire' && item.dependencies?.includes('logistique')) return 'renfort: sécuriser logistique';
@@ -3339,6 +3440,7 @@ function renderAtlasMilitaryLayer(shell) {
   const closureAfterActionComparison = buildAtlasMilitaryClosureAfterActionComparison(nextBestClosureRecommendation);
   const postClosureRelapseWatchlist = buildAtlasMilitaryPostClosureRelapseWatchlist(closureAfterActionComparison, nextBestClosureRecommendation);
   const relapsePreventionCommitChecklist = buildAtlasMilitaryRelapsePreventionCommitChecklist(postClosureRelapseWatchlist);
+  const neighborFrontShiftPreview = buildAtlasMilitaryNeighborFrontShiftPreview(nextBestClosureRecommendation, relapsePreventionCommitChecklist, features);
   const commitmentWarningStack = buildAtlasMilitaryWarningPriorityStack(commitmentWarnings, features);
 
   if (!features.routes.length && !features.riskZones.length) {
@@ -3380,6 +3482,7 @@ function renderAtlasMilitaryLayer(shell) {
       ${renderAtlasMilitaryClosureAfterActionComparison(closureAfterActionComparison)}
       ${renderAtlasMilitaryPostClosureRelapseWatchlist(postClosureRelapseWatchlist)}
       ${renderAtlasMilitaryRelapsePreventionCommitChecklist(relapsePreventionCommitChecklist)}
+      ${renderAtlasMilitaryNeighborFrontShiftPreview(neighborFrontShiftPreview)}
       ${renderAtlasMilitaryWarningPriorityStack(commitmentWarningStack, stagedCommitment, shell)}
       ${renderAtlasMilitaryCommitmentFrontConflicts(commitmentConflicts)}
       ${features.riskZones.map((zone) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -14014,3 +14014,38 @@ button { font: inherit; }
 .atlas-military-relapse-commit-checklist-row--fragile circle { fill: rgba(251, 191, 36, 0.88); }
 .atlas-military-relapse-commit-checklist-row--watch circle { fill: rgba(96, 165, 250, 0.84); }
 .atlas-military-relapse-commit-checklist-row--fragile .atlas-military-relapse-commit-checklist-row__detail { fill: #fed7aa; }
+
+.atlas-military-neighbor-front-shift__panel {
+  fill: rgba(30, 41, 59, 0.76);
+  stroke: rgba(196, 181, 253, 0.42);
+  stroke-width: 0.26;
+  filter: drop-shadow(0 2px 5px rgba(2, 6, 23, 0.42));
+}
+.atlas-military-neighbor-front-shift__title,
+.atlas-military-neighbor-front-shift__focus,
+.atlas-military-neighbor-front-shift-row text,
+.atlas-military-neighbor-front-shift__empty {
+  fill: #ede9fe;
+  font-size: 0.66px;
+  font-weight: 900;
+  paint-order: stroke;
+  stroke: rgba(2, 6, 23, 0.9);
+  stroke-width: 0.2;
+}
+.atlas-military-neighbor-front-shift__focus,
+.atlas-military-neighbor-front-shift-row__reason,
+.atlas-military-neighbor-front-shift__empty {
+  fill: #ddd6fe;
+  font-size: 0.42px;
+}
+.atlas-military-neighbor-front-shift-row circle {
+  fill: rgba(167, 139, 250, 0.84);
+  stroke: rgba(245, 243, 255, 0.72);
+  stroke-width: 0.12;
+}
+.atlas-military-neighbor-front-shift-row--soulage circle { fill: rgba(74, 222, 128, 0.86); }
+.atlas-military-neighbor-front-shift-row--neutre circle { fill: rgba(148, 163, 184, 0.82); }
+.atlas-military-neighbor-front-shift-row--fragilise circle,
+.atlas-military-neighbor-front-shift-row--rechute circle { fill: rgba(251, 113, 133, 0.88); }
+.atlas-military-neighbor-front-shift-row--fragilise .atlas-military-neighbor-front-shift-row__reason,
+.atlas-military-neighbor-front-shift-row--rechute .atlas-military-neighbor-front-shift-row__reason { fill: #fecdd3; }


### PR DESCRIPTION
Alpha: Implements #1376.\n\nSummary:\n- Adds a compact neighboring-front shift preview after the focused contested-province order.\n- Identifies up to three adjacent fronts from atlas military routes and classifies them as soulage, neutre, fragilise, or rechute probable.\n- Keeps the A22 checklist separate and adds compact styles/tests for the new panel.\n\nValidation:\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test