### PR TITLE
Gamma: Show immediate cultural synergy

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1283,7 +1283,7 @@ function buildCulturalBundleReplacementRecommendations(groups, cleanupPrompts, f
   };
 }
 
-function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview, replacementRecommendations) {
+function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview, replacementRecommendations, visiblePriorities = []) {
   const urgentReplacementIds = new Set(replacementRecommendations.entries.map((entry) => entry.bundleId));
   const candidates = cleanupPrompts
     .map((prompt) => {
@@ -1398,6 +1398,9 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
     const recommendedBeyondMinimumBenefit = minimalSafeAction && missedWindowConsequence
       ? buildCulturalBeyondMinimumBenefit(candidate, missedFallout, missedWindowConsequence)
       : null;
+    const immediateSynergy = recommendedBeyondMinimumBenefit
+      ? buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedCandidates, missedWindowConsequence)
+      : null;
 
     return {
       ...candidate,
@@ -1417,6 +1420,7 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
       lateRiskyAction,
       minimalActionThresholdReason,
       recommendedBeyondMinimumBenefit,
+      immediateSynergy,
     };
   });
   const top = rankedCandidates[0] ?? null;
@@ -1448,6 +1452,51 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
   };
 }
 
+function buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedCandidates, missedWindowConsequence) {
+  const safePriorities = visiblePriorities.filter((priority) => priority.confidence !== 'low' && priority.level !== 'fragile');
+  const sameClusterPriority = safePriorities.find((priority) => priority.cultureName === candidate.clusterLabel);
+  const neighboringPriority = safePriorities.find((priority) => priority.cultureName !== candidate.clusterLabel && priority.action !== 'attendre') ?? null;
+  const narrativePrompt = normalizeText(`${candidate.minimalRevisitAction ?? ''} ${candidate.reason ?? ''}`);
+
+  if (sameClusterPriority?.discoveryId && sameClusterPriority.discoveryId !== 'signal culturel') {
+    return {
+      state: 'synergy-this-turn',
+      label: 'Synergie ce tour',
+      sourceType: 'discovery',
+      sourceLabel: sameClusterPriority.discoveryId,
+      benefit: `${sameClusterPriority.discoveryId} renforce ${sameClusterPriority.action} avec ${candidate.clusterLabel}`,
+      avoidedRisk: `évite de séparer la découverte du suivi reporté: ${missedWindowConsequence}`,
+      summary: `synergie ce tour: ${sameClusterPriority.discoveryId} + ${candidate.clusterLabel}; ${sameClusterPriority.action} sécurisé.`,
+    };
+  }
+
+  if (/récit|recit|narrati/i.test(narrativePrompt)) {
+    return {
+      state: 'synergy-this-turn',
+      label: 'Synergie ce tour',
+      sourceType: 'narrative',
+      sourceLabel: candidate.minimalRevisitAction ?? candidate.clusterLabel,
+      benefit: `le récit actif devient un suivi culturel immédiat pour ${candidate.clusterLabel}`,
+      avoidedRisk: `évite de laisser le récit dépasser la fenêtre sûre: ${missedWindowConsequence}`,
+      summary: `synergie ce tour: récit actif + ${candidate.clusterLabel}; suivi narratif sécurisé.`,
+    };
+  }
+
+  if (neighboringPriority && sortedCandidates.length > 1) {
+    return {
+      state: 'synergy-this-turn',
+      label: 'Synergie ce tour',
+      sourceType: 'neighbor-cluster',
+      sourceLabel: neighboringPriority.cultureName,
+      benefit: `${candidate.clusterLabel} reste aligné avec ${neighboringPriority.cultureName}`,
+      avoidedRisk: `évite que le cluster voisin reprenne seul la priorité: ${missedWindowConsequence}`,
+      summary: `synergie ce tour: ${candidate.clusterLabel} + ${neighboringPriority.cultureName}; priorités proches alignées.`,
+    };
+  }
+
+  return null;
+}
+
 function buildCulturalBeyondMinimumBenefit(candidate, missedFallout, missedWindowConsequence) {
   const recommendedAction = candidate.action
     ? `faire maintenant: ${candidate.action}`
@@ -1476,7 +1525,7 @@ function buildCulturalBeyondMinimumBenefit(candidate, missedFallout, missedWindo
   };
 }
 
-function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder) {
+function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder, visiblePriorities = []) {
   const groups = promptHistoryDrawer.groups.map((group) => {
     const currentEntries = group.entries.filter((entry) => entry.source === 'current');
     const historyEntries = group.entries.filter((entry) => entry.source === 'history');
@@ -1540,7 +1589,7 @@ function buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptH
     : `${cleanupPrompts.length} prompt${cleanupPrompts.length > 1 ? 's' : ''} de nettoyage: ${cleanupPrompts.map((prompt) => `${prompt.clusterLabel} → ${prompt.action}`).join(' | ')}.`;
   const falloutPreview = buildCulturalBundleFalloutPreview(cleanupPrompts);
   const replacementRecommendations = buildCulturalBundleReplacementRecommendations(groups, cleanupPrompts, falloutPreview);
-  const safeToDeferBundles = buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview, replacementRecommendations);
+  const safeToDeferBundles = buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview, replacementRecommendations, visiblePriorities);
 
   return {
     state: groups.length === 0
@@ -1672,7 +1721,7 @@ function buildCulturalCommitmentBundles(stabilizationRecommendations, activeReco
   const recommendationRotationPreview = buildCulturalRecommendationRotationPreview(promptFreshnessFilter, promptHistoryDrawer);
   const rotationCommitmentSummary = buildCulturalRotationCommitmentSummary(recommendationRotationPreview, promptChoiceComparison, bundles, incompatibilities);
   const commitmentFollowThroughReminder = buildCulturalCommitmentFollowThroughReminder(rotationCommitmentSummary, promptHistoryDrawer, turn);
-  const followThroughBundlePlan = buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder);
+  const followThroughBundlePlan = buildCulturalFollowThroughBundlePlan(rotationCommitmentSummary, promptHistoryDrawer, commitmentFollowThroughReminder, recommendations);
 
   return {
     state: bundles.length === 0 ? 'quiet' : incompatibilities.length > 0 ? 'needs-choice' : 'compatible',

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -917,6 +917,11 @@ test('buildCultureTurnReportDeltas explains the benefit of acting beyond the cul
     entry.recommendedBeyondMinimumBenefit?.concreteGain ?? null,
     entry.recommendedBeyondMinimumBenefit?.nextTurnAvoidance ?? null,
     entry.recommendedBeyondMinimumBenefit?.avoids ?? null,
+    entry.immediateSynergy?.label ?? null,
+    entry.immediateSynergy?.sourceType ?? null,
+    entry.immediateSynergy?.sourceLabel ?? null,
+    entry.immediateSynergy?.benefit ?? null,
+    entry.immediateSynergy?.avoidedRisk ?? null,
   ]), [
     [
       'Compact d’Aurora',
@@ -925,8 +930,13 @@ test('buildCultureTurnReportDeltas explains the benefit of acting beyond the cul
       'gain concret: sécurise payoff 5 sans attendre la bascule',
       'évite une urgence de consolidation au prochain tour',
       'Compact d’Aurora: consolidation retardée d’un tour si le bundle n’est pas réévalué.',
+      'Synergie ce tour',
+      'discovery',
+      'archive-routes',
+      'archive-routes renforce amplifier avec Compact d’Aurora',
+      'évite de séparer la découverte du suivi reporté: Compact d’Aurora: consolidation retardée d’un tour si le bundle n’est pas réévalué.',
     ],
-    ['Harbor Compact', 'later', null, null, null, null],
+    ['Harbor Compact', 'later', null, null, null, null, null, null, null, null, null],
   ]);
 });
 

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -183,8 +183,12 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Si manqué:/);
   assert.match(webAppSource, /Action minimale:/);
   assert.match(webAppSource, /Au-delà du minimum:/);
+  assert.match(webAppSource, /Synergie ce tour:/);
+  assert.match(webAppSource, /Bénéfice:/);
+  assert.match(webAppSource, /risque évité:/);
   assert.match(webAppSource, /Évite au prochain tour:/);
   assert.match(webAppSource, /recommendedBeyondMinimumBenefit/);
+  assert.match(webAppSource, /immediateSynergy/);
   assert.match(webAppSource, /nextTurnAvoidance/);
   assert.match(webAppSource, /Seuil:/);
   assert.match(webAppSource, /tardif risqué:/);

--- a/web/app.js
+++ b/web/app.js
@@ -7651,6 +7651,8 @@ function renderCultureTurnReport(report) {
                   ${entry.revisitPriority === 'next' && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.immediateSynergy ? `<small>Synergie ce tour: ${entry.immediateSynergy.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.immediateSynergy ? `<small>Bénéfice: ${entry.immediateSynergy.benefit}; risque évité: ${entry.immediateSynergy.avoidedRisk}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.recommendedBeyondMinimumBenefit ? `<small>Évite au prochain tour: ${entry.recommendedBeyondMinimumBenefit.nextTurnAvoidance}; ${entry.recommendedBeyondMinimumBenefit.avoids}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalActionAcceptableUntil ? `<small>Seuil: minimale jusqu’à ${entry.minimalActionAcceptableUntil}; recommandé: ${entry.recommendedAction}; tardif risqué: ${entry.lateRiskyAction}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalActionThresholdReason ? `<small>Pourquoi: ${entry.minimalActionThresholdReason}</small>` : ''}


### PR DESCRIPTION
Gamma: Implements #1498.

Summary:
- Adds a compact `immediateSynergy` cue for the top beyond-minimum cultural action when a safe visible priority can reinforce it this turn.
- Detects safe synergies from visible discovery priorities first, then narrative prompts or neighboring cultural clusters.
- Renders the “synergie ce tour” benefit and avoided risk only on the next-priority deferred bundle so later safe bundles are not made artificially urgent.

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: PR prête pour validation avant merge.