### PR TITLE
Gamma: Show cultural minimal action threshold

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1383,6 +1383,18 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
             ? 'évite de masquer l’opportunité fraîche'
             : 'évite de franchir le seuil de risque')
       : null;
+    const minimalActionAcceptableUntil = minimalSafeAction ? candidate.nextReviewWindow : null;
+    const recommendedAction = minimalSafeAction
+      ? `revoir ${candidate.clusterLabel} avant ${candidate.nextReviewWindow}`
+      : null;
+    const lateRiskyAction = minimalSafeAction
+      ? `agir après ${candidate.nextReviewWindow} avec ${candidate.turningSignal}`
+      : null;
+    const minimalActionThresholdReason = minimalSafeAction
+      ? (candidate.deadlineStatus === 'near-deadline'
+        ? `${candidate.deadlineHint}: la petite action cesse de suffire si ${candidate.turningSignal}.`
+        : `payoff ${candidate.payoffScore}: la petite action reste seulement valable jusqu’à la ${candidate.nextReviewWindow}.`)
+      : null;
 
     return {
       ...candidate,
@@ -1397,6 +1409,10 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
         : 0,
       minimalSafeAction,
       preventedConsequence,
+      minimalActionAcceptableUntil,
+      recommendedAction,
+      lateRiskyAction,
+      minimalActionThresholdReason,
     };
   });
   const top = rankedCandidates[0] ?? null;
@@ -1404,6 +1420,7 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
     ? top.missedWindowConsequence
     : null;
   const primaryMinimalSafeAction = top?.minimalSafeAction ?? null;
+  const primaryMinimalActionThreshold = top?.minimalActionAcceptableUntil ?? null;
 
   return {
     state: rankedCandidates.length === 0 ? 'none' : 'ready',
@@ -1413,6 +1430,7 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
     primaryDeferId: rankedCandidates.length > 1 ? top?.deferId ?? null : null,
     primaryMissedWindowConsequence,
     primaryMinimalSafeAction,
+    primaryMinimalActionThreshold,
     minimalSafeActionFallback: primaryMinimalSafeAction
       ? 'Action minimale calculée depuis le suivi courant du bundle reporté.'
       : 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
@@ -1827,6 +1845,7 @@ export function buildCultureTurnReportDeltas({
             primaryDeferId: null,
             primaryMissedWindowConsequence: null,
             primaryMinimalSafeAction: null,
+            primaryMinimalActionThreshold: null,
             minimalSafeActionFallback: 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
             missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
             priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -479,6 +479,7 @@ test('buildCultureTurnReportDeltas summarizes selected culture event, research, 
         primaryDeferId: null,
         primaryMissedWindowConsequence: null,
         primaryMinimalSafeAction: null,
+        primaryMinimalActionThreshold: null,
         minimalSafeActionFallback: 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
         missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
         priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
@@ -820,6 +821,7 @@ test('buildCultureTurnReportDeltas shows the consequence of missing the next def
   const safeToDefer = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles;
   assert.equal(safeToDefer.primaryMissedWindowConsequence, 'Compact d’Aurora: consolidation retardée d’un tour si le bundle n’est pas réévalué.');
   assert.equal(safeToDefer.primaryMinimalSafeAction, 'confirmer Ouvrir le récit d’expansion');
+  assert.equal(safeToDefer.primaryMinimalActionThreshold, 'prochaine rotation culturelle');
   assert.equal(safeToDefer.missedWindowFallback, 'Conséquence calculée depuis le fallout/payoff existant du bundle reporté.');
   assert.equal(safeToDefer.minimalSafeActionFallback, 'Action minimale calculée depuis le suivi courant du bundle reporté.');
   assert.deepEqual(safeToDefer.entries.map((entry) => [
@@ -830,6 +832,10 @@ test('buildCultureTurnReportDeltas shows the consequence of missing the next def
     entry.missedWindowSeverity,
     entry.minimalSafeAction,
     entry.preventedConsequence,
+    entry.minimalActionAcceptableUntil,
+    entry.recommendedAction,
+    entry.lateRiskyAction,
+    entry.minimalActionThresholdReason,
   ]), [
     [
       'Compact d’Aurora',
@@ -839,8 +845,12 @@ test('buildCultureTurnReportDeltas shows the consequence of missing the next def
       1,
       'confirmer Ouvrir le récit d’expansion',
       'évite une consolidation retardée',
+      'prochaine rotation culturelle',
+      'revoir Compact d’Aurora avant prochaine rotation culturelle',
+      'agir après prochaine rotation culturelle avec perte du soutien actif',
+      'à revoir dès le prochain tour: la petite action cesse de suffire si perte du soutien actif.',
     ],
-    ['Harbor Compact', 'later', null, null, 0, null, null],
+    ['Harbor Compact', 'later', null, null, 0, null, null, null, null, null, null],
   ]);
 });
 
@@ -935,6 +945,7 @@ test('buildCultureTurnReportDeltas keeps a no-deadline safe defer fallback stabl
     primaryDeferId: null,
     primaryMissedWindowConsequence: null,
     primaryMinimalSafeAction: null,
+    primaryMinimalActionThreshold: null,
     minimalSafeActionFallback: 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
     missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
     priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
@@ -1073,6 +1084,7 @@ test('buildCultureTurnReportDeltas returns compact quiet state without culture s
           primaryDeferId: null,
           primaryMissedWindowConsequence: null,
           primaryMinimalSafeAction: null,
+          primaryMinimalActionThreshold: null,
           minimalSafeActionFallback: 'Fallback: aucune action minimale sûre connue pour conserver ce report.',
           missedWindowFallback: 'Fallback: aucune conséquence de fenêtre manquée à afficher sans action reportée prioritaire.',
           priorityFallback: 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -182,9 +182,16 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Payoff:/);
   assert.match(webAppSource, /Si manqué:/);
   assert.match(webAppSource, /Action minimale:/);
+  assert.match(webAppSource, /Seuil:/);
+  assert.match(webAppSource, /tardif risqué:/);
+  assert.match(webAppSource, /Pourquoi:/);
   assert.match(webAppSource, /missedWindowConsequence/);
   assert.match(webAppSource, /minimalSafeAction/);
   assert.match(webAppSource, /preventedConsequence/);
+  assert.match(webAppSource, /minimalActionAcceptableUntil/);
+  assert.match(webAppSource, /recommendedAction/);
+  assert.match(webAppSource, /lateRiskyAction/);
+  assert.match(webAppSource, /minimalActionThresholdReason/);
   assert.match(webAppSource, /deadlineHint/);
   assert.match(webAppSource, /deadlineStatus/);
   assert.match(webAppSource, /revisitPriority/);

--- a/web/app.js
+++ b/web/app.js
@@ -7552,6 +7552,8 @@ function renderCultureTurnReport(report) {
                   <small>Payoff: ${entry.payoffScore ?? 0}</small>
                   ${entry.revisitPriority === 'next' && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.minimalActionAcceptableUntil ? `<small>Seuil: minimale jusqu’à ${entry.minimalActionAcceptableUntil}; recommandé: ${entry.recommendedAction}; tardif risqué: ${entry.lateRiskyAction}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.minimalActionThresholdReason ? `<small>Pourquoi: ${entry.minimalActionThresholdReason}</small>` : ''}
                   <small>Condition: ${entry.condition}</small>
                   <small>Bascule: ${entry.turningSignal}</small>
                   <small>${entry.riskThreshold}</small>


### PR DESCRIPTION
Gamma: Implements #1478.

Summary:
- shows the next threshold where a minimal deferred-cultural action stops being enough
- contrasts minimal, recommended, and late-risky actions for the prioritized deferred revisit
- adds a short deadline/payoff reason without duplicating prior defer priority or missed-window hints
- preserves explicit no-data fallback behavior

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test