### PR TITLE
Epsilon: Surface secondary protection from climate prevention

### DIFF
--- a/test/ui/climate/webAtlasClimatePreventiveSecondaryProtection.test.js
+++ b/test/ui/climate/webAtlasClimatePreventiveSecondaryProtection.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas surfaces secondary protection from preventive climate actions', () => {
+  assert.match(webAppSource, /function buildAtlasClimatePreventiveSecondaryProtection/);
+  assert.match(webAppSource, /function renderAtlasClimatePreventiveSecondaryProtection/);
+  assert.match(webAppSource, /Protection secondaire/);
+  assert.match(webAppSource, /Protège aussi/);
+  assert.match(webAppSource, /Effet local uniquement/);
+  assert.match(webAppSource, /catastrophe régionale en cascade/);
+  assert.match(webAppSource, /piste mythique sensible/);
+  assert.match(webAppSource, /benefitKind/);
+  assert.match(webAppSource, /change l’intérêt du choix préventif/);
+  assert.match(webAppSource, /buildAtlasClimatePreventiveSecondaryProtection\(\s*atlasClimateSmallestPreventiveAction,\s*atlasClimateFollowUpThresholdProtection,\s*atlasClimateThresholdProgressAfterReadinessAction,\s*\)/);
+  assert.match(webAppSource, /renderAtlasClimateSmallestPreventiveAction\(atlasClimateSmallestPreventiveAction\)\}\s*\$\{renderAtlasClimatePreventiveSecondaryProtection\(atlasClimatePreventiveSecondaryProtection\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-secondary-protection/);
+  assert.match(stylesSource, /\.map-world-climate-secondary-protection--catastrophe/);
+  assert.match(stylesSource, /\.map-world-climate-secondary-protection--myth-track/);
+  assert.match(stylesSource, /\.map-world-climate-secondary-protection--threshold/);
+  assert.match(stylesSource, /\.map-world-climate-secondary-protection--zone/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -13200,6 +13200,74 @@ function renderAtlasClimateSmallestPreventiveAction(view) {
   `;
 }
 
+function buildAtlasClimatePreventiveSecondaryProtection(preventiveView, protectionView, thresholdProgressView) {
+  if (!preventiveView || preventiveView.state !== 'act-now' || !preventiveView.action || !thresholdProgressView?.progress) {
+    return {
+      state: 'empty',
+      protection: null,
+      summary: 'Aucun bénéfice secondaire climatique notable à afficher.',
+    };
+  }
+
+  const progress = thresholdProgressView.progress;
+  const otherAction = (protectionView?.actions ?? []).find((action) => action.rank > 1 && action.className !== 'insufficient') ?? null;
+  const secondaryTarget = otherAction?.target
+    ?? otherAction?.label
+    ?? (/mythe|mythique/i.test(preventiveView.action.mainConsumer) ? 'piste mythique sensible' : null)
+    ?? (/catastrophe|cascade/i.test(preventiveView.action.mainConsumer) ? 'catastrophe régionale en cascade' : null)
+    ?? (/zone|région|province/i.test(preventiveView.action.mainConsumer) ? progress.provinceLabel : null);
+  const changesInterest = Boolean(otherAction) || /mythe|catastrophe|cascade|région|zone|province/i.test(`${preventiveView.action.mainConsumer} ${preventiveView.action.avoidedLoss}`);
+
+  if (!secondaryTarget || !changesInterest) {
+    return {
+      state: 'empty',
+      protection: null,
+      summary: 'Effet local uniquement: ne pas ajouter de ligne secondaire.',
+    };
+  }
+
+  const benefitKind = /mythe|mythique/i.test(secondaryTarget)
+    ? 'myth-track'
+    : /catastrophe|cascade/i.test(secondaryTarget)
+      ? 'catastrophe'
+      : /seuil/i.test(secondaryTarget)
+        ? 'threshold'
+        : 'zone';
+
+  return {
+    state: benefitKind,
+    protection: {
+      target: secondaryTarget,
+      benefitKind,
+      action: preventiveView.action.minimalAction,
+      oneLine: `Protège aussi ${secondaryTarget}: ${otherAction?.reason ?? preventiveView.action.avoidedLoss}.`,
+      priorityReason: otherAction
+        ? 'ce bénéfice secondaire transforme la prévention en choix prioritaire plutôt qu’en simple gain local'
+        : 'le consommateur de marge menace un risque non local identifié',
+    },
+    summary: `${secondaryTarget}: bénéfice secondaire affiché car il change l’intérêt du choix préventif.`,
+  };
+}
+
+function renderAtlasClimatePreventiveSecondaryProtection(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || !view || view.state === 'empty' || !view.protection) {
+    return '';
+  }
+
+  return `
+    <aside class="map-world-climate-secondary-protection map-world-climate-secondary-protection--${view.state}" aria-label="Bénéfice secondaire de l’action préventive climatique">
+      <div class="map-world-climate-secondary-protection__header">
+        <strong>Protection secondaire</strong>
+        <span>${view.protection.benefitKind}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Bénéfice</b> · ${view.protection.oneLine}</small>
+      <small><b>Action liée</b> · ${view.protection.action}</small>
+      <small><b>Pourquoi l’afficher</b> · ${view.protection.priorityReason}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasSelectedClimateFollowUpReadinessRecap(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -21466,6 +21534,11 @@ function render() {
     atlasClimateFollowUpThresholdProtection,
     atlasClimateThresholdProgressAfterReadinessAction,
   );
+  const atlasClimatePreventiveSecondaryProtection = buildAtlasClimatePreventiveSecondaryProtection(
+    atlasClimateSmallestPreventiveAction,
+    atlasClimateFollowUpThresholdProtection,
+    atlasClimateThresholdProgressAfterReadinessAction,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -21527,6 +21600,7 @@ function render() {
           ${renderAtlasClimateFollowUpSafetyMargin(atlasClimateFollowUpSafetyMargin)}
           ${renderAtlasClimateNextTurnSafetyMarginLoss(atlasClimateNextTurnSafetyMarginLoss)}
           ${renderAtlasClimateSmallestPreventiveAction(atlasClimateSmallestPreventiveAction)}
+          ${renderAtlasClimatePreventiveSecondaryProtection(atlasClimatePreventiveSecondaryProtection)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -13316,6 +13316,35 @@ button { font: inherit; }
 .map-world-climate-smallest-prevention--unavailable span,
 .map-world-climate-smallest-prevention--unavailable small { color: #e2e8f0; }
 
+.map-world-climate-secondary-protection {
+  display: grid;
+  gap: 6px;
+  max-width: 62ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(88, 28, 135, 0.42), rgba(15, 23, 42, 0.84));
+  border: 1px solid rgba(196, 181, 253, 0.38);
+}
+.map-world-climate-secondary-protection--catastrophe { border-color: rgba(248, 113, 113, 0.5); }
+.map-world-climate-secondary-protection--myth-track { border-color: rgba(216, 180, 254, 0.5); }
+.map-world-climate-secondary-protection--threshold { border-color: rgba(74, 222, 128, 0.4); }
+.map-world-climate-secondary-protection--zone { border-color: rgba(125, 211, 252, 0.42); }
+.map-world-climate-secondary-protection__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-secondary-protection p,
+.map-world-climate-secondary-protection span,
+.map-world-climate-secondary-protection small {
+  color: #ede9fe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);
   box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.12);


### PR DESCRIPTION
Epsilon: PR prête pour #1420.

## Résumé
- Ajoute un encart “Protection secondaire” après la prévention minimale climat.
- Affiche une seule ligne de bénéfice secondaire quand l’action protège aussi une zone, catastrophe, seuil ou piste mythique identifiable.
- Reste silencieux si l’effet est seulement local/évident pour éviter une liste longue.

## Tests
- node --test test/ui/climate/webAtlasClimatePreventiveSecondaryProtection.test.js test/ui/climate/webAtlasClimateSmallestPreventiveAction.test.js test/ui/climate/webAtlasClimateNextTurnSafetyMarginLoss.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?