### PR TITLE
Delta: Recommend safest minimal intrigue verification

### DIFF
--- a/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
+++ b/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
@@ -154,11 +154,71 @@ function buildWaitVerificationRequirement(timingRecommendationChange, lowConfide
   };
 }
 
+function buildSafestMinimalVerification(prompt, timingRecommendationChange = null) {
+  if (!prompt || prompt.state !== 'low-confidence') {
+    return {
+      state: 'not-needed',
+      recommended: false,
+      label: 'Aucune vérification minimale prioritaire',
+      action: 'Conserver la recommandation actuelle.',
+      whyEnough: 'La confiance visible ne demande pas de déblocage avant attente.',
+      fullReviewRequired: false,
+      fallback: true,
+    };
+  }
+
+  const cause = prompt.cause ?? timingRecommendationChange?.confidenceShift?.cause ?? 'signal contradictoire';
+  const principalRisk = cause === 'exposition'
+    ? 'exposition excessive'
+    : cause === 'délai'
+      ? 'timing fragile'
+      : cause === 'signal contradictoire'
+        ? 'signal contradictoire'
+        : 'confiance basse';
+  const planByRisk = {
+    'exposition excessive': {
+      label: 'Contrôle exposition minimal',
+      action: 'Comparer seulement le niveau d’exposition visible au seuil sûr avant d’attendre.',
+      whyEnough: 'Ce contrôle suffit si l’exposition repasse sous le seuil lisible sans rouvrir la cible masquée.',
+      fullReviewRequired: false,
+    },
+    'timing fragile': {
+      label: 'Contrôle fraîcheur du signal',
+      action: 'Vérifier que le signal de timing n’a pas vieilli depuis le dernier tour.',
+      whyEnough: 'La fraîcheur confirmée suffit à débloquer une attente courte sans refaire toute l’enquête.',
+      fullReviewRequired: false,
+    },
+    'signal contradictoire': {
+      label: 'Recoupement fog-safe rapide',
+      action: 'Comparer le signal principal avec un second indice visible avant de choisir attendre.',
+      whyEnough: 'Un second indice aligné suffit; s’il diverge, une revue complète reste nécessaire.',
+      fullReviewRequired: true,
+    },
+    'confiance basse': {
+      label: 'Contrôle confiance minimal',
+      action: 'Relire la cause visible de perte de confiance et confirmer qu’elle n’empire pas.',
+      whyEnough: 'Cela suffit seulement si la cause reste stable; sinon il faut une revue complète.',
+      fullReviewRequired: prompt.confidence === 'reste instable',
+    },
+  };
+  const plan = planByRisk[principalRisk] ?? planByRisk['confiance basse'];
+
+  return {
+    state: plan.fullReviewRequired ? 'full-review-needed' : 'minimal-sufficient',
+    recommended: true,
+    principalRisk,
+    label: plan.label,
+    action: plan.action,
+    whyEnough: plan.whyEnough,
+    fullReviewRequired: plan.fullReviewRequired,
+    fallback: false,
+  };
+}
+
 function buildMinimumVerificationPrompt(timingRecommendationChange) {
   if (!timingRecommendationChange) {
     const waitVerificationRequirement = buildWaitVerificationRequirement(null, false);
-
-    return {
+    const prompt = {
       state: 'sufficient-confidence',
       confidence: 'suffisante',
       cause: 'aucun changement de timing confirmé',
@@ -166,6 +226,11 @@ function buildMinimumVerificationPrompt(timingRecommendationChange) {
       waitLessRisky: false,
       summary: 'Confiance suffisante: garder la recommandation actuelle sans étape de vérification supplémentaire.',
       waitVerificationRequirement,
+    };
+
+    return {
+      ...prompt,
+      safestMinimalVerification: buildSafestMinimalVerification(prompt),
     };
   }
 
@@ -181,7 +246,7 @@ function buildMinimumVerificationPrompt(timingRecommendationChange) {
   };
 
   if (!lowConfidence) {
-    return {
+    const prompt = {
       state: 'sufficient-confidence',
       confidence: 'suffisante',
       cause: confidenceShift?.cause ?? timingRecommendationChange.cause,
@@ -190,11 +255,15 @@ function buildMinimumVerificationPrompt(timingRecommendationChange) {
       summary: 'Confiance suffisante: la variation soutient le timing recommandé sans étape supplémentaire.',
       waitVerificationRequirement,
     };
+
+    return {
+      ...prompt,
+      safestMinimalVerification: buildSafestMinimalVerification(prompt, timingRecommendationChange),
+    };
   }
 
   const waitLessRisky = timingRecommendationChange.currentTiming === 'short-wait';
-
-  return {
+  const prompt = {
     state: 'low-confidence',
     confidence: confidenceShift.variation,
     cause: confidenceShift.cause,
@@ -204,6 +273,11 @@ function buildMinimumVerificationPrompt(timingRecommendationChange) {
       ? 'Attendre un tour est moins risqué que forcer l’action tant que la confiance reste basse.'
       : 'Agir maintenant reste indiqué, mais seulement après une vérification minimale du signal visible.',
     waitVerificationRequirement,
+  };
+
+  return {
+    ...prompt,
+    safestMinimalVerification: buildSafestMinimalVerification(prompt, timingRecommendationChange),
   };
 }
 

--- a/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
@@ -107,6 +107,16 @@ test('buildIntrigueTurnReportDeltas flags changed timing recommendations fog-saf
         consequence: 'Conséquence probable: le signal vieillit et la vérification suivante sera moins fiable.',
         fallback: false,
       },
+      safestMinimalVerification: {
+        state: 'minimal-sufficient',
+        recommended: true,
+        principalRisk: 'exposition excessive',
+        label: 'Contrôle exposition minimal',
+        action: 'Comparer seulement le niveau d’exposition visible au seuil sûr avant d’attendre.',
+        whyEnough: 'Ce contrôle suffit si l’exposition repasse sous le seuil lisible sans rouvrir la cible masquée.',
+        fullReviewRequired: false,
+        fallback: false,
+      },
     },
   });
   assert.ok(report.deltas.some((delta) => delta.type === 'timing' && delta.detail === 'agir maintenant → attendre: cause visible exposition.'));
@@ -151,6 +161,46 @@ test('buildIntrigueTurnReportDeltas explains confidence loss when timing flips t
       consequence: 'Conséquence probable: la réponse immédiate perd sa fenêtre et le prochain recheck coûtera plus cher.',
       fallback: false,
     },
+    safestMinimalVerification: {
+      state: 'minimal-sufficient',
+      recommended: true,
+      principalRisk: 'timing fragile',
+      label: 'Contrôle fraîcheur du signal',
+      action: 'Vérifier que le signal de timing n’a pas vieilli depuis le dernier tour.',
+      whyEnough: 'La fraîcheur confirmée suffit à débloquer une attente courte sans refaire toute l’enquête.',
+      fullReviewRequired: false,
+      fallback: false,
+    },
+  });
+});
+
+test('buildIntrigueTurnReportDeltas requires full review when minimal verification finds a contradictory signal', () => {
+  const view = buildIntrigueView();
+  view.selectedProvince.drillDown.postRecapStabilizationChoices = {
+    timingComparison: {
+      recommendedTiming: 'short-wait',
+      dominantReason: 'priorité inversée',
+      actNow: { risk: 'indice A pousse à agir' },
+      shortWait: { outcome: 'indice B pousse à temporiser' },
+      summary: 'Les indices visibles ne pointent pas dans le même sens.',
+    },
+  };
+
+  const report = buildIntrigueTurnReportDeltas(province, view, {
+    previousActionCode: 'contenir',
+    previousTimingRecommendation: 'act-now',
+  });
+
+  assert.equal(report.minimumVerificationPrompt.cause, 'signal contradictoire');
+  assert.deepEqual(report.minimumVerificationPrompt.safestMinimalVerification, {
+    state: 'full-review-needed',
+    recommended: true,
+    principalRisk: 'signal contradictoire',
+    label: 'Recoupement fog-safe rapide',
+    action: 'Comparer le signal principal avec un second indice visible avant de choisir attendre.',
+    whyEnough: 'Un second indice aligné suffit; s’il diverge, une revue complète reste nécessaire.',
+    fullReviewRequired: true,
+    fallback: false,
   });
 });
 
@@ -169,6 +219,15 @@ test('buildIntrigueTurnReportDeltas returns a neutral prompt when confidence is 
       mandatory: false,
       reason: 'raison exacte non calculable ou confiance suffisante',
       consequence: 'Attendre ne demande pas de verrouillage supplémentaire avec les signaux visibles.',
+      fallback: true,
+    },
+    safestMinimalVerification: {
+      state: 'not-needed',
+      recommended: false,
+      label: 'Aucune vérification minimale prioritaire',
+      action: 'Conserver la recommandation actuelle.',
+      whyEnough: 'La confiance visible ne demande pas de déblocage avant attente.',
+      fullReviewRequired: false,
       fallback: true,
     },
   });

--- a/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
@@ -17,5 +17,8 @@ test('playable map wires intrigue aftermath deltas into selected province turn r
   assert.match(webAppSource, /minimumVerificationPrompt/);
   assert.match(webAppSource, /Obligatoire avant d’attendre/);
   assert.match(webAppSource, /waitVerificationRequirement/);
+  assert.match(webAppSource, /safestMinimalVerification/);
+  assert.match(webAppSource, /Plus sûre:/);
+  assert.match(webAppSource, /Revue complète si le recoupement diverge/);
   assert.match(webAppSource, /renderIntrigueTurnReportDeltas\(province, intrigueView\)/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -8112,6 +8112,9 @@ function renderIntrigueTurnReportDeltas(province, intrigueView) {
           ${report.minimumVerificationPrompt.waitVerificationRequirement?.mandatory ? `
             <small class="province-intrigue-turn-report__wait-risk">Obligatoire avant d’attendre: ${report.minimumVerificationPrompt.waitVerificationRequirement.reason}. ${report.minimumVerificationPrompt.waitVerificationRequirement.consequence}</small>
           ` : `<small class="province-intrigue-turn-report__wait-risk">${report.minimumVerificationPrompt.waitVerificationRequirement?.consequence ?? 'Attendre ne demande pas de verrouillage supplémentaire avec les signaux visibles.'}</small>`}
+          ${report.minimumVerificationPrompt.safestMinimalVerification?.recommended ? `
+            <small class="province-intrigue-turn-report__minimal-check">Plus sûre: ${report.minimumVerificationPrompt.safestMinimalVerification.label} · ${report.minimumVerificationPrompt.safestMinimalVerification.action} ${report.minimumVerificationPrompt.safestMinimalVerification.whyEnough}${report.minimumVerificationPrompt.safestMinimalVerification.fullReviewRequired ? ' Revue complète si le recoupement diverge.' : ''}</small>
+          ` : `<small class="province-intrigue-turn-report__minimal-check">${report.minimumVerificationPrompt.safestMinimalVerification?.whyEnough ?? 'Aucune vérification minimale fiable à proposer.'}</small>`}
         </div>
       ` : ''}
       ${report.deltas.length > 0 ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -9609,6 +9609,11 @@ button { font: inherit; }
   border-top: 1px solid rgba(148, 163, 184, 0.14);
 }
 .province-intrigue-turn-report__verification--low-confidence .province-intrigue-turn-report__wait-risk { color: rgba(253, 224, 71, 0.88); }
+.province-intrigue-turn-report__minimal-check {
+  padding-top: 4px;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+.province-intrigue-turn-report__verification--low-confidence .province-intrigue-turn-report__minimal-check { color: rgba(191, 219, 254, 0.9); }
 .province-intrigue-turn-report__list {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Implements #1409.

Summary:
- Adds a fog-safe safest minimal verification recommendation to the intrigue wait prompt.
- Maps the principal visible risk to a compact check for contradiction, low confidence, fragile timing, or excess exposure.
- Shows why the minimal check is enough and flags when a full review is still required.

Validation:
- node --test test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: ready for validation before merge.
