### PR TITLE
Epsilon: Keep secondary climate watch visible

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -13,10 +13,16 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /pression seuil/);
   assert.match(webAppSource, /promotionCondition/);
   assert.match(webAppSource, /Devient primaire/);
+  assert.match(webAppSource, /Secondaire suivant/);
+  assert.match(webAppSource, /nextSecondaryRisk/);
   assert.match(webAppSource, /devient action primaire si la pression reste ≥80 au prochain check/);
   assert.match(webAppSource, /devient action primaire si \$\{progress\.deadline\} confirme \$\{watchGap\.nearestRiskLabel\}/);
   assert.match(webAppSource, /find\(\(gap\) => gap\.nearestThresholdScore >= 55\)/);
   assert.match(webAppSource, /filter\(\(gap\) => !gap\.nearest && gap\.label !== gapActionView\.recommendation\.target\)/);
+  assert.match(webAppSource, /gap\.label !== watchGap\.label/);
+  assert.match(webAppSource, /seuil plus loin/);
+  assert.match(webAppSource, /protection déjà active/);
+  assert.match(webAppSource, /coût trop élevé/);
   assert.match(webAppSource, /seul watch item restant après l’action du gap prioritaire/);
   assert.match(webAppSource, /renderAtlasClimateNearestCoverageGapAction\(atlasClimateNearestCoverageGapAction\)\}\s*\$\{renderAtlasClimatePostGapActionWatch\(atlasClimatePostGapActionWatch\)\}/);
 
@@ -29,5 +35,6 @@ test('atlas keeps a quiet fallback when no secondary climate watch is close enou
   assert.match(webAppSource, /Veille secondaire climat indisponible après action minimale/);
   assert.match(webAppSource, /Veille calme: aucun second gap climat assez proche du seuil après cette action/);
   assert.match(webAppSource, /Ne pas créer de liste/);
+  assert.match(webAppSource, /aucun second risque assez lisible sans créer une file/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch--quiet/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -13744,6 +13744,7 @@ function buildAtlasClimateRemainingCoverageGaps(preventiveView, secondaryProtect
           ? action.action
           : `relire ${progress.threshold} avant d’étendre la prévention`,
         nearestThresholdScore,
+        className: action.className,
         nearestRiskLabel: action.className === 'stabilizes-short-term'
           ? 'risque de seuil le plus proche'
           : 'risque de seuil secondaire',
@@ -13889,6 +13890,25 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
   const promotionCondition = watchGap.nearestThresholdScore >= 80
     ? `devient action primaire si la pression reste ≥80 au prochain check ${progress.deadline}`
     : `devient action primaire si ${progress.deadline} confirme ${watchGap.nearestRiskLabel}`;
+  const nextSecondaryGap = (coverageView.blindSpots ?? [])
+    .filter((gap) => !gap.nearest && gap.label !== gapActionView.recommendation.target && gap.label !== watchGap.label)
+    .find((gap) => gap.nearestThresholdScore >= 40) ?? null;
+  const protectedSecondary = !nextSecondaryGap ? coverageView.secondaryProtections?.[0] ?? coverageView.activeProtections?.[0] ?? null : null;
+  const nextSecondaryRisk = nextSecondaryGap
+    ? {
+      label: nextSecondaryGap.label,
+      phrase: `${nextSecondaryGap.label}: reste secondaire, seuil plus loin (${nextSecondaryGap.nearestThresholdScore}).`,
+      reason: nextSecondaryGap.className === 'insufficient'
+        ? 'coût trop élevé pour passer avant l’action primaire'
+        : 'seuil plus loin que le watch item promu',
+    }
+    : protectedSecondary
+      ? {
+        label: protectedSecondary.label,
+        phrase: `${protectedSecondary.label}: reste secondaire car protection déjà active.`,
+        reason: 'protection déjà active',
+      }
+      : null;
 
   return {
     state: 'watch',
@@ -13899,6 +13919,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       nextCheck: watchGap.nextAction,
       promotionCondition,
     },
+    nextSecondaryRisk,
     summary: `${watchGap.label}: seul watch item restant après l’action du gap prioritaire.`,
   };
 }
@@ -13930,6 +13951,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <p>${view.summary}</p>
       <small><b>Watch item</b> · ${view.watchItem.phrase}</small>
       <small><b>Devient primaire</b> · ${view.watchItem.promotionCondition}</small>
+      ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>
       <small><b>Prochain check</b> · ${view.watchItem.nextCheck}</small>
     </aside>


### PR DESCRIPTION
Epsilon: PR prête pour #1480.

## Résumé
- Garde un risque climat secondaire visible quand le watch item devient l’action primaire.
- Explique pourquoi ce risque reste secondaire: seuil plus loin, protection déjà active ou coût trop élevé.
- Reste compact: un seul “Secondaire suivant”, sans recréer une file complète ni concurrencer l’action principale.

## Tests
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js test/ui/climate/webAtlasClimateRemainingCoverageGaps.test.js test/ui/climate/webAtlasClimateNearestCoverageGapAction.test.js
- node --check web/app.js
- git diff --check
- npm test

Zeta, peux-tu valider avant tout merge ?