### PR TITLE
Beta: Compare adjacent spillover guard actions

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -847,6 +847,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       summary: 'Aucun spillover logistique: aucune récupération locale sélectionnée.',
       dependencyTrace: 'Dépendance inconnue: aucun levier local ne permet de tracer la source du spillover.',
       guardAction: { label: 'Garde indisponible', reason: 'Aucune chaîne de spillover à réduire pour l’instant.', fallback: true },
+      guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: aucune garde concrète à classer.' },
     };
   }
 
@@ -890,27 +891,47 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       summary: 'Aucun spillover logistique voisin concret après cette récupération locale.',
       dependencyTrace: 'Dépendance inconnue: aucune route voisine exposée ne confirme la chaîne source → route affectée → conséquence.',
       guardAction: { label: 'Garde indisponible', reason: 'Aucun relais voisin confirmé; surveiller la route après résolution locale.', fallback: true },
+      guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: coût de garde non comparable sans route exposée.' },
     };
   }
 
   const source = choice?.bottleneck?.label ?? option?.causeLabel ?? 'source inconnue';
   const consequence = criticalRoute.detail ?? `${criticalRoute.route} peut récupérer la pression déplacée.`;
-  const guardAction = criticalRoute.tone === 'high'
-    ? {
-      label: `Sécuriser ${criticalRoute.route} juste après ${priorityAction.route}`,
-      reason: `${criticalRoute.city} absorbe la pression déplacée si ${priorityAction.cost} reste le seul levier engagé.`,
+  const guardCandidates = [criticalRoute, ...secondaryRoutes]
+    .map((route, index) => ({
+      route: route.route,
+      city: route.city,
+      label: index === 0 ? `Sécuriser ${route.route} juste après ${priorityAction.route}` : `Garder ${route.route} en relais léger`,
+      reason: index === 0
+        ? `${route.city} absorbe la pression déplacée si ${priorityAction.cost} reste le seul levier engagé.`
+        : `Protège ${route.city} avec moins de capacité consommée que la route critique.`,
+      tradeoff: `${route.route} protégée vs ${route.tone === 'high' ? 'capacité forte consommée' : 'capacité légère consommée'}`,
+      disruption: (route.tone === 'high' ? 3 : 2) + index,
       fallback: false,
+    }))
+    .sort((left, right) => left.disruption - right.disruption || left.route.localeCompare(right.route));
+
+  const guardAction = guardCandidates[0] ?? {
+    label: 'Garde indisponible',
+    reason: 'Comparaison des coûts de garde impossible avec les signaux actuels.',
+    fallback: true,
+  };
+  const guardComparison = guardCandidates.length > 1
+    ? {
+      state: 'compare',
+      candidates: guardCandidates,
+      summary: `${guardAction.label} est le moins disruptif: ${guardAction.tradeoff}.`,
     }
-    : secondaryRoutes.length > 0
+    : guardCandidates.length === 1
       ? {
-        label: `Garder ${criticalRoute.route} en premier relais`,
-        reason: `Réduit la chaîne avant qu’elle n’atteigne ${secondaryRoutes[0].route}.`,
-        fallback: false,
+        state: 'single',
+        candidates: guardCandidates,
+        summary: 'Une seule garde concrète identifiée; comportement inchangé.',
       }
       : {
-        label: `Surveiller ${criticalRoute.route} après résolution`,
-        reason: `${criticalRoute.city} est le seul relais exposé identifié.`,
-        fallback: false,
+        state: 'fallback',
+        candidates: [],
+        summary: 'Comparaison impossible: coût de garde non comparable avec les signaux actuels.',
       };
 
   return {
@@ -920,6 +941,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
     summary: `${criticalRoute.route} est la route voisine critique; ${secondaryRoutes.length > 0 ? `${secondaryRoutes.length} route${secondaryRoutes.length > 1 ? 's' : ''} secondaire${secondaryRoutes.length > 1 ? 's' : ''} exposée${secondaryRoutes.length > 1 ? 's' : ''}.` : 'aucune autre route secondaire exposée.'}`,
     dependencyTrace: `${source} → ${criticalRoute.route}/${criticalRoute.city} → ${consequence}`,
     guardAction,
+    guardComparison,
   };
 }
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -120,8 +120,12 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.dependencyTrace, /→/);
   assert.match(preview.adjacentRouteSpilloverRisk.dependencyTrace, /capacité saturée|stock critique|risque élevé|Ember Line|Hill Spur|Iron Plain|Hill Hub/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardAction.fallback, false);
-  assert.match(preview.adjacentRouteSpilloverRisk.guardAction.label, /Sécuriser|Garder|Surveiller/);
-  assert.match(preview.adjacentRouteSpilloverRisk.guardAction.reason, /pression déplacée|chaîne|relais exposé/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardAction.label, /Sécuriser|Garder/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardAction.reason, /pression déplacée|capacité consommée/);
+  assert.ok(['compare', 'single'].includes(preview.adjacentRouteSpilloverRisk.guardComparison.state));
+  assert.match(preview.adjacentRouteSpilloverRisk.guardComparison.summary, /moins disruptif|Une seule garde/);
+  assert.ok(preview.adjacentRouteSpilloverRisk.guardComparison.candidates.length >= 1);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardComparison.candidates[0].tradeoff, /protégée vs .*capacité/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -198,6 +202,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.equal(preview.adjacentRouteSpilloverRisk.guardAction.fallback, true);
   assert.match(preview.adjacentRouteSpilloverRisk.guardAction.label, /Garde indisponible/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardAction.reason, /Aucune chaîne de spillover/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardComparison.state, 'fallback');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardComparison.summary, /Comparaison impossible/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -99,6 +99,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /dependencyTrace/);
   assert.match(webAppSource, /Garde:/);
   assert.match(webAppSource, /guardAction/);
+  assert.match(webAppSource, /Comparaison garde:/);
+  assert.match(webAppSource, /guardComparison/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -8313,6 +8313,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               <small>Critique: ${preview.adjacentRouteSpilloverRisk.criticalRoute.route} vers ${preview.adjacentRouteSpilloverRisk.criticalRoute.city}. ${preview.adjacentRouteSpilloverRisk.secondaryRoutes.length > 0 ? `Secondaires: ${preview.adjacentRouteSpilloverRisk.secondaryRoutes.map((route) => `${route.route} (${route.city})`).join(', ')}.` : 'Pas de route secondaire exposée.'}</small>
               <em>Dépendance: ${preview.adjacentRouteSpilloverRisk.dependencyTrace}</em>
               <small>Garde: ${preview.adjacentRouteSpilloverRisk.guardAction.label} — ${preview.adjacentRouteSpilloverRisk.guardAction.reason}</small>
+              ${preview.adjacentRouteSpilloverRisk.guardComparison ? `<small>Comparaison garde: ${preview.adjacentRouteSpilloverRisk.guardComparison.summary}</small>` : ''}
             </div>
           ` : ''}
         </div>


### PR DESCRIPTION
Beta: Implements #1457.

Summary:
- Adds guard comparison metadata to adjacent logistics spillover risk.
- Ranks multiple guard candidates by least disruption first and exposes a short protected-route vs consumed-capacity tradeoff.
- Preserves single-guard behavior and adds fallback comparison text when costs cannot be compared safely.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
