### PR TITLE
Gamma: Suggest minimal cultural defer support

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1326,6 +1326,10 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
           ? 1
           : 0;
       const payoffScore = group?.unlockScore ?? 0;
+      const currentSupport = (group?.details ?? []).find((detail) => detail.source === 'current') ?? null;
+      const minimalRevisitAction = currentSupport
+        ? `confirmer ${currentSupport.promptLabel}`
+        : null;
 
       return {
         deferId: `${prompt.cleanupId}:safe-to-defer`,
@@ -1344,6 +1348,7 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
         priorityReason: deadlinePressure > 0
           ? `${deadlineHint}; payoff ${payoffScore}`
           : `fenêtre non calculable; payoff ${payoffScore}`,
+        minimalRevisitAction,
         nextReviewWindow,
         falloutSeverity: fallout?.severity ?? 0,
       };
@@ -1368,6 +1373,16 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
         ? missedFallout.consequence
         : `${candidate.clusterLabel}: ${candidate.riskThreshold}`)
       : null;
+    const minimalSafeAction = revisitPriority === 'next' ? candidate.minimalRevisitAction : null;
+    const preventedConsequence = minimalSafeAction && missedWindowConsequence
+      ? (missedFallout?.consequenceType === 'consolidation-delay'
+        ? 'évite une consolidation retardée'
+        : missedFallout?.consequenceType === 'tension'
+          ? 'évite de maintenir la tension culturelle'
+          : missedFallout?.consequenceType === 'opportunity-lost'
+            ? 'évite de masquer l’opportunité fraîche'
+            : 'évite de franchir le seuil de risque')
+      : null;
 
     return {
       ...candidate,
@@ -1380,12 +1395,15 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
       missedWindowSeverity: revisitPriority === 'next'
         ? missedFallout?.severity ?? candidate.deadlinePressure
         : 0,
+      minimalSafeAction,
+      preventedConsequence,
     };
   });
   const top = rankedCandidates[0] ?? null;
   const primaryMissedWindowConsequence = top?.revisitPriority === 'next'
     ? top.missedWindowConsequence
     : null;
+  const primaryMinimalSafeAction = top?.minimalSafeAction ?? null;
 
   return {
     state: rankedCandidates.length === 0 ? 'none' : 'ready',
@@ -1394,6 +1412,10 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
       : 'Aucun bundle culturel sûr à reporter ce tour.',
     primaryDeferId: rankedCandidates.length > 1 ? top?.deferId ?? null : null,
     primaryMissedWindowConsequence,
+    primaryMinimalSafeAction,
+    minimalSafeActionFallback: primaryMinimalSafeAction
+      ? 'Action minimale calculée depuis le suivi courant du bundle reporté.'
+      : 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
     missedWindowFallback: primaryMissedWindowConsequence
       ? 'Conséquence calculée depuis le fallout/payoff existant du bundle reporté.'
       : 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
@@ -1804,6 +1826,8 @@ export function buildCultureTurnReportDeltas({
             summary: 'Aucun bundle culturel sûr à reporter ce tour.',
             primaryDeferId: null,
             primaryMissedWindowConsequence: null,
+            primaryMinimalSafeAction: null,
+            minimalSafeActionFallback: 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
             missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
             priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
             entries: [],

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -478,6 +478,8 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
         summary: 'Aucun bundle culturel sûr à reporter ce tour.',
         primaryDeferId: null,
         primaryMissedWindowConsequence: null,
+        primaryMinimalSafeAction: null,
+        minimalSafeActionFallback: 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
         missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
         priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
         entries: [],
@@ -817,13 +819,17 @@ test('buildCultureTurnReportDeltas shows the consequence of missing the next def
 
   const safeToDefer = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles;
   assert.equal(safeToDefer.primaryMissedWindowConsequence, 'Compact d’Aurora: consolidation retardée d’un tour si le bundle n’est pas réévalué.');
+  assert.equal(safeToDefer.primaryMinimalSafeAction, 'confirmer Ouvrir le récit d’expansion');
   assert.equal(safeToDefer.missedWindowFallback, 'Conséquence calculée depuis le fallout/payoff existant du bundle reporté.');
+  assert.equal(safeToDefer.minimalSafeActionFallback, 'Action minimale calculée depuis le suivi courant du bundle reporté.');
   assert.deepEqual(safeToDefer.entries.map((entry) => [
     entry.clusterLabel,
     entry.revisitPriority,
     entry.missedWindowConsequence,
     entry.missedWindowConsequenceType,
     entry.missedWindowSeverity,
+    entry.minimalSafeAction,
+    entry.preventedConsequence,
   ]), [
     [
       'Compact d’Aurora',
@@ -831,8 +837,10 @@ test('buildCultureTurnReportDeltas shows the consequence of missing the next def
       'Compact d’Aurora: consolidation retardée d’un tour si le bundle n’est pas réévalué.',
       'consolidation-delay',
       1,
+      'confirmer Ouvrir le récit d’expansion',
+      'évite une consolidation retardée',
     ],
-    ['Harbor Compact', 'later', null, null, 0],
+    ['Harbor Compact', 'later', null, null, 0, null, null],
   ]);
 });
 
@@ -926,6 +934,8 @@ test('buildCultureTurnReportDeltas keeps a no-deadline safe defer fallback stabl
     summary: 'Aucun bundle culturel sûr à reporter ce tour.',
     primaryDeferId: null,
     primaryMissedWindowConsequence: null,
+    primaryMinimalSafeAction: null,
+    minimalSafeActionFallback: 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
     missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
     priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
     entries: [],
@@ -1062,6 +1072,8 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
           summary: 'Aucun bundle culturel sûr à reporter ce tour.',
           primaryDeferId: null,
           primaryMissedWindowConsequence: null,
+          primaryMinimalSafeAction: null,
+          minimalSafeActionFallback: 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
           missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
           priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
           entries: [],

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -181,7 +181,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Priorité: à revisiter en premier/);
   assert.match(webAppSource, /Payoff:/);
   assert.match(webAppSource, /Si manqué:/);
+  assert.match(webAppSource, /Action minimale:/);
   assert.match(webAppSource, /missedWindowConsequence/);
+  assert.match(webAppSource, /minimalSafeAction/);
+  assert.match(webAppSource, /preventedConsequence/);
   assert.match(webAppSource, /deadlineHint/);
   assert.match(webAppSource, /deadlineStatus/);
   assert.match(webAppSource, /revisitPriority/);

--- a/web/app.js
+++ b/web/app.js
@@ -7551,6 +7551,7 @@ function renderCultureTurnReport(report) {
                   <small>Délai: ${entry.deadlineHint ?? 'fenêtre non calculable'}</small>
                   <small>Payoff: ${entry.payoffScore ?? 0}</small>
                   ${entry.revisitPriority === 'next' && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
                   <small>Condition: ${entry.condition}</small>
                   <small>Bascule: ${entry.turningSignal}</small>
                   <small>${entry.riskThreshold}</small>


### PR DESCRIPTION
Gamma: Implements #1468.

Summary:
- surfaces the smallest support/revisit action for the prioritized deferred cultural action when current follow-up data exists
- explains which missed-window consequence the minimal action prevents
- keeps urgent replacement recommendations separate and higher priority than the defer-support hint
- preserves explicit no-action fallback behavior when no minimal safe action is known

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test