### PR TITLE
Beta: Suggest adjacent spillover guard action

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -846,6 +846,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       secondaryRoutes: [],
       summary: 'Aucun spillover logistique: aucune récupération locale sélectionnée.',
       dependencyTrace: 'Dépendance inconnue: aucun levier local ne permet de tracer la source du spillover.',
+      guardAction: { label: 'Garde indisponible', reason: 'Aucune chaîne de spillover à réduire pour l’instant.', fallback: true },
     };
   }
 
@@ -888,11 +889,29 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       secondaryRoutes: [],
       summary: 'Aucun spillover logistique voisin concret après cette récupération locale.',
       dependencyTrace: 'Dépendance inconnue: aucune route voisine exposée ne confirme la chaîne source → route affectée → conséquence.',
+      guardAction: { label: 'Garde indisponible', reason: 'Aucun relais voisin confirmé; surveiller la route après résolution locale.', fallback: true },
     };
   }
 
   const source = choice?.bottleneck?.label ?? option?.causeLabel ?? 'source inconnue';
   const consequence = criticalRoute.detail ?? `${criticalRoute.route} peut récupérer la pression déplacée.`;
+  const guardAction = criticalRoute.tone === 'high'
+    ? {
+      label: `Sécuriser ${criticalRoute.route} juste après ${priorityAction.route}`,
+      reason: `${criticalRoute.city} absorbe la pression déplacée si ${priorityAction.cost} reste le seul levier engagé.`,
+      fallback: false,
+    }
+    : secondaryRoutes.length > 0
+      ? {
+        label: `Garder ${criticalRoute.route} en premier relais`,
+        reason: `Réduit la chaîne avant qu’elle n’atteigne ${secondaryRoutes[0].route}.`,
+        fallback: false,
+      }
+      : {
+        label: `Surveiller ${criticalRoute.route} après résolution`,
+        reason: `${criticalRoute.city} est le seul relais exposé identifié.`,
+        fallback: false,
+      };
 
   return {
     state: secondaryRoutes.length > 0 ? 'chain' : 'single',
@@ -900,6 +919,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
     secondaryRoutes,
     summary: `${criticalRoute.route} est la route voisine critique; ${secondaryRoutes.length > 0 ? `${secondaryRoutes.length} route${secondaryRoutes.length > 1 ? 's' : ''} secondaire${secondaryRoutes.length > 1 ? 's' : ''} exposée${secondaryRoutes.length > 1 ? 's' : ''}.` : 'aucune autre route secondaire exposée.'}`,
     dependencyTrace: `${source} → ${criticalRoute.route}/${criticalRoute.city} → ${consequence}`,
+    guardAction,
   };
 }
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -119,6 +119,9 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.criticalRoute.route, /Ember Line|Hill Spur|Safe Road/);
   assert.match(preview.adjacentRouteSpilloverRisk.dependencyTrace, /→/);
   assert.match(preview.adjacentRouteSpilloverRisk.dependencyTrace, /capacité saturée|stock critique|risque élevé|Ember Line|Hill Spur|Iron Plain|Hill Hub/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardAction.fallback, false);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardAction.label, /Sécuriser|Garder|Surveiller/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardAction.reason, /pression déplacée|chaîne|relais exposé/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -192,6 +195,9 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.equal(preview.adjacentRouteSpilloverRisk.state, 'empty');
   assert.match(preview.adjacentRouteSpilloverRisk.summary, /Aucun spillover/);
   assert.match(preview.adjacentRouteSpilloverRisk.dependencyTrace, /Dépendance inconnue/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardAction.fallback, true);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardAction.label, /Garde indisponible/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardAction.reason, /Aucune chaîne de spillover/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -97,6 +97,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Critique:/);
   assert.match(webAppSource, /Dépendance:/);
   assert.match(webAppSource, /dependencyTrace/);
+  assert.match(webAppSource, /Garde:/);
+  assert.match(webAppSource, /guardAction/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -8262,6 +8262,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               <span>${preview.adjacentRouteSpilloverRisk.summary}</span>
               <small>Critique: ${preview.adjacentRouteSpilloverRisk.criticalRoute.route} vers ${preview.adjacentRouteSpilloverRisk.criticalRoute.city}. ${preview.adjacentRouteSpilloverRisk.secondaryRoutes.length > 0 ? `Secondaires: ${preview.adjacentRouteSpilloverRisk.secondaryRoutes.map((route) => `${route.route} (${route.city})`).join(', ')}.` : 'Pas de route secondaire exposée.'}</small>
               <em>Dépendance: ${preview.adjacentRouteSpilloverRisk.dependencyTrace}</em>
+              <small>Garde: ${preview.adjacentRouteSpilloverRisk.guardAction.label} — ${preview.adjacentRouteSpilloverRisk.guardAction.reason}</small>
             </div>
           ` : ''}
         </div>


### PR DESCRIPTION
Beta: Implements #1447.

Summary:
- Adds a compact guard/sequencing hint to the adjacent spillover risk preview.
- Explains why the guard matters with a short consequence phrase.
- Keeps the recommendation derived from existing route/recovery preview signals and includes fallback guard text when no concrete chain is traceable.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
