### PR TITLE
Beta: Show spillover guard opportunity cost

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -849,6 +849,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       guardAction: { label: 'Garde indisponible', reason: 'Aucune chaîne de spillover à réduire pour l’instant.', fallback: true },
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: aucune garde concrète à classer.' },
       guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Capacité de garde indisponible sans récupération locale.' },
+      guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune chaîne de garde à prolonger.', stopChain: false },
     };
   }
 
@@ -894,6 +895,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       guardAction: { label: 'Garde indisponible', reason: 'Aucun relais voisin confirmé; surveiller la route après résolution locale.', fallback: true },
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: coût de garde non comparable sans route exposée.' },
       guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Aucune route exposée ne permet de comparer la capacité de garde.' },
+      guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune route adjacente exposée à comparer.', stopChain: false },
     };
   }
 
@@ -952,6 +954,41 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         phrase: 'enchaîner après la récupération',
         reason: `${guardAction.route} reste assez léger pour suivre ${priorityAction.route} sans remplacer l’action locale.`,
       };
+  const nextGuardCost = guardComparison.candidates.find((candidate) => candidate.route !== guardAction.route) ?? null;
+  const guardOpportunityCost = guardSequencing.state === 'chainable' && nextGuardCost
+    ? {
+      state: nextGuardCost.disruption > guardAction.disruption ? 'stop' : 'continue',
+      protectedRoute: guardAction.route,
+      delayedRoute: nextGuardCost.route,
+      summary: `Protège ${guardAction.route}, retarde ${nextGuardCost.route}.`,
+      stopChain: nextGuardCost.disruption > guardAction.disruption,
+      stopReason: nextGuardCost.disruption > guardAction.disruption
+        ? `Arrêter la chaîne après ${guardAction.route}: ${nextGuardCost.route} consommerait plus de capacité que le bénéfice attendu.`
+        : `La chaîne peut continuer vers ${nextGuardCost.route} sans surcoût dominant.`,
+    }
+    : guardSequencing.state === 'chainable'
+      ? {
+        state: 'single',
+        protectedRoute: guardAction.route,
+        delayedRoute: priorityAction.route,
+        summary: `Protège ${guardAction.route}, surveille ${priorityAction.route}.`,
+        stopChain: false,
+        stopReason: 'Aucune deuxième garde adjacente ne justifie d’arrêter la chaîne.',
+      }
+      : guardSequencing.state === 'competing'
+        ? {
+          state: 'competing',
+          protectedRoute: guardAction.route,
+          delayedRoute: priorityAction.route,
+          summary: `Protège ${guardAction.route}, retarde ${priorityAction.route}.`,
+          stopChain: true,
+          stopReason: `Ne pas prolonger: la garde remplace déjà la récupération sur ${priorityAction.route} ce tour.`,
+        }
+        : {
+          state: 'fallback',
+          summary: 'Coût d’opportunité indisponible: enchaînement de garde non comparable.',
+          stopChain: false,
+        };
 
   return {
     state: secondaryRoutes.length > 0 ? 'chain' : 'single',
@@ -962,6 +999,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
     guardAction,
     guardComparison,
     guardSequencing,
+    guardOpportunityCost,
   };
 }
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -129,6 +129,10 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.adjacentRouteSpilloverRisk.guardSequencing.state, 'competing');
   assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.phrase, /choisir la garde au lieu de la récupération/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.reason, /partage|capacité/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.state, 'competing');
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopChain, true);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.summary, /Protège .*retarde/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopReason, /Ne pas prolonger|remplace déjà/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -195,6 +199,10 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.equal(preview.adjacentRouteSpilloverRisk.guardSequencing.state, 'chainable');
   assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.phrase, /enchaîner après la récupération/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.reason, /sans remplacer l’action locale/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.state, 'stop');
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopChain, true);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.summary, /Protège .*retarde/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopReason, /Arrêter la chaîne|consommerait plus de capacité/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
@@ -231,6 +239,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.adjacentRouteSpilloverRisk.guardComparison.summary, /Comparaison impossible/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardSequencing.state, 'unknown');
   assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.phrase, /enchaînement inconnu/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.state, 'fallback');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.summary, /Coût d’opportunité indisponible/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -103,6 +103,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /guardComparison/);
   assert.match(webAppSource, /Séquence:/);
   assert.match(webAppSource, /guardSequencing/);
+  assert.match(webAppSource, /Coût opportunité:/);
+  assert.match(webAppSource, /guardOpportunityCost/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);
   assert.match(webAppSource, /Engager récupération/);

--- a/web/app.js
+++ b/web/app.js
@@ -8441,6 +8441,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               <small>Garde: ${preview.adjacentRouteSpilloverRisk.guardAction.label} — ${preview.adjacentRouteSpilloverRisk.guardAction.reason}</small>
               ${preview.adjacentRouteSpilloverRisk.guardComparison ? `<small>Comparaison garde: ${preview.adjacentRouteSpilloverRisk.guardComparison.summary}</small>` : ''}
               ${preview.adjacentRouteSpilloverRisk.guardSequencing ? `<small>Séquence: ${preview.adjacentRouteSpilloverRisk.guardSequencing.phrase} — ${preview.adjacentRouteSpilloverRisk.guardSequencing.reason}</small>` : ''}
+              ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost ? `<small>Coût opportunité: ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.summary} ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopChain ? `Stop: ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopReason}` : preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopReason ?? ''}</small>` : ''}
             </div>
           ` : ''}
         </div>


### PR DESCRIPTION
Beta: Implements #1477.

Summary:
- Adds opportunity-cost metadata for adjacent spillover guard chains.
- Shows the compact tradeoff as protected route vs delayed route.
- Flags when to stop extending a guard chain because the next guard would cost more capacity than the expected benefit, with fallback text when not comparable.

Tests:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check web/app.js
- git diff --check
- npm test
