### PR TITLE
Alpha: Show shared front residual risk

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -227,3 +227,22 @@ test('atlas military shows safe shared handling hints for grouped front urgency'
   assert.match(stylesSource, /\.atlas-military-neighbor-shared-handling--shared/);
   assert.match(stylesSource, /\.atlas-military-neighbor-shared-handling--separate/);
 });
+
+// MAP-A30: before committing a shared grouped-front order, show whether the
+// group is covered or which flank still needs follow-up.
+test('atlas military shows residual risk after shared grouped front handling', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryNeighborSharedResidualRisk\(cluster, sharedHandlingHint\)/);
+  assert.match(webAppSource, /function renderAtlasMilitaryNeighborSharedResidualRisk\(risk, y\)/);
+  assert.match(webAppSource, /Risque résiduel après traitement groupé du front voisin/);
+  assert.match(webAppSource, /Groupe couvert après ordre/);
+  assert.match(webAppSource, /confirmer puis surveiller léger/);
+  assert.match(webAppSource, /Risque résiduel: flanc à suivre/);
+  assert.match(webAppSource, /pression restante après ordre groupé/);
+  assert.match(webAppSource, /prévoir suivi sur \$\{exposedFlank\}/);
+  assert.match(webAppSource, /sharedHandlingHint\?\.tone !== 'shared'/);
+  assert.match(webAppSource, /sharedResidualRisk: buildAtlasMilitaryNeighborSharedResidualRisk/);
+  assert.match(webAppSource, /renderAtlasMilitaryNeighborSharedResidualRisk\(preview\.sharedResidualRisk, residualY\)/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-shared-residual__label/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-shared-residual--covered/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-shared-residual--residual/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2569,6 +2569,37 @@ function buildAtlasMilitaryNeighborSharedHandlingHint(cluster) {
   };
 }
 
+function buildAtlasMilitaryNeighborSharedResidualRisk(cluster, sharedHandlingHint) {
+  if (!cluster?.visible || sharedHandlingHint?.tone !== 'shared') {
+    return {
+      visible: false,
+      tone: 'quiet',
+      label: 'Risque résiduel non affiché',
+      detail: 'aucun ordre groupé commun à évaluer',
+      action: 'suivre le détail province',
+    };
+  }
+
+  const exposedFlank = cluster.tone === 'critical' ? cluster.provinces[0] : null;
+  if (exposedFlank) {
+    return {
+      visible: true,
+      tone: 'residual',
+      label: 'Risque résiduel: flanc à suivre',
+      detail: `${exposedFlank}: pression restante après ordre groupé`,
+      action: `prévoir suivi sur ${exposedFlank}`,
+    };
+  }
+
+  return {
+    visible: true,
+    tone: 'covered',
+    label: 'Groupe couvert après ordre',
+    detail: `${cluster.provinces.length} provinces couvertes par la même action`,
+    action: 'confirmer puis surveiller léger',
+  };
+}
+
 function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, features) {
   const focus = recommendation?.primary ?? null;
   const focusProvince = focus?.provinceLabel ?? checklist?.points?.[0]?.detail?.split(':')?.[0] ?? null;
@@ -2583,6 +2614,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       contestedPriority: buildAtlasMilitaryNeighborContestedHandlingPriority([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])),
       urgencyCluster: buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])),
       sharedHandlingHint: buildAtlasMilitaryNeighborSharedHandlingHint(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), []))),
+      sharedResidualRisk: buildAtlasMilitaryNeighborSharedResidualRisk(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])), buildAtlasMilitaryNeighborSharedHandlingHint(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])))),
       summary: 'Prévision voisins indisponible: aucun ordre de province en focus.',
       empty: true,
     };
@@ -2613,6 +2645,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
   const contestedPriority = buildAtlasMilitaryNeighborContestedHandlingPriority(shifts, reviewStaleness, reviewChange);
   const urgencyCluster = buildAtlasMilitaryNeighborFrontUrgencyCluster(shifts, reviewStaleness, reviewChange);
   const sharedHandlingHint = buildAtlasMilitaryNeighborSharedHandlingHint(urgencyCluster);
+  const sharedResidualRisk = buildAtlasMilitaryNeighborSharedResidualRisk(urgencyCluster, sharedHandlingHint);
 
   if (!shifts.length) {
     return {
@@ -2625,6 +2658,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       contestedPriority,
       urgencyCluster,
       sharedHandlingHint,
+      sharedResidualRisk,
       summary: `${focusProvince}: aucun front voisin lisible après engagement.`,
       empty: true,
     };
@@ -2640,7 +2674,8 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
     contestedPriority,
     urgencyCluster,
     sharedHandlingHint,
-    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}; ${reviewStaleness.label}; ${reviewChange.label}${urgencyCluster.visible ? `; ${urgencyCluster.label}; ${sharedHandlingHint.label}` : contestedPriority.visible ? `; ${contestedPriority.label}` : ''}.`,
+    sharedResidualRisk,
+    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}; ${reviewStaleness.label}; ${reviewChange.label}${urgencyCluster.visible ? `; ${urgencyCluster.label}; ${sharedHandlingHint.label}${sharedResidualRisk.visible ? `; ${sharedResidualRisk.label}` : ''}` : contestedPriority.visible ? `; ${contestedPriority.label}` : ''}.`,
     empty: false,
   };
 }
@@ -2702,17 +2737,29 @@ function renderAtlasMilitaryNeighborSharedHandlingHint(hint, y) {
   `;
 }
 
+function renderAtlasMilitaryNeighborSharedResidualRisk(risk, y) {
+  if (!risk?.visible) return '';
+  return `
+    <g class="atlas-military-neighbor-shared-residual atlas-military-neighbor-shared-residual--${risk.tone}" aria-label="Risque résiduel après traitement groupé du front voisin: ${risk.label}; ${risk.detail}; action ${risk.action}">
+      <text class="atlas-military-neighbor-shared-residual__label" x="44.2" y="${y}">${risk.label}</text>
+      <text class="atlas-military-neighbor-shared-residual__detail" x="44.2" y="${y + 1.35}">${risk.detail} · ${risk.action}</text>
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
   const priorityY = preview.empty ? 163.8 : 163.85 + (preview.shifts.length * 3.45);
   const staleY = priorityY + 2.75;
   const changeY = staleY + 2.75;
   const clusterY = changeY + 2.75;
   const hintY = clusterY + (preview.urgencyCluster?.visible ? 2.75 : 0);
-  const contestedY = hintY + (preview.sharedHandlingHint?.visible ? 2.75 : 0);
+  const residualY = hintY + (preview.sharedHandlingHint?.visible ? 2.75 : 0);
+  const contestedY = residualY + (preview.sharedResidualRisk?.visible ? 2.75 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;
   const hintHeight = preview.sharedHandlingHint?.visible ? 2.5 : 0;
+  const residualHeight = preview.sharedResidualRisk?.visible ? 2.5 : 0;
   const contestedHeight = preview.contestedPriority?.visible ? 2.5 : 0;
-  const height = (preview.empty ? 13.6 : 13.6 + (preview.shifts.length * 3.45)) + clusterHeight + hintHeight + contestedHeight;
+  const height = (preview.empty ? 13.6 : 13.6 + (preview.shifts.length * 3.45)) + clusterHeight + hintHeight + residualHeight + contestedHeight;
   return `
     <g class="atlas-military-neighbor-front-shift atlas-military-neighbor-front-shift--${preview.empty ? 'empty' : 'active'}" aria-label="Prévisualisation des fronts voisins après engagement: ${preview.summary}">
       <rect class="atlas-military-neighbor-front-shift__panel" x="43" y="157" width="35" height="${height}" rx="2.1"></rect>
@@ -2730,6 +2777,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
       ${renderAtlasMilitaryNeighborReviewChangeExplanation(preview.reviewChange, changeY)}
       ${renderAtlasMilitaryNeighborFrontUrgencyCluster(preview.urgencyCluster, clusterY)}
       ${renderAtlasMilitaryNeighborSharedHandlingHint(preview.sharedHandlingHint, hintY)}
+      ${renderAtlasMilitaryNeighborSharedResidualRisk(preview.sharedResidualRisk, residualY)}
       ${renderAtlasMilitaryNeighborContestedHandlingPriority(preview.contestedPriority, contestedY)}
     </g>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14398,7 +14398,8 @@ button { font: inherit; }
 .atlas-military-neighbor-review-change__detail,
 .atlas-military-neighbor-contested-priority__reason,
 .atlas-military-neighbor-front-cluster__detail,
-.atlas-military-neighbor-shared-handling__detail {
+.atlas-military-neighbor-shared-handling__detail,
+.atlas-military-neighbor-shared-residual__detail {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14407,7 +14408,8 @@ button { font: inherit; }
 .atlas-military-neighbor-review-change__label,
 .atlas-military-neighbor-contested-priority__label,
 .atlas-military-neighbor-front-cluster__label,
-.atlas-military-neighbor-shared-handling__label {
+.atlas-military-neighbor-shared-handling__label,
+.atlas-military-neighbor-shared-residual__label {
   fill: #f5f3ff;
   font-size: 0.55px;
   font-weight: 900;
@@ -14431,8 +14433,10 @@ button { font: inherit; }
 .atlas-military-neighbor-front-cluster--contested .atlas-military-neighbor-front-cluster__label { fill: #fed7aa; }
 .atlas-military-neighbor-contested-priority--watch .atlas-military-neighbor-contested-priority__label,
 .atlas-military-neighbor-front-cluster--watch .atlas-military-neighbor-front-cluster__label { fill: #fde68a; }
-.atlas-military-neighbor-shared-handling--shared .atlas-military-neighbor-shared-handling__label { fill: #bbf7d0; }
-.atlas-military-neighbor-shared-handling--separate .atlas-military-neighbor-shared-handling__label { fill: #fed7aa; }
+.atlas-military-neighbor-shared-handling--shared .atlas-military-neighbor-shared-handling__label,
+.atlas-military-neighbor-shared-residual--covered .atlas-military-neighbor-shared-residual__label { fill: #bbf7d0; }
+.atlas-military-neighbor-shared-handling--separate .atlas-military-neighbor-shared-handling__label,
+.atlas-military-neighbor-shared-residual--residual .atlas-military-neighbor-shared-residual__label { fill: #fed7aa; }
 .atlas-military-neighbor-front-shift-row circle {
   fill: rgba(167, 139, 250, 0.84);
   stroke: rgba(245, 243, 255, 0.72);


### PR DESCRIPTION
Alpha: Implements MAP-A30.

Summary:
- adds compact residual-risk copy after a shared grouped-front handling hint
- distinguishes fully covered groups from shared orders that still leave a flank to follow up
- keeps the signal inline in the existing war/map panel without a modal or simulation layer
- adds focused coverage for covered and residual-risk cases

Validation:
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test

Closes #1446