### PR TITLE
Alpha: Recommend residual front follow-up

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -246,3 +246,28 @@ test('atlas military shows residual risk after shared grouped front handling', (
   assert.match(stylesSource, /\.atlas-military-neighbor-shared-residual--covered/);
   assert.match(stylesSource, /\.atlas-military-neighbor-shared-residual--residual/);
 });
+
+// MAP-A31: when residual grouped-front risk remains, name the next follow-up
+// order and keep fully covered groups quiet.
+test('atlas military recommends follow-up order for residual grouped front risk', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryNeighborResidualFollowUpOrder\(sharedResidualRisk, cluster\)/);
+  assert.match(webAppSource, /function renderAtlasMilitaryNeighborResidualFollowUpOrder\(followUp, y\)/);
+  assert.match(webAppSource, /Ordre de suivi recommandé pour risque résiduel/);
+  assert.match(webAppSource, /Suivi recommandé: \$\{provinceLabel\}/);
+  assert.match(webAppSource, /dominantReason = cluster\?\.tone === 'critical'/);
+  assert.match(webAppSource, /\? 'urgence'/);
+  assert.match(webAppSource, /\? 'exposition'/);
+  assert.match(webAppSource, /: 'mouvement ennemi probable'/);
+  assert.match(webAppSource, /ordre rapide: verrouiller le flanc/);
+  assert.match(webAppSource, /ordre de couverture: protéger la province/);
+  assert.match(webAppSource, /ordre d’interception: bloquer le mouvement/);
+  assert.match(webAppSource, /sharedResidualRisk\.tone !== 'residual'/);
+  assert.match(webAppSource, /Aucun suivi requis/);
+  assert.match(webAppSource, /groupe couvert par l’ordre partagé/);
+  assert.match(webAppSource, /residualFollowUpOrder: buildAtlasMilitaryNeighborResidualFollowUpOrder/);
+  assert.match(webAppSource, /renderAtlasMilitaryNeighborResidualFollowUpOrder\(preview\.residualFollowUpOrder, followUpY\)/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-residual-follow-up__label/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-residual-follow-up--urgent/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-residual-follow-up--exposed/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-residual-follow-up--movement/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2585,6 +2585,7 @@ function buildAtlasMilitaryNeighborSharedResidualRisk(cluster, sharedHandlingHin
     return {
       visible: true,
       tone: 'residual',
+      provinceLabel: exposedFlank,
       label: 'Risque résiduel: flanc à suivre',
       detail: `${exposedFlank}: pression restante après ordre groupé`,
       action: `prévoir suivi sur ${exposedFlank}`,
@@ -2594,9 +2595,44 @@ function buildAtlasMilitaryNeighborSharedResidualRisk(cluster, sharedHandlingHin
   return {
     visible: true,
     tone: 'covered',
+    provinceLabel: null,
     label: 'Groupe couvert après ordre',
     detail: `${cluster.provinces.length} provinces couvertes par la même action`,
     action: 'confirmer puis surveiller léger',
+  };
+}
+
+function buildAtlasMilitaryNeighborResidualFollowUpOrder(sharedResidualRisk, cluster) {
+  if (!sharedResidualRisk?.visible || sharedResidualRisk.tone !== 'residual') {
+    return {
+      visible: false,
+      tone: 'covered',
+      label: 'Aucun suivi requis',
+      reason: 'groupe couvert par l’ordre partagé',
+      action: 'ne pas inventer de travail',
+    };
+  }
+
+  const provinceLabel = sharedResidualRisk.provinceLabel ?? cluster?.provinces?.[0] ?? 'flanc exposé';
+  const dominantReason = cluster?.tone === 'critical'
+    ? 'urgence'
+    : cluster?.tone === 'contested'
+      ? 'exposition'
+      : 'mouvement ennemi probable';
+  const actionByReason = {
+    urgence: 'ordre rapide: verrouiller le flanc',
+    exposition: 'ordre de couverture: protéger la province',
+    'mouvement ennemi probable': 'ordre d’interception: bloquer le mouvement',
+  };
+
+  return {
+    visible: true,
+    tone: dominantReason === 'urgence' ? 'urgent' : dominantReason === 'exposition' ? 'exposed' : 'movement',
+    provinceLabel,
+    label: `Suivi recommandé: ${provinceLabel}`,
+    reason: dominantReason,
+    action: actionByReason[dominantReason],
+    detail: `${dominantReason}: ${actionByReason[dominantReason]}`,
   };
 }
 
@@ -2615,6 +2651,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       urgencyCluster: buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])),
       sharedHandlingHint: buildAtlasMilitaryNeighborSharedHandlingHint(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), []))),
       sharedResidualRisk: buildAtlasMilitaryNeighborSharedResidualRisk(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])), buildAtlasMilitaryNeighborSharedHandlingHint(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])))),
+      residualFollowUpOrder: buildAtlasMilitaryNeighborResidualFollowUpOrder(buildAtlasMilitaryNeighborSharedResidualRisk(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])), buildAtlasMilitaryNeighborSharedHandlingHint(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])))), buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), []))),
       summary: 'Prévision voisins indisponible: aucun ordre de province en focus.',
       empty: true,
     };
@@ -2646,6 +2683,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
   const urgencyCluster = buildAtlasMilitaryNeighborFrontUrgencyCluster(shifts, reviewStaleness, reviewChange);
   const sharedHandlingHint = buildAtlasMilitaryNeighborSharedHandlingHint(urgencyCluster);
   const sharedResidualRisk = buildAtlasMilitaryNeighborSharedResidualRisk(urgencyCluster, sharedHandlingHint);
+  const residualFollowUpOrder = buildAtlasMilitaryNeighborResidualFollowUpOrder(sharedResidualRisk, urgencyCluster);
 
   if (!shifts.length) {
     return {
@@ -2659,6 +2697,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       urgencyCluster,
       sharedHandlingHint,
       sharedResidualRisk,
+      residualFollowUpOrder,
       summary: `${focusProvince}: aucun front voisin lisible après engagement.`,
       empty: true,
     };
@@ -2675,7 +2714,8 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
     urgencyCluster,
     sharedHandlingHint,
     sharedResidualRisk,
-    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}; ${reviewStaleness.label}; ${reviewChange.label}${urgencyCluster.visible ? `; ${urgencyCluster.label}; ${sharedHandlingHint.label}${sharedResidualRisk.visible ? `; ${sharedResidualRisk.label}` : ''}` : contestedPriority.visible ? `; ${contestedPriority.label}` : ''}.`,
+    residualFollowUpOrder,
+    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}; ${reviewStaleness.label}; ${reviewChange.label}${urgencyCluster.visible ? `; ${urgencyCluster.label}; ${sharedHandlingHint.label}${sharedResidualRisk.visible ? `; ${sharedResidualRisk.label}${residualFollowUpOrder.visible ? `; ${residualFollowUpOrder.label}` : ''}` : ''}` : contestedPriority.visible ? `; ${contestedPriority.label}` : ''}.`,
     empty: false,
   };
 }
@@ -2747,6 +2787,16 @@ function renderAtlasMilitaryNeighborSharedResidualRisk(risk, y) {
   `;
 }
 
+function renderAtlasMilitaryNeighborResidualFollowUpOrder(followUp, y) {
+  if (!followUp?.visible) return '';
+  return `
+    <g class="atlas-military-neighbor-residual-follow-up atlas-military-neighbor-residual-follow-up--${followUp.tone}" aria-label="Ordre de suivi recommandé pour risque résiduel: ${followUp.label}; raison ${followUp.reason}; action ${followUp.action}">
+      <text class="atlas-military-neighbor-residual-follow-up__label" x="44.2" y="${y}">${followUp.label}</text>
+      <text class="atlas-military-neighbor-residual-follow-up__detail" x="44.2" y="${y + 1.35}">${followUp.detail}</text>
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
   const priorityY = preview.empty ? 163.8 : 163.85 + (preview.shifts.length * 3.45);
   const staleY = priorityY + 2.75;
@@ -2754,12 +2804,14 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
   const clusterY = changeY + 2.75;
   const hintY = clusterY + (preview.urgencyCluster?.visible ? 2.75 : 0);
   const residualY = hintY + (preview.sharedHandlingHint?.visible ? 2.75 : 0);
-  const contestedY = residualY + (preview.sharedResidualRisk?.visible ? 2.75 : 0);
+  const followUpY = residualY + (preview.sharedResidualRisk?.visible ? 2.75 : 0);
+  const contestedY = followUpY + (preview.residualFollowUpOrder?.visible ? 2.75 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;
   const hintHeight = preview.sharedHandlingHint?.visible ? 2.5 : 0;
   const residualHeight = preview.sharedResidualRisk?.visible ? 2.5 : 0;
+  const followUpHeight = preview.residualFollowUpOrder?.visible ? 2.5 : 0;
   const contestedHeight = preview.contestedPriority?.visible ? 2.5 : 0;
-  const height = (preview.empty ? 13.6 : 13.6 + (preview.shifts.length * 3.45)) + clusterHeight + hintHeight + residualHeight + contestedHeight;
+  const height = (preview.empty ? 13.6 : 13.6 + (preview.shifts.length * 3.45)) + clusterHeight + hintHeight + residualHeight + followUpHeight + contestedHeight;
   return `
     <g class="atlas-military-neighbor-front-shift atlas-military-neighbor-front-shift--${preview.empty ? 'empty' : 'active'}" aria-label="Prévisualisation des fronts voisins après engagement: ${preview.summary}">
       <rect class="atlas-military-neighbor-front-shift__panel" x="43" y="157" width="35" height="${height}" rx="2.1"></rect>
@@ -2778,6 +2830,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
       ${renderAtlasMilitaryNeighborFrontUrgencyCluster(preview.urgencyCluster, clusterY)}
       ${renderAtlasMilitaryNeighborSharedHandlingHint(preview.sharedHandlingHint, hintY)}
       ${renderAtlasMilitaryNeighborSharedResidualRisk(preview.sharedResidualRisk, residualY)}
+      ${renderAtlasMilitaryNeighborResidualFollowUpOrder(preview.residualFollowUpOrder, followUpY)}
       ${renderAtlasMilitaryNeighborContestedHandlingPriority(preview.contestedPriority, contestedY)}
     </g>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14441,7 +14441,8 @@ button { font: inherit; }
 .atlas-military-neighbor-contested-priority__reason,
 .atlas-military-neighbor-front-cluster__detail,
 .atlas-military-neighbor-shared-handling__detail,
-.atlas-military-neighbor-shared-residual__detail {
+.atlas-military-neighbor-shared-residual__detail,
+.atlas-military-neighbor-residual-follow-up__detail {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14451,7 +14452,8 @@ button { font: inherit; }
 .atlas-military-neighbor-contested-priority__label,
 .atlas-military-neighbor-front-cluster__label,
 .atlas-military-neighbor-shared-handling__label,
-.atlas-military-neighbor-shared-residual__label {
+.atlas-military-neighbor-shared-residual__label,
+.atlas-military-neighbor-residual-follow-up__label {
   fill: #f5f3ff;
   font-size: 0.55px;
   font-weight: 900;
@@ -14478,7 +14480,10 @@ button { font: inherit; }
 .atlas-military-neighbor-shared-handling--shared .atlas-military-neighbor-shared-handling__label,
 .atlas-military-neighbor-shared-residual--covered .atlas-military-neighbor-shared-residual__label { fill: #bbf7d0; }
 .atlas-military-neighbor-shared-handling--separate .atlas-military-neighbor-shared-handling__label,
-.atlas-military-neighbor-shared-residual--residual .atlas-military-neighbor-shared-residual__label { fill: #fed7aa; }
+.atlas-military-neighbor-shared-residual--residual .atlas-military-neighbor-shared-residual__label,
+.atlas-military-neighbor-residual-follow-up--exposed .atlas-military-neighbor-residual-follow-up__label { fill: #fed7aa; }
+.atlas-military-neighbor-residual-follow-up--urgent .atlas-military-neighbor-residual-follow-up__label { fill: #fecdd3; }
+.atlas-military-neighbor-residual-follow-up--movement .atlas-military-neighbor-residual-follow-up__label { fill: #fde68a; }
 .atlas-military-neighbor-front-shift-row circle {
   fill: rgba(167, 139, 250, 0.84);
   stroke: rgba(245, 243, 255, 0.72);


### PR DESCRIPTION
Alpha: Implements MAP-A31.

Summary:
- adds one compact follow-up order when shared grouped-front handling leaves residual risk
- explains the next follow-up with a dominant reason: urgency, exposure, or likely enemy movement
- keeps covered shared groups quiet/no-follow-up while preserving existing province detail
- extends focused source-level coverage for residual follow-up and covered no-follow-up states

Validation:
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test

Closes #1456