### PR TITLE
[MAP-E33] Clarify secondary climate watch promotion

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -13,10 +13,22 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /pression seuil/);
   assert.match(webAppSource, /promotionCondition/);
   assert.match(webAppSource, /Devient primaire/);
+  assert.match(webAppSource, /Moment promotion/);
+  assert.match(webAppSource, /Transfert attention/);
   assert.match(webAppSource, /Secondaire suivant/);
   assert.match(webAppSource, /nextSecondaryRisk/);
   assert.match(webAppSource, /devient action primaire si la pression reste ≥80 au prochain check/);
   assert.match(webAppSource, /devient action primaire si \$\{progress\.deadline\} confirme \$\{watchGap\.nearestRiskLabel\}/);
+  assert.match(webAppSource, /promotionTiming/);
+  assert.match(webAppSource, /promotionCue/);
+  assert.match(webAppSource, /shortSecondaryLabel/);
+  assert.match(webAppSource, /attendue ce tour-ci après résolution de l’action climatique principale/);
+  assert.match(webAppSource, /au prochain tour si \$\{progress\.deadline\} confirme la pression secondaire/);
+  assert.match(webAppSource, /seulement si la protection échoue ou si le seuil secondaire se rapproche/);
+  assert.match(webAppSource, /garder en veille courte sans remplacer l’action principale ce tour-ci/);
+  assert.match(webAppSource, /secondaire prêt/);
+  assert.match(webAppSource, /veille tour\+1/);
+  assert.match(webAppSource, /veille conditionnelle/);
   assert.match(webAppSource, /find\(\(gap\) => gap\.nearestThresholdScore >= 55\)/);
   assert.match(webAppSource, /filter\(\(gap\) => !gap\.nearest && gap\.label !== gapActionView\.recommendation\.target\)/);
   assert.match(webAppSource, /gap\.label !== watchGap\.label/);
@@ -28,6 +40,7 @@ test('atlas shows one remaining climate watch item after the smallest gap action
 
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch--watch/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__cue/);
 });
 
 test('atlas keeps a quiet fallback when no secondary climate watch is close enough', () => {

--- a/web/app.js
+++ b/web/app.js
@@ -13995,6 +13995,21 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
   const promotionCondition = watchGap.nearestThresholdScore >= 80
     ? `devient action primaire si la pression reste ≥80 au prochain check ${progress.deadline}`
     : `devient action primaire si ${progress.deadline} confirme ${watchGap.nearestRiskLabel}`;
+  const promotionTiming = watchGap.nearestThresholdScore >= 80
+    ? 'attendue ce tour-ci après résolution de l’action climatique principale'
+    : watchGap.nearestThresholdScore >= 65
+      ? `au prochain tour si ${progress.deadline} confirme la pression secondaire`
+      : 'seulement si la protection échoue ou si le seuil secondaire se rapproche';
+  const promotionCue = watchGap.nearestThresholdScore >= 80
+    ? 'préparer le transfert d’attention dès que l’action principale est validée'
+    : watchGap.nearestThresholdScore >= 65
+      ? 'garder en veille courte sans remplacer l’action principale ce tour-ci'
+      : 'rester secondaire: ne promouvoir que sur échec de protection';
+  const shortSecondaryLabel = watchGap.nearestThresholdScore >= 80
+    ? 'secondaire prêt'
+    : watchGap.nearestThresholdScore >= 65
+      ? 'veille tour+1'
+      : 'veille conditionnelle';
   const nextSecondaryGap = (coverageView.blindSpots ?? [])
     .filter((gap) => !gap.nearest && gap.label !== gapActionView.recommendation.target && gap.label !== watchGap.label)
     .find((gap) => gap.nearestThresholdScore >= 40) ?? null;
@@ -14023,6 +14038,9 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       thresholdPressure: watchGap.nearestRiskLabel,
       nextCheck: watchGap.nextAction,
       promotionCondition,
+      promotionTiming,
+      promotionCue,
+      shortSecondaryLabel,
     },
     nextSecondaryRisk,
     summary: `${watchGap.label}: seul watch item restant après l’action du gap prioritaire.`,
@@ -14055,7 +14073,10 @@ function renderAtlasClimatePostGapActionWatch(view) {
       </div>
       <p>${view.summary}</p>
       <small><b>Watch item</b> · ${view.watchItem.phrase}</small>
+      <span class="map-world-climate-post-gap-watch__cue">${view.watchItem.shortSecondaryLabel}</span>
       <small><b>Devient primaire</b> · ${view.watchItem.promotionCondition}</small>
+      <small><b>Moment promotion</b> · ${view.watchItem.promotionTiming}</small>
+      <small><b>Transfert attention</b> · ${view.watchItem.promotionCue}</small>
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>
       <small><b>Prochain check</b> · ${view.watchItem.nextCheck}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13554,6 +13554,15 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch--quiet p,
 .map-world-climate-post-gap-watch--quiet span,
 .map-world-climate-post-gap-watch--quiet small { color: #cbd5e1; }
+.map-world-climate-post-gap-watch__cue {
+  width: fit-content;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.14);
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
 
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);


### PR DESCRIPTION
Epsilon: Implements #1490.

- Adds explicit timing for when the secondary climate watch promotes: this turn, next turn, or only if protection fails.
- Keeps the secondary risk marked as secondary with a short cue until the promotion condition is met.
- Extends the existing climate post-gap watch test coverage and cue styling.

Test: `npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js`

Zeta: ready for validation before merge.