### PR TITLE
[MAP-E35] Suggest secondary climate watch upkeep

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -16,6 +16,7 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /Moment promotion/);
   assert.match(webAppSource, /Transfert attention/);
   assert.match(webAppSource, /Reste secondaire si/);
+  assert.match(webAppSource, /Entretien minimal/);
   assert.match(webAppSource, /Secondaire suivant/);
   assert.match(webAppSource, /nextSecondaryRisk/);
   assert.match(webAppSource, /devient action primaire si la pression reste ≥80 au prochain check/);
@@ -25,10 +26,20 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /shortSecondaryLabel/);
   assert.match(webAppSource, /minimalProtection/);
   assert.match(webAppSource, /secondaryProtectionGuard/);
+  assert.match(webAppSource, /secondaryUpkeep/);
+  assert.match(webAppSource, /state: 'available'/);
+  assert.match(webAppSource, /state: 'impossible'/);
+  assert.match(webAppSource, /state: 'fallback'/);
+  assert.match(webAppSource, /garde \$\{watchGap\.label\} secondaire sans lancer une prévention complète/);
+  assert.match(webAppSource, /aucune action minimale calculable depuis la protection visible/);
+  assert.match(webAppSource, /relire la veille secondaire au prochain signal climat avant d’investir/);
+  assert.match(webAppSource, /ne pas confondre avec une prévention complète ou une action primaire/);
   assert.match(webAppSource, /coverageView\.secondaryProtections\?\.\[0\]/);
   assert.match(webAppSource, /coverageView\.activeProtections\?\.\[0\]/);
   assert.match(webAppSource, /reste secondaire si \$\{minimalProtection\.label\} tient/);
   assert.match(webAppSource, /action minimale: \$\{view\.watchItem\.secondaryProtectionGuard\.minimalAction\}/);
+  assert.match(webAppSource, /action minimale indisponible/);
+  assert.match(webAppSource, /map-world-climate-post-gap-watch__upkeep--\$\{view\.watchItem\.secondaryUpkeep\.state\}/);
   assert.match(webAppSource, /attendue ce tour-ci après résolution de l’action climatique principale/);
   assert.match(webAppSource, /au prochain tour si \$\{progress\.deadline\} confirme la pression secondaire/);
   assert.match(webAppSource, /seulement si la protection échoue ou si le seuil secondaire se rapproche/);
@@ -49,6 +60,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch--watch/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__cue/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__guard/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--available/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--impossible/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--fallback/);
 });
 
 test('atlas keeps a quiet fallback when no secondary climate watch is close enough', () => {
@@ -58,4 +73,25 @@ test('atlas keeps a quiet fallback when no secondary climate watch is close enou
   assert.match(webAppSource, /Ne pas créer de liste/);
   assert.match(webAppSource, /aucun second risque assez lisible sans créer une file/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch--quiet/);
+});
+
+test('atlas suggests available upkeep for a conditional secondary climate watch', () => {
+  assert.match(webAppSource, /secondaryUpkeep = secondaryProtectionGuard\?\.minimalAction/);
+  assert.match(webAppSource, /label: 'entretien minimal'/);
+  assert.match(webAppSource, /garde \$\{watchGap\.label\} secondaire sans lancer une prévention complète/);
+  assert.match(webAppSource, /<b>Entretien minimal<\/b>/);
+});
+
+test('atlas marks secondary climate upkeep impossible when no minimal action is calculable', () => {
+  assert.match(webAppSource, /state: 'impossible'/);
+  assert.match(webAppSource, /label: 'entretien impossible'/);
+  assert.match(webAppSource, /action minimale indisponible/);
+  assert.match(webAppSource, /aucune action minimale calculable depuis la protection visible/);
+});
+
+test('atlas keeps a readable upkeep fallback without adding climate mechanics', () => {
+  assert.match(webAppSource, /state: 'fallback'/);
+  assert.match(webAppSource, /label: 'fallback entretien'/);
+  assert.match(webAppSource, /relire la veille secondaire au prochain signal climat avant d’investir/);
+  assert.match(webAppSource, /aucune mitigation minimale disponible pour maintenir ce statut/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14111,9 +14111,29 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
     ? {
       label: minimalProtection.label,
       condition: `reste secondaire si ${minimalProtection.label} tient: ${minimalProtection.detail ?? minimalProtection.action}`,
-      minimalAction: minimalProtection.action ?? 'maintenir la mitigation minimale déjà affichée',
+      minimalAction: minimalProtection.action ?? null,
     }
     : null;
+  const secondaryUpkeep = secondaryProtectionGuard?.minimalAction
+    ? {
+      state: 'available',
+      label: 'entretien minimal',
+      action: secondaryProtectionGuard.minimalAction,
+      reason: `garde ${watchGap.label} secondaire sans lancer une prévention complète`,
+    }
+    : secondaryProtectionGuard
+      ? {
+        state: 'impossible',
+        label: 'entretien impossible',
+        action: 'aucune action minimale calculable depuis la protection visible',
+        reason: 'ne pas confondre avec une prévention complète ou une action primaire',
+      }
+      : {
+        state: 'fallback',
+        label: 'fallback entretien',
+        action: 'relire la veille secondaire au prochain signal climat avant d’investir',
+        reason: 'aucune mitigation minimale disponible pour maintenir ce statut',
+      };
   const nextSecondaryGap = (coverageView.blindSpots ?? [])
     .filter((gap) => !gap.nearest && gap.label !== gapActionView.recommendation.target && gap.label !== watchGap.label)
     .find((gap) => gap.nearestThresholdScore >= 40) ?? null;
@@ -14146,6 +14166,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       promotionCue,
       shortSecondaryLabel,
       secondaryProtectionGuard,
+      secondaryUpkeep,
     },
     nextSecondaryRisk,
     summary: `${watchGap.label}: seul watch item restant après l’action du gap prioritaire.`,
@@ -14182,7 +14203,8 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small><b>Devient primaire</b> · ${view.watchItem.promotionCondition}</small>
       <small><b>Moment promotion</b> · ${view.watchItem.promotionTiming}</small>
       <small><b>Transfert attention</b> · ${view.watchItem.promotionCue}</small>
-      ${view.watchItem.secondaryProtectionGuard ? `<small class="map-world-climate-post-gap-watch__guard"><b>Reste secondaire si</b> · ${view.watchItem.secondaryProtectionGuard.condition}; action minimale: ${view.watchItem.secondaryProtectionGuard.minimalAction}</small>` : ''}
+      ${view.watchItem.secondaryProtectionGuard ? `<small class="map-world-climate-post-gap-watch__guard"><b>Reste secondaire si</b> · ${view.watchItem.secondaryProtectionGuard.condition}${view.watchItem.secondaryProtectionGuard.minimalAction ? `; action minimale: ${view.watchItem.secondaryProtectionGuard.minimalAction}` : '; action minimale indisponible'}</small>` : ''}
+      <small class="map-world-climate-post-gap-watch__upkeep map-world-climate-post-gap-watch__upkeep--${view.watchItem.secondaryUpkeep.state}"><b>Entretien minimal</b> · ${view.watchItem.secondaryUpkeep.label}: ${view.watchItem.secondaryUpkeep.action}; ${view.watchItem.secondaryUpkeep.reason}</small>
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>
       <small><b>Prochain check</b> · ${view.watchItem.nextCheck}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13582,6 +13582,14 @@ button { font: inherit; }
   padding-left: 8px;
   border-left: 2px solid rgba(74, 222, 128, 0.38);
 }
+.map-world-climate-post-gap-watch__upkeep {
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.32);
+}
+.map-world-climate-post-gap-watch__upkeep--available { border: 1px solid rgba(74, 222, 128, 0.36); }
+.map-world-climate-post-gap-watch__upkeep--impossible { border: 1px solid rgba(251, 191, 36, 0.34); }
+.map-world-climate-post-gap-watch__upkeep--fallback { border: 1px solid rgba(148, 163, 184, 0.28); }
 
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);


### PR DESCRIPTION
Epsilon: Implements #1510.

- Adds a secondary climate watch upkeep recommendation derived from the existing protection guard.
- Separates minimal upkeep from full prevention/primary action language.
- Provides explicit available, impossible, and fallback upkeep states without changing climate simulation mechanics.
- Extends climate post-gap watch UI tests for available upkeep, impossible upkeep, and fallback.

Validations:
- `node --check web/app.js`
- `git diff --check`
- `npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js`

Zeta: ready for validation before merge.