### PR TITLE
Gamma: Mark cultural bundles safe to defer

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1283,6 +1283,52 @@ function buildCulturalBundleReplacementRecommendations(groups, cleanupPrompts, f
   };
 }
 
+function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview, replacementRecommendations) {
+  const urgentReplacementIds = new Set(replacementRecommendations.entries.map((entry) => entry.bundleId));
+  const candidates = cleanupPrompts
+    .map((prompt) => {
+      const group = groups.find((candidate) => candidate.bundleId === prompt.bundleId) ?? null;
+      const fallout = falloutPreview.entries.find((entry) => entry.bundleId === prompt.bundleId) ?? null;
+      const hasActiveSupport = (group?.details ?? []).some((detail) => detail.source === 'current');
+      const lowFallout = (fallout?.severity ?? 0) <= 1;
+      const alreadyCovered = prompt.state === 'resolved' || (hasActiveSupport && prompt.state === 'review');
+      const safe = !urgentReplacementIds.has(prompt.bundleId) && (lowFallout || alreadyCovered);
+
+      if (!safe) {
+        return null;
+      }
+
+      const condition = alreadyCovered
+        ? (hasActiveSupport
+          ? 'soutien actif déjà visible dans la rotation culturelle'
+          : 'risque stabilisé par l’historique lisible')
+        : 'fallout faible au prochain tour';
+
+      return {
+        deferId: `${prompt.cleanupId}:safe-to-defer`,
+        bundleId: prompt.bundleId,
+        clusterLabel: prompt.clusterLabel,
+        state: 'safe-to-defer',
+        label: 'Peut attendre',
+        condition,
+        reason: `${prompt.clusterLabel}: ${condition}; ${prompt.action}.`,
+        nextReviewWindow: lowFallout ? 'prochaine rotation culturelle' : 'prochain tour culturel',
+        falloutSeverity: fallout?.severity ?? 0,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.falloutSeverity - right.falloutSeverity || left.clusterLabel.localeCompare(right.clusterLabel));
+  const top = candidates[0] ?? null;
+
+  return {
+    state: candidates.length === 0 ? 'none' : 'ready',
+    summary: top
+      ? `${top.clusterLabel}: Peut attendre — ${top.condition}.`
+      : 'Aucun bundle culturel sûr à reporter ce tour.',
+    entries: candidates,
+  };
+}
+
 function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder) {
   const groups = promptHistoryDrawer.groups.map((group) => {
     const currentEntries = group.entries.filter((entry) => entry.source === 'current');
@@ -1347,6 +1393,7 @@ function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptH
     : `${cleanupPrompts.length} prompt${cleanupPrompts.length > 1 ? 's' : ''} de nettoyage: ${cleanupPrompts.map((prompt) => `${prompt.clusterLabel} → ${prompt.action}`).join(' | ')}.`;
   const falloutPreview = buildCulturalBundleFalloutPreview(cleanupPrompts);
   const replacementRecommendations = buildCulturalBundleReplacementRecommendations(groups, cleanupPrompts, falloutPreview);
+  const safeToDeferBundles = buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview, replacementRecommendations);
 
   return {
     state: groups.length === 0
@@ -1365,6 +1412,7 @@ function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptH
     cleanupSummary,
     falloutPreview,
     replacementRecommendations,
+    safeToDeferBundles,
     detailMode: groups.length === 0
       ? 'Aucun détail individuel à ouvrir.'
       : 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
@@ -1674,6 +1722,11 @@ export function buildCultureTurnReportDeltas({
             skipConsequenceSummary: 'Fallback: conséquence au prochain tour non calculable.',
             nextReviewWindow: null,
             rankingFallback: 'Fallback: aucun score disponible, garder les bundles dans l’ordre actuel.',
+            entries: [],
+          },
+          safeToDeferBundles: {
+            state: 'none',
+            summary: 'Aucun bundle culturel sûr à reporter ce tour.',
             entries: [],
           },
           detailMode: 'Aucun détail individuel à ouvrir.',

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -473,6 +473,11 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
           },
         ],
       },
+      safeToDeferBundles: {
+        state: 'none',
+        summary: 'Aucun bundle culturel sûr à reporter ce tour.',
+        entries: [],
+      },
       detailMode: 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
     },
     dependencyExplanation: 'expansion prudente: archive-routes → amplifier → expansion prudente',
@@ -575,6 +580,49 @@ test('buildCultureTurnReportDeltas marks stale cultural follow-through reminders
     ['Harbor Compact', 'replan', 'replanifier après cleanup du risque', 'Ouvrir le récit d’expansion'],
   ]);
   assert.match(report.commitmentBundles.followThroughBundlePlan.replacementRecommendations.entries[0].avoidedConsequence, /opportunité fraîche masquée/);
+});
+
+test('buildCultureTurnReportDeltas marks resolved cultural bundles safe to defer', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 9,
+    selectedRegionId: 'river-gate',
+    localTimeline: {
+      items: [
+        {
+          timelineId: 'river-gate:event:quiet-followup',
+          kind: 'event',
+          signal: 'watch',
+          title: 'Suivi calme',
+          summary: 'Risque stabilisé.',
+          regionId: 'river-gate',
+          cultureName: 'Compact d’Aurora',
+        },
+      ],
+    },
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'deferred',
+        outcome: 'soutien actif confirmé',
+      },
+    ],
+  });
+
+  assert.deepEqual(report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries.map((entry) => [
+    entry.clusterLabel,
+    entry.label,
+    entry.condition,
+    entry.nextReviewWindow,
+  ]), [
+    ['Compact d’Aurora', 'Peut attendre', 'risque stabilisé par l’historique lisible', 'prochaine rotation culturelle'],
+  ]);
+  assert.match(report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.summary, /Peut attendre/);
+  assert.equal(report.commitmentBundles.followThroughBundlePlan.replacementRecommendations.entries.some((entry) => entry.clusterLabel === 'Compact d’Aurora'), false);
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
@@ -700,6 +748,11 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
           skipConsequenceSummary: 'Fallback: conséquence au prochain tour non calculable.',
           nextReviewWindow: null,
           rankingFallback: 'Fallback: aucun score disponible, garder les bundles dans l’ordre actuel.',
+          entries: [],
+        },
+        safeToDeferBundles: {
+          state: 'none',
+          summary: 'Aucun bundle culturel sûr à reporter ce tour.',
           entries: [],
         },
         detailMode: 'Aucun détail individuel à ouvrir.',

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -175,6 +175,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Si ignoré:/);
   assert.match(webAppSource, /À reconsidérer:/);
   assert.match(webAppSource, /Évite:/);
+  assert.match(webAppSource, /culture-turn-report__safe-defer-bundles/);
+  assert.match(webAppSource, /Peut attendre/);
+  assert.match(webAppSource, /Condition:/);
+  assert.match(webAppSource, /safeToDeferBundles/);
   assert.match(webAppSource, /culture-turn-report__cleanup-prompts/);
   assert.match(webAppSource, /Prompts de nettoyage des bundles culturels/);
   assert.match(webAppSource, /cleanupPrompts/);
@@ -261,6 +265,9 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.culture-turn-report__replacement-recommendation--defensive/);
   assert.match(stylesSource, /\.culture-turn-report__replacement-recommendation--opportunistic/);
   assert.match(stylesSource, /\.culture-turn-report__replacement-recommendation\.is-recommended/);
+  assert.match(stylesSource, /\.culture-turn-report__safe-defer-bundles/);
+  assert.match(stylesSource, /\.culture-turn-report__safe-defer-bundles--none/);
+  assert.match(stylesSource, /\.culture-turn-report__safe-defer-entry/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompts/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--obsolete/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--resolved/);

--- a/web/app.js
+++ b/web/app.js
@@ -7180,6 +7180,21 @@ function renderCultureTurnReport(report) {
             </div>
           ` : ''}
         </div>
+        <div class="culture-turn-report__safe-defer-bundles culture-turn-report__safe-defer-bundles--${report.commitmentBundles?.followThroughBundlePlan?.safeToDeferBundles?.state ?? 'none'}" aria-label="Bundles culturels sûrs à reporter">
+          <span>Peut attendre</span>
+          <strong>${report.commitmentBundles?.followThroughBundlePlan?.safeToDeferBundles?.summary ?? 'Aucun bundle culturel sûr à reporter ce tour.'}</strong>
+          ${(report.commitmentBundles?.followThroughBundlePlan?.safeToDeferBundles?.entries ?? []).length > 0 ? `
+            <div class="culture-turn-report__safe-defer-list">
+              ${report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries.map((entry) => `
+                <span class="culture-turn-report__safe-defer-entry">
+                  <b>${entry.clusterLabel} · ${entry.label}</b>
+                  <small>Condition: ${entry.condition}</small>
+                  <small>À revoir: ${entry.nextReviewWindow}</small>
+                </span>
+              `).join('')}
+            </div>
+          ` : ''}
+        </div>
         <div class="culture-turn-report__cleanup-prompts" aria-label="Prompts de nettoyage des bundles culturels">
           <strong>${report.commitmentBundles?.followThroughBundlePlan?.cleanupSummary ?? 'Aucun prompt de nettoyage culturel à proposer.'}</strong>
           ${(report.commitmentBundles?.followThroughBundlePlan?.cleanupPrompts ?? []).length > 0 ? `

--- a/web/styles.css
+++ b/web/styles.css
@@ -2107,6 +2107,33 @@ button { font: inherit; }
   border-width: 2px;
   box-shadow: 0 0 0 1px rgba(125, 211, 252, 0.18);
 }
+.culture-turn-report__safe-defer-bundles {
+  display: grid;
+  gap: 5px;
+  padding: 7px 8px;
+  border-radius: 10px;
+  background: rgba(20, 83, 45, 0.14);
+  border: 1px solid rgba(74, 222, 128, 0.26);
+}
+.culture-turn-report__safe-defer-bundles > span {
+  color: #bbf7d0;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.culture-turn-report__safe-defer-bundles > strong { color: #dcfce7; font-size: 11px; }
+.culture-turn-report__safe-defer-bundles--none { border-color: rgba(148, 163, 184, 0.18); background: rgba(30, 41, 59, 0.18); }
+.culture-turn-report__safe-defer-list { display: grid; gap: 5px; }
+.culture-turn-report__safe-defer-entry {
+  display: grid;
+  gap: 2px;
+  padding: 6px 7px;
+  border-radius: 9px;
+  background: rgba(2, 6, 23, 0.2);
+  border: 1px solid rgba(74, 222, 128, 0.22);
+}
+.culture-turn-report__safe-defer-entry b { color: #f0fdf4; }
+.culture-turn-report__safe-defer-entry small { color: var(--muted); }
 .culture-turn-report__cleanup-prompts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Gamma: Implements #1418.

Summary:
- adds safe-to-defer metadata for cultural follow-through bundles whose fallout is low or already covered
- surfaces a short “Peut attendre” block with the safety condition and next review window
- keeps urgent replacement recommendations prioritized and unchanged
- adds a resolved-history fixture covering a defer-safe bundle

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test