### PR TITLE
Beta: Recommend next secondary logistics bottleneck

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -649,6 +649,11 @@ function buildSecondaryBottleneckPreview(priorityAction, routeChoices) {
       resource: null,
       summary: 'Aucun levier recommandé: impossible de projeter le prochain goulot logistique.',
       detail: 'Attendre un signal recovery avant d’afficher une alerte aval.',
+      nextRecommendation: {
+        action: 'Aucune suite immédiate',
+        target: '—',
+        reason: 'aucun bottleneck secondaire pertinent après ce levier; garder une veille légère.',
+      },
     };
   }
 
@@ -665,6 +670,40 @@ function buildSecondaryBottleneckPreview(priorityAction, routeChoices) {
   const route = shortage?.route ?? neighbor?.route ?? priorityAction.route;
   const city = shortage?.target ?? neighbor?.target ?? option?.affectedCity ?? 'ville liée';
   const resource = shortage?.resource ?? priorityAction.resource;
+  const candidates = [
+    ...(choice?.downstreamShortages ?? []).filter((candidate) => candidate.status !== 'résolue').map((candidate) => ({
+      route: candidate.route,
+      city: candidate.target,
+      resource: candidate.resource,
+      status: candidate.status,
+      detail: candidate.detail,
+      score: candidate.status === 'aggravée' ? 48 : candidate.status === 'déplacée' ? 34 : 20,
+    })),
+    ...(choice?.neighborEffects ?? []).filter((effect) => effect.tone !== 'low').map((effect) => ({
+      route: effect.route,
+      city: effect.target,
+      resource,
+      status: effect.tone === 'high' ? 'aggravée' : 'déplacée',
+      detail: effect.detail,
+      score: effect.tone === 'high' ? 42 : 28,
+    })),
+  ].sort((left, right) => right.score - left.score || left.route.localeCompare(right.route));
+  const next = candidates[0] ?? null;
+  const nextRecommendation = next
+    ? {
+        action: `Traiter ensuite ${next.route}`,
+        target: `${next.city} · ${next.resource}`,
+        reason: next.status === 'aggravée'
+          ? `évite que ${next.city} manque de ${next.resource} au tour suivant.`
+          : next.status === 'déplacée'
+            ? `empêche le déplacement de pression de devenir le nouveau goulot.`
+            : `clarifie la dette aval avant qu’elle bloque la reprise.`,
+      }
+    : {
+        action: 'Aucune suite immédiate',
+        target: `${route} · ${city}`,
+        reason: 'aucun bottleneck secondaire pertinent après ce levier; garder une veille légère.',
+      };
 
   return {
     state: status === 'bloquant' ? 'blocked' : status === 'à surveiller' ? 'watch' : 'absorbable',
@@ -675,6 +714,7 @@ function buildSecondaryBottleneckPreview(priorityAction, routeChoices) {
     resource,
     summary: `${priorityAction.action} appliqué: prochain goulot ${status} sur ${route} près de ${city}.`,
     detail: shortage?.detail ?? bottleneck?.detail ?? `${resource} reste à suivre après ${priorityAction.action}.`,
+    nextRecommendation,
   };
 }
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -99,6 +99,9 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.secondaryBottleneckPreview.status, 'bloquant');
   assert.match(preview.secondaryBottleneckPreview.summary, /prochain goulot|Ember Line|Hill Spur|Iron Plain|Hill Hub/);
   assert.match(preview.secondaryBottleneckPreview.detail, /Outils|pression aval|manquer|retarder|reste à surveiller/);
+  assert.match(preview.secondaryBottleneckPreview.nextRecommendation.action, /Traiter ensuite/);
+  assert.match(preview.secondaryBottleneckPreview.nextRecommendation.target, /Iron Plain|Hill Hub|Outils/);
+  assert.match(preview.secondaryBottleneckPreview.nextRecommendation.reason, /évite|empêche|clarifie/);
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
   assert.match(preview.primaryLogisticsAction.downstreamImpact, /pénurie|route|province|délai/);
@@ -161,6 +164,7 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.deepEqual(preview.selectedActionPreview.badges, []);
   assert.equal(preview.secondaryBottleneckPreview.state, 'empty');
   assert.match(preview.secondaryBottleneckPreview.summary, /impossible de projeter/);
+  assert.match(preview.secondaryBottleneckPreview.nextRecommendation.reason, /aucun bottleneck secondaire pertinent/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -76,6 +76,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Goulot suivant/);
   assert.match(webAppSource, /secondaryBottleneckPreview/);
   assert.match(webAppSource, /Prochain goulot logistique après le levier recovery/);
+  assert.match(webAppSource, /Suite recommandée/);
+  assert.match(webAppSource, /nextRecommendation/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -7837,6 +7837,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
           <strong>${preview.secondaryBottleneckPreview.route} · ${preview.secondaryBottleneckPreview.city}</strong>
           <p>${preview.secondaryBottleneckPreview.summary}</p>
           <small>${preview.secondaryBottleneckPreview.resource}: ${preview.secondaryBottleneckPreview.detail}</small>
+          <em>Suite recommandée: ${preview.secondaryBottleneckPreview.nextRecommendation.action} (${preview.secondaryBottleneckPreview.nextRecommendation.target}) — ${preview.secondaryBottleneckPreview.nextRecommendation.reason}</em>
         </div>
       ` : ''}
       <div class="province-logistics-queue-action province-logistics-queue-action--${preview.primaryLogisticsAction.status}" aria-label="Engager une action logistique depuis la carte">


### PR DESCRIPTION
Beta: Implements #1387.

Summary:
- Adds a next-step recommendation for the secondary bottleneck after the main logistics recovery lever.
- Picks the most useful downstream bottleneck by severity and explains the gain/risk avoided in one compact line.
- Keeps a fallback when no relevant secondary bottleneck exists, without repeating capacity-cost text.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
