### PR TITLE
Epsilon: Suggest smallest action for nearest climate gap

### DIFF
--- a/test/ui/climate/webAtlasClimateNearestCoverageGapAction.test.js
+++ b/test/ui/climate/webAtlasClimateNearestCoverageGapAction.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas suggests the smallest action for the nearest climate coverage gap', () => {
+  assert.match(webAppSource, /function buildAtlasClimateNearestCoverageGapAction/);
+  assert.match(webAppSource, /function renderAtlasClimateNearestCoverageGapAction/);
+  assert.match(webAppSource, /Action gap prioritaire/);
+  assert.match(webAppSource, /Plus petit suivi/);
+  assert.match(webAppSource, /protège contre le basculement du seuil/);
+  assert.match(webAppSource, /Fallback: aucun angle mort restant/);
+  assert.match(webAppSource, /Aucun suivi spécifique/);
+  assert.match(webAppSource, /autre\$\{view\.recommendation\.otherGapsKept > 1 \? 's' : ''\} gap/);
+  assert.match(webAppSource, /buildAtlasClimateNearestCoverageGapAction\(\s*atlasClimateRemainingCoverageGaps,\s*atlasClimateThresholdProgressAfterReadinessAction,\s*\)/);
+  assert.match(webAppSource, /renderAtlasClimateRemainingCoverageGaps\(atlasClimateRemainingCoverageGaps\)\}\s*\$\{renderAtlasClimateNearestCoverageGapAction\(atlasClimateNearestCoverageGapAction\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-nearest-gap-action/);
+  assert.match(stylesSource, /\.map-world-climate-nearest-gap-action--fallback/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -13597,6 +13597,79 @@ function renderAtlasClimateRemainingCoverageGaps(view) {
   `;
 }
 
+function buildAtlasClimateNearestCoverageGapAction(coverageView, thresholdProgressView) {
+  if (!coverageView || coverageView.state === 'empty' || !thresholdProgressView?.progress) {
+    return {
+      state: 'unavailable',
+      recommendation: null,
+      summary: 'Aucune action de suivi calculable pour le gap climat le plus proche.',
+    };
+  }
+
+  const nearestGap = (coverageView.blindSpots ?? []).find((gap) => gap.nearest) ?? coverageView.blindSpots?.[0] ?? null;
+  const progress = thresholdProgressView.progress;
+
+  if (!nearestGap) {
+    return {
+      state: 'fallback',
+      recommendation: null,
+      summary: 'Fallback: aucun angle mort restant; garder une veille climat plutôt qu’ajouter une action.',
+    };
+  }
+
+  const concreteAction = nearestGap.nextAction && !/relire .* avant d’étendre/i.test(nearestGap.nextAction)
+    ? nearestGap.nextAction
+    : `Confirmer ${progress.threshold} sur ${nearestGap.label} avant d’ajouter une prévention.`;
+  const protectsAgainst = nearestGap.nearestRiskLabel === 'risque de seuil le plus proche'
+    ? `protège contre le basculement du seuil ${progress.threshold}`
+    : `réduit le risque secondaire avant ${progress.deadline}`;
+
+  return {
+    state: 'recommended',
+    recommendation: {
+      target: nearestGap.label,
+      action: concreteAction,
+      protectsAgainst,
+      reason: `${nearestGap.reason}; score seuil ${nearestGap.nearestThresholdScore}.`,
+      otherGapsKept: Math.max(0, (coverageView.blindSpots?.length ?? 0) - 1),
+    },
+    summary: `${nearestGap.label}: plus petite action proposée pour le gap climat le plus proche du seuil.`,
+  };
+}
+
+function renderAtlasClimateNearestCoverageGapAction(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || !view || view.state === 'empty') {
+    return '';
+  }
+
+  if (!view.recommendation) {
+    return `
+      <aside class="map-world-climate-nearest-gap-action map-world-climate-nearest-gap-action--fallback" aria-label="Action minimale pour le gap climat le plus proche">
+        <div class="map-world-climate-nearest-gap-action__header">
+          <strong>Action gap prioritaire</strong>
+          <span>fallback</span>
+        </div>
+        <p>${view.summary}</p>
+        <small><b>Fallback</b> · Aucun suivi spécifique: conserver les autres gaps visibles et relire la couverture au prochain signal.</small>
+      </aside>
+    `;
+  }
+
+  return `
+    <aside class="map-world-climate-nearest-gap-action map-world-climate-nearest-gap-action--${view.state}" aria-label="Action minimale pour le gap climat le plus proche">
+      <div class="map-world-climate-nearest-gap-action__header">
+        <strong>Action gap prioritaire</strong>
+        <span>${view.recommendation.target}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Plus petit suivi</b> · ${view.recommendation.action}</small>
+      <small><b>Protège</b> · ${view.recommendation.protectsAgainst}</small>
+      <small><b>Pourquoi ce gap</b> · ${view.recommendation.reason}</small>
+      <small><b>Autres gaps</b> · ${view.recommendation.otherGapsKept > 0 ? `${view.recommendation.otherGapsKept} autre${view.recommendation.otherGapsKept > 1 ? 's' : ''} gap${view.recommendation.otherGapsKept > 1 ? 's' : ''} restent affichés` : 'aucun autre gap prioritaire masqué'}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasSelectedClimateFollowUpReadinessRecap(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -21874,6 +21947,10 @@ function render() {
     atlasClimateFollowUpThresholdProtection,
     atlasClimateThresholdProgressAfterReadinessAction,
   );
+  const atlasClimateNearestCoverageGapAction = buildAtlasClimateNearestCoverageGapAction(
+    atlasClimateRemainingCoverageGaps,
+    atlasClimateThresholdProgressAfterReadinessAction,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -21937,6 +22014,7 @@ function render() {
           ${renderAtlasClimateSmallestPreventiveAction(atlasClimateSmallestPreventiveAction)}
           ${renderAtlasClimatePreventiveSecondaryProtection(atlasClimatePreventiveSecondaryProtection)}
           ${renderAtlasClimateRemainingCoverageGaps(atlasClimateRemainingCoverageGaps)}
+          ${renderAtlasClimateNearestCoverageGapAction(atlasClimateNearestCoverageGapAction)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -13445,6 +13445,35 @@ button { font: inherit; }
 .map-world-climate-coverage-gaps--covered span,
 .map-world-climate-coverage-gaps--covered small { color: #dcfce7; }
 
+.map-world-climate-nearest-gap-action {
+  display: grid;
+  gap: 6px;
+  max-width: 66ch;
+  margin-top: 6px;
+  padding: 10px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(120, 53, 15, 0.42), rgba(15, 23, 42, 0.84));
+  border: 1px solid rgba(251, 191, 36, 0.44);
+}
+.map-world-climate-nearest-gap-action--fallback { border-color: rgba(148, 163, 184, 0.36); }
+.map-world-climate-nearest-gap-action__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-nearest-gap-action p,
+.map-world-climate-nearest-gap-action span,
+.map-world-climate-nearest-gap-action small {
+  color: #fef3c7;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-nearest-gap-action--fallback p,
+.map-world-climate-nearest-gap-action--fallback span,
+.map-world-climate-nearest-gap-action--fallback small { color: #e2e8f0; }
+
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);
   box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.12);


### PR DESCRIPTION
Epsilon: PR prête pour #1450.

## Résumé
- Ajoute une carte compacte pour le gap climat restant le plus proche d’un seuil.
- Propose le plus petit suivi/mitigation identifié et explique le risque protégé en une phrase.
- Conserve les autres gaps visibles et ajoute un fallback quand aucun suivi spécifique n’est calculable.

## Tests
- node --test test/ui/climate/webAtlasClimateNearestCoverageGapAction.test.js test/ui/climate/webAtlasClimateRemainingCoverageGaps.test.js test/ui/climate/webAtlasClimatePreventiveSecondaryProtection.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?