### PR TITLE
Alpha: Warn on stale neighboring reviews

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -123,3 +123,25 @@ test('atlas military summarizes post-commit neighboring province review priority
   assert.match(stylesSource, /\.atlas-military-neighbor-review-priority--stable/);
   assert.match(stylesSource, /\.atlas-military-neighbor-review-priority--rechute/);
 });
+
+// MAP-A25: flag stale neighboring review summaries when orders, fronts, or turns
+// move past the last analysis.
+test('atlas military warns when neighboring province reviews become stale', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryNeighborReviewStaleness\(recommendation, shifts\)/);
+  assert.match(webAppSource, /function renderAtlasMilitaryNeighborReviewStaleness\(staleness, y\)/);
+  assert.match(webAppSource, /Avertissement fraîcheur revue voisine/);
+  assert.match(webAppSource, /Revue voisine périmée/);
+  assert.match(webAppSource, /nouvel ordre: \$\{primary\.previousDecision\} → \$\{primary\.nextAction\}/);
+  assert.match(webAppSource, /Front voisin changé/);
+  assert.match(webAppSource, /front changé: \$\{frontChange\.routeLabel\}/);
+  assert.match(webAppSource, /Revue du tour précédent/);
+  assert.match(webAppSource, /tour passé: tour \$\{state\.turn\}/);
+  assert.match(webAppSource, /vérifier uniquement les provinces critiques/);
+  assert.match(webAppSource, /ignorer pour ce tour si aucun risque critique/);
+  assert.match(webAppSource, /âge\/cause non disponible: surveiller sans alerte/);
+  assert.match(webAppSource, /reviewStaleness: buildAtlasMilitaryNeighborReviewStaleness\(recommendation, \[\]\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryNeighborReviewStaleness\(preview\.reviewStaleness, staleY\)/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-review-staleness__label/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-review-staleness--front/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-review-staleness--unknown/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2350,6 +2350,48 @@ function buildAtlasMilitaryNeighborReviewPriority(shifts) {
   };
 }
 
+function buildAtlasMilitaryNeighborReviewStaleness(recommendation, shifts) {
+  const primary = recommendation?.primary ?? null;
+  if (primary?.previousDecision && primary.previousDecision !== primary.nextAction) {
+    return {
+      stale: true,
+      tone: 'order',
+      label: 'Revue voisine périmée',
+      reason: `nouvel ordre: ${primary.previousDecision} → ${primary.nextAction}`,
+      action: 'relancer la revue voisins',
+    };
+  }
+
+  const frontChange = shifts.find((shift) => shift.contested || shift.occupied || shift.tone === 'rechute') ?? null;
+  if (frontChange) {
+    return {
+      stale: true,
+      tone: 'front',
+      label: 'Front voisin changé',
+      reason: `front changé: ${frontChange.routeLabel}`,
+      action: frontChange.tone === 'rechute' ? 'vérifier uniquement les provinces critiques' : 'relancer la revue voisins',
+    };
+  }
+
+  if ((state?.turn ?? 1) > 1) {
+    return {
+      stale: true,
+      tone: 'turn',
+      label: 'Revue du tour précédent',
+      reason: `tour passé: tour ${state.turn}`,
+      action: 'ignorer pour ce tour si aucun risque critique',
+    };
+  }
+
+  return {
+    stale: false,
+    tone: 'unknown',
+    label: 'Fraîcheur revue discrète',
+    reason: 'âge/cause non disponible: surveiller sans alerte',
+    action: 'aucune action immédiate',
+  };
+}
+
 function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, features) {
   const focus = recommendation?.primary ?? null;
   const focusProvince = focus?.provinceLabel ?? checklist?.points?.[0]?.detail?.split(':')?.[0] ?? null;
@@ -2359,6 +2401,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       focusOrder: 'ordre contesté non sélectionné',
       shifts: [],
       reviewPriority: buildAtlasMilitaryNeighborReviewPriority([]),
+      reviewStaleness: buildAtlasMilitaryNeighborReviewStaleness(recommendation, []),
       summary: 'Prévision voisins indisponible: aucun ordre de province en focus.',
       empty: true,
     };
@@ -2376,12 +2419,15 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       neighborLabel,
       routeLabel: `${route.sourceLabel} ↔ ${route.targetLabel}`,
       pressure: route.pressure,
+      contested: route.contested,
+      occupied: route.occupied,
       effect: effect.label,
       tone: effect.tone,
       reason: effect.reason,
     };
   });
   const reviewPriority = buildAtlasMilitaryNeighborReviewPriority(shifts);
+  const reviewStaleness = buildAtlasMilitaryNeighborReviewStaleness(recommendation, shifts);
 
   if (!shifts.length) {
     return {
@@ -2389,6 +2435,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       focusOrder: focus?.nextAction ?? 'ordre contesté recommandé',
       shifts: [],
       reviewPriority,
+      reviewStaleness,
       summary: `${focusProvince}: aucun front voisin lisible après engagement.`,
       empty: true,
     };
@@ -2399,7 +2446,8 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
     focusOrder: focus?.nextAction ?? 'ordre contesté recommandé',
     shifts,
     reviewPriority,
-    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}.`,
+    reviewStaleness,
+    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}; ${reviewStaleness.label}.`,
     empty: false,
   };
 }
@@ -2413,9 +2461,19 @@ function renderAtlasMilitaryNeighborReviewPriority(priority, y) {
   `;
 }
 
+function renderAtlasMilitaryNeighborReviewStaleness(staleness, y) {
+  return `
+    <g class="atlas-military-neighbor-review-staleness atlas-military-neighbor-review-staleness--${staleness.tone}" aria-label="Avertissement fraîcheur revue voisine: ${staleness.label}; ${staleness.reason}; action ${staleness.action}">
+      <text class="atlas-military-neighbor-review-staleness__label" x="44.2" y="${y}">${staleness.label}</text>
+      <text class="atlas-military-neighbor-review-staleness__action" x="44.2" y="${y + 1.35}">${staleness.reason} · ${staleness.action}</text>
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
   const priorityY = preview.empty ? 163.8 : 163.85 + (preview.shifts.length * 3.45);
-  const height = preview.empty ? 8.3 : 8.3 + (preview.shifts.length * 3.45);
+  const staleY = priorityY + 2.75;
+  const height = preview.empty ? 10.9 : 10.9 + (preview.shifts.length * 3.45);
   return `
     <g class="atlas-military-neighbor-front-shift atlas-military-neighbor-front-shift--${preview.empty ? 'empty' : 'active'}" aria-label="Prévisualisation des fronts voisins après engagement: ${preview.summary}">
       <rect class="atlas-military-neighbor-front-shift__panel" x="43" y="157" width="35" height="${height}" rx="2.1"></rect>
@@ -2429,6 +2487,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
         </g>
       `).join('')}
       ${renderAtlasMilitaryNeighborReviewPriority(preview.reviewPriority, priorityY)}
+      ${renderAtlasMilitaryNeighborReviewStaleness(preview.reviewStaleness, staleY)}
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -14177,11 +14177,13 @@ button { font: inherit; }
 .atlas-military-neighbor-front-shift__focus,
 .atlas-military-neighbor-front-shift-row__reason,
 .atlas-military-neighbor-front-shift__empty,
-.atlas-military-neighbor-review-priority__reason {
+.atlas-military-neighbor-review-priority__reason,
+.atlas-military-neighbor-review-staleness__action {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
-.atlas-military-neighbor-review-priority__label {
+.atlas-military-neighbor-review-priority__label,
+.atlas-military-neighbor-review-staleness__label {
   fill: #f5f3ff;
   font-size: 0.55px;
   font-weight: 900;
@@ -14191,7 +14193,11 @@ button { font: inherit; }
 }
 .atlas-military-neighbor-review-priority--stable .atlas-military-neighbor-review-priority__label { fill: #bbf7d0; }
 .atlas-military-neighbor-review-priority--fragilise .atlas-military-neighbor-review-priority__label,
-.atlas-military-neighbor-review-priority--rechute .atlas-military-neighbor-review-priority__label { fill: #fecdd3; }
+.atlas-military-neighbor-review-priority--rechute .atlas-military-neighbor-review-priority__label,
+.atlas-military-neighbor-review-staleness--order .atlas-military-neighbor-review-staleness__label,
+.atlas-military-neighbor-review-staleness--front .atlas-military-neighbor-review-staleness__label,
+.atlas-military-neighbor-review-staleness--turn .atlas-military-neighbor-review-staleness__label { fill: #fecdd3; }
+.atlas-military-neighbor-review-staleness--unknown .atlas-military-neighbor-review-staleness__label { fill: #c4b5fd; }
 .atlas-military-neighbor-front-shift-row circle {
   fill: rgba(167, 139, 250, 0.84);
   stroke: rgba(245, 243, 255, 0.72);


### PR DESCRIPTION
Alpha: Implements MAP-A25.

Summary:
- adds a compact freshness warning next to the neighboring review priority
- detects stale review causes from changed orders, front changes, or passed turns
- includes readable actions for relaunching the review, ignoring for the turn, or checking critical provinces only
- keeps a discreet fallback when freshness cause/age is unavailable

Validation:
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test

Closes #1396