### PR TITLE
Delta: Add low-confidence intrigue verification prompts

### DIFF
--- a/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
+++ b/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
@@ -119,6 +119,53 @@ function buildConfidenceShift(currentTiming, currentTimingComparison) {
   };
 }
 
+function buildMinimumVerificationPrompt(timingRecommendationChange) {
+  if (!timingRecommendationChange) {
+    return {
+      state: 'sufficient-confidence',
+      confidence: 'suffisante',
+      cause: 'aucun changement de timing confirmé',
+      verification: 'Aucune vérification minimale requise avant l’action recommandée.',
+      waitLessRisky: false,
+      summary: 'Confiance suffisante: garder la recommandation actuelle sans étape de vérification supplémentaire.',
+    };
+  }
+
+  const confidenceShift = timingRecommendationChange.confidenceShift;
+  const lowConfidence = confidenceShift?.variation === 'baisse' || confidenceShift?.variation === 'reste instable';
+  const verificationByCause = {
+    exposition: 'Vérifier le niveau d’exposition visible avant d’engager une réponse lourde.',
+    délai: 'Confirmer que le signal n’a pas vieilli avant de forcer l’action immédiate.',
+    couverture: 'Contrôler qu’une couverture minimale reste disponible avant d’exposer un agent.',
+    cellule: 'Recouper l’état public de la cellule avant de transformer le timing en ordre.',
+    'signal contradictoire': 'Comparer le signal principal avec un second indice fog-safe avant action.',
+  };
+
+  if (!lowConfidence) {
+    return {
+      state: 'sufficient-confidence',
+      confidence: 'suffisante',
+      cause: confidenceShift?.cause ?? timingRecommendationChange.cause,
+      verification: 'Aucune vérification minimale requise avant l’action recommandée.',
+      waitLessRisky: false,
+      summary: 'Confiance suffisante: la variation soutient le timing recommandé sans étape supplémentaire.',
+    };
+  }
+
+  const waitLessRisky = timingRecommendationChange.currentTiming === 'short-wait';
+
+  return {
+    state: 'low-confidence',
+    confidence: confidenceShift.variation,
+    cause: confidenceShift.cause,
+    verification: verificationByCause[confidenceShift.cause] ?? verificationByCause['signal contradictoire'],
+    waitLessRisky,
+    summary: waitLessRisky
+      ? 'Attendre un tour est moins risqué que forcer l’action tant que la confiance reste basse.'
+      : 'Agir maintenant reste indiqué, mais seulement après une vérification minimale du signal visible.',
+  };
+}
+
 function buildTimingRecommendationChange({ previousTimingRecommendation, currentTimingComparison }) {
   const previous = normalizeTimingRecommendation(previousTimingRecommendation);
   const current = normalizeTimingRecommendation(currentTimingComparison?.recommendedTiming);
@@ -131,7 +178,7 @@ function buildTimingRecommendationChange({ previousTimingRecommendation, current
   const cause = getTimingChangeCause(currentTimingComparison);
   const confidenceShift = buildConfidenceShift(current, currentTimingComparison);
 
-  return {
+  const timingRecommendationChange = {
     previousTiming: previous,
     currentTiming: current,
     direction,
@@ -141,6 +188,11 @@ function buildTimingRecommendationChange({ previousTimingRecommendation, current
     detail: `${direction}: cause visible ${cause}.`,
     confidenceShift,
     fogSafe: true,
+  };
+
+  return {
+    ...timingRecommendationChange,
+    minimumVerificationPrompt: buildMinimumVerificationPrompt(timingRecommendationChange),
   };
 }
 
@@ -239,6 +291,8 @@ export function buildIntrigueTurnReportDeltas(province, intrigueView, options = 
       ?? null,
     currentTimingComparison: timingComparison,
   });
+  const minimumVerificationPrompt = timingRecommendationChange?.minimumVerificationPrompt
+    ?? buildMinimumVerificationPrompt(null);
   const deltas = [
     ...buildResponseDeltas(response, drillDown.responseAftermath?.summary),
     ...(timingRecommendationChange ? [{
@@ -266,5 +320,6 @@ export function buildIntrigueTurnReportDeltas(province, intrigueView, options = 
     deltas,
     retaliationRisk: drillDown.responseAftermath?.retaliationRisk ?? 'inconnu',
     timingRecommendationChange,
+    minimumVerificationPrompt,
   };
 }

--- a/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
@@ -93,6 +93,14 @@ test('buildIntrigueTurnReportDeltas flags changed timing recommendations fog-saf
       justification: 'la confiance fragile justifie d’attendre un signal plus sûr avant d’agir',
     },
     fogSafe: true,
+    minimumVerificationPrompt: {
+      state: 'low-confidence',
+      confidence: 'baisse',
+      cause: 'exposition',
+      verification: 'Vérifier le niveau d’exposition visible avant d’engager une réponse lourde.',
+      waitLessRisky: true,
+      summary: 'Attendre un tour est moins risqué que forcer l’action tant que la confiance reste basse.',
+    },
   });
   assert.ok(report.deltas.some((delta) => delta.type === 'timing' && delta.detail === 'agir maintenant → attendre: cause visible exposition.'));
 });
@@ -121,6 +129,27 @@ test('buildIntrigueTurnReportDeltas explains confidence loss when timing flips t
     justifies: 'act-now',
     label: 'baisse: délai',
     justification: 'la perte de confiance rend l’attente plus risquée que l’action immédiate',
+  });
+  assert.deepEqual(report.minimumVerificationPrompt, {
+    state: 'low-confidence',
+    confidence: 'baisse',
+    cause: 'délai',
+    verification: 'Confirmer que le signal n’a pas vieilli avant de forcer l’action immédiate.',
+    waitLessRisky: false,
+    summary: 'Agir maintenant reste indiqué, mais seulement après une vérification minimale du signal visible.',
+  });
+});
+
+test('buildIntrigueTurnReportDeltas returns a neutral prompt when confidence is sufficient', () => {
+  const report = buildIntrigueTurnReportDeltas(province, buildIntrigueView(), { previousActionCode: 'contenir' });
+
+  assert.deepEqual(report.minimumVerificationPrompt, {
+    state: 'sufficient-confidence',
+    confidence: 'suffisante',
+    cause: 'aucun changement de timing confirmé',
+    verification: 'Aucune vérification minimale requise avant l’action recommandée.',
+    waitLessRisky: false,
+    summary: 'Confiance suffisante: garder la recommandation actuelle sans étape de vérification supplémentaire.',
   });
 });
 

--- a/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
@@ -13,5 +13,7 @@ test('playable map wires intrigue aftermath deltas into selected province turn r
   assert.match(webAppSource, /Changement de recommandation de timing intrigue/);
   assert.match(webAppSource, /Confiance/);
   assert.match(webAppSource, /confidenceShift/);
+  assert.match(webAppSource, /Vérification minimale avant timing intrigue/);
+  assert.match(webAppSource, /minimumVerificationPrompt/);
   assert.match(webAppSource, /renderIntrigueTurnReportDeltas\(province, intrigueView\)/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -8035,6 +8035,13 @@ function renderIntrigueTurnReportDeltas(province, intrigueView) {
           <small>Confiance ${report.timingRecommendationChange.confidenceShift?.label ?? 'instable: signal contradictoire'} · ${report.timingRecommendationChange.confidenceShift?.justification ?? 'justification à confirmer sans révéler de donnée masquée'}</small>
         </div>
       ` : ''}
+      ${report.minimumVerificationPrompt ? `
+        <div class="province-intrigue-turn-report__verification province-intrigue-turn-report__verification--${report.minimumVerificationPrompt.state}" aria-label="Vérification minimale avant timing intrigue">
+          <b>${report.minimumVerificationPrompt.state === 'low-confidence' ? 'Vérification minimale' : 'Confiance suffisante'}</b>
+          <span>${report.minimumVerificationPrompt.verification}</span>
+          <small>${report.minimumVerificationPrompt.summary}</small>
+        </div>
+      ` : ''}
       ${report.deltas.length > 0 ? `
         <ul class="province-intrigue-turn-report__list">
           ${report.deltas.map((delta) => `

--- a/web/styles.css
+++ b/web/styles.css
@@ -9586,6 +9586,18 @@ button { font: inherit; }
 .province-intrigue-turn-report__timing-change span,
 .province-intrigue-turn-report__timing-change small { color: var(--muted); }
 .province-intrigue-turn-report__timing-change small { grid-column: 1 / -1; }
+.province-intrigue-turn-report__verification {
+  display: grid;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.34);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+.province-intrigue-turn-report__verification--low-confidence { border-color: rgba(250, 204, 21, 0.28); }
+.province-intrigue-turn-report__verification span,
+.province-intrigue-turn-report__verification small { color: var(--muted); }
 .province-intrigue-turn-report__list {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Résout #1389.

Résumé:
- Ajoute un prompt de vérification minimale pour les timings intrigue à confiance basse ou instable.
- Propose une vérification courte bornée aux causes visibles: exposition, délai, couverture, cellule ou signal contradictoire.
- Indique si attendre un tour est moins risqué que forcer l’action, avec un message neutre quand la confiance reste suffisante.

Tests:
- node --test test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?