### PR TITLE
Beta: Preview relapse risk after secondary logistics choice

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -744,6 +744,49 @@ function buildPrimarySecondaryTradeoff(priorityAction, selectedActionPreview, se
   };
 }
 
+
+function buildSecondaryChoiceRelapsePreview(priorityAction, selectedActionPreview, secondaryBottleneckPreview, primarySecondaryTradeoff) {
+  if (!priorityAction || !secondaryBottleneckPreview || secondaryBottleneckPreview.state === 'empty') {
+    return {
+      state: 'unknown',
+      summary: 'Rechute non chiffrable: aucun choix secondaire exploitable pour comparer la marge du levier principal.',
+      factor: 'projection insuffisante',
+      guardAction: 'Attendre un signal secondaire ou garder le levier principal en veille.',
+      safeSecondary: false,
+    };
+  }
+
+  const secondaryBetter = primarySecondaryTradeoff?.secondaryBetter ?? false;
+  const criticalRemaining = selectedActionPreview?.criticalRemaining ?? false;
+  const state = secondaryBetter
+    ? 'fragile'
+    : criticalRemaining || secondaryBottleneckPreview.state === 'blocked'
+      ? 'relapse-risk'
+      : secondaryBottleneckPreview.state === 'watch'
+        ? 'fragile'
+        : 'stable';
+  const factor = criticalRemaining
+    ? `dette logistique encore critique sur ${priorityAction.route}`
+    : secondaryBottleneckPreview.state === 'blocked'
+      ? `route critique ${secondaryBottleneckPreview.route} peut absorber la capacité avant stabilisation`
+      : secondaryBottleneckPreview.state === 'watch'
+        ? `momentum insuffisant si ${secondaryBottleneckPreview.route} reste sous surveillance`
+        : `marge suffisante après ${priorityAction.action}`;
+  const safeSecondary = state === 'stable';
+
+  return {
+    state,
+    summary: safeSecondary
+      ? `Choix secondaire sûr: le levier principal reste stable, ${factor}.`
+      : `Choix secondaire risqué: le levier principal devient ${state === 'relapse-risk' ? 'en rechute probable' : 'fragile'}, facteur clé: ${factor}.`,
+    factor,
+    guardAction: safeSecondary
+      ? `Action minimale: garder ${priorityAction.route} en veille pendant le traitement secondaire.`
+      : `Action minimale: sécuriser ${priorityAction.route} avec ${priorityAction.cost} avant de traiter ${secondaryBottleneckPreview.route}.`,
+    safeSecondary,
+  };
+}
+
 function buildPrimaryLogisticsQueueAction(priorityAction, selectedActionPreview, queuedLogisticsActions = []) {
   if (!priorityAction) {
     return {
@@ -794,7 +837,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const queuedLogisticsActions = Array.isArray(normalizedOptions.queuedLogisticsActions) ? normalizedOptions.queuedLogisticsActions : [];
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []), primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []), primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])), secondaryChoiceRelapsePreview: buildSecondaryChoiceRelapsePreview(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, []), null), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -833,6 +876,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       selectedActionPreview: buildSelectedActionImpactPreview(null, []),
       secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []),
       primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])),
+      secondaryChoiceRelapsePreview: buildSecondaryChoiceRelapsePreview(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, []), null),
       primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions),
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
@@ -848,6 +892,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const selectedActionPreview = buildSelectedActionImpactPreview(recommendedPriority, routeChoices);
   const secondaryBottleneckPreview = buildSecondaryBottleneckPreview(recommendedPriority, routeChoices);
   const primarySecondaryTradeoff = buildPrimarySecondaryTradeoff(recommendedPriority, selectedActionPreview, secondaryBottleneckPreview);
+  const secondaryChoiceRelapsePreview = buildSecondaryChoiceRelapsePreview(recommendedPriority, selectedActionPreview, secondaryBottleneckPreview, primarySecondaryTradeoff);
   const primaryLogisticsAction = buildPrimaryLogisticsQueueAction(recommendedPriority, selectedActionPreview, queuedLogisticsActions);
 
   return {
@@ -869,6 +914,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
     selectedActionPreview,
     secondaryBottleneckPreview,
     primarySecondaryTradeoff,
+    secondaryChoiceRelapsePreview,
     primaryLogisticsAction,
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -106,6 +106,11 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.primarySecondaryTradeoff.state, 'secondary');
   assert.match(preview.primarySecondaryTradeoff.summary, /Principal: .*Secondaire:/);
   assert.match(preview.primarySecondaryTradeoff.opportunityCost, /Coût d’opportunité|consomme|bloquer/);
+  assert.ok(['fragile', 'relapse-risk', 'stable'].includes(preview.secondaryChoiceRelapsePreview.state));
+  assert.equal(preview.secondaryChoiceRelapsePreview.safeSecondary, false);
+  assert.match(preview.secondaryChoiceRelapsePreview.summary, /Choix secondaire|rechute|fragile|stable/);
+  assert.match(preview.secondaryChoiceRelapsePreview.factor, /capacité|dette logistique|route critique|momentum|marge/);
+  assert.match(preview.secondaryChoiceRelapsePreview.guardAction, /Action minimale|Ember Line/);
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
   assert.match(preview.primaryLogisticsAction.downstreamImpact, /pénurie|route|province|délai/);
@@ -171,6 +176,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.secondaryBottleneckPreview.nextRecommendation.reason, /aucun bottleneck secondaire pertinent/);
   assert.equal(preview.primarySecondaryTradeoff.state, 'empty');
   assert.match(preview.primarySecondaryTradeoff.summary, /indisponible|aucun bottleneck secondaire/);
+  assert.equal(preview.secondaryChoiceRelapsePreview.state, 'unknown');
+  assert.match(preview.secondaryChoiceRelapsePreview.summary, /Rechute non chiffrable/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -82,6 +82,10 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Compromis entre levier principal et bottleneck secondaire/);
   assert.match(webAppSource, /Secondaire prioritaire|Principal prioritaire/);
   assert.match(webAppSource, /primarySecondaryTradeoff/);
+  assert.match(webAppSource, /province-logistics-secondary-relapse/);
+  assert.match(webAppSource, /Risque après choix secondaire/);
+  assert.match(webAppSource, /secondaryChoiceRelapsePreview/);
+  assert.match(webAppSource, /Risque de rechute si le bottleneck secondaire est choisi/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -7977,6 +7977,13 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               <small>${preview.primarySecondaryTradeoff.opportunityCost}</small>
             </div>
           ` : ''}
+          ${preview.secondaryChoiceRelapsePreview ? `
+            <div class="province-logistics-secondary-relapse province-logistics-secondary-relapse--${preview.secondaryChoiceRelapsePreview.state}" aria-label="Risque de rechute si le bottleneck secondaire est choisi">
+              <b>Risque après choix secondaire</b>
+              <span>${preview.secondaryChoiceRelapsePreview.summary}</span>
+              <small>${preview.secondaryChoiceRelapsePreview.guardAction}</small>
+            </div>
+          ` : ''}
         </div>
       ` : ''}
       <div class="province-logistics-queue-action province-logistics-queue-action--${preview.primaryLogisticsAction.status}" aria-label="Engager une action logistique depuis la carte">


### PR DESCRIPTION
Beta: Implements #1407.

Summary:
- Adds a relapse-risk preview when choosing the secondary logistics bottleneck instead of continuing the main recovery lever.
- Classifies the main lever as stable, fragile, or relapse-risk after the secondary choice.
- Explains the key relapse factor and the minimal guard action to protect the main lever first.
- Keeps a readable fallback when relapse projection cannot be quantified.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
