### PR TITLE
[MAP-E34] Show secondary climate watch protection guard

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -15,6 +15,7 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /Devient primaire/);
   assert.match(webAppSource, /Moment promotion/);
   assert.match(webAppSource, /Transfert attention/);
+  assert.match(webAppSource, /Reste secondaire si/);
   assert.match(webAppSource, /Secondaire suivant/);
   assert.match(webAppSource, /nextSecondaryRisk/);
   assert.match(webAppSource, /devient action primaire si la pression reste ≥80 au prochain check/);
@@ -22,6 +23,12 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /promotionTiming/);
   assert.match(webAppSource, /promotionCue/);
   assert.match(webAppSource, /shortSecondaryLabel/);
+  assert.match(webAppSource, /minimalProtection/);
+  assert.match(webAppSource, /secondaryProtectionGuard/);
+  assert.match(webAppSource, /coverageView\.secondaryProtections\?\.\[0\]/);
+  assert.match(webAppSource, /coverageView\.activeProtections\?\.\[0\]/);
+  assert.match(webAppSource, /reste secondaire si \$\{minimalProtection\.label\} tient/);
+  assert.match(webAppSource, /action minimale: \$\{view\.watchItem\.secondaryProtectionGuard\.minimalAction\}/);
   assert.match(webAppSource, /attendue ce tour-ci après résolution de l’action climatique principale/);
   assert.match(webAppSource, /au prochain tour si \$\{progress\.deadline\} confirme la pression secondaire/);
   assert.match(webAppSource, /seulement si la protection échoue ou si le seuil secondaire se rapproche/);
@@ -41,6 +48,7 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch--watch/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__cue/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__guard/);
 });
 
 test('atlas keeps a quiet fallback when no secondary climate watch is close enough', () => {

--- a/web/app.js
+++ b/web/app.js
@@ -14059,6 +14059,22 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
     : watchGap.nearestThresholdScore >= 65
       ? 'veille tour+1'
       : 'veille conditionnelle';
+  const minimalProtection = coverageView.secondaryProtections?.[0]
+    ?? coverageView.activeProtections?.[0]
+    ?? (gapActionView.recommendation
+      ? {
+        label: gapActionView.recommendation.target,
+        detail: gapActionView.recommendation.protectsAgainst,
+        action: gapActionView.recommendation.action,
+      }
+      : null);
+  const secondaryProtectionGuard = watchGap.nearestThresholdScore < 65 && minimalProtection
+    ? {
+      label: minimalProtection.label,
+      condition: `reste secondaire si ${minimalProtection.label} tient: ${minimalProtection.detail ?? minimalProtection.action}`,
+      minimalAction: minimalProtection.action ?? 'maintenir la mitigation minimale déjà affichée',
+    }
+    : null;
   const nextSecondaryGap = (coverageView.blindSpots ?? [])
     .filter((gap) => !gap.nearest && gap.label !== gapActionView.recommendation.target && gap.label !== watchGap.label)
     .find((gap) => gap.nearestThresholdScore >= 40) ?? null;
@@ -14090,6 +14106,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       promotionTiming,
       promotionCue,
       shortSecondaryLabel,
+      secondaryProtectionGuard,
     },
     nextSecondaryRisk,
     summary: `${watchGap.label}: seul watch item restant après l’action du gap prioritaire.`,
@@ -14126,6 +14143,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small><b>Devient primaire</b> · ${view.watchItem.promotionCondition}</small>
       <small><b>Moment promotion</b> · ${view.watchItem.promotionTiming}</small>
       <small><b>Transfert attention</b> · ${view.watchItem.promotionCue}</small>
+      ${view.watchItem.secondaryProtectionGuard ? `<small class="map-world-climate-post-gap-watch__guard"><b>Reste secondaire si</b> · ${view.watchItem.secondaryProtectionGuard.condition}; action minimale: ${view.watchItem.secondaryProtectionGuard.minimalAction}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>
       <small><b>Prochain check</b> · ${view.watchItem.nextCheck}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13563,6 +13563,10 @@ button { font: inherit; }
   font-weight: 700;
   letter-spacing: 0.01em;
 }
+.map-world-climate-post-gap-watch__guard {
+  padding-left: 8px;
+  border-left: 2px solid rgba(74, 222, 128, 0.38);
+}
 
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);


### PR DESCRIPTION
Epsilon: Implements #1500.

- Reuses existing climate coverage/action UI data to identify the minimal protection that keeps a conditional secondary watch secondary.
- Adds a concise “Reste secondaire si…” line with the concrete guard condition and minimal action.
- Keeps the primary/secondary hierarchy unchanged and only renders the guard for protection-failure promotion cases.
- Extends the existing climate post-gap watch UI test and guard styling.

Validations:
- `node --check web/app.js`
- `npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js`

Zeta: ready for validation before merge.