### PR TITLE
Beta: show residual exposure after fallback guard

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -849,7 +849,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       guardAction: { label: 'Garde indisponible', reason: 'Aucune chaîne de spillover à réduire pour l’instant.', fallback: true },
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: aucune garde concrète à classer.' },
       guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Capacité de garde indisponible sans récupération locale.' },
-      guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune chaîne de garde à prolonger.', stopChain: false },
+      guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune chaîne de garde à prolonger.', stopChain: false, residualExposure: { state: 'unknown', exposedRoutes: [], benefit: 'Bénéfice du fallback non calculable sans chaîne de garde.', residualRisk: 'Exposition restante non traçable précisément avec les signaux actuels.' } },
     };
   }
 
@@ -895,7 +895,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       guardAction: { label: 'Garde indisponible', reason: 'Aucun relais voisin confirmé; surveiller la route après résolution locale.', fallback: true },
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: coût de garde non comparable sans route exposée.' },
       guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Aucune route exposée ne permet de comparer la capacité de garde.' },
-      guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune route adjacente exposée à comparer.', stopChain: false },
+      guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune route adjacente exposée à comparer.', stopChain: false, residualExposure: { state: 'unknown', exposedRoutes: [], benefit: 'Bénéfice du fallback non calculable sans route exposée.', residualRisk: 'Exposition restante non traçable précisément avec les signaux actuels.' } },
     };
   }
 
@@ -985,6 +985,42 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
     };
   };
   const guardStopMarker = buildGuardStopMarker(nextGuardCost);
+  const buildFallbackExposure = (stopMarker, blockedGuard) => {
+    if (!stopMarker?.exceedsBenefit) {
+      return {
+        state: 'unknown',
+        exposedRoutes: [],
+        benefit: 'Bénéfice du fallback non calculable sans point d’arrêt confirmé.',
+        residualRisk: 'Exposition restante non traçable précisément avec les signaux actuels.',
+      };
+    }
+    const exposedRoutes = [blockedGuard, ...secondaryRoutes]
+      .filter((route) => route?.route && route.route !== guardAction.route)
+      .filter((route, index, list) => list.findIndex((entry) => entry.route === route.route) === index)
+      .slice(0, 2)
+      .map((route) => ({
+        route: route.route,
+        city: route.city,
+        tone: route.tone ?? 'medium',
+        reason: route.route === blockedGuard?.route
+          ? `${route.route} reste au-delà du point d’arrêt et ne reçoit pas de garde chaînée.`
+          : `${route.route} garde un signal spillover secondaire après le repli.`,
+      }));
+
+    return exposedRoutes.length > 0
+      ? {
+        state: 'traced',
+        exposedRoutes,
+        benefit: `Le fallback protège ${guardAction.route} et garde le bénéfice principal lisible.`,
+        residualRisk: `${exposedRoutes.map((route) => `${route.route}/${route.city}`).join(', ')} reste exposé après ce repli.`,
+      }
+      : {
+        state: 'unknown',
+        exposedRoutes: [],
+        benefit: `Le fallback protège ${guardAction.route}, mais la suite de chaîne n’est pas assez tracée.`,
+        residualRisk: 'Exposition restante non traçable précisément avec les signaux actuels.',
+      };
+  };
   const buildStopFallbackAction = (stopMarker, blockedGuard) => {
     if (!stopMarker?.exceedsBenefit || guardAction.fallback) {
       return null;
@@ -992,6 +1028,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
     const protectedTarget = guardAction.city ?? criticalRoute.city;
     const blockedRoute = blockedGuard?.route ?? stopMarker.route;
     const routeDelay = blockedGuard?.criticalDelay ? `${blockedRoute} est critique et resterait retardée.` : `${blockedRoute} dépasse le bénéfice attendu.`;
+    const residualExposure = buildFallbackExposure(stopMarker, blockedGuard);
 
     if (guardAction.tone === 'high') {
       return {
@@ -1001,6 +1038,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         target: guardAction.route,
         reason: `Préserve ${protectedTarget} sur le segment le plus rentable sans relancer la chaîne.`,
         opportunityCost: `${routeDelay} Coût limité à ${guardAction.tradeoff}.`,
+        residualExposure,
       };
     }
 
@@ -1012,6 +1050,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         target: guardAction.route,
         reason: `Conserve le bénéfice principal sur ${protectedTarget} avec un relais non-chaîné.`,
         opportunityCost: `${routeDelay} Pas de garde ajoutée au-delà de ${stopMarker.label}.`,
+        residualExposure,
       };
     }
 
@@ -1022,6 +1061,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       target: protectedTarget,
       reason: `Cible la ville ou route la plus rentable déjà identifiée par le spillover.`,
       opportunityCost: `${routeDelay} La chaîne reste arrêtée avant ${blockedRoute}.`,
+      residualExposure,
     };
   };
   const guardOpportunityCost = guardSequencing.state === 'chainable' && nextGuardCost
@@ -1074,6 +1114,12 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             target: priorityAction.route,
             reason: `La garde protège déjà ${guardAction.route}; remplacer la récupération préserverait moins bien le bénéfice principal.`,
             opportunityCost: `Ne pas rouvrir la chaîne: ${priorityAction.route} reste retardée ce tour.`,
+            residualExposure: {
+              state: 'traced',
+              exposedRoutes: [{ route: priorityAction.route, city: option?.affectedCity ?? null, tone: 'high', reason: `${priorityAction.route} reste retardée si la garde remplace la récupération.` }],
+              benefit: `Le repli évite de surpayer la chaîne et protège ${guardAction.route}.`,
+              residualRisk: `${priorityAction.route} reste exposée tant que la récupération locale est différée.`,
+            },
           },
           canContinueWithoutCriticalDelay: false,
         }
@@ -1083,6 +1129,12 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           stopChain: false,
           stopMarker: null,
           fallbackAction: null,
+          residualExposure: {
+            state: 'unknown',
+            exposedRoutes: [],
+            benefit: 'Bénéfice du fallback non calculable sans point d’arrêt confirmé.',
+            residualRisk: 'Exposition restante non traçable précisément avec les signaux actuels.',
+          },
           canContinueWithoutCriticalDelay: false,
         };
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -212,6 +212,11 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.label, /Rediriger un flux vers Ember Line/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.reason, /bénéfice principal.*relais non-chaîné/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.opportunityCost, /Safe Road.*Pas de garde ajoutée/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.state, 'traced');
+  assert.deepEqual(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.exposedRoutes.map((route) => route.route), ['Safe Road']);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.exposedRoutes[0].reason, /au-delà du point d’arrêt/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.benefit, /protège Ember Line/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.residualRisk, /Safe Road.*reste exposé/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
@@ -250,6 +255,9 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.adjacentRouteSpilloverRisk.guardSequencing.phrase, /enchaînement inconnu/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.state, 'fallback');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.summary, /Coût d’opportunité indisponible/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.residualExposure.state, 'unknown');
+  assert.deepEqual(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.residualExposure.exposedRoutes, []);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.residualExposure.residualRisk, /non traçable précisément/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -110,6 +110,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /province-logistics-spillover-fallback/);
   assert.match(webAppSource, /fallbackAction\.label/);
   assert.match(webAppSource, /Repli:/);
+  assert.match(webAppSource, /province-logistics-spillover-residual-benefit/);
+  assert.match(webAppSource, /province-logistics-spillover-residual-risk/);
+  assert.match(webAppSource, /Reste exposé:/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8596,6 +8596,10 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               ` : ''}
               ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost?.fallbackAction ? `
                 <small class="province-logistics-spillover-fallback">Repli: ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.label} — ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.reason} Coût: ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.opportunityCost}</small>
+                ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure ? `
+                  <small class="province-logistics-spillover-residual-benefit">Bénéfice: ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.benefit}</small>
+                  <small class="province-logistics-spillover-residual-risk">Reste exposé: ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.residualRisk}</small>
+                ` : ''}
               ` : ''}
               ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost?.canContinueWithoutCriticalDelay ? '<small>Continuer la chaîne reste acceptable: aucune route critique n’est retardée.</small>' : ''}
             </div>


### PR DESCRIPTION
Beta: Implements #1507.

Summary:
- adds residual exposure details to recommended spillover fallback guards;
- separates fallback benefit from remaining exposed route/province risk;
- keeps an unknown fallback phrase when exposure cannot be traced precisely.

Validation:
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js
- node --check web/app.js
- git diff --check
- npm test

Closes #1507