### PR TITLE
Delta: Show minimal check follow-up options

### DIFF
--- a/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
+++ b/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
@@ -172,6 +172,43 @@ function buildNextTurnUnlock(principalRisk, fullReviewRequired, timingRecommenda
   return 'Au prochain tour, elle réduira l’incertitude avant de choisir entre agir et attendre.';
 }
 
+function buildUnlockedFollowUpOptions(principalRisk, fullReviewRequired, timingRecommendationChange) {
+  const canWaitNextTurn = timingRecommendationChange?.currentTiming === 'short-wait';
+  const optionsByRisk = {
+    'exposition excessive': [
+      { type: 'defensive', label: 'Défensif', consequence: 'réduire l’exposition avant toute réponse lourde' },
+      { type: 'wait', label: 'Attente', consequence: 'attendre un tour si le seuil visible redevient sûr' },
+      { type: 'offensive', label: 'Offensif', consequence: 'agir seulement si l’exposition reste maîtrisée' },
+    ],
+    'timing fragile': [
+      { type: 'offensive', label: 'Offensif', consequence: 'agir vite si la fenêtre visible se ferme' },
+      { type: 'wait', label: 'Attente', consequence: 'attendre si le signal reste frais au prochain tour' },
+      { type: 'defensive', label: 'Défensif', consequence: 'limiter le coût d’un recheck si la fenêtre est perdue' },
+    ],
+    'signal contradictoire': [
+      { type: 'offensive', label: 'Offensif', consequence: 'agir si les deux indices visibles convergent' },
+      { type: 'defensive', label: 'Défensif', consequence: 'basculer en revue complète si le recoupement diverge' },
+      { type: 'wait', label: 'Attente', consequence: 'différer seulement si l’incertitude baisse sans contradiction' },
+    ],
+    'confiance basse': [
+      { type: 'defensive', label: 'Défensif', consequence: 'stabiliser la lecture si la confiance reste basse' },
+      { type: 'wait', label: 'Attente', consequence: 'attendre si la cause visible n’empire pas' },
+      { type: 'offensive', label: 'Offensif', consequence: 'agir si le contrôle confirme un signal exploitable' },
+    ],
+  };
+  const options = optionsByRisk[principalRisk] ?? optionsByRisk['confiance basse'];
+
+  if (fullReviewRequired) {
+    return options.slice(0, 2);
+  }
+
+  if (!canWaitNextTurn) {
+    return options.filter((option) => option.type !== 'wait').slice(0, 2);
+  }
+
+  return options.slice(0, 3);
+}
+
 function buildSafestMinimalVerification(prompt, timingRecommendationChange = null) {
   if (!prompt || prompt.state !== 'low-confidence') {
     return {
@@ -181,6 +218,7 @@ function buildSafestMinimalVerification(prompt, timingRecommendationChange = nul
       action: 'Conserver la recommandation actuelle.',
       whyEnough: 'La confiance visible ne demande pas de déblocage avant attente.',
       unlockNextTurn: 'Aucun choix supplémentaire à débloquer au prochain tour.',
+      followUpOptions: [],
       fullReviewRequired: false,
       fallback: true,
     };
@@ -230,6 +268,7 @@ function buildSafestMinimalVerification(prompt, timingRecommendationChange = nul
     action: plan.action,
     whyEnough: plan.whyEnough,
     unlockNextTurn: buildNextTurnUnlock(principalRisk, plan.fullReviewRequired, timingRecommendationChange),
+    followUpOptions: buildUnlockedFollowUpOptions(principalRisk, plan.fullReviewRequired, timingRecommendationChange),
     fullReviewRequired: plan.fullReviewRequired,
     fallback: false,
   };

--- a/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
@@ -115,6 +115,11 @@ test('buildIntrigueTurnReportDeltas flags changed timing recommendations fog-saf
         action: 'Comparer seulement le niveau d’exposition visible au seuil sûr avant d’attendre.',
         whyEnough: 'Ce contrôle suffit si l’exposition repasse sous le seuil lisible sans rouvrir la cible masquée.',
         unlockNextTurn: 'Au prochain tour, elle permettra de choisir plus sûrement entre attendre encore ou agir sans surcharger la revue.',
+        followUpOptions: [
+          { type: 'defensive', label: 'Défensif', consequence: 'réduire l’exposition avant toute réponse lourde' },
+          { type: 'wait', label: 'Attente', consequence: 'attendre un tour si le seuil visible redevient sûr' },
+          { type: 'offensive', label: 'Offensif', consequence: 'agir seulement si l’exposition reste maîtrisée' },
+        ],
         fullReviewRequired: false,
         fallback: false,
       },
@@ -170,6 +175,10 @@ test('buildIntrigueTurnReportDeltas explains confidence loss when timing flips t
       action: 'Vérifier que le signal de timing n’a pas vieilli depuis le dernier tour.',
       whyEnough: 'La fraîcheur confirmée suffit à débloquer une attente courte sans refaire toute l’enquête.',
       unlockNextTurn: 'Au prochain tour, elle permettra de confirmer si l’action immédiate reste nécessaire ou si attendre redevient sûr.',
+      followUpOptions: [
+        { type: 'offensive', label: 'Offensif', consequence: 'agir vite si la fenêtre visible se ferme' },
+        { type: 'defensive', label: 'Défensif', consequence: 'limiter le coût d’un recheck si la fenêtre est perdue' },
+      ],
       fullReviewRequired: false,
       fallback: false,
     },
@@ -202,6 +211,10 @@ test('buildIntrigueTurnReportDeltas requires full review when minimal verificati
     action: 'Comparer le signal principal avec un second indice visible avant de choisir attendre.',
     whyEnough: 'Un second indice aligné suffit; s’il diverge, une revue complète reste nécessaire.',
     unlockNextTurn: 'Au prochain tour, elle réduira l’incertitude pour choisir entre agir maintenant ou lancer une revue complète.',
+    followUpOptions: [
+      { type: 'offensive', label: 'Offensif', consequence: 'agir si les deux indices visibles convergent' },
+      { type: 'defensive', label: 'Défensif', consequence: 'basculer en revue complète si le recoupement diverge' },
+    ],
     fullReviewRequired: true,
     fallback: false,
   });
@@ -231,6 +244,7 @@ test('buildIntrigueTurnReportDeltas returns a neutral prompt when confidence is 
       action: 'Conserver la recommandation actuelle.',
       whyEnough: 'La confiance visible ne demande pas de déblocage avant attente.',
       unlockNextTurn: 'Aucun choix supplémentaire à débloquer au prochain tour.',
+      followUpOptions: [],
       fullReviewRequired: false,
       fallback: true,
     },

--- a/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
@@ -22,6 +22,9 @@ test('playable map wires intrigue aftermath deltas into selected province turn r
   assert.match(webAppSource, /Débloque:/);
   assert.match(webAppSource, /unlockNextTurn/);
   assert.match(webAppSource, /province-intrigue-turn-report__next-turn-unlock/);
+  assert.match(webAppSource, /followUpOptions/);
+  assert.match(webAppSource, /Suites débloquées par la vérification minimale/);
+  assert.match(webAppSource, /province-intrigue-turn-report__followup--/);
   assert.match(webAppSource, /Revue complète si le recoupement diverge/);
   assert.match(webAppSource, /renderIntrigueTurnReportDeltas\(province, intrigueView\)/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -8269,6 +8269,16 @@ function renderIntrigueTurnReportDeltas(province, intrigueView) {
           ${report.minimumVerificationPrompt.safestMinimalVerification?.recommended ? `
             <small class="province-intrigue-turn-report__minimal-check">Plus sûre: ${report.minimumVerificationPrompt.safestMinimalVerification.label} · ${report.minimumVerificationPrompt.safestMinimalVerification.action} ${report.minimumVerificationPrompt.safestMinimalVerification.whyEnough}${report.minimumVerificationPrompt.safestMinimalVerification.fullReviewRequired ? ' Revue complète si le recoupement diverge.' : ''}</small>
             <small class="province-intrigue-turn-report__next-turn-unlock">Débloque: ${report.minimumVerificationPrompt.safestMinimalVerification.unlockNextTurn}</small>
+            ${report.minimumVerificationPrompt.safestMinimalVerification.followUpOptions?.length ? `
+              <ul class="province-intrigue-turn-report__followups" aria-label="Suites débloquées par la vérification minimale">
+                ${report.minimumVerificationPrompt.safestMinimalVerification.followUpOptions.map((option) => `
+                  <li class="province-intrigue-turn-report__followup province-intrigue-turn-report__followup--${option.type}">
+                    <b>${option.label}</b>
+                    <span>${option.consequence}</span>
+                  </li>
+                `).join('')}
+              </ul>
+            ` : ''}
           ` : `<small class="province-intrigue-turn-report__minimal-check">${report.minimumVerificationPrompt.safestMinimalVerification?.whyEnough ?? 'Aucune vérification minimale fiable à proposer.'}</small>`}
         </div>
       ` : ''}

--- a/web/styles.css
+++ b/web/styles.css
@@ -9646,6 +9646,28 @@ button { font: inherit; }
 }
 .province-intrigue-turn-report__verification--low-confidence .province-intrigue-turn-report__minimal-check { color: rgba(191, 219, 254, 0.9); }
 .province-intrigue-turn-report__verification--low-confidence .province-intrigue-turn-report__next-turn-unlock { color: rgba(165, 243, 252, 0.9); }
+.province-intrigue-turn-report__followups {
+  display: grid;
+  gap: 4px;
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.province-intrigue-turn-report__followup {
+  display: grid;
+  grid-template-columns: minmax(72px, max-content) 1fr;
+  gap: 6px;
+  align-items: center;
+  padding: 4px 6px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.32);
+  border-left: 2px solid rgba(148, 163, 184, 0.36);
+}
+.province-intrigue-turn-report__followup--offensive { border-left-color: rgba(248, 113, 113, 0.56); }
+.province-intrigue-turn-report__followup--defensive { border-left-color: rgba(96, 165, 250, 0.56); }
+.province-intrigue-turn-report__followup--wait { border-left-color: rgba(250, 204, 21, 0.56); }
+.province-intrigue-turn-report__followup b { color: rgba(226, 232, 240, 0.9); }
+.province-intrigue-turn-report__followup span { color: var(--muted); }
 .province-intrigue-turn-report__list {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Implements #1429.

Summary:
- Adds compact follow-up options unlocked by minimal intrigue checks.
- Distinguishes offensive, defensive, and wait follow-ups when multiple next-turn choices are available.
- Keeps the display fog-safe and consequence-focused without adding new intrigue systems.

Validation:
- node --test test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: ready for validation before merge.
