### PR TITLE
Beta: suggest fallback for stopped spillover guards

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -985,6 +985,45 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
     };
   };
   const guardStopMarker = buildGuardStopMarker(nextGuardCost);
+  const buildStopFallbackAction = (stopMarker, blockedGuard) => {
+    if (!stopMarker?.exceedsBenefit || guardAction.fallback) {
+      return null;
+    }
+    const protectedTarget = guardAction.city ?? criticalRoute.city;
+    const blockedRoute = blockedGuard?.route ?? stopMarker.route;
+    const routeDelay = blockedGuard?.criticalDelay ? `${blockedRoute} est critique et resterait retardée.` : `${blockedRoute} dépasse le bénéfice attendu.`;
+
+    if (guardAction.tone === 'high') {
+      return {
+        state: 'recommended',
+        action: 'fortify-key-segment',
+        label: `Fortifier ${guardAction.route}`,
+        target: guardAction.route,
+        reason: `Préserve ${protectedTarget} sur le segment le plus rentable sans relancer la chaîne.`,
+        opportunityCost: `${routeDelay} Coût limité à ${guardAction.tradeoff}.`,
+      };
+    }
+
+    if (choice?.choiceId === 'reroute' || criticalRoute.tone === 'medium') {
+      return {
+        state: 'recommended',
+        action: 'reroute-flow',
+        label: `Rediriger un flux vers ${guardAction.route}`,
+        target: guardAction.route,
+        reason: `Conserve le bénéfice principal sur ${protectedTarget} avec un relais non-chaîné.`,
+        opportunityCost: `${routeDelay} Pas de garde ajoutée au-delà de ${stopMarker.label}.`,
+      };
+    }
+
+    return {
+      state: 'recommended',
+      action: 'protect-profitable-city',
+      label: `Protéger ${protectedTarget}`,
+      target: protectedTarget,
+      reason: `Cible la ville ou route la plus rentable déjà identifiée par le spillover.`,
+      opportunityCost: `${routeDelay} La chaîne reste arrêtée avant ${blockedRoute}.`,
+    };
+  };
   const guardOpportunityCost = guardSequencing.state === 'chainable' && nextGuardCost
     ? {
       state: guardStopMarker?.exceedsBenefit ? 'stop' : 'continue',
@@ -996,6 +1035,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         ? `Arrêter la chaîne après ${guardAction.route}: ${nextGuardCost.route} consommerait plus de capacité que le bénéfice attendu.`
         : `La chaîne peut continuer vers ${nextGuardCost.route} sans surcoût dominant.`,
       stopMarker: guardStopMarker,
+      fallbackAction: buildStopFallbackAction(guardStopMarker, nextGuardCost),
       canContinueWithoutCriticalDelay: guardStopMarker ? !guardStopMarker.exceedsBenefit && !guardStopMarker.criticalDelayed : false,
     }
     : guardSequencing.state === 'chainable'
@@ -1007,6 +1047,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         stopChain: false,
         stopReason: 'Aucune deuxième garde adjacente ne justifie d’arrêter la chaîne.',
         stopMarker: null,
+        fallbackAction: null,
         canContinueWithoutCriticalDelay: true,
       }
       : guardSequencing.state === 'competing'
@@ -1026,6 +1067,14 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             exceedsBenefit: true,
             criticalDelayed: true,
           },
+          fallbackAction: {
+            state: 'recommended',
+            action: 'defer-chain',
+            label: `Différer ${priorityAction.route}`,
+            target: priorityAction.route,
+            reason: `La garde protège déjà ${guardAction.route}; remplacer la récupération préserverait moins bien le bénéfice principal.`,
+            opportunityCost: `Ne pas rouvrir la chaîne: ${priorityAction.route} reste retardée ce tour.`,
+          },
           canContinueWithoutCriticalDelay: false,
         }
         : {
@@ -1033,6 +1082,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           summary: 'Coût d’opportunité indisponible: enchaînement de garde non comparable.',
           stopChain: false,
           stopMarker: null,
+          fallbackAction: null,
           canContinueWithoutCriticalDelay: false,
         };
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -207,6 +207,11 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopMarker.label, 'Point d’arrêt: avant Safe Road');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopMarker.reason, /premier segment où le coût cumulé .* dépasse le bénéfice attendu/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopMarker.decisionLabel, /Arrêter ici protège Ember Line sans retarder Safe Road/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.state, 'recommended');
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.action, 'reroute-flow');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.label, /Rediriger un flux vers Ember Line/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.reason, /bénéfice principal.*relais non-chaîné/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.opportunityCost, /Safe Road.*Pas de garde ajoutée/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -107,6 +107,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /guardOpportunityCost/);
   assert.match(webAppSource, /province-logistics-spillover-stop/);
   assert.match(webAppSource, /stopMarker\.decisionLabel/);
+  assert.match(webAppSource, /province-logistics-spillover-fallback/);
+  assert.match(webAppSource, /fallbackAction\.label/);
+  assert.match(webAppSource, /Repli:/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8548,6 +8548,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                 <small class="province-logistics-spillover-stop">${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopMarker.label} — ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopMarker.reason}</small>
                 <strong>${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopMarker.decisionLabel}</strong>
               ` : ''}
+              ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost?.fallbackAction ? `
+                <small class="province-logistics-spillover-fallback">Repli: ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.label} — ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.reason} Coût: ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.opportunityCost}</small>
+              ` : ''}
               ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost?.canContinueWithoutCriticalDelay ? '<small>Continuer la chaîne reste acceptable: aucune route critique n’est retardée.</small>' : ''}
             </div>
           ` : ''}


### PR DESCRIPTION
Beta: Implements #1497.

Summary:
- adds a compact non-chain fallback action when spillover guard opportunity cost reaches a stop marker;
- selects a fallback among fortifying the key segment, rerouting a flow, protecting the profitable target, or deferring a competing route based on existing preview signals;
- renders the fallback reason and opportunity cost without reopening the stopped guard chain.

Validation:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js
- node --check web/app.js
- git diff --check
- npm test

Closes #1497