### PR TITLE
Beta: Trace adjacent spillover dependency

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -840,7 +840,13 @@ function buildLocalRecoveryCapacityConflictWarning(priorityAction, routeChoices)
 
 function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
   if (!priorityAction) {
-    return { state: 'empty', criticalRoute: null, secondaryRoutes: [], summary: 'Aucun spillover logistique: aucune récupération locale sélectionnée.' };
+    return {
+      state: 'empty',
+      criticalRoute: null,
+      secondaryRoutes: [],
+      summary: 'Aucun spillover logistique: aucune récupération locale sélectionnée.',
+      dependencyTrace: 'Dépendance inconnue: aucun levier local ne permet de tracer la source du spillover.',
+    };
   }
 
   const option = routeChoices.find((candidate) => candidate.routeId === priorityAction.routeId) ?? null;
@@ -881,14 +887,19 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       criticalRoute: null,
       secondaryRoutes: [],
       summary: 'Aucun spillover logistique voisin concret après cette récupération locale.',
+      dependencyTrace: 'Dépendance inconnue: aucune route voisine exposée ne confirme la chaîne source → route affectée → conséquence.',
     };
   }
+
+  const source = choice?.bottleneck?.label ?? option?.causeLabel ?? 'source inconnue';
+  const consequence = criticalRoute.detail ?? `${criticalRoute.route} peut récupérer la pression déplacée.`;
 
   return {
     state: secondaryRoutes.length > 0 ? 'chain' : 'single',
     criticalRoute,
     secondaryRoutes,
     summary: `${criticalRoute.route} est la route voisine critique; ${secondaryRoutes.length > 0 ? `${secondaryRoutes.length} route${secondaryRoutes.length > 1 ? 's' : ''} secondaire${secondaryRoutes.length > 1 ? 's' : ''} exposée${secondaryRoutes.length > 1 ? 's' : ''}.` : 'aucune autre route secondaire exposée.'}`,
+    dependencyTrace: `${source} → ${criticalRoute.route}/${criticalRoute.city} → ${consequence}`,
   };
 }
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -117,6 +117,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.ok(['single', 'chain'].includes(preview.adjacentRouteSpilloverRisk.state));
   assert.match(preview.adjacentRouteSpilloverRisk.summary, /route voisine critique|secondaire|exposée/);
   assert.match(preview.adjacentRouteSpilloverRisk.criticalRoute.route, /Ember Line|Hill Spur|Safe Road/);
+  assert.match(preview.adjacentRouteSpilloverRisk.dependencyTrace, /→/);
+  assert.match(preview.adjacentRouteSpilloverRisk.dependencyTrace, /capacité saturée|stock critique|risque élevé|Ember Line|Hill Spur|Iron Plain|Hill Hub/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -189,6 +191,7 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.localRecoveryCapacityConflictWarning.summary, /Aucun conflit transversal/);
   assert.equal(preview.adjacentRouteSpilloverRisk.state, 'empty');
   assert.match(preview.adjacentRouteSpilloverRisk.summary, /Aucun spillover/);
+  assert.match(preview.adjacentRouteSpilloverRisk.dependencyTrace, /Dépendance inconnue/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -95,6 +95,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Risque de spillover logistique sur routes voisines/);
   assert.match(webAppSource, /adjacentRouteSpilloverRisk/);
   assert.match(webAppSource, /Critique:/);
+  assert.match(webAppSource, /Dépendance:/);
+  assert.match(webAppSource, /dependencyTrace/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -8207,6 +8207,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               <b>Spillover voisin</b>
               <span>${preview.adjacentRouteSpilloverRisk.summary}</span>
               <small>Critique: ${preview.adjacentRouteSpilloverRisk.criticalRoute.route} vers ${preview.adjacentRouteSpilloverRisk.criticalRoute.city}. ${preview.adjacentRouteSpilloverRisk.secondaryRoutes.length > 0 ? `Secondaires: ${preview.adjacentRouteSpilloverRisk.secondaryRoutes.map((route) => `${route.route} (${route.city})`).join(', ')}.` : 'Pas de route secondaire exposée.'}</small>
+              <em>Dépendance: ${preview.adjacentRouteSpilloverRisk.dependencyTrace}</em>
             </div>
           ` : ''}
         </div>


### PR DESCRIPTION
Beta: Implements #1437.

Summary:
- Adds a compact dependency trace to the adjacent spillover risk preview: source bottleneck → affected route/province → likely consequence.
- Keeps the signal derived from existing logistics choice preview data.
- Adds fallback dependency text when no local recovery/spillover source can be traced.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
