### PR TITLE
Gamma: Show cultural safe-defer deadlines

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1315,6 +1315,10 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
           ? 'fallout en hausse'
           : 'suivi absent';
       const riskThreshold = `Devient risqué si ${riskTrigger} avant la ${nextReviewWindow}.`;
+      const deadlineStatus = hasActiveSupport ? 'near-deadline' : 'safe-this-turn';
+      const deadlineHint = deadlineStatus === 'near-deadline'
+        ? 'à revoir dès le prochain tour'
+        : 'sûr ce tour';
 
       return {
         deferId: `${prompt.cleanupId}:safe-to-defer`,
@@ -1326,6 +1330,8 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
         reason: `${prompt.clusterLabel}: ${condition}; ${prompt.action}.`,
         riskThreshold,
         turningSignal,
+        deadlineHint,
+        deadlineStatus,
         nextReviewWindow,
         falloutSeverity: fallout?.severity ?? 0,
       };
@@ -1337,7 +1343,7 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
   return {
     state: candidates.length === 0 ? 'none' : 'ready',
     summary: top
-      ? `${top.clusterLabel}: Peut attendre — ${top.condition}; ${top.riskThreshold}`
+      ? `${top.clusterLabel}: Peut attendre — ${top.deadlineHint}; ${top.riskThreshold}`
       : 'Aucun bundle culturel sûr à reporter ce tour.',
     entries: candidates,
   };

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -619,6 +619,8 @@ test('buildCultureTurnReportDeltas marks resolved cultural bundles safe to defer
     entry.condition,
     entry.turningSignal,
     entry.riskThreshold,
+    entry.deadlineHint,
+    entry.deadlineStatus,
     entry.nextReviewWindow,
   ]), [
     [
@@ -627,11 +629,62 @@ test('buildCultureTurnReportDeltas marks resolved cultural bundles safe to defer
       'risque stabilisé par l’historique lisible',
       'fallout en hausse',
       'Devient risqué si le fallout dépasse le niveau faible avant la prochaine rotation culturelle.',
+      'sûr ce tour',
+      'safe-this-turn',
       'prochaine rotation culturelle',
     ],
   ]);
-  assert.match(report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.summary, /Devient risqué/);
+  assert.match(report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.summary, /sûr ce tour/);
   assert.equal(report.commitmentBundles.followThroughBundlePlan.replacementRecommendations.entries.some((entry) => entry.clusterLabel === 'Compact d’Aurora'), false);
+});
+
+test('buildCultureTurnReportDeltas escalates safe defer deadline when current support must be reviewed soon', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 9,
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'explorer',
+      },
+    },
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'deferred',
+        outcome: 'soutien actif confirmé',
+      },
+    ],
+  });
+
+  assert.deepEqual(report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries.map((entry) => [
+    entry.clusterLabel,
+    entry.condition,
+    entry.turningSignal,
+    entry.deadlineHint,
+    entry.deadlineStatus,
+  ]), [
+    [
+      'Compact d’Aurora',
+      'soutien actif déjà visible dans la rotation culturelle',
+      'perte du soutien actif',
+      'à revoir dès le prochain tour',
+      'near-deadline',
+    ],
+  ]);
 });
 
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -177,6 +177,9 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Évite:/);
   assert.match(webAppSource, /culture-turn-report__safe-defer-bundles/);
   assert.match(webAppSource, /Peut attendre/);
+  assert.match(webAppSource, /Délai:/);
+  assert.match(webAppSource, /deadlineHint/);
+  assert.match(webAppSource, /deadlineStatus/);
   assert.match(webAppSource, /Condition:/);
   assert.match(webAppSource, /Bascule:/);
   assert.match(webAppSource, /riskThreshold/);
@@ -270,6 +273,8 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.culture-turn-report__safe-defer-bundles/);
   assert.match(stylesSource, /\.culture-turn-report__safe-defer-bundles--none/);
   assert.match(stylesSource, /\.culture-turn-report__safe-defer-entry/);
+  assert.match(stylesSource, /\.culture-turn-report__safe-defer-entry--safe-this-turn/);
+  assert.match(stylesSource, /\.culture-turn-report__safe-defer-entry--near-deadline/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompts/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--obsolete/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--resolved/);

--- a/web/app.js
+++ b/web/app.js
@@ -7373,8 +7373,9 @@ function renderCultureTurnReport(report) {
           ${(report.commitmentBundles?.followThroughBundlePlan?.safeToDeferBundles?.entries ?? []).length > 0 ? `
             <div class="culture-turn-report__safe-defer-list">
               ${report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries.map((entry) => `
-                <span class="culture-turn-report__safe-defer-entry">
+                <span class="culture-turn-report__safe-defer-entry culture-turn-report__safe-defer-entry--${entry.deadlineStatus ?? 'no-deadline'}">
                   <b>${entry.clusterLabel} · ${entry.label}</b>
+                  <small>Délai: ${entry.deadlineHint ?? 'fenêtre non calculable'}</small>
                   <small>Condition: ${entry.condition}</small>
                   <small>Bascule: ${entry.turningSignal}</small>
                   <small>${entry.riskThreshold}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2134,6 +2134,8 @@ button { font: inherit; }
 }
 .culture-turn-report__safe-defer-entry b { color: #f0fdf4; }
 .culture-turn-report__safe-defer-entry small { color: var(--muted); }
+.culture-turn-report__safe-defer-entry--safe-this-turn { border-color: rgba(74, 222, 128, 0.28); }
+.culture-turn-report__safe-defer-entry--near-deadline { border-color: rgba(251, 191, 36, 0.42); }
 .culture-turn-report__cleanup-prompts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Gamma: Implements #1438.

Summary:
- adds compact deadline hints for safe-to-defer cultural bundles
- distinguishes safe-this-turn from near-deadline defer windows
- surfaces the deadline hint in the culture turn report without changing cultural mechanics
- adds safe, near-deadline, and no-deadline/empty coverage

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test