### PR TITLE
Beta: Show adjacent spillover guard sequencing

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -848,6 +848,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       dependencyTrace: 'Dépendance inconnue: aucun levier local ne permet de tracer la source du spillover.',
       guardAction: { label: 'Garde indisponible', reason: 'Aucune chaîne de spillover à réduire pour l’instant.', fallback: true },
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: aucune garde concrète à classer.' },
+      guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Capacité de garde indisponible sans récupération locale.' },
     };
   }
 
@@ -892,6 +893,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       dependencyTrace: 'Dépendance inconnue: aucune route voisine exposée ne confirme la chaîne source → route affectée → conséquence.',
       guardAction: { label: 'Garde indisponible', reason: 'Aucun relais voisin confirmé; surveiller la route après résolution locale.', fallback: true },
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: coût de garde non comparable sans route exposée.' },
+      guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Aucune route exposée ne permet de comparer la capacité de garde.' },
     };
   }
 
@@ -933,6 +935,23 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         candidates: [],
         summary: 'Comparaison impossible: coût de garde non comparable avec les signaux actuels.',
       };
+  const guardSequencing = guardAction.fallback
+    ? {
+      state: 'unknown',
+      phrase: 'enchaînement inconnu',
+      reason: 'Capacité de garde indisponible avec les signaux actuels.',
+    }
+    : guardComparison.state === 'single' && guardAction.route === criticalRoute.route && criticalRoute.resource === priorityAction.resource
+      ? {
+        state: 'competing',
+        phrase: 'choisir la garde au lieu de la récupération ce tour',
+        reason: `${guardAction.route} partage ${priorityAction.resource} avec ${priorityAction.route}; la capacité ne couvre pas les deux sans délai.`,
+      }
+      : {
+        state: 'chainable',
+        phrase: 'enchaîner après la récupération',
+        reason: `${guardAction.route} reste assez léger pour suivre ${priorityAction.route} sans remplacer l’action locale.`,
+      };
 
   return {
     state: secondaryRoutes.length > 0 ? 'chain' : 'single',
@@ -942,6 +961,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
     dependencyTrace: `${source} → ${criticalRoute.route}/${criticalRoute.city} → ${consequence}`,
     guardAction,
     guardComparison,
+    guardSequencing,
   };
 }
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -126,6 +126,9 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.guardComparison.summary, /moins disruptif|Une seule garde/);
   assert.ok(preview.adjacentRouteSpilloverRisk.guardComparison.candidates.length >= 1);
   assert.match(preview.adjacentRouteSpilloverRisk.guardComparison.candidates[0].tradeoff, /protégée vs .*capacité/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardSequencing.state, 'competing');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.phrase, /choisir la garde au lieu de la récupération/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.reason, /partage|capacité/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -172,6 +175,28 @@ test('buildProvinceLogisticsChoicePreview exposes readable cost delay risk and i
   assert.ok(preview.priorityActions.some((action) => action.downstreamStatus === 'aggravée' || action.shortagesAvoided >= 0));
 });
 
+
+test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainable when capacity can follow', () => {
+  const economyView = buildEconomyView();
+  economyView.overlay.routes[0] = {
+    ...economyView.overlay.routes[0],
+    riskLevel: 82,
+    totalCapacity: 9,
+    resources: [{ resourceId: 'tools', capacity: 2 }],
+  };
+  economyView.comparison.rows = economyView.comparison.rows.map((row) => (
+    row.cityId === 'iron-city' || row.cityId === 'hill-city' ? { ...row, tensionLevel: 'medium' } : row
+  ));
+  const preview = buildProvinceLogisticsChoicePreview(province, economyView, {
+    resourceLabelById: { grain: 'Grain', tools: 'Outils' },
+  });
+
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardComparison.state, 'compare');
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardSequencing.state, 'chainable');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.phrase, /enchaîner après la récupération/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.reason, /sans remplacer l’action locale/);
+});
+
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
   const preview = buildProvinceLogisticsChoicePreview({ provinceId: 'isolated' }, buildEconomyView());
 
@@ -204,6 +229,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.adjacentRouteSpilloverRisk.guardAction.reason, /Aucune chaîne de spillover/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardComparison.state, 'fallback');
   assert.match(preview.adjacentRouteSpilloverRisk.guardComparison.summary, /Comparaison impossible/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardSequencing.state, 'unknown');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.phrase, /enchaînement inconnu/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -101,6 +101,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /guardAction/);
   assert.match(webAppSource, /Comparaison garde:/);
   assert.match(webAppSource, /guardComparison/);
+  assert.match(webAppSource, /Séquence:/);
+  assert.match(webAppSource, /guardSequencing/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -8368,6 +8368,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               <em>Dépendance: ${preview.adjacentRouteSpilloverRisk.dependencyTrace}</em>
               <small>Garde: ${preview.adjacentRouteSpilloverRisk.guardAction.label} — ${preview.adjacentRouteSpilloverRisk.guardAction.reason}</small>
               ${preview.adjacentRouteSpilloverRisk.guardComparison ? `<small>Comparaison garde: ${preview.adjacentRouteSpilloverRisk.guardComparison.summary}</small>` : ''}
+              ${preview.adjacentRouteSpilloverRisk.guardSequencing ? `<small>Séquence: ${preview.adjacentRouteSpilloverRisk.guardSequencing.phrase} — ${preview.adjacentRouteSpilloverRisk.guardSequencing.reason}</small>` : ''}
             </div>
           ` : ''}
         </div>


### PR DESCRIPTION
Beta: Implements #1467.

Summary:
- Adds guard sequencing metadata to adjacent logistics spillover risk.
- Indicates whether the recommended guard can chain after the current recovery, competes for the same capacity this turn, or is unknown.
- Keeps existing single-guard/comparison/fallback behavior intact.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
