### PR TITLE
Beta: Surface primary secondary logistics tradeoff

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -718,6 +718,32 @@ function buildSecondaryBottleneckPreview(priorityAction, routeChoices) {
   };
 }
 
+
+function buildPrimarySecondaryTradeoff(priorityAction, selectedActionPreview, secondaryBottleneckPreview) {
+  if (!priorityAction || !secondaryBottleneckPreview || secondaryBottleneckPreview.state === 'empty') {
+    return {
+      state: 'empty',
+      summary: 'Compromis principal/secondaire indisponible: aucun bottleneck secondaire chiffrable.',
+      opportunityCost: 'Coût d’opportunité non chiffrable avec les signaux actuels.',
+      secondaryBetter: false,
+    };
+  }
+
+  const secondaryBlocking = secondaryBottleneckPreview.state === 'blocked';
+  const secondaryBetter = secondaryBlocking && selectedActionPreview?.criticalRemaining;
+  const primaryEffect = selectedActionPreview?.summary ?? priorityAction.impact;
+  const secondaryEffect = secondaryBottleneckPreview.nextRecommendation?.reason ?? secondaryBottleneckPreview.detail;
+
+  return {
+    state: secondaryBetter ? 'secondary' : secondaryBottleneckPreview.state === 'watch' ? 'balanced' : 'primary',
+    summary: `Principal: ${primaryEffect} Secondaire: ${secondaryEffect}`,
+    opportunityCost: secondaryBetter
+      ? `Coût d’opportunité: continuer ${priorityAction.action} consomme ${priorityAction.cost} pendant que ${secondaryBottleneckPreview.route} peut bloquer.`
+      : `Coût d’opportunité: traiter ${secondaryBottleneckPreview.route} maintenant retarde ${priorityAction.action} (${priorityAction.cost}).`,
+    secondaryBetter,
+  };
+}
+
 function buildPrimaryLogisticsQueueAction(priorityAction, selectedActionPreview, queuedLogisticsActions = []) {
   if (!priorityAction) {
     return {
@@ -768,7 +794,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const queuedLogisticsActions = Array.isArray(normalizedOptions.queuedLogisticsActions) ? normalizedOptions.queuedLogisticsActions : [];
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []), primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -806,6 +832,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       recoveryLeverRanking: buildRecoveryLeverRanking([], [], false),
       selectedActionPreview: buildSelectedActionImpactPreview(null, []),
       secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []),
+      primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])),
       primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions),
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
@@ -820,6 +847,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const recoveryLeverRanking = buildRecoveryLeverRanking(routeChoices, priorityActions, hasBlocker);
   const selectedActionPreview = buildSelectedActionImpactPreview(recommendedPriority, routeChoices);
   const secondaryBottleneckPreview = buildSecondaryBottleneckPreview(recommendedPriority, routeChoices);
+  const primarySecondaryTradeoff = buildPrimarySecondaryTradeoff(recommendedPriority, selectedActionPreview, secondaryBottleneckPreview);
   const primaryLogisticsAction = buildPrimaryLogisticsQueueAction(recommendedPriority, selectedActionPreview, queuedLogisticsActions);
 
   return {
@@ -840,6 +868,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
     recoveryLeverRanking,
     selectedActionPreview,
     secondaryBottleneckPreview,
+    primarySecondaryTradeoff,
     primaryLogisticsAction,
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -102,6 +102,10 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.secondaryBottleneckPreview.nextRecommendation.action, /Traiter ensuite/);
   assert.match(preview.secondaryBottleneckPreview.nextRecommendation.target, /Iron Plain|Hill Hub|Outils/);
   assert.match(preview.secondaryBottleneckPreview.nextRecommendation.reason, /évite|empêche|clarifie/);
+  assert.equal(preview.primarySecondaryTradeoff.secondaryBetter, true);
+  assert.equal(preview.primarySecondaryTradeoff.state, 'secondary');
+  assert.match(preview.primarySecondaryTradeoff.summary, /Principal: .*Secondaire:/);
+  assert.match(preview.primarySecondaryTradeoff.opportunityCost, /Coût d’opportunité|consomme|bloquer/);
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
   assert.match(preview.primaryLogisticsAction.downstreamImpact, /pénurie|route|province|délai/);
@@ -165,6 +169,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.equal(preview.secondaryBottleneckPreview.state, 'empty');
   assert.match(preview.secondaryBottleneckPreview.summary, /impossible de projeter/);
   assert.match(preview.secondaryBottleneckPreview.nextRecommendation.reason, /aucun bottleneck secondaire pertinent/);
+  assert.equal(preview.primarySecondaryTradeoff.state, 'empty');
+  assert.match(preview.primarySecondaryTradeoff.summary, /indisponible|aucun bottleneck secondaire/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -78,6 +78,10 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Prochain goulot logistique après le levier recovery/);
   assert.match(webAppSource, /Suite recommandée/);
   assert.match(webAppSource, /nextRecommendation/);
+  assert.match(webAppSource, /province-logistics-primary-secondary-tradeoff/);
+  assert.match(webAppSource, /Compromis entre levier principal et bottleneck secondaire/);
+  assert.match(webAppSource, /Secondaire prioritaire|Principal prioritaire/);
+  assert.match(webAppSource, /primarySecondaryTradeoff/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -7908,6 +7908,13 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
           <p>${preview.secondaryBottleneckPreview.summary}</p>
           <small>${preview.secondaryBottleneckPreview.resource}: ${preview.secondaryBottleneckPreview.detail}</small>
           <em>Suite recommandée: ${preview.secondaryBottleneckPreview.nextRecommendation.action} (${preview.secondaryBottleneckPreview.nextRecommendation.target}) — ${preview.secondaryBottleneckPreview.nextRecommendation.reason}</em>
+          ${preview.primarySecondaryTradeoff && preview.primarySecondaryTradeoff.state !== 'empty' ? `
+            <div class="province-logistics-primary-secondary-tradeoff province-logistics-primary-secondary-tradeoff--${preview.primarySecondaryTradeoff.state}" aria-label="Compromis entre levier principal et bottleneck secondaire">
+              <b>${preview.primarySecondaryTradeoff.secondaryBetter ? 'Secondaire prioritaire' : 'Principal prioritaire'}</b>
+              <span>${preview.primarySecondaryTradeoff.summary}</span>
+              <small>${preview.primarySecondaryTradeoff.opportunityCost}</small>
+            </div>
+          ` : ''}
         </div>
       ` : ''}
       <div class="province-logistics-queue-action province-logistics-queue-action--${preview.primaryLogisticsAction.status}" aria-label="Engager une action logistique depuis la carte">


### PR DESCRIPTION
Beta: Implements #1397.

Summary:
- Adds a compact primary-vs-secondary logistics recovery tradeoff line.
- Highlights the main opportunity cost without repeating the capacity-cost detail.
- Flags when the secondary bottleneck should become the priority over continuing the primary lever.
- Keeps a fallback when the comparison cannot be quantified.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
