### PR TITLE
Epsilon: Preview next-turn climate safety margin loss

### DIFF
--- a/test/ui/climate/webAtlasClimateNextTurnSafetyMarginLoss.test.js
+++ b/test/ui/climate/webAtlasClimateNextTurnSafetyMarginLoss.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas previews climate safety margin loss on the next turn', () => {
+  assert.match(webAppSource, /function buildAtlasClimateNextTurnSafetyMarginLoss/);
+  assert.match(webAppSource, /function renderAtlasClimateNextTurnSafetyMarginLoss/);
+  assert.match(webAppSource, /Marge prochain tour/);
+  assert.match(webAppSource, /marge stable/);
+  assert.match(webAppSource, /diminue légèrement/);
+  assert.match(webAppSource, /devient dangereuse/);
+  assert.match(webAppSource, /projection inconnue/);
+  assert.match(webAppSource, /Consommateur principal/);
+  assert.match(webAppSource, /action préventive préférable maintenant/);
+  assert.match(webAppSource, /Projection indisponible/);
+  assert.match(webAppSource, /buildAtlasClimateNextTurnSafetyMarginLoss\(\s*atlasClimateFollowUpSafetyMargin,\s*atlasClimateThresholdProgressAfterReadinessAction,\s*atlasClimateFollowUpThresholdProtection,\s*\)/);
+  assert.match(webAppSource, /renderAtlasClimateFollowUpSafetyMargin\(atlasClimateFollowUpSafetyMargin\)\}\s*\$\{renderAtlasClimateNextTurnSafetyMarginLoss\(atlasClimateNextTurnSafetyMarginLoss\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-next-turn-margin-loss/);
+  assert.match(stylesSource, /\.map-world-climate-next-turn-margin-loss--slight-loss/);
+  assert.match(stylesSource, /\.map-world-climate-next-turn-margin-loss--dangerous-next-turn/);
+  assert.match(stylesSource, /\.map-world-climate-next-turn-margin-loss--unknown/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -12933,6 +12933,102 @@ function renderAtlasClimateFollowUpSafetyMargin(view) {
   `;
 }
 
+function buildAtlasClimateNextTurnSafetyMarginLoss(safetyMarginView, thresholdProgressView, protectionView) {
+  if (!safetyMarginView || safetyMarginView.state === 'empty' || !safetyMarginView.margin || !thresholdProgressView?.progress) {
+    return {
+      state: 'unknown',
+      projection: null,
+      summary: 'Projection prochain tour indisponible: marge actuelle non calculable.',
+    };
+  }
+
+  const current = safetyMarginView.margin;
+  const progress = thresholdProgressView.progress;
+  const nonProtectiveActions = (protectionView?.actions ?? []).filter((action) => action.className !== 'protects-threshold');
+  const currentWeak = safetyMarginView.state === 'weak' || safetyMarginView.state === 'unknown';
+  const hasPreventiveNeed = current.secondActionNeeded || nonProtectiveActions.some((action) => action.className === 'stabilizes-short-term');
+  const state = currentWeak
+    ? 'dangerous-next-turn'
+    : safetyMarginView.state === 'correct' || hasPreventiveNeed
+      ? 'slight-loss'
+      : 'stable';
+  const label = state === 'stable'
+    ? 'marge stable'
+    : state === 'slight-loss'
+      ? 'diminue légèrement'
+      : state === 'dangerous-next-turn'
+        ? 'devient dangereuse'
+        : 'projection inconnue';
+  const mainConsumer = state === 'stable'
+    ? 'aucun consommateur dominant: la veille carte suffit'
+    : current.consumesMargin || (nonProtectiveActions[0]?.reason ?? 'fenêtre climatique non confirmée');
+  const preferNow = state === 'dangerous-next-turn' || (state === 'slight-loss' && current.secondActionNeeded);
+  const recommendedTiming = preferNow
+    ? `Agir maintenant: ${current.recommendation}`
+    : state === 'stable'
+      ? 'Attendre possible: relire la marge au prochain tour avant nouveau bundle.'
+      : 'Préparer maintenant si le coût est faible, sinon relire dès le début du prochain tour.';
+  const nextTurnEffect = state === 'stable'
+    ? `${current.label} devrait rester stable avant ${progress.deadline}.`
+    : state === 'slight-loss'
+      ? `${current.label} devrait perdre un cran de confort si ${mainConsumer} continue.`
+      : state === 'dangerous-next-turn'
+        ? `${current.label} risque de devenir dangereuse au prochain tour avant ${progress.threshold}.`
+        : 'Projection non disponible: conserver un message de prudence.';
+
+  return {
+    state,
+    projection: {
+      label,
+      currentMargin: current.label,
+      protectedThreshold: progress.threshold,
+      deadline: progress.deadline,
+      nextTurnEffect,
+      mainConsumer,
+      preferNow,
+      recommendedTiming,
+      fallback: state === 'unknown' ? 'Fallback lisible: afficher projection inconnue et demander une relecture climat au début du tour suivant.' : '',
+    },
+    summary: state === 'unknown'
+      ? 'Perte de marge prochain tour inconnue: ne pas promettre de sécurité durable.'
+      : `${label}: ${preferNow ? 'action préventive préférable maintenant' : 'pas d’urgence immédiate'} avant le prochain seuil.`,
+  };
+}
+
+function renderAtlasClimateNextTurnSafetyMarginLoss(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || !view || view.state === 'empty') {
+    return '';
+  }
+
+  if (!view.projection) {
+    return `
+      <aside class="map-world-climate-next-turn-margin-loss map-world-climate-next-turn-margin-loss--unknown" aria-label="Projection de perte de marge climat au prochain tour">
+        <div class="map-world-climate-next-turn-margin-loss__header">
+          <strong>Marge prochain tour</strong>
+          <span>projection inconnue</span>
+        </div>
+        <p>${view.summary}</p>
+        <small><b>Fallback</b> · Projection indisponible: relire la carte climat au début du prochain tour.</small>
+      </aside>
+    `;
+  }
+
+  return `
+    <aside class="map-world-climate-next-turn-margin-loss map-world-climate-next-turn-margin-loss--${view.state}" aria-label="Projection de perte de marge climat au prochain tour">
+      <div class="map-world-climate-next-turn-margin-loss__header">
+        <strong>Marge prochain tour</strong>
+        <span>${view.projection.label}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Effet projeté</b> · ${view.projection.nextTurnEffect}</small>
+      <small><b>Consommateur principal</b> · ${view.projection.mainConsumer}</small>
+      <small><b>Timing recommandé</b> · ${view.projection.recommendedTiming}</small>
+      <small><b>Seuil concerné</b> · ${view.projection.protectedThreshold} · ${view.projection.deadline}</small>
+      ${view.projection.fallback ? `<small><b>Fallback</b> · ${view.projection.fallback}</small>` : ''}
+    </aside>
+  `;
+}
+
 function renderAtlasSelectedClimateFollowUpReadinessRecap(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -21189,6 +21285,11 @@ function render() {
     atlasNextClimateFollowUpAction,
     atlasClimateThresholdProgressAfterReadinessAction,
   );
+  const atlasClimateNextTurnSafetyMarginLoss = buildAtlasClimateNextTurnSafetyMarginLoss(
+    atlasClimateFollowUpSafetyMargin,
+    atlasClimateThresholdProgressAfterReadinessAction,
+    atlasClimateFollowUpThresholdProtection,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -21248,6 +21349,7 @@ function render() {
           ${renderAtlasNextClimateFollowUpAction(atlasNextClimateFollowUpAction)}
           ${renderAtlasClimateFollowUpThresholdProtection(atlasClimateFollowUpThresholdProtection)}
           ${renderAtlasClimateFollowUpSafetyMargin(atlasClimateFollowUpSafetyMargin)}
+          ${renderAtlasClimateNextTurnSafetyMarginLoss(atlasClimateNextTurnSafetyMarginLoss)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -13229,6 +13229,43 @@ button { font: inherit; }
 .map-world-climate-follow-up-safety-margin--unknown span,
 .map-world-climate-follow-up-safety-margin--unknown small { color: #e2e8f0; }
 
+.map-world-climate-next-turn-margin-loss {
+  display: grid;
+  gap: 6px;
+  max-width: 62ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(30, 64, 175, 0.36), rgba(15, 23, 42, 0.84));
+  border: 1px solid rgba(96, 165, 250, 0.36);
+}
+.map-world-climate-next-turn-margin-loss--slight-loss { border-color: rgba(251, 191, 36, 0.48); }
+.map-world-climate-next-turn-margin-loss--dangerous-next-turn { border-color: rgba(248, 113, 113, 0.54); }
+.map-world-climate-next-turn-margin-loss--unknown { border-color: rgba(148, 163, 184, 0.36); }
+.map-world-climate-next-turn-margin-loss__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-next-turn-margin-loss p,
+.map-world-climate-next-turn-margin-loss span,
+.map-world-climate-next-turn-margin-loss small {
+  color: #dbeafe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-next-turn-margin-loss--slight-loss p,
+.map-world-climate-next-turn-margin-loss--slight-loss span,
+.map-world-climate-next-turn-margin-loss--slight-loss small { color: #fef3c7; }
+.map-world-climate-next-turn-margin-loss--dangerous-next-turn p,
+.map-world-climate-next-turn-margin-loss--dangerous-next-turn span,
+.map-world-climate-next-turn-margin-loss--dangerous-next-turn small { color: #fee2e2; }
+.map-world-climate-next-turn-margin-loss--unknown p,
+.map-world-climate-next-turn-margin-loss--unknown span,
+.map-world-climate-next-turn-margin-loss--unknown small { color: #e2e8f0; }
+
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);
   box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.12);


### PR DESCRIPTION
Epsilon: PR prête pour #1400.

## Résumé
- Ajoute un encart “Marge prochain tour” après la marge de sécurité du follow-up climat.
- Prévisualise si la marge reste stable, diminue légèrement, ou devient dangereuse au prochain tour.
- Explique le consommateur principal de marge, recommande le timing préventif maintenant vs prochain tour, et garde un fallback lisible si la projection est indisponible.

## Tests
- node --test test/ui/climate/webAtlasClimateNextTurnSafetyMarginLoss.test.js test/ui/climate/webAtlasClimateFollowUpSafetyMargin.test.js test/ui/climate/webAtlasClimateFollowUpThresholdProtection.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?