### PR TITLE
Epsilon: Show safety margin after climate follow-ups

### DIFF
--- a/test/ui/climate/webAtlasClimateFollowUpSafetyMargin.test.js
+++ b/test/ui/climate/webAtlasClimateFollowUpSafetyMargin.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas shows safety margin after climate threshold follow-up actions', () => {
+  assert.match(webAppSource, /function buildAtlasClimateFollowUpSafetyMargin/);
+  assert.match(webAppSource, /function renderAtlasClimateFollowUpSafetyMargin/);
+  assert.match(webAppSource, /Marge après follow-up/);
+  assert.match(webAppSource, /marge confortable/);
+  assert.match(webAppSource, /marge correcte/);
+  assert.match(webAppSource, /marge faible/);
+  assert.match(webAppSource, /marge inconnue/);
+  assert.match(webAppSource, /Consomme la marge/);
+  assert.match(webAppSource, /Seconde action préventive/);
+  assert.match(webAppSource, /Fallback lisible/);
+  assert.match(webAppSource, /buildAtlasClimateFollowUpSafetyMargin\(\s*atlasClimateFollowUpThresholdProtection,\s*atlasNextClimateFollowUpAction,\s*atlasClimateThresholdProgressAfterReadinessAction,\s*\)/);
+  assert.match(webAppSource, /renderAtlasClimateFollowUpThresholdProtection\(atlasClimateFollowUpThresholdProtection\)\}\s*\$\{renderAtlasClimateFollowUpSafetyMargin\(atlasClimateFollowUpSafetyMargin\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-follow-up-safety-margin/);
+  assert.match(stylesSource, /\.map-world-climate-follow-up-safety-margin--correct/);
+  assert.match(stylesSource, /\.map-world-climate-follow-up-safety-margin--weak/);
+  assert.match(stylesSource, /\.map-world-climate-follow-up-safety-margin--unknown/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -12765,6 +12765,101 @@ function renderAtlasClimateFollowUpThresholdProtection(view) {
   `;
 }
 
+function buildAtlasClimateFollowUpSafetyMargin(protectionView, nextFollowUpView, thresholdProgressView) {
+  if (!protectionView || protectionView.state === 'empty' || !protectionView.bestAction || !thresholdProgressView?.progress) {
+    return {
+      state: 'unknown',
+      margin: null,
+      summary: 'Marge de sécurité non calculable: aucun follow-up de seuil exploitable.',
+    };
+  }
+
+  const bestAction = protectionView.bestAction;
+  const progress = thresholdProgressView.progress;
+  const pendingCount = protectionView.actions.filter((action) => action.className !== 'protects-threshold').length;
+  const secondPreventiveAction = protectionView.actions.find((action) => action.rank > 1 && action.className === 'stabilizes-short-term') ?? null;
+  const consumesMargin = bestAction.className === 'protects-threshold'
+    ? (pendingCount > 1 ? 'files de suivi concurrentes' : 'pression de fenêtre climatique restante')
+    : bestAction.className === 'stabilizes-short-term'
+      ? 'seuil encore relu comme fragile après l’action recommandée'
+      : 'action qui repousse le risque sans protéger le seuil';
+  const marginLevel = bestAction.className === 'protects-threshold' && pendingCount === 0
+    ? 'comfortable'
+    : bestAction.className === 'protects-threshold'
+      ? 'correct'
+      : bestAction.className === 'stabilizes-short-term'
+        ? 'weak'
+        : 'unknown';
+  const label = marginLevel === 'comfortable'
+    ? 'marge confortable'
+    : marginLevel === 'correct'
+      ? 'marge correcte'
+      : marginLevel === 'weak'
+        ? 'marge faible'
+        : 'marge inconnue';
+  const secondActionNeeded = marginLevel === 'weak' || (marginLevel === 'correct' && Boolean(secondPreventiveAction));
+  const recommendation = secondActionNeeded
+    ? (secondPreventiveAction
+      ? `Seconde action préventive: ${secondPreventiveAction.action}`
+      : 'Seconde action préventive nécessaire avant d’élargir le plan climat.')
+    : marginLevel === 'comfortable'
+      ? 'Aucune seconde action immédiate: garder la veille carte.'
+      : 'Seconde action non urgente: relire le seuil au prochain tour.';
+
+  return {
+    state: marginLevel,
+    margin: {
+      label,
+      bestAction: bestAction.action,
+      protectedThreshold: progress.threshold,
+      deadline: progress.deadline,
+      consumesMargin,
+      secondActionNeeded,
+      recommendation,
+      fallback: marginLevel === 'unknown' ? 'Fallback lisible: afficher marge inconnue et demander une relecture climat avant promesse de seuil.' : '',
+      rationale: nextFollowUpView?.recommendation?.residualRisk ?? bestAction.thresholdLink,
+    },
+    summary: marginLevel === 'unknown'
+      ? 'Marge de sécurité climat inconnue après follow-up: rester prudent.'
+      : `${label}: ${bestAction.label} laisse ${secondActionNeeded ? 'un besoin de prévention' : 'assez de place'} avant le prochain seuil.`,
+  };
+}
+
+function renderAtlasClimateFollowUpSafetyMargin(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || !view || view.state === 'empty') {
+    return '';
+  }
+
+  if (!view.margin) {
+    return `
+      <aside class="map-world-climate-follow-up-safety-margin map-world-climate-follow-up-safety-margin--unknown" aria-label="Marge de sécurité après follow-up climat recommandée">
+        <div class="map-world-climate-follow-up-safety-margin__header">
+          <strong>Marge après follow-up</strong>
+          <span>marge inconnue</span>
+        </div>
+        <p>${view.summary}</p>
+        <small><b>Fallback</b> · Relecture climat requise avant de promettre un seuil sécurisé.</small>
+      </aside>
+    `;
+  }
+
+  return `
+    <aside class="map-world-climate-follow-up-safety-margin map-world-climate-follow-up-safety-margin--${view.state}" aria-label="Marge de sécurité après follow-up climat recommandée">
+      <div class="map-world-climate-follow-up-safety-margin__header">
+        <strong>Marge après follow-up</strong>
+        <span>${view.margin.label}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Action retenue</b> · ${view.margin.bestAction}</small>
+      <small><b>Seuil protégé</b> · ${view.margin.protectedThreshold} · ${view.margin.deadline}</small>
+      <small><b>Consomme la marge</b> · ${view.margin.consumesMargin}</small>
+      <small><b>Prévention</b> · ${view.margin.recommendation}</small>
+      <small><b>Risque résiduel</b> · ${view.margin.rationale}</small>
+      ${view.margin.fallback ? `<small><b>Fallback</b> · ${view.margin.fallback}</small>` : ''}
+    </aside>
+  `;
+}
+
 function renderAtlasSelectedClimateFollowUpReadinessRecap(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -21016,6 +21111,11 @@ function render() {
     atlasClimateThresholdProgressAfterReadinessAction,
     atlasClimateReboundFollowUpQueue,
   );
+  const atlasClimateFollowUpSafetyMargin = buildAtlasClimateFollowUpSafetyMargin(
+    atlasClimateFollowUpThresholdProtection,
+    atlasNextClimateFollowUpAction,
+    atlasClimateThresholdProgressAfterReadinessAction,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -21074,6 +21174,7 @@ function render() {
           ${renderAtlasSelectedClimateFollowUpReadinessRecap(atlasSelectedClimateFollowUpReadinessRecap)}
           ${renderAtlasNextClimateFollowUpAction(atlasNextClimateFollowUpAction)}
           ${renderAtlasClimateFollowUpThresholdProtection(atlasClimateFollowUpThresholdProtection)}
+          ${renderAtlasClimateFollowUpSafetyMargin(atlasClimateFollowUpSafetyMargin)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -13183,6 +13183,40 @@ button { font: inherit; }
 .map-world-climate-threshold-protection__item--stabilizes-short-term { border-color: rgba(251, 191, 36, 0.46); }
 .map-world-climate-threshold-protection__item--insufficient { border-color: rgba(248, 113, 113, 0.5); }
 
+.map-world-climate-follow-up-safety-margin {
+  display: grid;
+  gap: 6px;
+  max-width: 62ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(20, 83, 45, 0.42), rgba(15, 23, 42, 0.82));
+  border: 1px solid rgba(74, 222, 128, 0.36);
+}
+.map-world-climate-follow-up-safety-margin--correct { border-color: rgba(125, 211, 252, 0.4); }
+.map-world-climate-follow-up-safety-margin--weak { border-color: rgba(251, 191, 36, 0.5); }
+.map-world-climate-follow-up-safety-margin--unknown { border-color: rgba(148, 163, 184, 0.36); }
+.map-world-climate-follow-up-safety-margin__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-follow-up-safety-margin p,
+.map-world-climate-follow-up-safety-margin span,
+.map-world-climate-follow-up-safety-margin small {
+  color: #dcfce7;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-follow-up-safety-margin--weak p,
+.map-world-climate-follow-up-safety-margin--weak span,
+.map-world-climate-follow-up-safety-margin--weak small { color: #fef3c7; }
+.map-world-climate-follow-up-safety-margin--unknown p,
+.map-world-climate-follow-up-safety-margin--unknown span,
+.map-world-climate-follow-up-safety-margin--unknown small { color: #e2e8f0; }
+
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);
   box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.12);


### PR DESCRIPTION
Epsilon: PR prête pour #1390.

## Résumé
- Ajoute un indicateur “Marge après follow-up” après la protection du prochain seuil climat.
- Classe la marge en confortable / correcte / faible / inconnue selon le follow-up retenu, la protection de seuil et les suivis restants.
- Explique ce qui consomme le plus la marge et met en avant la seconde action préventive quand nécessaire, avec fallback lisible si non calculable.

## Tests
- node --test test/ui/climate/webAtlasClimateFollowUpSafetyMargin.test.js test/ui/climate/webAtlasClimateFollowUpThresholdProtection.test.js test/ui/climate/webAtlasClimateFollowUpCompatibilityBundles.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?