### PR TITLE
Gamma: Prioritize cultural deferrals

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1320,6 +1320,13 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
         ? 'à revoir dès le prochain tour'
         : 'sûr ce tour';
 
+      const deadlinePressure = deadlineStatus === 'near-deadline'
+        ? 2
+        : deadlineStatus === 'safe-this-turn'
+          ? 1
+          : 0;
+      const payoffScore = group?.unlockScore ?? 0;
+
       return {
         deferId: `${prompt.cleanupId}:safe-to-defer`,
         bundleId: prompt.bundleId,
@@ -1332,20 +1339,44 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
         turningSignal,
         deadlineHint,
         deadlineStatus,
+        deadlinePressure,
+        payoffScore,
+        priorityReason: deadlinePressure > 0
+          ? `${deadlineHint}; payoff ${payoffScore}`
+          : `fenêtre non calculable; payoff ${payoffScore}`,
         nextReviewWindow,
         falloutSeverity: fallout?.severity ?? 0,
       };
     })
-    .filter(Boolean)
-    .sort((left, right) => left.falloutSeverity - right.falloutSeverity || left.clusterLabel.localeCompare(right.clusterLabel));
-  const top = candidates[0] ?? null;
+    .filter(Boolean);
+  const hasDeadlineData = candidates.some((candidate) => candidate.deadlinePressure > 0);
+  const sortedCandidates = [...candidates].sort((left, right) => {
+    if (!hasDeadlineData) {
+      return left.falloutSeverity - right.falloutSeverity || left.clusterLabel.localeCompare(right.clusterLabel);
+    }
+
+    return right.deadlinePressure - left.deadlinePressure
+      || right.payoffScore - left.payoffScore
+      || left.falloutSeverity - right.falloutSeverity
+      || left.clusterLabel.localeCompare(right.clusterLabel);
+  });
+  const rankedCandidates = sortedCandidates.map((candidate, index) => ({
+    ...candidate,
+    revisitRank: sortedCandidates.length > 1 ? index + 1 : null,
+    revisitPriority: sortedCandidates.length > 1 && index === 0 ? 'next' : 'later',
+  }));
+  const top = rankedCandidates[0] ?? null;
 
   return {
-    state: candidates.length === 0 ? 'none' : 'ready',
+    state: rankedCandidates.length === 0 ? 'none' : 'ready',
     summary: top
       ? `${top.clusterLabel}: Peut attendre — ${top.deadlineHint}; ${top.riskThreshold}`
       : 'Aucun bundle culturel sûr à reporter ce tour.',
-    entries: candidates,
+    primaryDeferId: rankedCandidates.length > 1 ? top?.deferId ?? null : null,
+    priorityFallback: hasDeadlineData
+      ? 'Priorité par pression de délai, puis payoff culturel.'
+      : 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
+    entries: rankedCandidates,
   };
 }
 
@@ -1747,6 +1778,8 @@ export function buildCultureTurnReportDeltas({
           safeToDeferBundles: {
             state: 'none',
             summary: 'Aucun bundle culturel sûr à reporter ce tour.',
+            primaryDeferId: null,
+            priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
             entries: [],
           },
           detailMode: 'Aucun détail individuel à ouvrir.',

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -476,6 +476,8 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
       safeToDeferBundles: {
         state: 'none',
         summary: 'Aucun bundle culturel sûr à reporter ce tour.',
+        primaryDeferId: null,
+        priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
         entries: [],
       },
       detailMode: 'Ouvrir les détails pour vérifier chaque suivi individuel du groupe.',
@@ -687,6 +689,169 @@ test('buildCultureTurnReportDeltas escalates safe defer deadline when current su
   ]);
 });
 
+test('buildCultureTurnReportDeltas prioritizes safe defer entries by deadline pressure before payoff', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 9,
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'amplifier',
+      },
+    },
+    localTimeline: {
+      items: [
+        {
+          timelineId: 'harbor:event:quiet-followup',
+          kind: 'event',
+          signal: 'watch',
+          title: 'Suivi calme',
+          summary: 'Risque stabilisé.',
+          regionId: 'harbor',
+          cultureName: 'Harbor Compact',
+        },
+      ],
+    },
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'deferred',
+        outcome: 'soutien actif confirmé',
+      },
+      {
+        decisionId: 'turn-8-harbor-calm',
+        turn: 8,
+        regionId: 'harbor',
+        clusterLabel: 'Harbor Compact',
+        theme: 'Calmer le port',
+        promptLabel: 'Calmer le port',
+        choiceState: 'deferred',
+        outcome: 'risque stabilisé',
+      },
+    ],
+  });
+
+  const safeToDefer = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles;
+  assert.equal(safeToDefer.priorityFallback, 'Priorité par pression de délai, puis payoff culturel.');
+  assert.deepEqual(safeToDefer.entries.map((entry) => [
+    entry.clusterLabel,
+    entry.deadlineStatus,
+    entry.revisitRank,
+    entry.revisitPriority,
+  ]), [
+    ['Compact d’Aurora', 'near-deadline', 1, 'next'],
+    ['Harbor Compact', 'safe-this-turn', 2, 'later'],
+  ]);
+  assert.equal(safeToDefer.primaryDeferId, safeToDefer.entries[0].deferId);
+});
+
+test('buildCultureTurnReportDeltas breaks safe defer deadline ties by cultural payoff', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 9,
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-marker',
+      regionId: 'river-gate',
+      cultureName: 'Map Marker Culture',
+      influenceTier: 'strong',
+      influenceScore: 80,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'amplifier',
+      },
+    },
+    activeRecommendations: [
+      {
+        recommendationId: 'river-gate:aurora:amplify',
+        regionId: 'river-gate',
+        cultureName: 'Compact d’Aurora',
+        action: 'amplifier',
+        tone: 'opportunity',
+        level: 'surging',
+        discoveryId: 'aurora-forum',
+        confidence: 'high',
+        supportKey: 'amplifier',
+        markerIds: ['aurora-marker'],
+        rank: 1,
+      },
+      {
+        recommendationId: 'harbor:compact:support',
+        regionId: 'harbor',
+        cultureName: 'Harbor Compact',
+        action: 'soutenir',
+        tone: 'opportunity',
+        level: 'surging',
+        discoveryId: 'harbor-forum',
+        confidence: 'high',
+        supportKey: 'soutenir',
+        markerIds: ['harbor-marker'],
+        rank: 2,
+      },
+    ],
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'deferred',
+        outcome: 'soutien actif confirmé',
+      },
+      {
+        decisionId: 'turn-8-harbor-support',
+        turn: 8,
+        regionId: 'harbor',
+        clusterLabel: 'Harbor Compact',
+        theme: 'Ancrer le soutien régional',
+        promptLabel: 'Ancrer le soutien régional',
+        choiceState: 'deferred',
+        outcome: 'soutien actif confirmé',
+      },
+    ],
+  });
+
+  assert.deepEqual(report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries.map((entry) => [
+    entry.clusterLabel,
+    entry.deadlineStatus,
+    entry.payoffScore,
+    entry.revisitRank,
+    entry.revisitPriority,
+  ]), [
+    ['Harbor Compact', 'near-deadline', 5, 1, 'next'],
+    ['Compact d’Aurora', 'near-deadline', 2, 2, 'later'],
+  ]);
+});
+
+test('buildCultureTurnReportDeltas keeps a no-deadline safe defer fallback stable', () => {
+  const report = buildCultureTurnReportDeltas({ turn: 2, selectedRegionId: 'quiet-field' });
+
+  assert.deepEqual(report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles, {
+    state: 'none',
+    summary: 'Aucun bundle culturel sûr à reporter ce tour.',
+    primaryDeferId: null,
+    priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
+    entries: [],
+  });
+});
+
 test('buildCultureTurnReportDeltas returns compact quiet state without culture signals', () => {
   assert.deepEqual(buildCultureTurnReportDeltas({ turn: 2, selectedRegionId: 'quiet-field' }), {
     state: 'quiet',
@@ -815,6 +980,8 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
         safeToDeferBundles: {
           state: 'none',
           summary: 'Aucun bundle culturel sûr à reporter ce tour.',
+          primaryDeferId: null,
+          priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
           entries: [],
         },
         detailMode: 'Aucun détail individuel à ouvrir.',

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -178,8 +178,12 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /culture-turn-report__safe-defer-bundles/);
   assert.match(webAppSource, /Peut attendre/);
   assert.match(webAppSource, /Délai:/);
+  assert.match(webAppSource, /Priorité: à revisiter en premier/);
+  assert.match(webAppSource, /Payoff:/);
   assert.match(webAppSource, /deadlineHint/);
   assert.match(webAppSource, /deadlineStatus/);
+  assert.match(webAppSource, /revisitPriority/);
+  assert.match(webAppSource, /revisitRank/);
   assert.match(webAppSource, /Condition:/);
   assert.match(webAppSource, /Bascule:/);
   assert.match(webAppSource, /riskThreshold/);
@@ -275,6 +279,7 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(stylesSource, /\.culture-turn-report__safe-defer-entry/);
   assert.match(stylesSource, /\.culture-turn-report__safe-defer-entry--safe-this-turn/);
   assert.match(stylesSource, /\.culture-turn-report__safe-defer-entry--near-deadline/);
+  assert.match(stylesSource, /\.culture-turn-report__safe-defer-entry--next/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompts/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--obsolete/);
   assert.match(stylesSource, /\.culture-turn-report__cleanup-prompt--resolved/);

--- a/web/app.js
+++ b/web/app.js
@@ -7373,9 +7373,11 @@ function renderCultureTurnReport(report) {
           ${(report.commitmentBundles?.followThroughBundlePlan?.safeToDeferBundles?.entries ?? []).length > 0 ? `
             <div class="culture-turn-report__safe-defer-list">
               ${report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries.map((entry) => `
-                <span class="culture-turn-report__safe-defer-entry culture-turn-report__safe-defer-entry--${entry.deadlineStatus ?? 'no-deadline'}">
-                  <b>${entry.clusterLabel} · ${entry.label}</b>
+                <span class="culture-turn-report__safe-defer-entry culture-turn-report__safe-defer-entry--${entry.deadlineStatus ?? 'no-deadline'} culture-turn-report__safe-defer-entry--${entry.revisitPriority ?? 'unranked'}">
+                  <b>${entry.revisitRank ? `#${entry.revisitRank} ` : ''}${entry.clusterLabel} · ${entry.label}</b>
+                  ${entry.revisitPriority === 'next' ? '<small>Priorité: à revisiter en premier</small>' : ''}
                   <small>Délai: ${entry.deadlineHint ?? 'fenêtre non calculable'}</small>
+                  <small>Payoff: ${entry.payoffScore ?? 0}</small>
                   <small>Condition: ${entry.condition}</small>
                   <small>Bascule: ${entry.turningSignal}</small>
                   <small>${entry.riskThreshold}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -2136,6 +2136,7 @@ button { font: inherit; }
 .culture-turn-report__safe-defer-entry small { color: var(--muted); }
 .culture-turn-report__safe-defer-entry--safe-this-turn { border-color: rgba(74, 222, 128, 0.28); }
 .culture-turn-report__safe-defer-entry--near-deadline { border-color: rgba(251, 191, 36, 0.42); }
+.culture-turn-report__safe-defer-entry--next { background: rgba(251, 191, 36, 0.12); }
 .culture-turn-report__cleanup-prompts {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
Gamma: Implements #1448.

Summary:
- ranks multiple safe-to-defer cultural actions by deadline pressure first, then cultural payoff
- marks the next deferred action to revisit while leaving urgent replacement recommendations above the defer queue
- keeps stable fallback behavior when no safe/deadline queue exists
- surfaces revisit rank/priority and payoff in the culture turn report

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test