### PR TITLE
Delta: Explain confidence shifts behind intrigue timing

### DIFF
--- a/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
+++ b/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
@@ -77,6 +77,48 @@ function getTimingChangeCause(timingComparison) {
   return 'confiance';
 }
 
+function getConfidenceCause(timingComparison) {
+  const joinedText = [
+    timingComparison?.dominantReason,
+    timingComparison?.summary,
+    timingComparison?.actNow?.risk,
+    timingComparison?.actNow?.outcome,
+    timingComparison?.shortWait?.risk,
+    timingComparison?.shortWait?.outcome,
+  ].filter(Boolean).join(' ');
+
+  if (/exposition|budget/i.test(joinedText)) return 'exposition';
+  if (/délai|delai|attendre|fenêtre|fenetre|vieilli|périmer|perimer/i.test(joinedText)) return 'délai';
+  if (/couverture|agent|relais/i.test(joinedText)) return 'couverture';
+  if (/cellule|réseau|reseau/i.test(joinedText)) return 'cellule';
+  return 'signal contradictoire';
+}
+
+function buildConfidenceShift(currentTiming, currentTimingComparison) {
+  const cause = getConfidenceCause(currentTimingComparison);
+  const dominantReason = currentTimingComparison?.dominantReason ?? null;
+  const variation = currentTiming === 'act-now'
+    ? 'baisse'
+    : dominantReason === 'information-manquante'
+      ? 'reste instable'
+      : cause === 'exposition' || cause === 'signal contradictoire'
+        ? 'baisse'
+        : 'augmente';
+  const justification = currentTiming === 'act-now'
+    ? 'la perte de confiance rend l’attente plus risquée que l’action immédiate'
+    : variation === 'augmente'
+      ? 'la confiance remonte assez pour laisser attendre sans perdre le signal visible'
+      : 'la confiance fragile justifie d’attendre un signal plus sûr avant d’agir';
+
+  return {
+    variation,
+    cause,
+    justifies: currentTiming,
+    label: `${variation}: ${cause}`,
+    justification,
+  };
+}
+
 function buildTimingRecommendationChange({ previousTimingRecommendation, currentTimingComparison }) {
   const previous = normalizeTimingRecommendation(previousTimingRecommendation);
   const current = normalizeTimingRecommendation(currentTimingComparison?.recommendedTiming);
@@ -87,6 +129,7 @@ function buildTimingRecommendationChange({ previousTimingRecommendation, current
 
   const direction = `${TIMING_LABELS[previous]} → ${TIMING_LABELS[current]}`;
   const cause = getTimingChangeCause(currentTimingComparison);
+  const confidenceShift = buildConfidenceShift(current, currentTimingComparison);
 
   return {
     previousTiming: previous,
@@ -96,6 +139,7 @@ function buildTimingRecommendationChange({ previousTimingRecommendation, current
     tone: current === 'act-now' ? 'worse' : 'watch',
     label: 'Timing recommandé modifié',
     detail: `${direction}: cause visible ${cause}.`,
+    confidenceShift,
     fogSafe: true,
   };
 }

--- a/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
@@ -85,9 +85,43 @@ test('buildIntrigueTurnReportDeltas flags changed timing recommendations fog-saf
     tone: 'watch',
     label: 'Timing recommandé modifié',
     detail: 'agir maintenant → attendre: cause visible exposition.',
+    confidenceShift: {
+      variation: 'baisse',
+      cause: 'exposition',
+      justifies: 'short-wait',
+      label: 'baisse: exposition',
+      justification: 'la confiance fragile justifie d’attendre un signal plus sûr avant d’agir',
+    },
     fogSafe: true,
   });
   assert.ok(report.deltas.some((delta) => delta.type === 'timing' && delta.detail === 'agir maintenant → attendre: cause visible exposition.'));
+});
+
+test('buildIntrigueTurnReportDeltas explains confidence loss when timing flips to act now', () => {
+  const view = buildIntrigueView();
+  view.selectedProvince.drillDown.postRecapStabilizationChoices = {
+    timingComparison: {
+      recommendedTiming: 'act-now',
+      dominantReason: 'fenêtre-adverse',
+      actNow: { outcome: 'Stabiliser verrouille la fenêtre sûre visible.' },
+      shortWait: { risk: 'signal vieilli et délai de recheck plus coûteux' },
+      summary: 'Choix urgent: la fenêtre visible se dégrade plus vite que le bénéfice d’attendre.',
+    },
+  };
+
+  const report = buildIntrigueTurnReportDeltas(province, view, {
+    previousActionCode: 'contenir',
+    previousTimingRecommendation: 'short-wait',
+  });
+
+  assert.equal(report.timingRecommendationChange.direction, 'attendre → agir maintenant');
+  assert.deepEqual(report.timingRecommendationChange.confidenceShift, {
+    variation: 'baisse',
+    cause: 'délai',
+    justifies: 'act-now',
+    label: 'baisse: délai',
+    justification: 'la perte de confiance rend l’attente plus risquée que l’action immédiate',
+  });
 });
 
 test('buildIntrigueTurnReportDeltas keeps unknown intelligence discreet', () => {

--- a/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
@@ -11,5 +11,7 @@ test('playable map wires intrigue aftermath deltas into selected province turn r
   assert.match(webAppSource, /Risque représailles/);
   assert.match(webAppSource, /previousTimingRecommendation/);
   assert.match(webAppSource, /Changement de recommandation de timing intrigue/);
+  assert.match(webAppSource, /Confiance/);
+  assert.match(webAppSource, /confidenceShift/);
   assert.match(webAppSource, /renderIntrigueTurnReportDeltas\(province, intrigueView\)/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -7950,6 +7950,7 @@ function renderIntrigueTurnReportDeltas(province, intrigueView) {
         <div class="province-intrigue-turn-report__timing-change province-intrigue-turn-report__timing-change--${report.timingRecommendationChange.tone}" aria-label="Changement de recommandation de timing intrigue">
           <b>${report.timingRecommendationChange.direction}</b>
           <span>Cause visible: ${report.timingRecommendationChange.cause}</span>
+          <small>Confiance ${report.timingRecommendationChange.confidenceShift?.label ?? 'instable: signal contradictoire'} · ${report.timingRecommendationChange.confidenceShift?.justification ?? 'justification à confirmer sans révéler de donnée masquée'}</small>
         </div>
       ` : ''}
       ${report.deltas.length > 0 ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -9542,9 +9542,9 @@ button { font: inherit; }
   color: var(--muted);
 }
 .province-intrigue-turn-report__timing-change {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 8px;
   margin-top: 10px;
   padding: 8px 10px;
   border-radius: 12px;
@@ -9552,7 +9552,9 @@ button { font: inherit; }
   border: 1px solid rgba(250, 204, 21, 0.24);
 }
 .province-intrigue-turn-report__timing-change--worse { border-color: rgba(248, 113, 113, 0.34); }
-.province-intrigue-turn-report__timing-change span { color: var(--muted); }
+.province-intrigue-turn-report__timing-change span,
+.province-intrigue-turn-report__timing-change small { color: var(--muted); }
+.province-intrigue-turn-report__timing-change small { grid-column: 1 / -1; }
 .province-intrigue-turn-report__list {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Résout #1379.

Résumé:
- Ajoute une justification compacte de confiance aux changements de timing intrigue MAP-D21.
- Signale si la confiance augmente, baisse ou reste instable, avec cause visible bornée: exposition, délai, couverture, cellule ou signal contradictoire.
- Indique si la variation justifie agir maintenant ou attendre, sans exposer cible, relais, cellule cachée ou vérité sous fog-of-war.

Tests:
- node --test test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?