### PR TITLE
Epsilon: Show remaining climate coverage gaps

### DIFF
--- a/test/ui/climate/webAtlasClimateRemainingCoverageGaps.test.js
+++ b/test/ui/climate/webAtlasClimateRemainingCoverageGaps.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas shows remaining climate coverage gaps after prevention', () => {
+  assert.match(webAppSource, /function buildAtlasClimateRemainingCoverageGaps/);
+  assert.match(webAppSource, /function renderAtlasClimateRemainingCoverageGaps/);
+  assert.match(webAppSource, /Couverture restante/);
+  assert.match(webAppSource, /Protections actives/);
+  assert.match(webAppSource, /Protections secondaires/);
+  assert.match(webAppSource, /Angles morts restants/);
+  assert.match(webAppSource, /Prochaine petite prévention/);
+  assert.match(webAppSource, /aucun angle mort prioritaire/);
+  assert.match(webAppSource, /buildAtlasClimateRemainingCoverageGaps\(\s*atlasClimateSmallestPreventiveAction,\s*atlasClimatePreventiveSecondaryProtection,\s*atlasClimateFollowUpThresholdProtection,\s*atlasClimateThresholdProgressAfterReadinessAction,\s*\)/);
+  assert.match(webAppSource, /renderAtlasClimatePreventiveSecondaryProtection\(atlasClimatePreventiveSecondaryProtection\)\}\s*\$\{renderAtlasClimateRemainingCoverageGaps\(atlasClimateRemainingCoverageGaps\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-coverage-gaps/);
+  assert.match(stylesSource, /\.map-world-climate-coverage-gaps--has-gaps/);
+  assert.match(stylesSource, /\.map-world-climate-coverage-gaps--covered/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -13442,6 +13442,87 @@ function renderAtlasClimatePreventiveSecondaryProtection(view) {
   `;
 }
 
+function buildAtlasClimateRemainingCoverageGaps(preventiveView, secondaryProtectionView, protectionView, thresholdProgressView) {
+  if (!preventiveView || preventiveView.state === 'empty' || !thresholdProgressView?.progress) {
+    return {
+      state: 'empty',
+      activeProtections: [],
+      secondaryProtections: [],
+      blindSpots: [],
+      nextSmallAction: '',
+      summary: 'Aucune couverture climat restante à résumer après prévention.',
+    };
+  }
+
+  const progress = thresholdProgressView.progress;
+  const activeProtections = preventiveView.action
+    ? [{
+      label: preventiveView.action.target,
+      detail: preventiveView.action.avoidedLoss,
+      action: preventiveView.action.minimalAction,
+    }]
+    : [];
+  const secondaryProtections = secondaryProtectionView?.protection
+    ? [{
+      label: secondaryProtectionView.protection.target,
+      detail: secondaryProtectionView.protection.oneLine,
+      action: secondaryProtectionView.protection.action,
+    }]
+    : [];
+  const coveredLabels = new Set([
+    ...activeProtections.map((item) => item.label),
+    ...secondaryProtections.map((item) => item.label),
+  ].filter(Boolean));
+  const blindSpots = (protectionView?.actions ?? [])
+    .filter((action) => action.className !== 'protects-threshold' && !coveredLabels.has(action.label))
+    .slice(0, 3)
+    .map((action) => ({
+      label: action.label,
+      reason: action.className === 'stabilizes-short-term'
+        ? `reste partiellement couvert: ${action.thresholdLink}`
+        : `angle mort: ${action.thresholdLink}`,
+      nextAction: action.className === 'stabilizes-short-term'
+        ? action.action
+        : `relire ${progress.threshold} avant d’étendre la prévention`,
+    }));
+  const nextSmallAction = blindSpots[0]
+    ? `Prochaine petite prévention: ${blindSpots[0].nextAction}`
+    : secondaryProtections.length > 0
+      ? 'Prochaine petite prévention: surveiller seulement la couverture secondaire déjà gagnée.'
+      : 'Prochaine petite prévention: relire la carte climat avant nouvelle dépense.';
+
+  return {
+    state: blindSpots.length > 0 ? 'has-gaps' : 'covered',
+    activeProtections,
+    secondaryProtections,
+    blindSpots,
+    nextSmallAction,
+    summary: blindSpots.length > 0
+      ? `${blindSpots.length} angle${blindSpots.length > 1 ? 's' : ''} mort${blindSpots.length > 1 ? 's' : ''} climat reste${blindSpots.length > 1 ? 'nt' : ''} après prévention.`
+      : 'Les protections climat visibles couvrent le prochain seuil sans angle mort notable.',
+  };
+}
+
+function renderAtlasClimateRemainingCoverageGaps(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || !view || view.state === 'empty') {
+    return '';
+  }
+
+  return `
+    <section class="map-world-climate-coverage-gaps map-world-climate-coverage-gaps--${view.state}" aria-label="Couverture climatique restante après protections préventives">
+      <div class="map-world-climate-coverage-gaps__header">
+        <strong>Couverture restante</strong>
+        <span>${view.state === 'has-gaps' ? 'angles morts' : 'couvert'}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Protections actives</b> · ${view.activeProtections.length > 0 ? view.activeProtections.map((item) => `${item.label}: ${item.detail}`).join(' | ') : 'aucune protection active calculée'}</small>
+      <small><b>Protections secondaires</b> · ${view.secondaryProtections.length > 0 ? view.secondaryProtections.map((item) => `${item.label}: ${item.detail}`).join(' | ') : 'aucune protection secondaire utile'}</small>
+      <small><b>Angles morts restants</b> · ${view.blindSpots.length > 0 ? view.blindSpots.map((item) => `${item.label}: ${item.reason}`).join(' | ') : 'aucun angle mort prioritaire'}</small>
+      <small><b>Choix suivant</b> · ${view.nextSmallAction}</small>
+    </section>
+  `;
+}
+
 function renderAtlasSelectedClimateFollowUpReadinessRecap(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -21713,6 +21794,12 @@ function render() {
     atlasClimateFollowUpThresholdProtection,
     atlasClimateThresholdProgressAfterReadinessAction,
   );
+  const atlasClimateRemainingCoverageGaps = buildAtlasClimateRemainingCoverageGaps(
+    atlasClimateSmallestPreventiveAction,
+    atlasClimatePreventiveSecondaryProtection,
+    atlasClimateFollowUpThresholdProtection,
+    atlasClimateThresholdProgressAfterReadinessAction,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -21775,6 +21862,7 @@ function render() {
           ${renderAtlasClimateNextTurnSafetyMarginLoss(atlasClimateNextTurnSafetyMarginLoss)}
           ${renderAtlasClimateSmallestPreventiveAction(atlasClimateSmallestPreventiveAction)}
           ${renderAtlasClimatePreventiveSecondaryProtection(atlasClimatePreventiveSecondaryProtection)}
+          ${renderAtlasClimateRemainingCoverageGaps(atlasClimateRemainingCoverageGaps)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -13399,6 +13399,39 @@ button { font: inherit; }
   margin: 0;
 }
 
+.map-world-climate-coverage-gaps {
+  display: grid;
+  gap: 6px;
+  max-width: 66ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.84), rgba(14, 116, 144, 0.2));
+  border: 1px solid rgba(125, 211, 252, 0.38);
+}
+.map-world-climate-coverage-gaps--has-gaps { border-color: rgba(251, 191, 36, 0.5); }
+.map-world-climate-coverage-gaps--covered { border-color: rgba(74, 222, 128, 0.4); }
+.map-world-climate-coverage-gaps__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-coverage-gaps p,
+.map-world-climate-coverage-gaps span,
+.map-world-climate-coverage-gaps small {
+  color: #cffafe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-coverage-gaps--has-gaps p,
+.map-world-climate-coverage-gaps--has-gaps span,
+.map-world-climate-coverage-gaps--has-gaps small { color: #fef3c7; }
+.map-world-climate-coverage-gaps--covered p,
+.map-world-climate-coverage-gaps--covered span,
+.map-world-climate-coverage-gaps--covered small { color: #dcfce7; }
+
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);
   box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.12);


### PR DESCRIPTION
Epsilon: PR prête pour #1430.

## Résumé
- Ajoute un encart “Couverture restante” après la prévention et la protection secondaire climat.
- Sépare protections actives, protections secondaires et angles morts restants.
- Ajoute une phrase courte “prochaine petite prévention” pour guider le prochain choix sans changer la simulation.

## Tests
- node --test test/ui/climate/webAtlasClimateRemainingCoverageGaps.test.js test/ui/climate/webAtlasClimatePreventiveSecondaryProtection.test.js test/ui/climate/webAtlasClimateSmallestPreventiveAction.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?