### PR TITLE
Gamma: Explain cultural defer risk threshold

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1303,6 +1303,18 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
           ? 'soutien actif déjà visible dans la rotation culturelle'
           : 'risque stabilisé par l’historique lisible')
         : 'fallout faible au prochain tour';
+      const nextReviewWindow = lowFallout ? 'prochaine rotation culturelle' : 'prochain tour culturel';
+      const riskTrigger = hasActiveSupport
+        ? 'le soutien actif disparaît'
+        : lowFallout
+          ? 'le fallout dépasse le niveau faible'
+          : 'aucun suivi courant ne couvre le bundle';
+      const turningSignal = hasActiveSupport
+        ? 'perte du soutien actif'
+        : lowFallout
+          ? 'fallout en hausse'
+          : 'suivi absent';
+      const riskThreshold = `Devient risqué si ${riskTrigger} avant la ${nextReviewWindow}.`;
 
       return {
         deferId: `${prompt.cleanupId}:safe-to-defer`,
@@ -1312,7 +1324,9 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
         label: 'Peut attendre',
         condition,
         reason: `${prompt.clusterLabel}: ${condition}; ${prompt.action}.`,
-        nextReviewWindow: lowFallout ? 'prochaine rotation culturelle' : 'prochain tour culturel',
+        riskThreshold,
+        turningSignal,
+        nextReviewWindow,
         falloutSeverity: fallout?.severity ?? 0,
       };
     })
@@ -1323,7 +1337,7 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
   return {
     state: candidates.length === 0 ? 'none' : 'ready',
     summary: top
-      ? `${top.clusterLabel}: Peut attendre — ${top.condition}.`
+      ? `${top.clusterLabel}: Peut attendre — ${top.condition}; ${top.riskThreshold}`
       : 'Aucun bundle culturel sûr à reporter ce tour.',
     entries: candidates,
   };

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -617,11 +617,20 @@ test('buildCultureTurnReportDeltas marks resolved cultural bundles safe to defer
     entry.clusterLabel,
     entry.label,
     entry.condition,
+    entry.turningSignal,
+    entry.riskThreshold,
     entry.nextReviewWindow,
   ]), [
-    ['Compact d’Aurora', 'Peut attendre', 'risque stabilisé par l’historique lisible', 'prochaine rotation culturelle'],
+    [
+      'Compact d’Aurora',
+      'Peut attendre',
+      'risque stabilisé par l’historique lisible',
+      'fallout en hausse',
+      'Devient risqué si le fallout dépasse le niveau faible avant la prochaine rotation culturelle.',
+      'prochaine rotation culturelle',
+    ],
   ]);
-  assert.match(report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.summary, /Peut attendre/);
+  assert.match(report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.summary, /Devient risqué/);
   assert.equal(report.commitmentBundles.followThroughBundlePlan.replacementRecommendations.entries.some((entry) => entry.clusterLabel === 'Compact d’Aurora'), false);
 });
 

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -178,6 +178,8 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /culture-turn-report__safe-defer-bundles/);
   assert.match(webAppSource, /Peut attendre/);
   assert.match(webAppSource, /Condition:/);
+  assert.match(webAppSource, /Bascule:/);
+  assert.match(webAppSource, /riskThreshold/);
   assert.match(webAppSource, /safeToDeferBundles/);
   assert.match(webAppSource, /culture-turn-report__cleanup-prompts/);
   assert.match(webAppSource, /Prompts de nettoyage des bundles culturels/);

--- a/web/app.js
+++ b/web/app.js
@@ -7323,6 +7323,8 @@ function renderCultureTurnReport(report) {
                 <span class="culture-turn-report__safe-defer-entry">
                   <b>${entry.clusterLabel} · ${entry.label}</b>
                   <small>Condition: ${entry.condition}</small>
+                  <small>Bascule: ${entry.turningSignal}</small>
+                  <small>${entry.riskThreshold}</small>
                   <small>À revoir: ${entry.nextReviewWindow}</small>
                 </span>
               `).join('')}


### PR DESCRIPTION
Gamma: Implements #1428.

Summary:
- adds compact risk-threshold metadata for safe-to-defer cultural bundles
- surfaces the first expected turning signal and when defer becomes risky
- keeps existing safe-to-defer/replacement priority mechanics unchanged
- updates the resolved-history fixture and UI coverage

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test