### PR TITLE
Gamma: Suggest cultural bundle replacements

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1169,6 +1169,64 @@ function buildCulturalBundleFalloutPreview(cleanupPrompts) {
   };
 }
 
+function buildCulturalBundleReplacementRecommendations(groups, cleanupPrompts, falloutPreview) {
+  const candidates = cleanupPrompts
+    .map((prompt) => {
+      const group = groups.find((candidate) => candidate.bundleId === prompt.bundleId) ?? null;
+      const fallout = falloutPreview.entries.find((entry) => entry.bundleId === prompt.bundleId) ?? null;
+      const freshDetail = group?.details.find((detail) => detail.source === 'current')
+        ?? groups.find((candidate) => candidate.bundleId !== prompt.bundleId)?.details.find((detail) => detail.source === 'current')
+        ?? null;
+      const highRisk = prompt.state === 'obsolete' || (fallout?.severity ?? 0) >= 2;
+      if (!highRisk) {
+        return null;
+      }
+      const alternativeType = prompt.state === 'obsolete' && freshDetail
+        ? 'renew'
+        : prompt.state === 'obsolete'
+          ? 'abandon'
+          : 'replan';
+      const action = alternativeType === 'renew'
+        ? `renouveler via ${freshDetail.promptLabel}`
+        : alternativeType === 'abandon'
+          ? 'abandonner ce bundle obsolète'
+          : 'replanifier après cleanup du risque';
+      const avoidedConsequence = fallout?.consequence
+        ?? (prompt.state === 'obsolete'
+          ? `${prompt.clusterLabel}: opportunité fraîche masquée.`
+          : `${prompt.clusterLabel}: tension culturelle prolongée.`);
+
+      return {
+        replacementId: `${prompt.cleanupId}:replacement`,
+        bundleId: prompt.bundleId,
+        clusterLabel: prompt.clusterLabel,
+        state: alternativeType,
+        action,
+        replacementPromptLabel: freshDetail?.promptLabel ?? null,
+        avoidedConsequence,
+        reason: `${prompt.reason} Alternative compacte: ${action}.`,
+        priority: (fallout?.severity ?? 0) + (prompt.state === 'obsolete' ? 2 : 1),
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => right.priority - left.priority || left.clusterLabel.localeCompare(right.clusterLabel))
+    .slice(0, 3);
+  const top = candidates[0] ?? null;
+
+  return {
+    state: candidates.length === 0
+      ? 'quiet'
+      : candidates.some((candidate) => candidate.state === 'renew' || candidate.state === 'abandon')
+        ? 'action-needed'
+        : 'replan',
+    summary: !top
+      ? 'Aucun remplacement culturel nécessaire ce tour.'
+      : `${top.clusterLabel}: ${top.action} pour éviter ${top.avoidedConsequence}`,
+    primaryReplacementId: top?.replacementId ?? null,
+    entries: candidates,
+  };
+}
+
 function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder) {
   const groups = promptHistoryDrawer.groups.map((group) => {
     const currentEntries = group.entries.filter((entry) => entry.source === 'current');
@@ -1232,6 +1290,7 @@ function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptH
     ? 'Aucun prompt de nettoyage culturel à proposer.'
     : `${cleanupPrompts.length} prompt${cleanupPrompts.length > 1 ? 's' : ''} de nettoyage: ${cleanupPrompts.map((prompt) => `${prompt.clusterLabel} → ${prompt.action}`).join(' | ')}.`;
   const falloutPreview = buildCulturalBundleFalloutPreview(cleanupPrompts);
+  const replacementRecommendations = buildCulturalBundleReplacementRecommendations(groups, cleanupPrompts, falloutPreview);
 
   return {
     state: groups.length === 0
@@ -1249,6 +1308,7 @@ function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptH
     cleanupPrompts,
     cleanupSummary,
     falloutPreview,
+    replacementRecommendations,
     detailMode: groups.length === 0
       ? 'Aucun détail individuel à ouvrir.'
       : 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
@@ -1549,6 +1609,12 @@ export function buildCultureTurnReportDeltas({
             consequence: 'Aucun fallout immédiat détecté.',
             severity: 0,
             minimalCleanupAction: null,
+            entries: [],
+          },
+          replacementRecommendations: {
+            state: 'quiet',
+            summary: 'Aucun remplacement culturel nécessaire ce tour.',
+            primaryReplacementId: null,
             entries: [],
           },
           detailMode: 'Aucun détail individuel à ouvrir.',

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -440,6 +440,24 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
           },
         ],
       },
+      replacementRecommendations: {
+        state: 'replan',
+        summary: 'Compact d’Aurora: replanifier après cleanup du risque pour éviter Compact d’Aurora: tension culturelle maintenue si le nettoyage est ignoré.',
+        primaryReplacementId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle:cleanup-prompt:replacement',
+        entries: [
+          {
+            replacementId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle:cleanup-prompt:replacement',
+            bundleId: 'culture-prompt-history:Compact d’Aurora:Ouvrir le récit d’expansion:follow-through-bundle',
+            clusterLabel: 'Compact d’Aurora',
+            state: 'replan',
+            action: 'replanifier après cleanup du risque',
+            replacementPromptLabel: 'Ouvrir le récit d’expansion',
+            avoidedConsequence: 'Compact d’Aurora: tension culturelle maintenue si le nettoyage est ignoré.',
+            reason: 'Compact d’Aurora: expansion prudente: verrouille le bénéfice culturel principal autour de Compact d’Aurora; Vérifier si Compact d’Aurora peut encore suivre Ouvrir le récit d’expansion. Alternative compacte: replanifier après cleanup du risque.',
+            priority: 3,
+          },
+        ],
+      },
       detailMode: 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
     },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
@@ -532,6 +550,16 @@ test('buildCultureTurnReportDeltas marks stale cultural follow-through reminders
   assert.equal(report.commitmentBundles.followThroughBundlePlan.falloutPreview.consequenceType, 'opportunity-lost');
   assert.match(report.commitmentBundles.followThroughBundlePlan.falloutPreview.consequence, /opportunité fraîche masquée/);
   assert.equal(report.commitmentBundles.followThroughBundlePlan.falloutPreview.minimalCleanupAction, 'remplacer par Ouvrir le récit d’expansion');
+  assert.deepEqual(report.commitmentBundles.followThroughBundlePlan.replacementRecommendations.entries.map((entry) => [
+    entry.clusterLabel,
+    entry.state,
+    entry.action,
+    entry.replacementPromptLabel,
+  ]), [
+    ['Compact d’Aurora', 'renew', 'renouveler via Ouvrir le récit d’expansion', 'Ouvrir le récit d’expansion'],
+    ['Harbor Compact', 'replan', 'replanifier après cleanup du risque', 'Ouvrir le récit d’expansion'],
+  ]);
+  assert.match(report.commitmentBundles.followThroughBundlePlan.replacementRecommendations.entries[0].avoidedConsequence, /opportunité fraîche masquée/);
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -648,6 +676,12 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
           consequence: 'Aucun fallout immédiat détecté.',
           severity: 0,
           minimalCleanupAction: null,
+          entries: [],
+        },
+        replacementRecommendations: {
+          state: 'quiet',
+          summary: 'Aucun remplacement culturel nécessaire ce tour.',
+          primaryReplacementId: null,
           entries: [],
         },
         detailMode: 'Aucun détail individuel à ouvrir.',

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -165,6 +165,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Fallout si ignoré/);
   assert.match(webAppSource, /falloutPreview/);
   assert.match(webAppSource, /Cleanup minimal:/);
+  assert.match(webAppSource, /culture-turn-report__replacement-recommendations/);
+  assert.match(webAppSource, /Remplacement recommandé/);
+  assert.match(webAppSource, /replacementRecommendations/);
+  assert.match(webAppSource, /Évite:/);
   assert.match(webAppSource, /culture-turn-report__cleanup-prompts/);
   assert.match(webAppSource, /Prompts de nettoyage des bundles culturels/);
   assert.match(webAppSource, /cleanupPrompts/);
@@ -244,6 +248,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.culture-turn-report__fallout-preview/);
   assert.match(stylesSource, /\.culture-turn-report__fallout-preview--action-needed/);
   assert.match(stylesSource, /\.culture-turn-report__fallout-preview--watch/);
+  assert.match(stylesSource, /\.culture-turn-report__replacement-recommendations/);
+  assert.match(stylesSource, /\.culture-turn-report__replacement-recommendations--action-needed/);
+  assert.match(stylesSource, /\.culture-turn-report__replacement-recommendation--renew/);
+  assert.match(stylesSource, /\.culture-turn-report__replacement-recommendation--abandon/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompts/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--obsolete/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--resolved/);

--- a/web/app.js
+++ b/web/app.js
@@ -6988,6 +6988,21 @@ function renderCultureTurnReport(report) {
           <small>Conséquence: ${report.commitmentBundles?.followThroughBundlePlan?.falloutPreview?.consequence ?? 'Aucun fallout immédiat détecté.'}</small>
           ${report.commitmentBundles?.followThroughBundlePlan?.falloutPreview?.minimalCleanupAction ? `<small>Cleanup minimal: ${report.commitmentBundles.followThroughBundlePlan.falloutPreview.minimalCleanupAction}</small>` : ''}
         </div>
+        <div class="culture-turn-report__replacement-recommendations culture-turn-report__replacement-recommendations--${report.commitmentBundles?.followThroughBundlePlan?.replacementRecommendations?.state ?? 'quiet'}" aria-label="Remplacements recommandés pour bundles culturels périmés">
+          <span>Remplacement recommandé</span>
+          <strong>${report.commitmentBundles?.followThroughBundlePlan?.replacementRecommendations?.summary ?? 'Aucun remplacement culturel nécessaire ce tour.'}</strong>
+          ${(report.commitmentBundles?.followThroughBundlePlan?.replacementRecommendations?.entries ?? []).length > 0 ? `
+            <div class="culture-turn-report__replacement-recommendation-list">
+              ${report.commitmentBundles.followThroughBundlePlan.replacementRecommendations.entries.map((entry) => `
+                <span class="culture-turn-report__replacement-recommendation culture-turn-report__replacement-recommendation--${entry.state}">
+                  <b>${entry.clusterLabel}</b>
+                  <small>${entry.action}${entry.replacementPromptLabel ? ` · prompt: ${entry.replacementPromptLabel}` : ''}</small>
+                  <small>Évite: ${entry.avoidedConsequence}</small>
+                </span>
+              `).join('')}
+            </div>
+          ` : ''}
+        </div>
         <div class="culture-turn-report__cleanup-prompts" aria-label="Prompts de nettoyage des bundles culturels">
           <strong>${report.commitmentBundles?.followThroughBundlePlan?.cleanupSummary ?? 'Aucun prompt de nettoyage culturel à proposer.'}</strong>
           ${(report.commitmentBundles?.followThroughBundlePlan?.cleanupPrompts ?? []).length > 0 ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -2070,6 +2070,37 @@ button { font: inherit; }
 .culture-turn-report__fallout-preview--action-needed { border-color: rgba(248, 113, 113, 0.45); }
 .culture-turn-report__fallout-preview--watch { border-color: rgba(251, 191, 36, 0.38); }
 .culture-turn-report__fallout-preview--quiet { border-color: rgba(74, 222, 128, 0.24); }
+.culture-turn-report__replacement-recommendations {
+  display: grid;
+  gap: 5px;
+  padding: 7px 8px;
+  border-radius: 10px;
+  background: rgba(30, 41, 59, 0.28);
+  border: 1px solid rgba(125, 211, 252, 0.22);
+}
+.culture-turn-report__replacement-recommendations > span {
+  color: #bae6fd;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__replacement-recommendations > strong { color: #f8fafc; font-size: 11px; }
+.culture-turn-report__replacement-recommendation-list { display: grid; gap: 5px; }
+.culture-turn-report__replacement-recommendation {
+  display: grid;
+  gap: 2px;
+  padding: 6px 7px;
+  border-radius: 9px;
+  background: rgba(2, 6, 23, 0.24);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+.culture-turn-report__replacement-recommendation b { color: #f8fafc; }
+.culture-turn-report__replacement-recommendation small { color: var(--muted); }
+.culture-turn-report__replacement-recommendations--action-needed { border-color: rgba(248, 113, 113, 0.45); }
+.culture-turn-report__replacement-recommendations--replan { border-color: rgba(251, 191, 36, 0.4); }
+.culture-turn-report__replacement-recommendation--renew { border-color: rgba(74, 222, 128, 0.34); }
+.culture-turn-report__replacement-recommendation--abandon { border-color: rgba(248, 113, 113, 0.4); }
+.culture-turn-report__replacement-recommendation--replan { border-color: rgba(251, 191, 36, 0.4); }
 .culture-turn-report__cleanup-prompts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Gamma: Fixes #1388.

Résumé:
- ajoute des recommandations de remplacement pour les bundles culturels stale ou à risque élevé;
- propose une alternative courte: renouveler, abandonner ou replanifier;
- affiche la conséquence évitée et garde la liste compacte quand plusieurs bundles existent;
- conserve la cohérence avec les prompts de cleanup/fallout MAP-G22/G23.

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?