### PR TITLE
Alpha: Show delay cost for blocked front prep

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -348,3 +348,20 @@ test('atlas military shows prep action to unlock the next front alternative', ()
   assert.match(webAppSource, /atlas-military-neighbor-blocked-follow-up-alt__prep/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt__prep/);
 });
+
+// MAP-A36: prep guidance should also show whether delaying it is acceptable or risky,
+// without inventing a cost when no fog-safe cost signal exists.
+test('atlas military shows delay cost for blocked front prep actions', () => {
+  assert.match(webAppSource, /function getAtlasMilitaryBlockedFollowUpPrepDelayCost\(option, checklistItem\)/);
+  assert.match(webAppSource, /Report acceptable/);
+  assert.match(webAppSource, /coût limité si relu au prochain tour/);
+  assert.match(webAppSource, /Report risqué/);
+  assert.match(webAppSource, /fenêtre qui se ferme/);
+  assert.match(webAppSource, /province qui reste exposée/);
+  assert.match(webAppSource, /option\.viabilityStatus === 'ready' \|\| option\.blockerType === 'unknown'\) return null/);
+  assert.match(webAppSource, /delayCost: getAtlasMilitaryBlockedFollowUpPrepDelayCost\(option, checklistItem\)/);
+  assert.match(webAppSource, /coût de report \$\{delayCost\.label\}: \$\{delayCost\.detail\}/);
+  assert.match(webAppSource, /atlas-military-neighbor-blocked-follow-up-alt__delay--\$\{delayCost\.tone\}/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt__delay--risky/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2724,6 +2724,31 @@ function getAtlasMilitaryBlockedFollowUpAlternativeViability(option, checklistIt
   };
 }
 
+function getAtlasMilitaryBlockedFollowUpPrepDelayCost(option, checklistItem) {
+  if (!option || option.viabilityStatus === 'ready' || option.blockerType === 'unknown') return null;
+  const priority = Math.max(option.score ?? 0, checklistItem?.priority ?? 0);
+  if (!priority && !option.blockerType) return null;
+  if (option.blockerType === 'climate' || priority >= 72) {
+    return {
+      tone: 'risky',
+      label: 'Report risqué',
+      detail: option.blockerType === 'climate' ? 'fenêtre qui se ferme' : 'risque qui augmente',
+    };
+  }
+  if (option.blockerType === 'intel' || priority >= 46) {
+    return {
+      tone: 'risky',
+      label: 'Report risqué',
+      detail: option.blockerType === 'intel' ? 'information manquante retarde le front' : 'province qui reste exposée',
+    };
+  }
+  return {
+    tone: 'acceptable',
+    label: 'Report acceptable',
+    detail: 'coût limité si relu au prochain tour',
+  };
+}
+
 function getAtlasMilitaryBlockedFollowUpPrepUnlock(option, checklistItem) {
   if (!option || option.viabilityStatus === 'ready') return null;
   const checklistAction = checklistItem?.checklist?.immediateAction ?? option.nextAction ?? 'préparer une action visible';
@@ -2739,6 +2764,7 @@ function getAtlasMilitaryBlockedFollowUpPrepUnlock(option, checklistItem) {
     label: `Préparer ${option.provinceLabel}`,
     action: actionByType[option.blockerType] ?? `préparer: ${checklistAction}`,
     unlocks: `débloque si ${prerequisite}`,
+    delayCost: getAtlasMilitaryBlockedFollowUpPrepDelayCost(option, checklistItem),
   };
 }
 
@@ -2787,6 +2813,7 @@ function buildAtlasMilitaryBlockedResidualFollowUpAlternative(followUp, conflict
         label: 'Préparer une alternative',
         action: 'résoudre conflit puis relire fronts visibles',
         unlocks: 'débloque si un front candidat reste fog-safe',
+        delayCost: null,
       },
     };
   }
@@ -2989,14 +3016,19 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 
 function renderAtlasMilitaryBlockedResidualFollowUpAlternative(alternative, y) {
   if (!alternative?.visible) return '';
+  const delayCost = alternative.prepUnlock?.delayCost ?? null;
   const prep = alternative.prepUnlock
     ? `<text class="atlas-military-neighbor-blocked-follow-up-alt__prep" x="44.2" y="${y + 2.7}">${alternative.prepUnlock.action} · ${alternative.prepUnlock.unlocks}</text>`
     : '';
+  const delay = delayCost
+    ? `<text class="atlas-military-neighbor-blocked-follow-up-alt__delay atlas-military-neighbor-blocked-follow-up-alt__delay--${delayCost.tone}" x="44.2" y="${y + 4.05}">${delayCost.label}: ${delayCost.detail}</text>`
+    : '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-alt atlas-military-neighbor-blocked-follow-up-alt--${alternative.tone}" aria-label="Alternative après suivi résiduel bloqué: ${alternative.label}; viabilité ${alternative.viabilityLabel}; ${alternative.minimumCondition}; raison ${alternative.reason}; ${alternative.detail}; action ${alternative.action}${alternative.prepUnlock ? `; préparation ${alternative.prepUnlock.label}: ${alternative.prepUnlock.action}; ${alternative.prepUnlock.unlocks}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-alt atlas-military-neighbor-blocked-follow-up-alt--${alternative.tone}" aria-label="Alternative après suivi résiduel bloqué: ${alternative.label}; viabilité ${alternative.viabilityLabel}; ${alternative.minimumCondition}; raison ${alternative.reason}; ${alternative.detail}; action ${alternative.action}${alternative.prepUnlock ? `; préparation ${alternative.prepUnlock.label}: ${alternative.prepUnlock.action}; ${alternative.prepUnlock.unlocks}` : ''}${delayCost ? `; coût de report ${delayCost.label}: ${delayCost.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-alt__label" x="44.2" y="${y}">${alternative.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-alt__detail" x="44.2" y="${y + 1.35}">${alternative.minimumCondition} · ${alternative.reason}: ${alternative.action}</text>
       ${prep}
+      ${delay}
     </g>
   `;
 }
@@ -3012,7 +3044,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
   const conflictY = followUpY + (preview.residualFollowUpOrder?.visible ? 2.75 : 0);
   const alternativeY = conflictY + (preview.residualFollowUpConflict?.visible ? 2.75 : 0);
   const alternativeBlockHeight = preview.blockedFollowUpAlternative?.visible
-    ? preview.blockedFollowUpAlternative?.prepUnlock ? 3.85 : 2.5
+    ? preview.blockedFollowUpAlternative?.prepUnlock?.delayCost ? 5.2 : preview.blockedFollowUpAlternative?.prepUnlock ? 3.85 : 2.5
     : 0;
   const contestedY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14541,11 +14541,14 @@ button { font: inherit; }
 .atlas-military-neighbor-residual-follow-up__detail,
 .atlas-military-neighbor-residual-follow-up-conflict__detail,
 .atlas-military-neighbor-blocked-follow-up-alt__detail,
-.atlas-military-neighbor-blocked-follow-up-alt__prep {
+.atlas-military-neighbor-blocked-follow-up-alt__prep,
+.atlas-military-neighbor-blocked-follow-up-alt__delay {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
 .atlas-military-neighbor-blocked-follow-up-alt__prep { fill: #bfdbfe; }
+.atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
+.atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,
 .atlas-military-neighbor-review-staleness__label,
 .atlas-military-neighbor-review-change__label,


### PR DESCRIPTION
Alpha: Implements #1506.

Summary:
- adds compact delay-cost metadata to blocked front prep guidance
- distinguishes acceptable deferral from risky deferral near the existing recommendation
- keeps unknown/fog-unsafe cases quiet instead of inventing delay cost

Validation:
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test