### PR TITLE
Beta: Show adjacent logistics spillover risk

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -837,6 +837,61 @@ function buildLocalRecoveryCapacityConflictWarning(priorityAction, routeChoices)
   };
 }
 
+
+function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
+  if (!priorityAction) {
+    return { state: 'empty', criticalRoute: null, secondaryRoutes: [], summary: 'Aucun spillover logistique: aucune récupération locale sélectionnée.' };
+  }
+
+  const option = routeChoices.find((candidate) => candidate.routeId === priorityAction.routeId) ?? null;
+  const choice = option?.recoveryChoices.find((candidate) => candidate.choiceId === priorityAction.choiceId) ?? option?.recoveryChoices[0] ?? null;
+  const signals = [
+    ...(choice?.downstreamShortages ?? []).filter((shortage) => shortage.status !== 'résolue').map((shortage) => ({
+      route: shortage.route,
+      city: shortage.target,
+      resource: shortage.resource,
+      tone: shortage.status === 'aggravée' ? 'high' : 'medium',
+      detail: shortage.detail,
+      score: shortage.status === 'aggravée' ? 50 : shortage.status === 'déplacée' ? 36 : 24,
+    })),
+    ...(choice?.neighborEffects ?? []).filter((effect) => effect.tone !== 'low').map((effect) => ({
+      route: effect.route,
+      city: effect.target,
+      resource: priorityAction.resource,
+      tone: effect.tone,
+      detail: effect.detail,
+      score: effect.tone === 'high' ? 44 : 30,
+    })),
+  ].filter((signal) => signal.route && signal.route !== priorityAction.route)
+    .sort((left, right) => right.score - left.score || left.route.localeCompare(right.route));
+
+  const deduped = [];
+  for (const signal of signals) {
+    if (!deduped.some((entry) => entry.route === signal.route)) {
+      deduped.push(signal);
+    }
+  }
+
+  const criticalRoute = deduped[0] ?? null;
+  const secondaryRoutes = deduped.slice(1, 3);
+
+  if (!criticalRoute) {
+    return {
+      state: 'empty',
+      criticalRoute: null,
+      secondaryRoutes: [],
+      summary: 'Aucun spillover logistique voisin concret après cette récupération locale.',
+    };
+  }
+
+  return {
+    state: secondaryRoutes.length > 0 ? 'chain' : 'single',
+    criticalRoute,
+    secondaryRoutes,
+    summary: `${criticalRoute.route} est la route voisine critique; ${secondaryRoutes.length > 0 ? `${secondaryRoutes.length} route${secondaryRoutes.length > 1 ? 's' : ''} secondaire${secondaryRoutes.length > 1 ? 's' : ''} exposée${secondaryRoutes.length > 1 ? 's' : ''}.` : 'aucune autre route secondaire exposée.'}`,
+  };
+}
+
 function buildPrimaryLogisticsQueueAction(priorityAction, selectedActionPreview, queuedLogisticsActions = []) {
   if (!priorityAction) {
     return {
@@ -887,7 +942,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const queuedLogisticsActions = Array.isArray(normalizedOptions.queuedLogisticsActions) ? normalizedOptions.queuedLogisticsActions : [];
 
   if (!province || !economyView) {
-    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []), primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])), secondaryChoiceRelapsePreview: buildSecondaryChoiceRelapsePreview(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, []), null), localRecoveryCapacityConflictWarning: buildLocalRecoveryCapacityConflictWarning(null, []), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
+    return { recommendedOptionId: null, timelineStatus: 'empty', timelineSummary: 'Aucune action route/logistique en file: timeline vide.', downstreamStatus: 'neutre', downstreamSummary: 'Aucune pénurie aval claire détectée.', priorityActions: [], prioritySummary: 'Aucune action logistique prioritaire disponible.', recoveryLeverRanking: buildRecoveryLeverRanking([], [], false), selectedActionPreview: buildSelectedActionImpactPreview(null, []), secondaryBottleneckPreview: buildSecondaryBottleneckPreview(null, []), primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])), secondaryChoiceRelapsePreview: buildSecondaryChoiceRelapsePreview(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, []), null), localRecoveryCapacityConflictWarning: buildLocalRecoveryCapacityConflictWarning(null, []), adjacentRouteSpilloverRisk: buildAdjacentRouteSpilloverRisk(null, []), primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions), status: 'stable', summary: 'Aucune donnée logistique disponible.', options: [] };
   }
 
   const cities = economyView.overlay?.cities ?? [];
@@ -928,6 +983,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
       primarySecondaryTradeoff: buildPrimarySecondaryTradeoff(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, [])),
       secondaryChoiceRelapsePreview: buildSecondaryChoiceRelapsePreview(null, buildSelectedActionImpactPreview(null, []), buildSecondaryBottleneckPreview(null, []), null),
       localRecoveryCapacityConflictWarning: buildLocalRecoveryCapacityConflictWarning(null, []),
+      adjacentRouteSpilloverRisk: buildAdjacentRouteSpilloverRisk(null, []),
       primaryLogisticsAction: buildPrimaryLogisticsQueueAction(null, buildSelectedActionImpactPreview(null, []), queuedLogisticsActions),
       status: 'stable',
       summary: 'Logistique stable: aucune route liée à la province sélectionnée.',
@@ -945,6 +1001,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
   const primarySecondaryTradeoff = buildPrimarySecondaryTradeoff(recommendedPriority, selectedActionPreview, secondaryBottleneckPreview);
   const secondaryChoiceRelapsePreview = buildSecondaryChoiceRelapsePreview(recommendedPriority, selectedActionPreview, secondaryBottleneckPreview, primarySecondaryTradeoff);
   const localRecoveryCapacityConflictWarning = buildLocalRecoveryCapacityConflictWarning(recommendedPriority, routeChoices);
+  const adjacentRouteSpilloverRisk = buildAdjacentRouteSpilloverRisk(recommendedPriority, routeChoices);
   const primaryLogisticsAction = buildPrimaryLogisticsQueueAction(recommendedPriority, selectedActionPreview, queuedLogisticsActions);
 
   return {
@@ -968,6 +1025,7 @@ export function buildProvinceLogisticsChoicePreview(province, economyView, optio
     primarySecondaryTradeoff,
     secondaryChoiceRelapsePreview,
     localRecoveryCapacityConflictWarning,
+    adjacentRouteSpilloverRisk,
     primaryLogisticsAction,
     status: hasBlocker ? recommended.tone : 'stable',
     summary: hasBlocker

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -114,6 +114,10 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.ok(['warning', 'critical'].includes(preview.localRecoveryCapacityConflictWarning.state));
   assert.match(preview.localRecoveryCapacityConflictWarning.summary, /Attention: ce choix retarde aussi/);
   assert.match(preview.localRecoveryCapacityConflictWarning.detail, /consomme|partage|Outils/);
+  assert.ok(['single', 'chain'].includes(preview.adjacentRouteSpilloverRisk.state));
+  assert.match(preview.adjacentRouteSpilloverRisk.summary, /route voisine critique|secondaire|exposée/);
+  assert.match(preview.adjacentRouteSpilloverRisk.criticalRoute.route, /Ember Line|Hill Spur|Safe Road/);
+  assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
   assert.match(preview.primaryLogisticsAction.downstreamImpact, /pénurie|route|province|délai/);
@@ -183,6 +187,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.secondaryChoiceRelapsePreview.summary, /Rechute non chiffrable/);
   assert.equal(preview.localRecoveryCapacityConflictWarning.state, 'empty');
   assert.match(preview.localRecoveryCapacityConflictWarning.summary, /Aucun conflit transversal/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.state, 'empty');
+  assert.match(preview.adjacentRouteSpilloverRisk.summary, /Aucun spillover/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -90,6 +90,11 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Conflit capacité/);
   assert.match(webAppSource, /Conflit de capacité entre récupération locale et route critique/);
   assert.match(webAppSource, /localRecoveryCapacityConflictWarning/);
+  assert.match(webAppSource, /province-logistics-spillover-risk/);
+  assert.match(webAppSource, /Spillover voisin/);
+  assert.match(webAppSource, /Risque de spillover logistique sur routes voisines/);
+  assert.match(webAppSource, /adjacentRouteSpilloverRisk/);
+  assert.match(webAppSource, /Critique:/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -8131,6 +8131,13 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               <small>${preview.localRecoveryCapacityConflictWarning.detail}</small>
             </div>
           ` : ''}
+          ${preview.adjacentRouteSpilloverRisk && preview.adjacentRouteSpilloverRisk.state !== 'empty' ? `
+            <div class="province-logistics-spillover-risk province-logistics-spillover-risk--${preview.adjacentRouteSpilloverRisk.state}" aria-label="Risque de spillover logistique sur routes voisines">
+              <b>Spillover voisin</b>
+              <span>${preview.adjacentRouteSpilloverRisk.summary}</span>
+              <small>Critique: ${preview.adjacentRouteSpilloverRisk.criticalRoute.route} vers ${preview.adjacentRouteSpilloverRisk.criticalRoute.city}. ${preview.adjacentRouteSpilloverRisk.secondaryRoutes.length > 0 ? `Secondaires: ${preview.adjacentRouteSpilloverRisk.secondaryRoutes.map((route) => `${route.route} (${route.city})`).join(', ')}.` : 'Pas de route secondaire exposée.'}</small>
+            </div>
+          ` : ''}
         </div>
       ` : ''}
       <div class="province-logistics-queue-action province-logistics-queue-action--${preview.primaryLogisticsAction.status}" aria-label="Engager une action logistique depuis la carte">


### PR DESCRIPTION
Beta: Implements #1427.

Summary:
- Adds a compact adjacent-route spillover risk preview after a local logistics recovery.
- Separates the immediate critical neighboring route from secondary exposed routes.
- Reuses existing downstream shortage and neighbor-effect signals, with no heavy new economy calculation.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
