### PR TITLE
Epsilon: Recommend smallest preventive climate action

### DIFF
--- a/test/ui/climate/webAtlasClimateSmallestPreventiveAction.test.js
+++ b/test/ui/climate/webAtlasClimateSmallestPreventiveAction.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas recommends the smallest preventive climate action before margin loss', () => {
+  assert.match(webAppSource, /function buildAtlasClimateSmallestPreventiveAction/);
+  assert.match(webAppSource, /function renderAtlasClimateSmallestPreventiveAction/);
+  assert.match(webAppSource, /Prévention minimale/);
+  assert.match(webAppSource, /action préventive minimale/);
+  assert.match(webAppSource, /attente sûre/);
+  assert.match(webAppSource, /fallback discret/);
+  assert.match(webAppSource, /Plus petite action/);
+  assert.match(webAppSource, /Perte évitée/);
+  assert.match(webAppSource, /Intervenir maintenant limite/);
+  assert.match(webAppSource, /Attendre reste sûr/);
+  assert.match(webAppSource, /buildAtlasClimateSmallestPreventiveAction\(\s*atlasClimateNextTurnSafetyMarginLoss,\s*atlasClimateFollowUpThresholdProtection,\s*atlasClimateThresholdProgressAfterReadinessAction,\s*\)/);
+  assert.match(webAppSource, /renderAtlasClimateNextTurnSafetyMarginLoss\(atlasClimateNextTurnSafetyMarginLoss\)\}\s*\$\{renderAtlasClimateSmallestPreventiveAction\(atlasClimateSmallestPreventiveAction\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-smallest-prevention/);
+  assert.match(stylesSource, /\.map-world-climate-smallest-prevention--act-now/);
+  assert.match(stylesSource, /\.map-world-climate-smallest-prevention--safe-to-wait/);
+  assert.match(stylesSource, /\.map-world-climate-smallest-prevention--unavailable/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -13102,6 +13102,101 @@ function renderAtlasClimateNextTurnSafetyMarginLoss(view) {
   `;
 }
 
+function buildAtlasClimateSmallestPreventiveAction(nextTurnLossView, protectionView, thresholdProgressView) {
+  if (!nextTurnLossView || nextTurnLossView.state === 'empty' || !nextTurnLossView.projection || !thresholdProgressView?.progress) {
+    return {
+      state: 'unavailable',
+      action: null,
+      summary: 'Aucune action préventive minimale calculable pour la marge climat.',
+    };
+  }
+
+  const projection = nextTurnLossView.projection;
+  const progress = thresholdProgressView.progress;
+  const candidate = (protectionView?.actions ?? []).find((action) => action.className === 'stabilizes-short-term')
+    ?? protectionView?.bestAction
+    ?? null;
+  const mustActNow = projection.preferNow || nextTurnLossView.state === 'dangerous-next-turn';
+  const safeToWait = nextTurnLossView.state === 'stable' || (!mustActNow && nextTurnLossView.state === 'slight-loss');
+
+  if (!candidate) {
+    return {
+      state: 'unavailable',
+      action: null,
+      summary: 'Fallback discret: aucune action minimale fiable; relire la carte climat avant engagement.',
+    };
+  }
+
+  const minimalAction = mustActNow
+    ? candidate.action
+    : safeToWait
+      ? 'Attendre reste sûr: conserver la veille et ne pas consommer de réserve maintenant.'
+      : 'Préparer une option légère sans la jouer tant que la projection reste inconnue.';
+  const avoidedLoss = mustActNow
+    ? `évite que ${projection.currentMargin} devienne dangereuse avant ${progress.threshold}`
+    : safeToWait
+      ? 'évite une dépense inutile: la marge ne se dégrade pas assez vite'
+      : 'évite de promettre une prévention sans projection fiable';
+  const target = candidate.label ?? progress.provinceLabel ?? projection.protectedThreshold;
+
+  return {
+    state: mustActNow ? 'act-now' : safeToWait ? 'safe-to-wait' : 'unavailable',
+    action: {
+      label: mustActNow ? 'action préventive minimale' : safeToWait ? 'attente sûre' : 'fallback discret',
+      target,
+      minimalAction,
+      avoidedLoss,
+      mainConsumer: projection.mainConsumer,
+      threshold: progress.threshold,
+      deadline: progress.deadline,
+      reason: mustActNow
+        ? `Intervenir maintenant limite ${projection.mainConsumer}.`
+        : safeToWait
+          ? 'La projection ne justifie pas encore une action immédiate.'
+          : 'Projection insuffisante pour calculer une action minimale.',
+    },
+    summary: mustActNow
+      ? `${target}: plus petite prévention recommandée maintenant avant perte de marge.`
+      : safeToWait
+        ? `${target}: attendre reste sûr; garder la prévention en réserve.`
+        : 'Action préventive minimale non calculable; afficher un fallback discret.',
+  };
+}
+
+function renderAtlasClimateSmallestPreventiveAction(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || !view || view.state === 'empty') {
+    return '';
+  }
+
+  if (!view.action) {
+    return `
+      <aside class="map-world-climate-smallest-prevention map-world-climate-smallest-prevention--unavailable" aria-label="Action préventive climatique minimale avant perte de marge">
+        <div class="map-world-climate-smallest-prevention__header">
+          <strong>Prévention minimale</strong>
+          <span>fallback discret</span>
+        </div>
+        <p>${view.summary}</p>
+        <small><b>Fallback</b> · Aucune action minimale calculable: relire la marge climat au prochain signal.</small>
+      </aside>
+    `;
+  }
+
+  return `
+    <aside class="map-world-climate-smallest-prevention map-world-climate-smallest-prevention--${view.state}" aria-label="Action préventive climatique minimale avant perte de marge">
+      <div class="map-world-climate-smallest-prevention__header">
+        <strong>Prévention minimale</strong>
+        <span>${view.action.label}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Cible</b> · ${view.action.target} · ${view.action.threshold} · ${view.action.deadline}</small>
+      <small><b>Plus petite action</b> · ${view.action.minimalAction}</small>
+      <small><b>Perte évitée</b> · ${view.action.avoidedLoss}</small>
+      <small><b>Pourquoi</b> · ${view.action.reason}</small>
+      <small><b>Consommateur</b> · ${view.action.mainConsumer}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasSelectedClimateFollowUpReadinessRecap(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -21363,6 +21458,11 @@ function render() {
     atlasClimateThresholdProgressAfterReadinessAction,
     atlasClimateFollowUpThresholdProtection,
   );
+  const atlasClimateSmallestPreventiveAction = buildAtlasClimateSmallestPreventiveAction(
+    atlasClimateNextTurnSafetyMarginLoss,
+    atlasClimateFollowUpThresholdProtection,
+    atlasClimateThresholdProgressAfterReadinessAction,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -21423,6 +21523,7 @@ function render() {
           ${renderAtlasClimateFollowUpThresholdProtection(atlasClimateFollowUpThresholdProtection)}
           ${renderAtlasClimateFollowUpSafetyMargin(atlasClimateFollowUpSafetyMargin)}
           ${renderAtlasClimateNextTurnSafetyMarginLoss(atlasClimateNextTurnSafetyMarginLoss)}
+          ${renderAtlasClimateSmallestPreventiveAction(atlasClimateSmallestPreventiveAction)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -13277,6 +13277,40 @@ button { font: inherit; }
 .map-world-climate-next-turn-margin-loss--unknown span,
 .map-world-climate-next-turn-margin-loss--unknown small { color: #e2e8f0; }
 
+.map-world-climate-smallest-prevention {
+  display: grid;
+  gap: 6px;
+  max-width: 62ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(101, 48, 11, 0.42), rgba(15, 23, 42, 0.84));
+  border: 1px solid rgba(251, 191, 36, 0.42);
+}
+.map-world-climate-smallest-prevention--act-now { border-color: rgba(248, 113, 113, 0.54); }
+.map-world-climate-smallest-prevention--safe-to-wait { border-color: rgba(74, 222, 128, 0.4); }
+.map-world-climate-smallest-prevention--unavailable { border-color: rgba(148, 163, 184, 0.36); }
+.map-world-climate-smallest-prevention__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-smallest-prevention p,
+.map-world-climate-smallest-prevention span,
+.map-world-climate-smallest-prevention small {
+  color: #fef3c7;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-smallest-prevention--safe-to-wait p,
+.map-world-climate-smallest-prevention--safe-to-wait span,
+.map-world-climate-smallest-prevention--safe-to-wait small { color: #dcfce7; }
+.map-world-climate-smallest-prevention--unavailable p,
+.map-world-climate-smallest-prevention--unavailable span,
+.map-world-climate-smallest-prevention--unavailable small { color: #e2e8f0; }
+
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);
   box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.12);


### PR DESCRIPTION
Epsilon: PR prête pour #1410.

## Résumé
- Ajoute un encart “Prévention minimale” après la projection de perte de marge climat.
- Recommande la plus petite action préventive quand agir maintenant est nécessaire, ou indique explicitement que l’attente reste sûre.
- Affiche cible/seuil/deadline, perte de marge évitée, facteur consommateur et fallback discret si aucune action minimale n’est calculable.

## Tests
- node --test test/ui/climate/webAtlasClimateSmallestPreventiveAction.test.js test/ui/climate/webAtlasClimateNextTurnSafetyMarginLoss.test.js test/ui/climate/webAtlasClimateFollowUpSafetyMargin.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?