### PR TITLE
Alpha: Suggest blocked follow-up alternatives

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -293,3 +293,27 @@ test('atlas military shows conflicts for residual front follow-up orders', () =>
   assert.match(stylesSource, /\.atlas-military-neighbor-residual-follow-up-conflict--reserved/);
   assert.match(stylesSource, /\.atlas-military-neighbor-residual-follow-up-conflict--safe/);
 });
+
+// MAP-A33: when a residual front follow-up is blocked, suggest a compact
+// alternative or explicitly say none is safe this turn.
+test('atlas military suggests alternatives when residual front follow-up is blocked', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryBlockedResidualFollowUpAlternative\(followUp, conflict, recommendation, checklist\)/);
+  assert.match(webAppSource, /function getAtlasMilitaryBlockedFollowUpAlternativeReason\(option, checklistItem\)/);
+  assert.match(webAppSource, /function renderAtlasMilitaryBlockedResidualFollowUpAlternative\(alternative, y\)/);
+  assert.match(webAppSource, /Alternative après suivi résiduel bloqué/);
+  assert.match(webAppSource, /Alternative: \$\{candidate\.provinceLabel\}/);
+  assert.match(webAppSource, /ordre principal \$\{recommendation\?\.primary\?\.provinceLabel \?\? 'indécis'\} · suivi bloqué \$\{followUp\.provinceLabel\}/);
+  assert.match(webAppSource, /Aucune alternative sûre ce tour/);
+  assert.match(webAppSource, /attendre résolution du conflit/);
+  assert.match(webAppSource, /return 'coût'/);
+  assert.match(webAppSource, /return 'dépendance'/);
+  assert.match(webAppSource, /return 'sécurité'/);
+  assert.match(webAppSource, /return 'urgence'/);
+  assert.match(webAppSource, /conflict\.tone === 'safe'/);
+  assert.match(webAppSource, /blockedFollowUpAlternative: buildAtlasMilitaryBlockedResidualFollowUpAlternative/);
+  assert.match(webAppSource, /renderAtlasMilitaryBlockedResidualFollowUpAlternative\(preview\.blockedFollowUpAlternative, alternativeY\)/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt__label/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt--blocked/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt--dependency/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt--safe/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2690,6 +2690,53 @@ function buildAtlasMilitaryNeighborResidualFollowUpConflict(followUp, recommenda
   };
 }
 
+function getAtlasMilitaryBlockedFollowUpAlternativeReason(option, checklistItem) {
+  if (option?.blockerType === 'logistics' || checklistItem?.blockerBadge?.type === 'logistics') return 'coût';
+  if (option?.blockerType === 'intel' || checklistItem?.blockerBadge?.type === 'intel') return 'dépendance';
+  if (option?.blockerType === 'climate' || checklistItem?.blockerBadge?.type === 'climate') return 'sécurité';
+  if ((option?.score ?? 0) >= 40 || checklistItem?.priority >= 40) return 'urgence';
+  return 'sécurité';
+}
+
+function buildAtlasMilitaryBlockedResidualFollowUpAlternative(followUp, conflict, recommendation, checklist) {
+  if (!followUp?.visible || !conflict?.visible || conflict.tone === 'safe') {
+    return {
+      visible: false,
+      tone: 'quiet',
+      label: 'Alternative non requise',
+      detail: 'suivi non bloqué ou absent',
+      reason: 'aucun blocage',
+    };
+  }
+
+  const candidate = (recommendation?.options ?? [])
+    .filter((option) => option.provinceLabel !== followUp.provinceLabel)
+    .sort((left, right) => right.score - left.score || left.provinceLabel.localeCompare(right.provinceLabel))[0] ?? null;
+  const checklistItem = (checklist?.items ?? []).find((item) => item.provinceLabel === candidate?.provinceLabel) ?? null;
+
+  if (!candidate) {
+    return {
+      visible: true,
+      tone: 'blocked',
+      label: 'Aucune alternative sûre ce tour',
+      detail: `ordre principal ${recommendation?.primary?.provinceLabel ?? 'indécis'} · suivi bloqué ${followUp.provinceLabel}`,
+      reason: 'dépendance',
+      action: 'attendre résolution du conflit',
+    };
+  }
+
+  const reason = getAtlasMilitaryBlockedFollowUpAlternativeReason(candidate, checklistItem);
+  return {
+    visible: true,
+    tone: reason === 'urgence' ? 'urgent' : reason === 'coût' ? 'cost' : reason === 'dépendance' ? 'dependency' : 'safe',
+    provinceLabel: candidate.provinceLabel,
+    label: `Alternative: ${candidate.provinceLabel}`,
+    detail: `ordre principal ${recommendation?.primary?.provinceLabel ?? 'indécis'} · suivi bloqué ${followUp.provinceLabel}`,
+    reason,
+    action: candidate.nextAction,
+  };
+}
+
 function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, features) {
   const focus = recommendation?.primary ?? null;
   const focusProvince = focus?.provinceLabel ?? checklist?.points?.[0]?.detail?.split(':')?.[0] ?? null;
@@ -2707,6 +2754,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       sharedResidualRisk: buildAtlasMilitaryNeighborSharedResidualRisk(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])), buildAtlasMilitaryNeighborSharedHandlingHint(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])))),
       residualFollowUpOrder: buildAtlasMilitaryNeighborResidualFollowUpOrder(buildAtlasMilitaryNeighborSharedResidualRisk(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])), buildAtlasMilitaryNeighborSharedHandlingHint(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])))), buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), []))),
       residualFollowUpConflict: buildAtlasMilitaryNeighborResidualFollowUpConflict(null, recommendation, checklist),
+      blockedFollowUpAlternative: buildAtlasMilitaryBlockedResidualFollowUpAlternative(null, buildAtlasMilitaryNeighborResidualFollowUpConflict(null, recommendation, checklist), recommendation, checklist),
       summary: 'Prévision voisins indisponible: aucun ordre de province en focus.',
       empty: true,
     };
@@ -2740,6 +2788,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
   const sharedResidualRisk = buildAtlasMilitaryNeighborSharedResidualRisk(urgencyCluster, sharedHandlingHint);
   const residualFollowUpOrder = buildAtlasMilitaryNeighborResidualFollowUpOrder(sharedResidualRisk, urgencyCluster);
   const residualFollowUpConflict = buildAtlasMilitaryNeighborResidualFollowUpConflict(residualFollowUpOrder, recommendation, checklist);
+  const blockedFollowUpAlternative = buildAtlasMilitaryBlockedResidualFollowUpAlternative(residualFollowUpOrder, residualFollowUpConflict, recommendation, checklist);
 
   if (!shifts.length) {
     return {
@@ -2755,6 +2804,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       sharedResidualRisk,
       residualFollowUpOrder,
       residualFollowUpConflict,
+      blockedFollowUpAlternative,
       summary: `${focusProvince}: aucun front voisin lisible après engagement.`,
       empty: true,
     };
@@ -2773,7 +2823,8 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
     sharedResidualRisk,
     residualFollowUpOrder,
     residualFollowUpConflict,
-    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}; ${reviewStaleness.label}; ${reviewChange.label}${urgencyCluster.visible ? `; ${urgencyCluster.label}; ${sharedHandlingHint.label}${sharedResidualRisk.visible ? `; ${sharedResidualRisk.label}${residualFollowUpOrder.visible ? `; ${residualFollowUpOrder.label}; ${residualFollowUpConflict.label}` : ''}` : ''}` : contestedPriority.visible ? `; ${contestedPriority.label}` : ''}.`,
+    blockedFollowUpAlternative,
+    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}; ${reviewStaleness.label}; ${reviewChange.label}${urgencyCluster.visible ? `; ${urgencyCluster.label}; ${sharedHandlingHint.label}${sharedResidualRisk.visible ? `; ${sharedResidualRisk.label}${residualFollowUpOrder.visible ? `; ${residualFollowUpOrder.label}; ${residualFollowUpConflict.label}${blockedFollowUpAlternative.visible ? `; ${blockedFollowUpAlternative.label}` : ''}` : ''}` : ''}` : contestedPriority.visible ? `; ${contestedPriority.label}` : ''}.`,
     empty: false,
   };
 }
@@ -2865,6 +2916,16 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
   `;
 }
 
+function renderAtlasMilitaryBlockedResidualFollowUpAlternative(alternative, y) {
+  if (!alternative?.visible) return '';
+  return `
+    <g class="atlas-military-neighbor-blocked-follow-up-alt atlas-military-neighbor-blocked-follow-up-alt--${alternative.tone}" aria-label="Alternative après suivi résiduel bloqué: ${alternative.label}; raison ${alternative.reason}; ${alternative.detail}; action ${alternative.action}">
+      <text class="atlas-military-neighbor-blocked-follow-up-alt__label" x="44.2" y="${y}">${alternative.label}</text>
+      <text class="atlas-military-neighbor-blocked-follow-up-alt__detail" x="44.2" y="${y + 1.35}">${alternative.reason}: ${alternative.action}</text>
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
   const priorityY = preview.empty ? 163.8 : 163.85 + (preview.shifts.length * 3.45);
   const staleY = priorityY + 2.75;
@@ -2874,14 +2935,16 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
   const residualY = hintY + (preview.sharedHandlingHint?.visible ? 2.75 : 0);
   const followUpY = residualY + (preview.sharedResidualRisk?.visible ? 2.75 : 0);
   const conflictY = followUpY + (preview.residualFollowUpOrder?.visible ? 2.75 : 0);
-  const contestedY = conflictY + (preview.residualFollowUpConflict?.visible ? 2.75 : 0);
+  const alternativeY = conflictY + (preview.residualFollowUpConflict?.visible ? 2.75 : 0);
+  const contestedY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? 2.75 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;
   const hintHeight = preview.sharedHandlingHint?.visible ? 2.5 : 0;
   const residualHeight = preview.sharedResidualRisk?.visible ? 2.5 : 0;
   const followUpHeight = preview.residualFollowUpOrder?.visible ? 2.5 : 0;
   const conflictHeight = preview.residualFollowUpConflict?.visible ? 2.5 : 0;
+  const alternativeHeight = preview.blockedFollowUpAlternative?.visible ? 2.5 : 0;
   const contestedHeight = preview.contestedPriority?.visible ? 2.5 : 0;
-  const height = (preview.empty ? 13.6 : 13.6 + (preview.shifts.length * 3.45)) + clusterHeight + hintHeight + residualHeight + followUpHeight + conflictHeight + contestedHeight;
+  const height = (preview.empty ? 13.6 : 13.6 + (preview.shifts.length * 3.45)) + clusterHeight + hintHeight + residualHeight + followUpHeight + conflictHeight + alternativeHeight + contestedHeight;
   return `
     <g class="atlas-military-neighbor-front-shift atlas-military-neighbor-front-shift--${preview.empty ? 'empty' : 'active'}" aria-label="Prévisualisation des fronts voisins après engagement: ${preview.summary}">
       <rect class="atlas-military-neighbor-front-shift__panel" x="43" y="157" width="35" height="${height}" rx="2.1"></rect>
@@ -2902,6 +2965,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
       ${renderAtlasMilitaryNeighborSharedResidualRisk(preview.sharedResidualRisk, residualY)}
       ${renderAtlasMilitaryNeighborResidualFollowUpOrder(preview.residualFollowUpOrder, followUpY)}
       ${renderAtlasMilitaryNeighborResidualFollowUpConflict(preview.residualFollowUpConflict, conflictY)}
+      ${renderAtlasMilitaryBlockedResidualFollowUpAlternative(preview.blockedFollowUpAlternative, alternativeY)}
       ${renderAtlasMilitaryNeighborContestedHandlingPriority(preview.contestedPriority, contestedY)}
     </g>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14499,7 +14499,8 @@ button { font: inherit; }
 .atlas-military-neighbor-shared-handling__detail,
 .atlas-military-neighbor-shared-residual__detail,
 .atlas-military-neighbor-residual-follow-up__detail,
-.atlas-military-neighbor-residual-follow-up-conflict__detail {
+.atlas-military-neighbor-residual-follow-up-conflict__detail,
+.atlas-military-neighbor-blocked-follow-up-alt__detail {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14511,7 +14512,8 @@ button { font: inherit; }
 .atlas-military-neighbor-shared-handling__label,
 .atlas-military-neighbor-shared-residual__label,
 .atlas-military-neighbor-residual-follow-up__label,
-.atlas-military-neighbor-residual-follow-up-conflict__label {
+.atlas-military-neighbor-residual-follow-up-conflict__label,
+.atlas-military-neighbor-blocked-follow-up-alt__label {
   fill: #f5f3ff;
   font-size: 0.55px;
   font-weight: 900;
@@ -14544,7 +14546,12 @@ button { font: inherit; }
 .atlas-military-neighbor-residual-follow-up-conflict--conflict .atlas-military-neighbor-residual-follow-up-conflict__label { fill: #fecdd3; }
 .atlas-military-neighbor-residual-follow-up--movement .atlas-military-neighbor-residual-follow-up__label,
 .atlas-military-neighbor-residual-follow-up-conflict--reserved .atlas-military-neighbor-residual-follow-up-conflict__label { fill: #fde68a; }
-.atlas-military-neighbor-residual-follow-up-conflict--safe .atlas-military-neighbor-residual-follow-up-conflict__label { fill: #bbf7d0; }
+.atlas-military-neighbor-residual-follow-up-conflict--safe .atlas-military-neighbor-residual-follow-up-conflict__label,
+.atlas-military-neighbor-blocked-follow-up-alt--safe .atlas-military-neighbor-blocked-follow-up-alt__label { fill: #bbf7d0; }
+.atlas-military-neighbor-blocked-follow-up-alt--urgent .atlas-military-neighbor-blocked-follow-up-alt__label,
+.atlas-military-neighbor-blocked-follow-up-alt--blocked .atlas-military-neighbor-blocked-follow-up-alt__label { fill: #fecdd3; }
+.atlas-military-neighbor-blocked-follow-up-alt--cost .atlas-military-neighbor-blocked-follow-up-alt__label,
+.atlas-military-neighbor-blocked-follow-up-alt--dependency .atlas-military-neighbor-blocked-follow-up-alt__label { fill: #fde68a; }
 .atlas-military-neighbor-front-shift-row circle {
   fill: rgba(167, 139, 250, 0.84);
   stroke: rgba(245, 243, 255, 0.72);


### PR DESCRIPTION
Alpha: Implements MAP-A33.

Summary:
- adds a compact alternative hint when a residual front follow-up is blocked by a conflict
- distinguishes ordre principal, suivi bloqué, and alternative in the existing map panel
- explains the alternative with a short reason: sécurité, urgence, coût, or dépendance
- explicitly reports when no safe alternative exists this turn, without duplicating MAP-A30–MAP-A32 hints

Validation:
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test

Closes #1476