### PR TITLE
Alpha: Show blocked front alternative viability

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -301,7 +301,7 @@ test('atlas military suggests alternatives when residual front follow-up is bloc
   assert.match(webAppSource, /function getAtlasMilitaryBlockedFollowUpAlternativeReason\(option, checklistItem\)/);
   assert.match(webAppSource, /function renderAtlasMilitaryBlockedResidualFollowUpAlternative\(alternative, y\)/);
   assert.match(webAppSource, /Alternative après suivi résiduel bloqué/);
-  assert.match(webAppSource, /Alternative: \$\{candidate\.provinceLabel\}/);
+  assert.match(webAppSource, /\$\{viability\.label\}: \$\{candidate\.provinceLabel\}/);
   assert.match(webAppSource, /ordre principal \$\{recommendation\?\.primary\?\.provinceLabel \?\? 'indécis'\} · suivi bloqué \$\{followUp\.provinceLabel\}/);
   assert.match(webAppSource, /Aucune alternative sûre ce tour/);
   assert.match(webAppSource, /attendre résolution du conflit/);
@@ -316,4 +316,20 @@ test('atlas military suggests alternatives when residual front follow-up is bloc
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt--blocked/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt--dependency/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt--safe/);
+});
+
+// MAP-A34: alternatives after a blocked residual follow-up must say whether they
+// are immediately playable, need a short preparation, or should be avoided this turn.
+test('atlas military shows viability conditions for blocked front alternatives', () => {
+  assert.match(webAppSource, /function getAtlasMilitaryBlockedFollowUpAlternativeViability\(option, checklistItem\)/);
+  assert.match(webAppSource, /Jouable maintenant/);
+  assert.match(webAppSource, /Préparation courte requise/);
+  assert.match(webAppSource, /À éviter ce tour/);
+  assert.match(webAppSource, /condition minimale: \$\{minimumCondition\}/);
+  assert.match(webAppSource, /viability\.status === 'ready' \? reasonTone : viability\.tone/);
+  assert.match(webAppSource, /viabilityStatus: viability\.status/);
+  assert.match(webAppSource, /minimumCondition: viability\.condition/);
+  assert.match(webAppSource, /viabilité \$\{alternative\.viabilityLabel\}; \$\{alternative\.minimumCondition\}/);
+  assert.match(webAppSource, /\$\{alternative\.minimumCondition\} · \$\{alternative\.reason\}: \$\{alternative\.action\}/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt--preparation/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -2698,6 +2698,32 @@ function getAtlasMilitaryBlockedFollowUpAlternativeReason(option, checklistItem)
   return 'sécurité';
 }
 
+function getAtlasMilitaryBlockedFollowUpAlternativeViability(option, checklistItem) {
+  const minimumCondition = checklistItem?.checklist?.missingPrerequisite ?? option?.waitState ?? 'condition tactique lisible';
+  if (!option || option.blockerType === 'unknown' || option.orderState === 'vérification requise') {
+    return {
+      status: 'avoid',
+      tone: 'blocked',
+      label: 'À éviter ce tour',
+      condition: `condition minimale: ${minimumCondition}`,
+    };
+  }
+  if (option.orderState === 'ordre préparé') {
+    return {
+      status: 'ready',
+      tone: 'safe',
+      label: 'Jouable maintenant',
+      condition: `condition minimale: ${minimumCondition}`,
+    };
+  }
+  return {
+    status: 'prep',
+    tone: 'preparation',
+    label: 'Préparation courte requise',
+    condition: `condition minimale: ${minimumCondition}`,
+  };
+}
+
 function buildAtlasMilitaryBlockedResidualFollowUpAlternative(followUp, conflict, recommendation, checklist) {
   if (!followUp?.visible || !conflict?.visible || conflict.tone === 'safe') {
     return {
@@ -2722,18 +2748,26 @@ function buildAtlasMilitaryBlockedResidualFollowUpAlternative(followUp, conflict
       detail: `ordre principal ${recommendation?.primary?.provinceLabel ?? 'indécis'} · suivi bloqué ${followUp.provinceLabel}`,
       reason: 'dépendance',
       action: 'attendre résolution du conflit',
+      viabilityStatus: 'avoid',
+      viabilityLabel: 'À éviter ce tour',
+      minimumCondition: 'condition minimale: conflit résolu sans nouveau risque',
     };
   }
 
   const reason = getAtlasMilitaryBlockedFollowUpAlternativeReason(candidate, checklistItem);
+  const viability = getAtlasMilitaryBlockedFollowUpAlternativeViability(candidate, checklistItem);
+  const reasonTone = reason === 'urgence' ? 'urgent' : reason === 'coût' ? 'cost' : reason === 'dépendance' ? 'dependency' : 'safe';
   return {
     visible: true,
-    tone: reason === 'urgence' ? 'urgent' : reason === 'coût' ? 'cost' : reason === 'dépendance' ? 'dependency' : 'safe',
+    tone: viability.status === 'ready' ? reasonTone : viability.tone,
     provinceLabel: candidate.provinceLabel,
-    label: `Alternative: ${candidate.provinceLabel}`,
+    label: `${viability.label}: ${candidate.provinceLabel}`,
     detail: `ordre principal ${recommendation?.primary?.provinceLabel ?? 'indécis'} · suivi bloqué ${followUp.provinceLabel}`,
     reason,
     action: candidate.nextAction,
+    viabilityStatus: viability.status,
+    viabilityLabel: viability.label,
+    minimumCondition: viability.condition,
   };
 }
 
@@ -2919,9 +2953,9 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedResidualFollowUpAlternative(alternative, y) {
   if (!alternative?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-alt atlas-military-neighbor-blocked-follow-up-alt--${alternative.tone}" aria-label="Alternative après suivi résiduel bloqué: ${alternative.label}; raison ${alternative.reason}; ${alternative.detail}; action ${alternative.action}">
+    <g class="atlas-military-neighbor-blocked-follow-up-alt atlas-military-neighbor-blocked-follow-up-alt--${alternative.tone}" aria-label="Alternative après suivi résiduel bloqué: ${alternative.label}; viabilité ${alternative.viabilityLabel}; ${alternative.minimumCondition}; raison ${alternative.reason}; ${alternative.detail}; action ${alternative.action}">
       <text class="atlas-military-neighbor-blocked-follow-up-alt__label" x="44.2" y="${y}">${alternative.label}</text>
-      <text class="atlas-military-neighbor-blocked-follow-up-alt__detail" x="44.2" y="${y + 1.35}">${alternative.reason}: ${alternative.action}</text>
+      <text class="atlas-military-neighbor-blocked-follow-up-alt__detail" x="44.2" y="${y + 1.35}">${alternative.minimumCondition} · ${alternative.reason}: ${alternative.action}</text>
     </g>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -14563,7 +14563,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-alt--urgent .atlas-military-neighbor-blocked-follow-up-alt__label,
 .atlas-military-neighbor-blocked-follow-up-alt--blocked .atlas-military-neighbor-blocked-follow-up-alt__label { fill: #fecdd3; }
 .atlas-military-neighbor-blocked-follow-up-alt--cost .atlas-military-neighbor-blocked-follow-up-alt__label,
-.atlas-military-neighbor-blocked-follow-up-alt--dependency .atlas-military-neighbor-blocked-follow-up-alt__label { fill: #fde68a; }
+.atlas-military-neighbor-blocked-follow-up-alt--dependency .atlas-military-neighbor-blocked-follow-up-alt__label,
+.atlas-military-neighbor-blocked-follow-up-alt--preparation .atlas-military-neighbor-blocked-follow-up-alt__label { fill: #fde68a; }
 .atlas-military-neighbor-front-shift-row circle {
   fill: rgba(167, 139, 250, 0.84);
   stroke: rgba(245, 243, 255, 0.72);


### PR DESCRIPTION
Alpha: Implements #1486.

Summary:
- adds a compact viability classifier for blocked residual front alternatives
- labels alternatives as playable now, short prep required, or avoid this turn
- renders the minimal viability condition alongside the existing front-risk/cost/dependency reason

Validation:
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test