### PR TITLE
Delta: Explain mandatory intrigue verification before waiting

### DIFF
--- a/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
+++ b/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
@@ -119,8 +119,45 @@ function buildConfidenceShift(currentTiming, currentTimingComparison) {
   };
 }
 
+function buildWaitVerificationRequirement(timingRecommendationChange, lowConfidence) {
+  if (!timingRecommendationChange || !lowConfidence) {
+    return {
+      state: 'not-required',
+      mandatory: false,
+      reason: 'raison exacte non calculable ou confiance suffisante',
+      consequence: 'Attendre ne demande pas de verrouillage supplémentaire avec les signaux visibles.',
+      fallback: true,
+    };
+  }
+
+  const cause = timingRecommendationChange.confidenceShift?.cause ?? timingRecommendationChange.cause;
+  const timingFragile = timingRecommendationChange.currentTiming === 'act-now' || cause === 'délai';
+  const contradictory = cause === 'signal contradictoire';
+  const mandatory = timingFragile || contradictory || timingRecommendationChange.confidenceShift?.variation === 'baisse';
+  const reason = contradictory
+    ? 'signal contradictoire: attendre sans recouper peut valider le mauvais timing'
+    : timingFragile
+      ? 'timing fragile: la fenêtre visible peut se refermer avant le prochain tour'
+      : 'confiance basse: attendre sans vérifier risque de figer une lecture dégradée';
+  const consequence = timingRecommendationChange.currentTiming === 'act-now'
+    ? 'Conséquence probable: la réponse immédiate perd sa fenêtre et le prochain recheck coûtera plus cher.'
+    : contradictory
+      ? 'Conséquence probable: le prochain tour peut partir sur une priorité inversée.'
+      : 'Conséquence probable: le signal vieillit et la vérification suivante sera moins fiable.';
+
+  return {
+    state: mandatory ? 'mandatory-before-wait' : 'optional-before-wait',
+    mandatory,
+    reason,
+    consequence,
+    fallback: false,
+  };
+}
+
 function buildMinimumVerificationPrompt(timingRecommendationChange) {
   if (!timingRecommendationChange) {
+    const waitVerificationRequirement = buildWaitVerificationRequirement(null, false);
+
     return {
       state: 'sufficient-confidence',
       confidence: 'suffisante',
@@ -128,11 +165,13 @@ function buildMinimumVerificationPrompt(timingRecommendationChange) {
       verification: 'Aucune vérification minimale requise avant l’action recommandée.',
       waitLessRisky: false,
       summary: 'Confiance suffisante: garder la recommandation actuelle sans étape de vérification supplémentaire.',
+      waitVerificationRequirement,
     };
   }
 
   const confidenceShift = timingRecommendationChange.confidenceShift;
   const lowConfidence = confidenceShift?.variation === 'baisse' || confidenceShift?.variation === 'reste instable';
+  const waitVerificationRequirement = buildWaitVerificationRequirement(timingRecommendationChange, lowConfidence);
   const verificationByCause = {
     exposition: 'Vérifier le niveau d’exposition visible avant d’engager une réponse lourde.',
     délai: 'Confirmer que le signal n’a pas vieilli avant de forcer l’action immédiate.',
@@ -149,6 +188,7 @@ function buildMinimumVerificationPrompt(timingRecommendationChange) {
       verification: 'Aucune vérification minimale requise avant l’action recommandée.',
       waitLessRisky: false,
       summary: 'Confiance suffisante: la variation soutient le timing recommandé sans étape supplémentaire.',
+      waitVerificationRequirement,
     };
   }
 
@@ -163,6 +203,7 @@ function buildMinimumVerificationPrompt(timingRecommendationChange) {
     summary: waitLessRisky
       ? 'Attendre un tour est moins risqué que forcer l’action tant que la confiance reste basse.'
       : 'Agir maintenant reste indiqué, mais seulement après une vérification minimale du signal visible.',
+    waitVerificationRequirement,
   };
 }
 

--- a/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
@@ -100,6 +100,13 @@ test('buildIntrigueTurnReportDeltas flags changed timing recommendations fog-saf
       verification: 'Vérifier le niveau d’exposition visible avant d’engager une réponse lourde.',
       waitLessRisky: true,
       summary: 'Attendre un tour est moins risqué que forcer l’action tant que la confiance reste basse.',
+      waitVerificationRequirement: {
+        state: 'mandatory-before-wait',
+        mandatory: true,
+        reason: 'confiance basse: attendre sans vérifier risque de figer une lecture dégradée',
+        consequence: 'Conséquence probable: le signal vieillit et la vérification suivante sera moins fiable.',
+        fallback: false,
+      },
     },
   });
   assert.ok(report.deltas.some((delta) => delta.type === 'timing' && delta.detail === 'agir maintenant → attendre: cause visible exposition.'));
@@ -137,6 +144,13 @@ test('buildIntrigueTurnReportDeltas explains confidence loss when timing flips t
     verification: 'Confirmer que le signal n’a pas vieilli avant de forcer l’action immédiate.',
     waitLessRisky: false,
     summary: 'Agir maintenant reste indiqué, mais seulement après une vérification minimale du signal visible.',
+    waitVerificationRequirement: {
+      state: 'mandatory-before-wait',
+      mandatory: true,
+      reason: 'timing fragile: la fenêtre visible peut se refermer avant le prochain tour',
+      consequence: 'Conséquence probable: la réponse immédiate perd sa fenêtre et le prochain recheck coûtera plus cher.',
+      fallback: false,
+    },
   });
 });
 
@@ -150,6 +164,13 @@ test('buildIntrigueTurnReportDeltas returns a neutral prompt when confidence is 
     verification: 'Aucune vérification minimale requise avant l’action recommandée.',
     waitLessRisky: false,
     summary: 'Confiance suffisante: garder la recommandation actuelle sans étape de vérification supplémentaire.',
+    waitVerificationRequirement: {
+      state: 'not-required',
+      mandatory: false,
+      reason: 'raison exacte non calculable ou confiance suffisante',
+      consequence: 'Attendre ne demande pas de verrouillage supplémentaire avec les signaux visibles.',
+      fallback: true,
+    },
   });
 });
 

--- a/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
@@ -15,5 +15,7 @@ test('playable map wires intrigue aftermath deltas into selected province turn r
   assert.match(webAppSource, /confidenceShift/);
   assert.match(webAppSource, /Vérification minimale avant timing intrigue/);
   assert.match(webAppSource, /minimumVerificationPrompt/);
+  assert.match(webAppSource, /Obligatoire avant d’attendre/);
+  assert.match(webAppSource, /waitVerificationRequirement/);
   assert.match(webAppSource, /renderIntrigueTurnReportDeltas\(province, intrigueView\)/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -8106,6 +8106,9 @@ function renderIntrigueTurnReportDeltas(province, intrigueView) {
           <b>${report.minimumVerificationPrompt.state === 'low-confidence' ? 'Vérification minimale' : 'Confiance suffisante'}</b>
           <span>${report.minimumVerificationPrompt.verification}</span>
           <small>${report.minimumVerificationPrompt.summary}</small>
+          ${report.minimumVerificationPrompt.waitVerificationRequirement?.mandatory ? `
+            <small class="province-intrigue-turn-report__wait-risk">Obligatoire avant d’attendre: ${report.minimumVerificationPrompt.waitVerificationRequirement.reason}. ${report.minimumVerificationPrompt.waitVerificationRequirement.consequence}</small>
+          ` : `<small class="province-intrigue-turn-report__wait-risk">${report.minimumVerificationPrompt.waitVerificationRequirement?.consequence ?? 'Attendre ne demande pas de verrouillage supplémentaire avec les signaux visibles.'}</small>`}
         </div>
       ` : ''}
       ${report.deltas.length > 0 ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -9598,6 +9598,11 @@ button { font: inherit; }
 .province-intrigue-turn-report__verification--low-confidence { border-color: rgba(250, 204, 21, 0.28); }
 .province-intrigue-turn-report__verification span,
 .province-intrigue-turn-report__verification small { color: var(--muted); }
+.province-intrigue-turn-report__wait-risk {
+  padding-top: 4px;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-intrigue-turn-report__verification--low-confidence .province-intrigue-turn-report__wait-risk { color: rgba(253, 224, 71, 0.88); }
 .province-intrigue-turn-report__list {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Résout #1399.

Résumé:
- Ajoute une justification compacte quand une vérification devient obligatoire avant de choisir attendre.
- Distingue confiance basse, timing fragile et signal contradictoire avec une conséquence probable si le joueur attend quand même.
- Garde un fallback neutre quand la raison exacte n’est pas calculable ou que la confiance reste suffisante.

Tests:
- node --test test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?