### PR TITLE
Delta: Mark expiring intrigue follow-up options

### DIFF
--- a/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
+++ b/src/ui/intrigue/buildIntrigueTurnReportDeltas.js
@@ -172,41 +172,91 @@ function buildNextTurnUnlock(principalRisk, fullReviewRequired, timingRecommenda
   return 'Au prochain tour, elle réduira l’incertitude avant de choisir entre agir et attendre.';
 }
 
+function withExpiry(option, expiry = null) {
+  if (!expiry) {
+    return {
+      ...option,
+      expiry: {
+        state: 'available',
+        label: 'reste disponible',
+        detail: 'aucune expiration visible avec les signaux actuels',
+      },
+    };
+  }
+
+  return {
+    ...option,
+    expiry: {
+      state: 'expiring',
+      ...expiry,
+    },
+  };
+}
+
+function summarizeFollowUpExpiry(options) {
+  if (options.length === 0) {
+    return 'Aucune suite débloquée: pas d’échéance à signaler.';
+  }
+
+  const expiring = options.filter((option) => option.expiry?.state === 'expiring');
+
+  if (expiring.length === 0) {
+    return 'Aucune suite ne montre d’expiration visible pour le prochain tour.';
+  }
+
+  return `${expiring.length} suite${expiring.length > 1 ? 's' : ''} à traiter vite avant dégradation.`;
+}
+
 function buildUnlockedFollowUpOptions(principalRisk, fullReviewRequired, timingRecommendationChange) {
   const canWaitNextTurn = timingRecommendationChange?.currentTiming === 'short-wait';
   const optionsByRisk = {
     'exposition excessive': [
-      { type: 'defensive', label: 'Défensif', consequence: 'réduire l’exposition avant toute réponse lourde' },
-      { type: 'wait', label: 'Attente', consequence: 'attendre un tour si le seuil visible redevient sûr' },
-      { type: 'offensive', label: 'Offensif', consequence: 'agir seulement si l’exposition reste maîtrisée' },
+      withExpiry(
+        { type: 'defensive', label: 'Défensif', consequence: 'réduire l’exposition avant toute réponse lourde' },
+        { label: 'à traiter maintenant', detail: 'l’exposition peut devenir moins récupérable après le prochain tour' },
+      ),
+      withExpiry({ type: 'wait', label: 'Attente', consequence: 'attendre un tour si le seuil visible redevient sûr' }),
+      withExpiry({ type: 'offensive', label: 'Offensif', consequence: 'agir seulement si l’exposition reste maîtrisée' }),
     ],
     'timing fragile': [
-      { type: 'offensive', label: 'Offensif', consequence: 'agir vite si la fenêtre visible se ferme' },
-      { type: 'wait', label: 'Attente', consequence: 'attendre si le signal reste frais au prochain tour' },
-      { type: 'defensive', label: 'Défensif', consequence: 'limiter le coût d’un recheck si la fenêtre est perdue' },
+      withExpiry(
+        { type: 'offensive', label: 'Offensif', consequence: 'agir vite si la fenêtre visible se ferme' },
+        { label: 'expire vite', detail: 'la fenêtre peut se refermer après ce tour' },
+      ),
+      withExpiry({ type: 'wait', label: 'Attente', consequence: 'attendre si le signal reste frais au prochain tour' }),
+      withExpiry(
+        { type: 'defensive', label: 'Défensif', consequence: 'limiter le coût d’un recheck si la fenêtre est perdue' },
+        { label: 'fiabilité en baisse', detail: 'le recheck devient moins fiable si le signal vieillit' },
+      ),
     ],
     'signal contradictoire': [
-      { type: 'offensive', label: 'Offensif', consequence: 'agir si les deux indices visibles convergent' },
-      { type: 'defensive', label: 'Défensif', consequence: 'basculer en revue complète si le recoupement diverge' },
-      { type: 'wait', label: 'Attente', consequence: 'différer seulement si l’incertitude baisse sans contradiction' },
+      withExpiry({ type: 'offensive', label: 'Offensif', consequence: 'agir si les deux indices visibles convergent' }),
+      withExpiry(
+        { type: 'defensive', label: 'Défensif', consequence: 'basculer en revue complète si le recoupement diverge' },
+        { label: 'à recouper vite', detail: 'la contradiction devient moins lisible si elle attend' },
+      ),
+      withExpiry({ type: 'wait', label: 'Attente', consequence: 'différer seulement si l’incertitude baisse sans contradiction' }),
     ],
     'confiance basse': [
-      { type: 'defensive', label: 'Défensif', consequence: 'stabiliser la lecture si la confiance reste basse' },
-      { type: 'wait', label: 'Attente', consequence: 'attendre si la cause visible n’empire pas' },
-      { type: 'offensive', label: 'Offensif', consequence: 'agir si le contrôle confirme un signal exploitable' },
+      withExpiry({ type: 'defensive', label: 'Défensif', consequence: 'stabiliser la lecture si la confiance reste basse' }),
+      withExpiry({ type: 'wait', label: 'Attente', consequence: 'attendre si la cause visible n’empire pas' }),
+      withExpiry(
+        { type: 'offensive', label: 'Offensif', consequence: 'agir si le contrôle confirme un signal exploitable' },
+        { label: 'signal fragile', detail: 'l’opportunité peut perdre en fiabilité au prochain tour' },
+      ),
     ],
   };
   const options = optionsByRisk[principalRisk] ?? optionsByRisk['confiance basse'];
+  const selectedOptions = fullReviewRequired
+    ? options.slice(0, 2)
+    : !canWaitNextTurn
+      ? options.filter((option) => option.type !== 'wait').slice(0, 2)
+      : options.slice(0, 3);
 
-  if (fullReviewRequired) {
-    return options.slice(0, 2);
-  }
-
-  if (!canWaitNextTurn) {
-    return options.filter((option) => option.type !== 'wait').slice(0, 2);
-  }
-
-  return options.slice(0, 3);
+  return {
+    options: selectedOptions,
+    expirySummary: summarizeFollowUpExpiry(selectedOptions),
+  };
 }
 
 function buildSafestMinimalVerification(prompt, timingRecommendationChange = null) {
@@ -219,6 +269,7 @@ function buildSafestMinimalVerification(prompt, timingRecommendationChange = nul
       whyEnough: 'La confiance visible ne demande pas de déblocage avant attente.',
       unlockNextTurn: 'Aucun choix supplémentaire à débloquer au prochain tour.',
       followUpOptions: [],
+      followUpExpirySummary: 'Aucune suite débloquée: pas d’échéance à signaler.',
       fullReviewRequired: false,
       fallback: true,
     };
@@ -259,6 +310,7 @@ function buildSafestMinimalVerification(prompt, timingRecommendationChange = nul
     },
   };
   const plan = planByRisk[principalRisk] ?? planByRisk['confiance basse'];
+  const followUp = buildUnlockedFollowUpOptions(principalRisk, plan.fullReviewRequired, timingRecommendationChange);
 
   return {
     state: plan.fullReviewRequired ? 'full-review-needed' : 'minimal-sufficient',
@@ -268,7 +320,8 @@ function buildSafestMinimalVerification(prompt, timingRecommendationChange = nul
     action: plan.action,
     whyEnough: plan.whyEnough,
     unlockNextTurn: buildNextTurnUnlock(principalRisk, plan.fullReviewRequired, timingRecommendationChange),
-    followUpOptions: buildUnlockedFollowUpOptions(principalRisk, plan.fullReviewRequired, timingRecommendationChange),
+    followUpOptions: followUp.options,
+    followUpExpirySummary: followUp.expirySummary,
     fullReviewRequired: plan.fullReviewRequired,
     fallback: false,
   };

--- a/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js
@@ -116,10 +116,38 @@ test('buildIntrigueTurnReportDeltas flags changed timing recommendations fog-saf
         whyEnough: 'Ce contrôle suffit si l’exposition repasse sous le seuil lisible sans rouvrir la cible masquée.',
         unlockNextTurn: 'Au prochain tour, elle permettra de choisir plus sûrement entre attendre encore ou agir sans surcharger la revue.',
         followUpOptions: [
-          { type: 'defensive', label: 'Défensif', consequence: 'réduire l’exposition avant toute réponse lourde' },
-          { type: 'wait', label: 'Attente', consequence: 'attendre un tour si le seuil visible redevient sûr' },
-          { type: 'offensive', label: 'Offensif', consequence: 'agir seulement si l’exposition reste maîtrisée' },
+          {
+            type: 'defensive',
+            label: 'Défensif',
+            consequence: 'réduire l’exposition avant toute réponse lourde',
+            expiry: {
+              state: 'expiring',
+              label: 'à traiter maintenant',
+              detail: 'l’exposition peut devenir moins récupérable après le prochain tour',
+            },
+          },
+          {
+            type: 'wait',
+            label: 'Attente',
+            consequence: 'attendre un tour si le seuil visible redevient sûr',
+            expiry: {
+              state: 'available',
+              label: 'reste disponible',
+              detail: 'aucune expiration visible avec les signaux actuels',
+            },
+          },
+          {
+            type: 'offensive',
+            label: 'Offensif',
+            consequence: 'agir seulement si l’exposition reste maîtrisée',
+            expiry: {
+              state: 'available',
+              label: 'reste disponible',
+              detail: 'aucune expiration visible avec les signaux actuels',
+            },
+          },
         ],
+        followUpExpirySummary: '1 suite à traiter vite avant dégradation.',
         fullReviewRequired: false,
         fallback: false,
       },
@@ -176,9 +204,28 @@ test('buildIntrigueTurnReportDeltas explains confidence loss when timing flips t
       whyEnough: 'La fraîcheur confirmée suffit à débloquer une attente courte sans refaire toute l’enquête.',
       unlockNextTurn: 'Au prochain tour, elle permettra de confirmer si l’action immédiate reste nécessaire ou si attendre redevient sûr.',
       followUpOptions: [
-        { type: 'offensive', label: 'Offensif', consequence: 'agir vite si la fenêtre visible se ferme' },
-        { type: 'defensive', label: 'Défensif', consequence: 'limiter le coût d’un recheck si la fenêtre est perdue' },
+        {
+          type: 'offensive',
+          label: 'Offensif',
+          consequence: 'agir vite si la fenêtre visible se ferme',
+          expiry: {
+            state: 'expiring',
+            label: 'expire vite',
+            detail: 'la fenêtre peut se refermer après ce tour',
+          },
+        },
+        {
+          type: 'defensive',
+          label: 'Défensif',
+          consequence: 'limiter le coût d’un recheck si la fenêtre est perdue',
+          expiry: {
+            state: 'expiring',
+            label: 'fiabilité en baisse',
+            detail: 'le recheck devient moins fiable si le signal vieillit',
+          },
+        },
       ],
+      followUpExpirySummary: '2 suites à traiter vite avant dégradation.',
       fullReviewRequired: false,
       fallback: false,
     },
@@ -212,9 +259,28 @@ test('buildIntrigueTurnReportDeltas requires full review when minimal verificati
     whyEnough: 'Un second indice aligné suffit; s’il diverge, une revue complète reste nécessaire.',
     unlockNextTurn: 'Au prochain tour, elle réduira l’incertitude pour choisir entre agir maintenant ou lancer une revue complète.',
     followUpOptions: [
-      { type: 'offensive', label: 'Offensif', consequence: 'agir si les deux indices visibles convergent' },
-      { type: 'defensive', label: 'Défensif', consequence: 'basculer en revue complète si le recoupement diverge' },
+      {
+        type: 'offensive',
+        label: 'Offensif',
+        consequence: 'agir si les deux indices visibles convergent',
+        expiry: {
+          state: 'available',
+          label: 'reste disponible',
+          detail: 'aucune expiration visible avec les signaux actuels',
+        },
+      },
+      {
+        type: 'defensive',
+        label: 'Défensif',
+        consequence: 'basculer en revue complète si le recoupement diverge',
+        expiry: {
+          state: 'expiring',
+          label: 'à recouper vite',
+          detail: 'la contradiction devient moins lisible si elle attend',
+        },
+      },
     ],
+    followUpExpirySummary: '1 suite à traiter vite avant dégradation.',
     fullReviewRequired: true,
     fallback: false,
   });
@@ -245,6 +311,7 @@ test('buildIntrigueTurnReportDeltas returns a neutral prompt when confidence is 
       whyEnough: 'La confiance visible ne demande pas de déblocage avant attente.',
       unlockNextTurn: 'Aucun choix supplémentaire à débloquer au prochain tour.',
       followUpOptions: [],
+      followUpExpirySummary: 'Aucune suite débloquée: pas d’échéance à signaler.',
       fullReviewRequired: false,
       fallback: true,
     },

--- a/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
+++ b/test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
@@ -25,6 +25,10 @@ test('playable map wires intrigue aftermath deltas into selected province turn r
   assert.match(webAppSource, /followUpOptions/);
   assert.match(webAppSource, /Suites débloquées par la vérification minimale/);
   assert.match(webAppSource, /province-intrigue-turn-report__followup--/);
+  assert.match(webAppSource, /followUpExpirySummary/);
+  assert.match(webAppSource, /Échéance:/);
+  assert.match(webAppSource, /province-intrigue-turn-report__expiry--/);
+  assert.match(webAppSource, /Aucune information d.expiration visible/);
   assert.match(webAppSource, /Revue complète si le recoupement diverge/);
   assert.match(webAppSource, /renderIntrigueTurnReportDeltas\(province, intrigueView\)/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -8401,12 +8401,14 @@ function renderIntrigueTurnReportDeltas(province, intrigueView) {
           ${report.minimumVerificationPrompt.safestMinimalVerification?.recommended ? `
             <small class="province-intrigue-turn-report__minimal-check">Plus sûre: ${report.minimumVerificationPrompt.safestMinimalVerification.label} · ${report.minimumVerificationPrompt.safestMinimalVerification.action} ${report.minimumVerificationPrompt.safestMinimalVerification.whyEnough}${report.minimumVerificationPrompt.safestMinimalVerification.fullReviewRequired ? ' Revue complète si le recoupement diverge.' : ''}</small>
             <small class="province-intrigue-turn-report__next-turn-unlock">Débloque: ${report.minimumVerificationPrompt.safestMinimalVerification.unlockNextTurn}</small>
+            <small class="province-intrigue-turn-report__expiry-summary">Échéance: ${report.minimumVerificationPrompt.safestMinimalVerification.followUpExpirySummary ?? 'Aucune information d’expiration visible.'}</small>
             ${report.minimumVerificationPrompt.safestMinimalVerification.followUpOptions?.length ? `
               <ul class="province-intrigue-turn-report__followups" aria-label="Suites débloquées par la vérification minimale">
                 ${report.minimumVerificationPrompt.safestMinimalVerification.followUpOptions.map((option) => `
-                  <li class="province-intrigue-turn-report__followup province-intrigue-turn-report__followup--${option.type}">
+                  <li class="province-intrigue-turn-report__followup province-intrigue-turn-report__followup--${option.type} province-intrigue-turn-report__followup--${option.expiry?.state ?? 'available'}">
                     <b>${option.label}</b>
                     <span>${option.consequence}</span>
+                    <small class="province-intrigue-turn-report__expiry province-intrigue-turn-report__expiry--${option.expiry?.state ?? 'available'}">${option.expiry?.label ?? 'échéance inconnue'} · ${option.expiry?.detail ?? 'aucune information d’expiration visible'}</small>
                   </li>
                 `).join('')}
               </ul>

--- a/web/styles.css
+++ b/web/styles.css
@@ -9653,6 +9653,9 @@ button { font: inherit; }
   padding: 0;
   list-style: none;
 }
+.province-intrigue-turn-report__expiry-summary {
+  color: rgba(253, 224, 71, 0.86);
+}
 .province-intrigue-turn-report__followup {
   display: grid;
   grid-template-columns: minmax(72px, max-content) 1fr;
@@ -9666,8 +9669,16 @@ button { font: inherit; }
 .province-intrigue-turn-report__followup--offensive { border-left-color: rgba(248, 113, 113, 0.56); }
 .province-intrigue-turn-report__followup--defensive { border-left-color: rgba(96, 165, 250, 0.56); }
 .province-intrigue-turn-report__followup--wait { border-left-color: rgba(250, 204, 21, 0.56); }
+.province-intrigue-turn-report__followup--expiring { box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.16); }
 .province-intrigue-turn-report__followup b { color: rgba(226, 232, 240, 0.9); }
 .province-intrigue-turn-report__followup span { color: var(--muted); }
+.province-intrigue-turn-report__expiry {
+  grid-column: 1 / -1;
+  padding-top: 3px;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+.province-intrigue-turn-report__expiry--expiring { color: rgba(253, 224, 71, 0.9); }
+.province-intrigue-turn-report__expiry--available { color: rgba(148, 163, 184, 0.78); }
 .province-intrigue-turn-report__list {
   display: grid;
   gap: 8px;


### PR DESCRIPTION
Delta: Implements #1439.

Summary:
- Marks unlocked intrigue follow-up options with compact expiry metadata when a visible option can expire or degrade.
- Keeps available/non-expiring options distinct with a graceful fallback summary when no expiry is visible.
- Renders expiry badges separately from the follow-up consequence copy.

Validation:
- node --test test/ui/intrigue/buildIntrigueTurnReportDeltas.test.js test/ui/intrigue/webIntrigueTurnReportDeltas.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: ready for validation before merge.
