### PR TITLE
Beta: Warn on critical route capacity conflicts

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -787,6 +787,56 @@ function buildSecondaryChoiceRelapsePreview(priorityAction, selectedActionPrevie
   };
 }
 
+
+function buildLocalRecoveryCapacityConflictWarning(priorityAction, routeChoices) {
+  if (!priorityAction) {
+    return {
+      state: 'empty',
+      route: null,
+      summary: 'Aucun conflit transversal: aucune récupération locale recommandée.',
+      detail: 'Aucune capacité critique à comparer.',
+    };
+  }
+
+  const selectedOption = routeChoices.find((option) => option.routeId === priorityAction.routeId) ?? null;
+  const selectedScore = (selectedOption?.residualRisk ?? 0) + (selectedOption?.recoveryChoices[0]?.bottleneck?.tone === 'high' ? 12 : 0);
+  const candidates = routeChoices
+    .filter((option) => option.routeId !== priorityAction.routeId && option.resources.includes(priorityAction.resource))
+    .map((option) => {
+      const routeStress = option.residualRisk + (option.tone === 'high' ? 18 : option.tone === 'medium' ? 8 : 0);
+      const sharedCapacity = option.recoveryChoices.some((choice) => choice.blocker === selectedOption?.recoveryChoices[0]?.blocker || choice.blocker === priorityAction.resource);
+      return {
+        route: option.routes[0],
+        city: option.affectedCity,
+        resource: priorityAction.resource,
+        routeStress,
+        sharedCapacity,
+        delay: option.delay,
+      };
+    })
+    .filter((candidate) => candidate.sharedCapacity && candidate.routeStress >= 54 && candidate.routeStress >= selectedScore - 12)
+    .sort((left, right) => right.routeStress - left.routeStress || left.route.localeCompare(right.route));
+  const conflict = candidates[0] ?? null;
+
+  if (!conflict) {
+    return {
+      state: 'empty',
+      route: null,
+      summary: 'Aucun conflit transversal concret: le levier local ne retarde pas une route plus fragile.',
+      detail: 'Capacité partagée sous le seuil critique.',
+    };
+  }
+
+  return {
+    state: conflict.routeStress >= 72 ? 'critical' : 'warning',
+    route: conflict.route,
+    city: conflict.city,
+    resource: conflict.resource,
+    summary: `Attention: ce choix retarde aussi ${conflict.route}, route critique vers ${conflict.city}.`,
+    detail: `${priorityAction.action} consomme ${priorityAction.cost}; ${conflict.route} partage ${conflict.resource} et peut perdre ${conflict.delay}.`,
+  };
+}
+
 function buildPrimaryLogisticsQueueAction(priorityAction, selectedActionPreview, queuedLogisticsActions = []) {
   if (!priorityAction) {
     return {
@@ -837,7 +887,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const queuedLogisticsActions = Array.isArray(normalizedOptions.queuedLogisticsActions) ? normalizedOptions.queuedLogisticsActions : [];
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []), primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])), secondaryChoiceRelapsePreview: buildSecondaryChoiceRelapsePreview(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, []), null), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []), primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])), secondaryChoiceRelapsePreview: buildSecondaryChoiceRelapsePreview(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, []), null), localRecoveryCapacityConflictWarning: buildLocalRecoveryCapacityConflictWarning(null, []), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -877,6 +927,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []),
       primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])),
       secondaryChoiceRelapsePreview: buildSecondaryChoiceRelapsePreview(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, []), null),
+      localRecoveryCapacityConflictWarning: buildLocalRecoveryCapacityConflictWarning(null, []),
       primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions),
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
@@ -893,6 +944,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const secondaryBottleneckPreview = buildSecondaryBottleneckPreview(recommendedPriority, routeChoices);
   const primarySecondaryTradeoff = buildPrimarySecondaryTradeoff(recommendedPriority, selectedActionPreview, secondaryBottleneckPreview);
   const secondaryChoiceRelapsePreview = buildSecondaryChoiceRelapsePreview(recommendedPriority, selectedActionPreview, secondaryBottleneckPreview, primarySecondaryTradeoff);
+  const localRecoveryCapacityConflictWarning = buildLocalRecoveryCapacityConflictWarning(recommendedPriority, routeChoices);
   const primaryLogisticsAction = buildPrimaryLogisticsQueueAction(recommendedPriority, selectedActionPreview, queuedLogisticsActions);
 
   return {
@@ -915,6 +967,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
     secondaryBottleneckPreview,
     primarySecondaryTradeoff,
     secondaryChoiceRelapsePreview,
+    localRecoveryCapacityConflictWarning,
     primaryLogisticsAction,
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -111,6 +111,9 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.secondaryChoiceRelapsePreview.summary, /Choix secondaire|rechute|fragile|stable/);
   assert.match(preview.secondaryChoiceRelapsePreview.factor, /capacité|dette logistique|route critique|momentum|marge/);
   assert.match(preview.secondaryChoiceRelapsePreview.guardAction, /Action minimale|Ember Line/);
+  assert.ok(['warning', 'critical'].includes(preview.localRecoveryCapacityConflictWarning.state));
+  assert.match(preview.localRecoveryCapacityConflictWarning.summary, /Attention: ce choix retarde aussi/);
+  assert.match(preview.localRecoveryCapacityConflictWarning.detail, /consomme|partage|Outils/);
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
   assert.match(preview.primaryLogisticsAction.downstreamImpact, /pénurie|route|province|délai/);
@@ -178,6 +181,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.primarySecondaryTradeoff.summary, /indisponible|aucun bottleneck secondaire/);
   assert.equal(preview.secondaryChoiceRelapsePreview.state, 'unknown');
   assert.match(preview.secondaryChoiceRelapsePreview.summary, /Rechute non chiffrable/);
+  assert.equal(preview.localRecoveryCapacityConflictWarning.state, 'empty');
+  assert.match(preview.localRecoveryCapacityConflictWarning.summary, /Aucun conflit transversal/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -86,6 +86,10 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Risque après choix secondaire/);
   assert.match(webAppSource, /secondaryChoiceRelapsePreview/);
   assert.match(webAppSource, /Risque de rechute si le bottleneck secondaire est choisi/);
+  assert.match(webAppSource, /province-logistics-capacity-conflict/);
+  assert.match(webAppSource, /Conflit capacité/);
+  assert.match(webAppSource, /Conflit de capacité entre récupération locale et route critique/);
+  assert.match(webAppSource, /localRecoveryCapacityConflictWarning/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -8044,6 +8044,13 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               <small>${preview.secondaryChoiceRelapsePreview.guardAction}</small>
             </div>
           ` : ''}
+          ${preview.localRecoveryCapacityConflictWarning && preview.localRecoveryCapacityConflictWarning.state !== 'empty' ? `
+            <div class="province-logistics-capacity-conflict province-logistics-capacity-conflict--${preview.localRecoveryCapacityConflictWarning.state}" aria-label="Conflit de capacité entre récupération locale et route critique">
+              <b>Conflit capacité</b>
+              <span>${preview.localRecoveryCapacityConflictWarning.summary}</span>
+              <small>${preview.localRecoveryCapacityConflictWarning.detail}</small>
+            </div>
+          ` : ''}
         </div>
       ` : ''}
       <div class="province-logistics-queue-action province-logistics-queue-action--${preview.primaryLogisticsAction.status}" aria-label="Engager une action logistique depuis la carte">


### PR DESCRIPTION
Beta: Implements #1417.

Summary:
- Adds a compact capacity-conflict warning when the local recovery lever consumes capacity also needed by another fragile route.
- Surfaces the indirect route delay before the player validates the local logistics action.
- Uses a threshold so stable/non-concrete capacity overlaps stay silent, avoiding duplication with relapse previews.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
