### PR TITLE
Gamma: Show beyond-minimum cultural benefit

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1395,6 +1395,9 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
         ? `${candidate.deadlineHint}: la petite action cesse de suffire si ${candidate.turningSignal}.`
         : `payoff ${candidate.payoffScore}: la petite action reste seulement valable jusqu’à la ${candidate.nextReviewWindow}.`)
       : null;
+    const recommendedBeyondMinimumBenefit = minimalSafeAction && missedWindowConsequence
+      ? buildCulturalBeyondMinimumBenefit(candidate, missedFallout, missedWindowConsequence)
+      : null;
 
     return {
       ...candidate,
@@ -1413,6 +1416,7 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
       recommendedAction,
       lateRiskyAction,
       minimalActionThresholdReason,
+      recommendedBeyondMinimumBenefit,
     };
   });
   const top = rankedCandidates[0] ?? null;
@@ -1441,6 +1445,34 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
       ? 'Priorité par pression de délai, puis payoff culturel.'
       : 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
     entries: rankedCandidates,
+  };
+}
+
+function buildCulturalBeyondMinimumBenefit(candidate, missedFallout, missedWindowConsequence) {
+  const recommendedAction = candidate.action
+    ? `faire maintenant: ${candidate.action}`
+    : `traiter ${candidate.clusterLabel} maintenant`;
+  const nextTurnAvoidance = missedFallout?.consequenceType === 'consolidation-delay'
+    ? 'évite une urgence de consolidation au prochain tour'
+    : missedFallout?.consequenceType === 'opportunity-lost'
+      ? 'évite une perte de payoff culturel au prochain tour'
+      : missedFallout?.consequenceType === 'replacement-forced'
+        ? 'évite un remplacement forcé au prochain tour'
+        : missedFallout?.consequenceType === 'tension'
+          ? 'évite de maintenir une tension culturelle au prochain tour'
+          : 'évite de transformer le report en seuil risqué au prochain tour';
+  const concreteGain = candidate.payoffScore > 0
+    ? `gain concret: sécurise payoff ${candidate.payoffScore} sans attendre la bascule`
+    : 'gain concret: conserve la fenêtre sûre sans créer d’urgence artificielle';
+
+  return {
+    state: 'recommended-over-minimum',
+    label: 'Au-delà du minimum',
+    recommendedAction,
+    concreteGain,
+    nextTurnAvoidance,
+    avoids: missedWindowConsequence,
+    summary: `${recommendedAction} — ${concreteGain}; ${nextTurnAvoidance}.`,
   };
 }
 

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -854,6 +854,82 @@ test('buildCultureTurnReportDeltas shows the consequence of missing the next def
   ]);
 });
 
+test('buildCultureTurnReportDeltas explains the benefit of acting beyond the cultural minimum', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 9,
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'amplifier',
+      },
+    },
+    localTimeline: {
+      items: [
+        {
+          timelineId: 'harbor:event:quiet-followup',
+          kind: 'event',
+          signal: 'watch',
+          title: 'Suivi calme',
+          summary: 'Risque stabilisé.',
+          regionId: 'harbor',
+          cultureName: 'Harbor Compact',
+        },
+      ],
+    },
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'deferred',
+        outcome: 'soutien actif confirmé',
+      },
+      {
+        decisionId: 'turn-8-harbor-calm',
+        turn: 8,
+        regionId: 'harbor',
+        clusterLabel: 'Harbor Compact',
+        theme: 'Calmer le port',
+        promptLabel: 'Calmer le port',
+        choiceState: 'deferred',
+        outcome: 'risque stabilisé',
+      },
+    ],
+  });
+
+  const safeToDefer = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles;
+  assert.deepEqual(safeToDefer.entries.map((entry) => [
+    entry.clusterLabel,
+    entry.revisitPriority,
+    entry.recommendedBeyondMinimumBenefit?.recommendedAction ?? null,
+    entry.recommendedBeyondMinimumBenefit?.concreteGain ?? null,
+    entry.recommendedBeyondMinimumBenefit?.nextTurnAvoidance ?? null,
+    entry.recommendedBeyondMinimumBenefit?.avoids ?? null,
+  ]), [
+    [
+      'Compact d’Aurora',
+      'next',
+      'traiter Compact d’Aurora maintenant',
+      'gain concret: sécurise payoff 5 sans attendre la bascule',
+      'évite une urgence de consolidation au prochain tour',
+      'Compact d’Aurora: consolidation retardée d’un tour si le bundle n’est pas réévalué.',
+    ],
+    ['Harbor Compact', 'later', null, null, null, null],
+  ]);
+});
+
 test('buildCultureTurnReportDeltas breaks safe defer deadline ties by cultural payoff', () => {
   const report = buildCultureTurnReportDeltas({
     turn: 9,

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -182,6 +182,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Payoff:/);
   assert.match(webAppSource, /Si manqué:/);
   assert.match(webAppSource, /Action minimale:/);
+  assert.match(webAppSource, /Au-delà du minimum:/);
+  assert.match(webAppSource, /Évite au prochain tour:/);
+  assert.match(webAppSource, /recommendedBeyondMinimumBenefit/);
+  assert.match(webAppSource, /nextTurnAvoidance/);
   assert.match(webAppSource, /Seuil:/);
   assert.match(webAppSource, /tardif risqué:/);
   assert.match(webAppSource, /Pourquoi:/);

--- a/web/app.js
+++ b/web/app.js
@@ -7616,6 +7616,8 @@ function renderCultureTurnReport(report) {
                   <small>Payoff: ${entry.payoffScore ?? 0}</small>
                   ${entry.revisitPriority === 'next' && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.recommendedBeyondMinimumBenefit ? `<small>Évite au prochain tour: ${entry.recommendedBeyondMinimumBenefit.nextTurnAvoidance}; ${entry.recommendedBeyondMinimumBenefit.avoids}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalActionAcceptableUntil ? `<small>Seuil: minimale jusqu’à ${entry.minimalActionAcceptableUntil}; recommandé: ${entry.recommendedAction}; tardif risqué: ${entry.lateRiskyAction}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalActionThresholdReason ? `<small>Pourquoi: ${entry.minimalActionThresholdReason}</small>` : ''}
                   <small>Condition: ${entry.condition}</small>


### PR DESCRIPTION
Gamma: Implements #1488.

Summary:
- Add a compact `recommendedBeyondMinimumBenefit` cue for the top safe-to-defer cultural bundle when the minimal action is still possible but nearing its limit.
- Explain the concrete gain of acting beyond the minimum now and what next-turn consequence it avoids.
- Render the cue in the culture turn report without marking later safe-to-defer bundles as urgent.

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check web/app.js
- git diff --check
- npm test