### PR TITLE
Epsilon: Flag climate follow-ups that protect readiness thresholds

### DIFF
--- a/test/ui/climate/webAtlasClimateFollowUpThresholdProtection.test.js
+++ b/test/ui/climate/webAtlasClimateFollowUpThresholdProtection.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas ranks climate follow-ups by next threshold protection', () => {
+  assert.match(webAppSource, /function buildAtlasClimateFollowUpThresholdProtection/);
+  assert.match(webAppSource, /function renderAtlasClimateFollowUpThresholdProtection/);
+  assert.match(webAppSource, /Protection prochain seuil/);
+  assert.match(webAppSource, /Meilleur follow-up seuil/);
+  assert.match(webAppSource, /protège le seuil/);
+  assert.match(webAppSource, /stabilise court terme/);
+  assert.match(webAppSource, /insuffisant/);
+  assert.match(webAppSource, /Lien seuil\/fenêtre/);
+  assert.match(webAppSource, /Repousse le risque sans sécuriser/);
+  assert.match(webAppSource, /buildAtlasClimateFollowUpThresholdProtection\(\s*atlasNextClimateFollowUpAction,\s*atlasClimateThresholdProgressAfterReadinessAction,\s*atlasClimateReboundFollowUpQueue,\s*\)/);
+  assert.match(webAppSource, /renderAtlasNextClimateFollowUpAction\(atlasNextClimateFollowUpAction\)\}\s*\$\{renderAtlasClimateFollowUpThresholdProtection\(atlasClimateFollowUpThresholdProtection\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-threshold-protection/);
+  assert.match(stylesSource, /\.map-world-climate-threshold-protection--stabilizes-short-term/);
+  assert.match(stylesSource, /\.map-world-climate-threshold-protection--insufficient/);
+  assert.match(stylesSource, /\.map-world-climate-threshold-protection__item--protects-threshold/);
+  assert.match(stylesSource, /\.map-world-climate-threshold-protection__item--stabilizes-short-term/);
+  assert.match(stylesSource, /\.map-world-climate-threshold-protection__item--insufficient/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -12568,6 +12568,120 @@ function renderAtlasNextClimateFollowUpAction(view) {
   `;
 }
 
+function buildAtlasClimateFollowUpThresholdProtection(nextFollowUpView, thresholdProgressView, queueView) {
+  if (!nextFollowUpView || nextFollowUpView.state === 'empty' || !nextFollowUpView.recommendation || !thresholdProgressView || thresholdProgressView.state === 'empty' || !thresholdProgressView.progress) {
+    return {
+      state: 'empty',
+      bestAction: null,
+      actions: [],
+      summary: 'Aucun classement de protection de seuil climat: follow-up ou seuil indisponible.',
+    };
+  }
+
+  const progress = thresholdProgressView.progress;
+  const primary = nextFollowUpView.recommendation;
+  const queueActions = (queueView?.items ?? [])
+    .filter((item) => item.label !== primary.label)
+    .map((item) => ({
+      label: item.label,
+      action: item.nextAction,
+      queueClassification: item.classification,
+      residualRisk: item.ignoredReboundRisk,
+    }));
+  const visibleActions = [
+    {
+      label: primary.label,
+      action: primary.action,
+      queueClassification: nextFollowUpView.state === 'immediate-action' ? 'primary-ready' : nextFollowUpView.state,
+      residualRisk: primary.residualRisk,
+      avoidedRisk: primary.avoidedRisk,
+      cooldownState: primary.cooldownState,
+    },
+    ...queueActions,
+  ].slice(0, 4);
+
+  const classifyAction = (action, index) => {
+    const protectsThreshold = index === 0
+      && thresholdProgressView.state === 'threshold-reached'
+      && (action.cooldownState === 'ready-now' || nextFollowUpView.state === 'immediate-action');
+    const stabilizesShortTerm = protectsThreshold
+      ? false
+      : index === 0 || action.queueClassification === 'urgent' || action.queueClassification === 'prudent' || /attendre|préparer|cooling-off|réserve|mitigation/i.test(action.action);
+    const className = protectsThreshold
+      ? 'protects-threshold'
+      : stabilizesShortTerm
+        ? 'stabilizes-short-term'
+        : 'insufficient';
+    const label = className === 'protects-threshold'
+      ? 'protège le seuil'
+      : className === 'stabilizes-short-term'
+        ? 'stabilise court terme'
+        : 'insuffisant';
+    const reason = className === 'protects-threshold'
+      ? `Protège ${progress.threshold} en évitant ${action.avoidedRisk ?? 'le rebond climatique'} avant ${progress.deadline}.`
+      : className === 'stabilizes-short-term'
+        ? `Stabilise la fenêtre ${progress.deadline}, mais demande encore une relecture du seuil avant d’élargir le plan.`
+        : `Repousse le risque sans sécuriser ${progress.threshold}: garder en attente tant que la fenêtre climatique reste fragile.`;
+    const thresholdLink = className === 'protects-threshold'
+      ? progress.nextMapFollowUp
+      : className === 'stabilizes-short-term'
+        ? (progress.missingLine || 'la protection reste partielle avant le prochain seuil')
+        : 'ne pas compter comme protection du prochain seuil';
+    const score = className === 'protects-threshold' ? 90 : className === 'stabilizes-short-term' ? 55 : 20;
+
+    return {
+      ...action,
+      rank: index + 1,
+      className,
+      label,
+      reason,
+      thresholdLink,
+      score,
+    };
+  };
+
+  const actions = visibleActions
+    .map(classifyAction)
+    .sort((left, right) => right.score - left.score || left.rank - right.rank)
+    .map((action, index) => ({ ...action, rank: index + 1 }));
+  const bestAction = actions[0] ?? null;
+
+  return {
+    state: bestAction?.className ?? 'empty',
+    bestAction,
+    actions,
+    summary: bestAction
+      ? `Meilleur follow-up seuil: ${bestAction.label} — ${bestAction.action}.`
+      : 'Aucun follow-up visible ne protège le prochain seuil climat.',
+  };
+}
+
+function renderAtlasClimateFollowUpThresholdProtection(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty' || !view.bestAction) {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-threshold-protection map-world-climate-threshold-protection--${view.state}" aria-label="Classement des follow-ups climat qui protègent le prochain seuil readiness">
+      <div class="map-world-climate-threshold-protection__header">
+        <strong>Protection prochain seuil</strong>
+        <span>${view.bestAction.label}</span>
+      </div>
+      <p>${view.summary}</p>
+      <ol class="map-world-climate-threshold-protection__list">
+        ${view.actions.map((action) => `
+          <li class="map-world-climate-threshold-protection__item map-world-climate-threshold-protection__item--${action.className}">
+            <b>${action.rank}. ${action.label}</b>
+            <span>${action.action}</span>
+            <small><b>Pourquoi</b> · ${action.reason}</small>
+            <small><b>Lien seuil/fenêtre</b> · ${action.thresholdLink}</small>
+          </li>
+        `).join('')}
+      </ol>
+    </section>
+  `;
+}
+
 function renderAtlasSelectedClimateFollowUpReadinessRecap(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -20814,6 +20928,11 @@ function render() {
     atlasSelectedClimateFollowUpReadinessRecap,
     atlasClimateFollowUpCompatibilityBundles,
   );
+  const atlasClimateFollowUpThresholdProtection = buildAtlasClimateFollowUpThresholdProtection(
+    atlasNextClimateFollowUpAction,
+    atlasClimateThresholdProgressAfterReadinessAction,
+    atlasClimateReboundFollowUpQueue,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -20871,6 +20990,7 @@ function render() {
           ${renderAtlasClimateFollowUpCompatibilityBundles(atlasClimateFollowUpCompatibilityBundles)}
           ${renderAtlasSelectedClimateFollowUpReadinessRecap(atlasSelectedClimateFollowUpReadinessRecap)}
           ${renderAtlasNextClimateFollowUpAction(atlasNextClimateFollowUpAction)}
+          ${renderAtlasClimateFollowUpThresholdProtection(atlasClimateFollowUpThresholdProtection)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -13106,6 +13106,50 @@ button { font: inherit; }
 .map-world-climate-next-follow-up--safe-wait { border-color: rgba(251, 191, 36, 0.48); }
 .map-world-climate-next-follow-up--minimal-prep { border-color: rgba(56, 189, 248, 0.42); }
 
+.map-world-climate-threshold-protection {
+  display: grid;
+  gap: 7px;
+  max-width: 62ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(6, 78, 59, 0.45), rgba(15, 23, 42, 0.8));
+  border: 1px solid rgba(52, 211, 153, 0.38);
+}
+.map-world-climate-threshold-protection--stabilizes-short-term { border-color: rgba(251, 191, 36, 0.48); }
+.map-world-climate-threshold-protection--insufficient { border-color: rgba(248, 113, 113, 0.5); }
+.map-world-climate-threshold-protection__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-threshold-protection p,
+.map-world-climate-threshold-protection span,
+.map-world-climate-threshold-protection small {
+  color: #d1fae5;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-threshold-protection__list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+}
+.map-world-climate-threshold-protection__item {
+  display: grid;
+  gap: 3px;
+  padding: 7px 8px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(52, 211, 153, 0.26);
+}
+.map-world-climate-threshold-protection__item--protects-threshold { border-color: rgba(74, 222, 128, 0.44); }
+.map-world-climate-threshold-protection__item--stabilizes-short-term { border-color: rgba(251, 191, 36, 0.46); }
+.map-world-climate-threshold-protection__item--insufficient { border-color: rgba(248, 113, 113, 0.5); }
+
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);
   box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.12);


### PR DESCRIPTION
Epsilon: PR prête pour #1380.

## Résumé
- Ajoute un classement “Protection prochain seuil” pour les follow-ups climat visibles.
- Identifie le meilleur follow-up, puis classe chaque action en protège le seuil / stabilise court terme / insuffisant.
- Lie chaque raison au seuil readiness et à la fenêtre climatique sans répéter l’encart de progression MAP-E21.

## Tests
- node --test test/ui/climate/webAtlasClimateFollowUpThresholdProtection.test.js test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js test/ui/climate/webAtlasClimateThresholdProgressAfterReadinessAction.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?