### PR TITLE
Epsilon: Show climate watch promotion condition

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -11,6 +11,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /Veille après action/);
   assert.match(webAppSource, /Watch item/);
   assert.match(webAppSource, /pression seuil/);
+  assert.match(webAppSource, /promotionCondition/);
+  assert.match(webAppSource, /Devient primaire/);
+  assert.match(webAppSource, /devient action primaire si la pression reste ≥80 au prochain check/);
+  assert.match(webAppSource, /devient action primaire si \$\{progress\.deadline\} confirme \$\{watchGap\.nearestRiskLabel\}/);
   assert.match(webAppSource, /find\(\(gap\) => gap\.nearestThresholdScore >= 55\)/);
   assert.match(webAppSource, /filter\(\(gap\) => !gap\.nearest && gap\.label !== gapActionView\.recommendation\.target\)/);
   assert.match(webAppSource, /seul watch item restant après l’action du gap prioritaire/);
@@ -22,6 +26,7 @@ test('atlas shows one remaining climate watch item after the smallest gap action
 
 test('atlas keeps a quiet fallback when no secondary climate watch is close enough', () => {
   assert.match(webAppSource, /state: 'quiet'/);
+  assert.match(webAppSource, /Veille secondaire climat indisponible après action minimale/);
   assert.match(webAppSource, /Veille calme: aucun second gap climat assez proche du seuil après cette action/);
   assert.match(webAppSource, /Ne pas créer de liste/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch--quiet/);

--- a/web/app.js
+++ b/web/app.js
@@ -13804,6 +13804,10 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
     };
   }
 
+  const promotionCondition = watchGap.nearestThresholdScore >= 80
+    ? `devient action primaire si la pression reste ≥80 au prochain check ${progress.deadline}`
+    : `devient action primaire si ${progress.deadline} confirme ${watchGap.nearestRiskLabel}`;
+
   return {
     state: 'watch',
     watchItem: {
@@ -13811,6 +13815,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       phrase: `${watchGap.label}: pression seuil ${watchGap.nearestThresholdScore}, prochaine vérification ${progress.deadline}.`,
       thresholdPressure: watchGap.nearestRiskLabel,
       nextCheck: watchGap.nextAction,
+      promotionCondition,
     },
     summary: `${watchGap.label}: seul watch item restant après l’action du gap prioritaire.`,
   };
@@ -13842,6 +13847,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       </div>
       <p>${view.summary}</p>
       <small><b>Watch item</b> · ${view.watchItem.phrase}</small>
+      <small><b>Devient primaire</b> · ${view.watchItem.promotionCondition}</small>
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>
       <small><b>Prochain check</b> · ${view.watchItem.nextCheck}</small>
     </aside>


### PR DESCRIPTION
Epsilon: PR prête pour #1470.

## Résumé
- Ajoute la condition compacte qui transforme le watch item climat en prochaine action primaire.
- Utilise la pression de seuil et le prochain check existants sans créer de file classée complète.
- Conserve l’état calme/fallback quand aucun watch item ou aucune condition sûre n’est disponible.

## Tests
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js test/ui/climate/webAtlasClimateNearestCoverageGapAction.test.js test/ui/climate/webAtlasClimateRemainingCoverageGaps.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?