### PR TITLE
Beta: Trace secondary logistics bottlenecks

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -637,6 +637,47 @@ function buildSelectedActionImpactPreview(priorityAction, routeChoices) {
 }
 
 
+
+function buildSecondaryBottleneckPreview(priorityAction, routeChoices) {
+  if (!priorityAction) {
+    return {
+      state: 'empty',
+      label: 'Aucun goulot secondaire',
+      status: 'absorbable',
+      route: null,
+      city: null,
+      resource: null,
+      summary: 'Aucun levier recommandé: impossible de projeter le prochain goulot logistique.',
+      detail: 'Attendre un signal recovery avant d’afficher une alerte aval.',
+    };
+  }
+
+  const option = routeChoices.find((candidate) => candidate.routeId === priorityAction.routeId) ?? routeChoices[0] ?? null;
+  const choice = option?.recoveryChoices.find((candidate) => candidate.choiceId === priorityAction.choiceId) ?? option?.recoveryChoices[0] ?? null;
+  const shortage = choice?.downstreamShortages.find((candidate) => candidate.status !== 'résolue') ?? choice?.downstreamShortages[0] ?? null;
+  const neighbor = choice?.neighborEffects.find((effect) => effect.tone !== 'low') ?? choice?.neighborEffects[0] ?? null;
+  const bottleneck = choice?.bottleneck ?? null;
+  const status = shortage?.status === 'aggravée' || bottleneck?.tone === 'high'
+    ? 'bloquant'
+    : shortage?.status === 'déplacée' || shortage?.status === 'inconnue' || bottleneck?.tone === 'medium'
+      ? 'à surveiller'
+      : 'absorbable';
+  const route = shortage?.route ?? neighbor?.route ?? priorityAction.route;
+  const city = shortage?.target ?? neighbor?.target ?? option?.affectedCity ?? 'ville liée';
+  const resource = shortage?.resource ?? priorityAction.resource;
+
+  return {
+    state: status === 'bloquant' ? 'blocked' : status === 'à surveiller' ? 'watch' : 'absorbable',
+    label: bottleneck?.label ?? shortage?.status ?? 'goulot aval',
+    status,
+    route,
+    city,
+    resource,
+    summary: `${priorityAction.action} appliqué: prochain goulot ${status} sur ${route} près de ${city}.`,
+    detail: shortage?.detail ?? bottleneck?.detail ?? `${resource} reste à suivre après ${priorityAction.action}.`,
+  };
+}
+
 function buildPrimaryLogisticsQueueAction(priorityAction, selectedActionPreview, queuedLogisticsActions = []) {
   if (!priorityAction) {
     return {
@@ -687,7 +728,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const queuedLogisticsActions = Array.isArray(normalizedOptions.queuedLogisticsActions) ? normalizedOptions.queuedLogisticsActions : [];
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -724,6 +765,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       prioritySummary: 'Aucune action logistique prioritaire disponible.',
       recoveryLeverRanking: buildRecoveryLeverRanking([], [], false),
       selectedActionPreview: buildSelectedActionImpactPreview(null, []),
+      secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []),
       primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions),
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
@@ -737,6 +779,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const recommendedPriority = priorityActions[0] ?? null;
   const recoveryLeverRanking = buildRecoveryLeverRanking(routeChoices, priorityActions, hasBlocker);
   const selectedActionPreview = buildSelectedActionImpactPreview(recommendedPriority, routeChoices);
+  const secondaryBottleneckPreview = buildSecondaryBottleneckPreview(recommendedPriority, routeChoices);
   const primaryLogisticsAction = buildPrimaryLogisticsQueueAction(recommendedPriority, selectedActionPreview, queuedLogisticsActions);
 
   return {
@@ -756,6 +799,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       : 'Aucune action logistique prioritaire disponible.',
     recoveryLeverRanking,
     selectedActionPreview,
+    secondaryBottleneckPreview,
     primaryLogisticsAction,
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -95,6 +95,10 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.ok(['critical', 'improved', 'limited'].includes(preview.selectedActionPreview.status));
   assert.equal(preview.selectedActionPreview.badges.length, 3);
   assert.match(`${preview.selectedActionPreview.currentState} ${preview.selectedActionPreview.projectedState}`, /Actuel|Projeté/);
+  assert.equal(preview.secondaryBottleneckPreview.state, 'blocked');
+  assert.equal(preview.secondaryBottleneckPreview.status, 'bloquant');
+  assert.match(preview.secondaryBottleneckPreview.summary, /prochain goulot|Ember Line|Hill Spur|Iron Plain|Hill Hub/);
+  assert.match(preview.secondaryBottleneckPreview.detail, /Outils|pression aval|manquer|retarder|reste à surveiller/);
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
   assert.match(preview.primaryLogisticsAction.downstreamImpact, /pénurie|route|province|délai/);
@@ -155,6 +159,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.deepEqual(preview.recoveryLeverRanking.levers, []);
   assert.equal(preview.selectedActionPreview.status, 'empty');
   assert.deepEqual(preview.selectedActionPreview.badges, []);
+  assert.equal(preview.secondaryBottleneckPreview.state, 'empty');
+  assert.match(preview.secondaryBottleneckPreview.summary, /impossible de projeter/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -72,6 +72,10 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Impact si engagé/);
   assert.match(webAppSource, /selectedActionPreview/);
   assert.match(webAppSource, /badge\.value/);
+  assert.match(webAppSource, /province-logistics-secondary-bottleneck/);
+  assert.match(webAppSource, /Goulot suivant/);
+  assert.match(webAppSource, /secondaryBottleneckPreview/);
+  assert.match(webAppSource, /Prochain goulot logistique après le levier recovery/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -7828,6 +7828,17 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
           </ol>
         </div>
       ` : ''}
+      ${preview.secondaryBottleneckPreview && preview.secondaryBottleneckPreview.state !== 'empty' ? `
+        <div class="province-logistics-secondary-bottleneck province-logistics-secondary-bottleneck--${preview.secondaryBottleneckPreview.state}" aria-label="Prochain goulot logistique après le levier recovery">
+          <div>
+            <b>Goulot suivant</b>
+            <span>${preview.secondaryBottleneckPreview.status}</span>
+          </div>
+          <strong>${preview.secondaryBottleneckPreview.route} · ${preview.secondaryBottleneckPreview.city}</strong>
+          <p>${preview.secondaryBottleneckPreview.summary}</p>
+          <small>${preview.secondaryBottleneckPreview.resource}: ${preview.secondaryBottleneckPreview.detail}</small>
+        </div>
+      ` : ''}
       <div class="province-logistics-queue-action province-logistics-queue-action--${preview.primaryLogisticsAction.status}" aria-label="Engager une action logistique depuis la carte">
         <div>
           <b>Action carte</b>


### PR DESCRIPTION
Beta: Implements #1377.

Summary:
- Adds a secondary bottleneck preview for the recommended logistics recovery lever.
- Classifies the next downstream bottleneck as absorbable, watch, or blocking.
- Links the alert to the visible route, city, and resource without duplicating the B22 capacity-cost detail.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
