### PR TITLE
Gamma: Show missed cultural defer consequence

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1360,12 +1360,32 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
       || left.falloutSeverity - right.falloutSeverity
       || left.clusterLabel.localeCompare(right.clusterLabel);
   });
-  const rankedCandidates = sortedCandidates.map((candidate, index) => ({
-    ...candidate,
-    revisitRank: sortedCandidates.length > 1 ? index + 1 : null,
-    revisitPriority: sortedCandidates.length > 1 && index === 0 ? 'next' : 'later',
-  }));
+  const rankedCandidates = sortedCandidates.map((candidate, index) => {
+    const revisitPriority = sortedCandidates.length > 1 && index === 0 ? 'next' : 'later';
+    const missedFallout = falloutPreview.entries.find((entry) => entry.bundleId === candidate.bundleId) ?? null;
+    const missedWindowConsequence = revisitPriority === 'next'
+      ? (missedFallout?.severity > 0
+        ? missedFallout.consequence
+        : `${candidate.clusterLabel}: ${candidate.riskThreshold}`)
+      : null;
+
+    return {
+      ...candidate,
+      revisitRank: sortedCandidates.length > 1 ? index + 1 : null,
+      revisitPriority,
+      missedWindowConsequence,
+      missedWindowConsequenceType: revisitPriority === 'next'
+        ? missedFallout?.consequenceType ?? 'threshold-risk'
+        : null,
+      missedWindowSeverity: revisitPriority === 'next'
+        ? missedFallout?.severity ?? candidate.deadlinePressure
+        : 0,
+    };
+  });
   const top = rankedCandidates[0] ?? null;
+  const primaryMissedWindowConsequence = top?.revisitPriority === 'next'
+    ? top.missedWindowConsequence
+    : null;
 
   return {
     state: rankedCandidates.length === 0 ? 'none' : 'ready',
@@ -1373,6 +1393,10 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
       ? `${top.clusterLabel}: Peut attendre — ${top.deadlineHint}; ${top.riskThreshold}`
       : 'Aucun bundle culturel sûr à reporter ce tour.',
     primaryDeferId: rankedCandidates.length > 1 ? top?.deferId ?? null : null,
+    primaryMissedWindowConsequence,
+    missedWindowFallback: primaryMissedWindowConsequence
+      ? 'Conséquence calculée depuis le fallout/payoff existant du bundle reporté.'
+      : 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
     priorityFallback: hasDeadlineData
       ? 'Priorité par pression de délai, puis payoff culturel.'
       : 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
@@ -1779,6 +1803,8 @@ export function buildCultureTurnReportDeltas({
             state: 'none',
             summary: 'Aucun bundle culturel sûr à reporter ce tour.',
             primaryDeferId: null,
+            primaryMissedWindowConsequence: null,
+            missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
             priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
             entries: [],
           },

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -477,6 +477,8 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
         state: 'none',
         summary: 'Aucun bundle culturel sûr à reporter ce tour.',
         primaryDeferId: null,
+        primaryMissedWindowConsequence: null,
+        missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
         priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
         entries: [],
       },
@@ -758,6 +760,82 @@ test('buildCultureTurnReportDeltas prioritizes safe defer entries by deadline pr
   assert.equal(safeToDefer.primaryDeferId, safeToDefer.entries[0].deferId);
 });
 
+test('buildCultureTurnReportDeltas shows the consequence of missing the next deferred revisit', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 9,
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'amplifier',
+      },
+    },
+    localTimeline: {
+      items: [
+        {
+          timelineId: 'harbor:event:quiet-followup',
+          kind: 'event',
+          signal: 'watch',
+          title: 'Suivi calme',
+          summary: 'Risque stabilisé.',
+          regionId: 'harbor',
+          cultureName: 'Harbor Compact',
+        },
+      ],
+    },
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'deferred',
+        outcome: 'soutien actif confirmé',
+      },
+      {
+        decisionId: 'turn-8-harbor-calm',
+        turn: 8,
+        regionId: 'harbor',
+        clusterLabel: 'Harbor Compact',
+        theme: 'Calmer le port',
+        promptLabel: 'Calmer le port',
+        choiceState: 'deferred',
+        outcome: 'risque stabilisé',
+      },
+    ],
+  });
+
+  const safeToDefer = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles;
+  assert.equal(safeToDefer.primaryMissedWindowConsequence, 'Compact d’Aurora: consolidation retardée d’un tour si le bundle n’est pas réévalué.');
+  assert.equal(safeToDefer.missedWindowFallback, 'Conséquence calculée depuis le fallout/payoff existant du bundle reporté.');
+  assert.deepEqual(safeToDefer.entries.map((entry) => [
+    entry.clusterLabel,
+    entry.revisitPriority,
+    entry.missedWindowConsequence,
+    entry.missedWindowConsequenceType,
+    entry.missedWindowSeverity,
+  ]), [
+    [
+      'Compact d’Aurora',
+      'next',
+      'Compact d’Aurora: consolidation retardée d’un tour si le bundle n’est pas réévalué.',
+      'consolidation-delay',
+      1,
+    ],
+    ['Harbor Compact', 'later', null, null, 0],
+  ]);
+});
+
 test('buildCultureTurnReportDeltas breaks safe defer deadline ties by cultural payoff', () => {
   const report = buildCultureTurnReportDeltas({
     turn: 9,
@@ -847,6 +925,8 @@ test('buildCultureTurnReportDeltas keeps a no-deadline safe defer fallback stabl
     state: 'none',
     summary: 'Aucun bundle culturel sûr à reporter ce tour.',
     primaryDeferId: null,
+    primaryMissedWindowConsequence: null,
+    missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
     priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
     entries: [],
   });
@@ -981,6 +1061,8 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
           state: 'none',
           summary: 'Aucun bundle culturel sûr à reporter ce tour.',
           primaryDeferId: null,
+          primaryMissedWindowConsequence: null,
+          missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
           priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
           entries: [],
         },

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -180,6 +180,8 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Délai:/);
   assert.match(webAppSource, /Priorité: à revisiter en premier/);
   assert.match(webAppSource, /Payoff:/);
+  assert.match(webAppSource, /Si manqué:/);
+  assert.match(webAppSource, /missedWindowConsequence/);
   assert.match(webAppSource, /deadlineHint/);
   assert.match(webAppSource, /deadlineStatus/);
   assert.match(webAppSource, /revisitPriority/);

--- a/web/app.js
+++ b/web/app.js
@@ -7479,6 +7479,7 @@ function renderCultureTurnReport(report) {
                   ${entry.revisitPriority === 'next' ? '<small>Priorité: à revisiter en premier</small>' : ''}
                   <small>Délai: ${entry.deadlineHint ?? 'fenêtre non calculable'}</small>
                   <small>Payoff: ${entry.payoffScore ?? 0}</small>
+                  ${entry.revisitPriority === 'next' && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   <small>Condition: ${entry.condition}</small>
                   <small>Bascule: ${entry.turningSignal}</small>
                   <small>${entry.riskThreshold}</small>


### PR DESCRIPTION
Gamma: Implements #1458.

Summary:
- adds a compact missed-window consequence for the next prioritized safe-to-defer cultural action
- derives the hint from existing fallout/risk data without changing cultural mechanics
- keeps urgent replacement recommendations separate and higher priority than the defer queue
- preserves a no-data fallback when no prioritized deferred action exists

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test