### PR TITLE
Epsilon: Show climate watch after gap action

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const webAppSource = readFileSync(new URL('../../../web/app.js', import.meta.url), 'utf8');
+const stylesSource = readFileSync(new URL('../../../web/styles.css', import.meta.url), 'utf8');
+
+test('atlas shows one remaining climate watch item after the smallest gap action', () => {
+  assert.match(webAppSource, /function buildAtlasClimatePostGapActionWatch/);
+  assert.match(webAppSource, /function renderAtlasClimatePostGapActionWatch/);
+  assert.match(webAppSource, /Veille après action/);
+  assert.match(webAppSource, /Watch item/);
+  assert.match(webAppSource, /pression seuil/);
+  assert.match(webAppSource, /find\(\(gap\) => gap\.nearestThresholdScore >= 55\)/);
+  assert.match(webAppSource, /filter\(\(gap\) => !gap\.nearest && gap\.label !== gapActionView\.recommendation\.target\)/);
+  assert.match(webAppSource, /seul watch item restant après l’action du gap prioritaire/);
+  assert.match(webAppSource, /renderAtlasClimateNearestCoverageGapAction\(atlasClimateNearestCoverageGapAction\)\}\s*\$\{renderAtlasClimatePostGapActionWatch\(atlasClimatePostGapActionWatch\)\}/);
+
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch--watch/);
+});
+
+test('atlas keeps a quiet fallback when no secondary climate watch is close enough', () => {
+  assert.match(webAppSource, /state: 'quiet'/);
+  assert.match(webAppSource, /Veille calme: aucun second gap climat assez proche du seuil après cette action/);
+  assert.match(webAppSource, /Ne pas créer de liste/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -13781,6 +13781,72 @@ function renderAtlasClimateNearestCoverageGapAction(view) {
   `;
 }
 
+function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresholdProgressView) {
+  if (!coverageView || coverageView.state === 'empty' || !gapActionView?.recommendation || !thresholdProgressView?.progress) {
+    return {
+      state: 'quiet',
+      watchItem: null,
+      summary: 'Veille secondaire climat indisponible après action minimale.',
+    };
+  }
+
+  const progress = thresholdProgressView.progress;
+  const watchGap = (coverageView.blindSpots ?? [])
+    .filter((gap) => !gap.nearest && gap.label !== gapActionView.recommendation.target)
+    .find((gap) => gap.nearestThresholdScore >= 55) ?? null;
+
+  if (!watchGap) {
+    return {
+      state: 'quiet',
+      watchItem: null,
+      summary: 'Veille calme: aucun second gap climat assez proche du seuil après cette action.',
+    };
+  }
+
+  return {
+    state: 'watch',
+    watchItem: {
+      label: watchGap.label,
+      phrase: `${watchGap.label}: pression seuil ${watchGap.nearestThresholdScore}, prochaine vérification ${progress.deadline}.`,
+      thresholdPressure: watchGap.nearestRiskLabel,
+      nextCheck: watchGap.nextAction,
+    },
+    summary: `${watchGap.label}: seul watch item restant après l’action du gap prioritaire.`,
+  };
+}
+
+function renderAtlasClimatePostGapActionWatch(view) {
+  if (state.activeOverlaySlot !== 'climate-overlay' || !view) {
+    return '';
+  }
+
+  if (!view.watchItem) {
+    return `
+      <aside class="map-world-climate-post-gap-watch map-world-climate-post-gap-watch--quiet" aria-label="Veille climat restante après action minimale">
+        <div class="map-world-climate-post-gap-watch__header">
+          <strong>Veille après action</strong>
+          <span>calme</span>
+        </div>
+        <p>${view.summary}</p>
+        <small><b>Fallback</b> · Ne pas créer de liste: relire seulement si un nouveau signal climat apparaît.</small>
+      </aside>
+    `;
+  }
+
+  return `
+    <aside class="map-world-climate-post-gap-watch map-world-climate-post-gap-watch--watch" aria-label="Veille climat restante après action minimale">
+      <div class="map-world-climate-post-gap-watch__header">
+        <strong>Veille après action</strong>
+        <span>${view.watchItem.label}</span>
+      </div>
+      <p>${view.summary}</p>
+      <small><b>Watch item</b> · ${view.watchItem.phrase}</small>
+      <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>
+      <small><b>Prochain check</b> · ${view.watchItem.nextCheck}</small>
+    </aside>
+  `;
+}
+
 function renderAtlasSelectedClimateFollowUpReadinessRecap(view) {
   if (state.activeOverlaySlot !== 'climate-overlay' || view.state === 'empty') {
     return '';
@@ -22062,6 +22128,11 @@ function render() {
     atlasClimateRemainingCoverageGaps,
     atlasClimateThresholdProgressAfterReadinessAction,
   );
+  const atlasClimatePostGapActionWatch = buildAtlasClimatePostGapActionWatch(
+    atlasClimateRemainingCoverageGaps,
+    atlasClimateNearestCoverageGapAction,
+    atlasClimateThresholdProgressAfterReadinessAction,
+  );
   const intrigueExposureSummary = buildMapIntrigueExposureSummary(shell, intrigueView);
 
   document.querySelector('#app').innerHTML = `
@@ -22126,6 +22197,7 @@ function render() {
           ${renderAtlasClimatePreventiveSecondaryProtection(atlasClimatePreventiveSecondaryProtection)}
           ${renderAtlasClimateRemainingCoverageGaps(atlasClimateRemainingCoverageGaps)}
           ${renderAtlasClimateNearestCoverageGapAction(atlasClimateNearestCoverageGapAction)}
+          ${renderAtlasClimatePostGapActionWatch(atlasClimatePostGapActionWatch)}
           ${renderMapIntrigueExposureSummary(intrigueExposureSummary)}
           ${economyView.pulse ? `
             <div class="economy-turn-pulse">

--- a/web/styles.css
+++ b/web/styles.css
@@ -13499,6 +13499,39 @@ button { font: inherit; }
 .map-world-climate-nearest-gap-action--fallback span,
 .map-world-climate-nearest-gap-action--fallback small { color: #e2e8f0; }
 
+.map-world-climate-post-gap-watch {
+  display: grid;
+  gap: 6px;
+  max-width: 66ch;
+  margin-top: 6px;
+  padding: 9px 11px;
+  border-radius: 15px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.84), rgba(8, 47, 73, 0.28));
+  border: 1px solid rgba(125, 211, 252, 0.34);
+}
+.map-world-climate-post-gap-watch--watch { border-color: rgba(251, 191, 36, 0.42); }
+.map-world-climate-post-gap-watch--quiet { border-color: rgba(148, 163, 184, 0.28); }
+.map-world-climate-post-gap-watch__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.map-world-climate-post-gap-watch p,
+.map-world-climate-post-gap-watch span,
+.map-world-climate-post-gap-watch small {
+  color: #e0f2fe;
+  font-size: 12px;
+  line-height: 1.35;
+  margin: 0;
+}
+.map-world-climate-post-gap-watch--watch p,
+.map-world-climate-post-gap-watch--watch span,
+.map-world-climate-post-gap-watch--watch small { color: #fef3c7; }
+.map-world-climate-post-gap-watch--quiet p,
+.map-world-climate-post-gap-watch--quiet span,
+.map-world-climate-post-gap-watch--quiet small { color: #cbd5e1; }
+
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);
   box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.12);


### PR DESCRIPTION
Epsilon: PR prête pour #1460.

## Résumé
- Ajoute une veille compacte après l’action minimale du gap climat prioritaire.
- Affiche au plus un second gap proche du seuil avec pression, prochain check et phrase courte.
- Garde un état calme/fallback quand aucun second watch item n’est assez proche ou que les données manquent.

## Tests
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js test/ui/climate/webAtlasClimateNearestCoverageGapAction.test.js test/ui/climate/webAtlasClimateRemainingCoverageGaps.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?