### PR TITLE
Gamma: Warn on expiring cultural synergy

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1454,12 +1454,14 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
 
 function buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedCandidates, missedWindowConsequence) {
   const safePriorities = visiblePriorities.filter((priority) => priority.confidence !== 'low' && priority.level !== 'fragile');
-  const sameClusterPriority = safePriorities.find((priority) => priority.cultureName === candidate.clusterLabel);
+  const sameClusterPriority = safePriorities
+    .filter((priority) => priority.cultureName === candidate.clusterLabel)
+    .sort((left, right) => Number(right.expiresSoon === true) - Number(left.expiresSoon === true))[0];
   const neighboringPriority = safePriorities.find((priority) => priority.cultureName !== candidate.clusterLabel && priority.action !== 'attendre') ?? null;
   const narrativePrompt = normalizeText(`${candidate.minimalRevisitAction ?? ''} ${candidate.reason ?? ''}`);
 
   if (sameClusterPriority?.discoveryId && sameClusterPriority.discoveryId !== 'signal culturel') {
-    return {
+    const synergy = {
       state: 'synergy-this-turn',
       label: 'Synergie ce tour',
       sourceType: 'discovery',
@@ -1468,10 +1470,14 @@ function buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedC
       avoidedRisk: `évite de séparer la découverte du suivi reporté: ${missedWindowConsequence}`,
       summary: `synergie ce tour: ${sameClusterPriority.discoveryId} + ${candidate.clusterLabel}; ${sameClusterPriority.action} sécurisé.`,
     };
+    return {
+      ...synergy,
+      expiryWarning: buildCulturalSynergyExpiryWarning(synergy, candidate, sameClusterPriority),
+    };
   }
 
   if (/récit|recit|narrati/i.test(narrativePrompt)) {
-    return {
+    const synergy = {
       state: 'synergy-this-turn',
       label: 'Synergie ce tour',
       sourceType: 'narrative',
@@ -1480,10 +1486,14 @@ function buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedC
       avoidedRisk: `évite de laisser le récit dépasser la fenêtre sûre: ${missedWindowConsequence}`,
       summary: `synergie ce tour: récit actif + ${candidate.clusterLabel}; suivi narratif sécurisé.`,
     };
+    return {
+      ...synergy,
+      expiryWarning: buildCulturalSynergyExpiryWarning(synergy, candidate, null),
+    };
   }
 
   if (neighboringPriority && sortedCandidates.length > 1) {
-    return {
+    const synergy = {
       state: 'synergy-this-turn',
       label: 'Synergie ce tour',
       sourceType: 'neighbor-cluster',
@@ -1492,9 +1502,33 @@ function buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedC
       avoidedRisk: `évite que le cluster voisin reprenne seul la priorité: ${missedWindowConsequence}`,
       summary: `synergie ce tour: ${candidate.clusterLabel} + ${neighboringPriority.cultureName}; priorités proches alignées.`,
     };
+    return {
+      ...synergy,
+      expiryWarning: buildCulturalSynergyExpiryWarning(synergy, candidate, neighboringPriority),
+    };
   }
 
   return null;
+}
+
+function buildCulturalSynergyExpiryWarning(synergy, candidate, priority) {
+  const expiresBeforeReview = priority?.expiresSoon === true;
+
+  if (!expiresBeforeReview) {
+    return null;
+  }
+
+  const reviewWindow = candidate.nextReviewWindow ?? priority?.timingLabel ?? 'prochaine revue culturelle';
+  const expiryCause = priority?.timingLabel ?? 'priorité visible temporaire';
+
+  return {
+    state: 'expires-before-review',
+    label: 'expire avant revue',
+    reviewWindow,
+    expiryCause,
+    lostBenefit: `${synergy.sourceLabel} ne renforcera plus ${candidate.clusterLabel} de façon sûre`,
+    summary: `expire avant revue: ${expiryCause}; agir maintenant capture ${synergy.sourceLabel}.`,
+  };
 }
 
 function buildCulturalBeyondMinimumBenefit(candidate, missedFallout, missedWindowConsequence) {

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -922,6 +922,9 @@ test('buildCultureTurnReportDeltas explains the benefit of acting beyond the cul
     entry.immediateSynergy?.sourceLabel ?? null,
     entry.immediateSynergy?.benefit ?? null,
     entry.immediateSynergy?.avoidedRisk ?? null,
+    entry.immediateSynergy?.expiryWarning?.label ?? null,
+    entry.immediateSynergy?.expiryWarning?.reviewWindow ?? null,
+    entry.immediateSynergy?.expiryWarning?.lostBenefit ?? null,
   ]), [
     [
       'Compact d’Aurora',
@@ -935,9 +938,96 @@ test('buildCultureTurnReportDeltas explains the benefit of acting beyond the cul
       'archive-routes',
       'archive-routes renforce amplifier avec Compact d’Aurora',
       'évite de séparer la découverte du suivi reporté: Compact d’Aurora: consolidation retardée d’un tour si le bundle n’est pas réévalué.',
+      null,
+      null,
+      null,
     ],
-    ['Harbor Compact', 'later', null, null, null, null, null, null, null, null, null],
+    ['Harbor Compact', 'later', null, null, null, null, null, null, null, null, null, null, null, null],
   ]);
+});
+
+
+test('buildCultureTurnReportDeltas warns when immediate cultural synergy expires before review', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 9,
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'amplifier',
+      },
+    },
+    activeRecommendations: [
+      {
+        recommendationId: 'river-gate:aurora:expiring-discovery',
+        regionId: 'river-gate',
+        cultureName: 'Compact d’Aurora',
+        action: 'amplifier',
+        tone: 'opportunity',
+        level: 'surging',
+        discoveryId: 'archive-routes',
+        confidence: 'high',
+        supportKey: 'amplifier',
+        markerIds: ['aurora-marker'],
+        rank: 1,
+        expiresSoon: true,
+        timingLabel: 'expire avant la prochaine revue',
+      },
+    ],
+    localTimeline: {
+      items: [
+        {
+          timelineId: 'harbor:event:quiet-followup',
+          kind: 'event',
+          signal: 'watch',
+          title: 'Suivi calme',
+          summary: 'Risque stabilisé.',
+          regionId: 'harbor',
+          cultureName: 'Harbor Compact',
+        },
+      ],
+    },
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'deferred',
+        outcome: 'soutien actif confirmé',
+      },
+      {
+        decisionId: 'turn-8-harbor-calm',
+        turn: 8,
+        regionId: 'harbor',
+        clusterLabel: 'Harbor Compact',
+        theme: 'Calmer le port',
+        promptLabel: 'Calmer le port',
+        choiceState: 'deferred',
+        outcome: 'risque stabilisé',
+      },
+    ],
+  });
+
+  const expiringSynergy = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries[0].immediateSynergy;
+  assert.deepEqual(expiringSynergy.expiryWarning, {
+    state: 'expires-before-review',
+    label: 'expire avant revue',
+    reviewWindow: 'prochaine rotation culturelle',
+    expiryCause: 'expire avant la prochaine revue',
+    lostBenefit: 'archive-routes ne renforcera plus Compact d’Aurora de façon sûre',
+    summary: 'expire avant revue: expire avant la prochaine revue; agir maintenant capture archive-routes.',
+  });
 });
 
 test('buildCultureTurnReportDeltas breaks safe defer deadline ties by cultural payoff', () => {

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -184,6 +184,8 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Action minimale:/);
   assert.match(webAppSource, /Au-delà du minimum:/);
   assert.match(webAppSource, /Synergie ce tour:/);
+  assert.match(webAppSource, /Synergie temporaire:/);
+  assert.match(webAppSource, /expiryWarning/);
   assert.match(webAppSource, /Bénéfice:/);
   assert.match(webAppSource, /risque évité:/);
   assert.match(webAppSource, /Évite au prochain tour:/);

--- a/web/app.js
+++ b/web/app.js
@@ -7728,6 +7728,7 @@ function renderCultureTurnReport(report) {
                   ${entry.revisitPriority === 'next' && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.immediateSynergy ? `<small>Synergie ce tour: ${entry.immediateSynergy.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.immediateSynergy?.expiryWarning ? `<small>Synergie temporaire: ${entry.immediateSynergy.expiryWarning.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.immediateSynergy ? `<small>Bénéfice: ${entry.immediateSynergy.benefit}; risque évité: ${entry.immediateSynergy.avoidedRisk}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.recommendedBeyondMinimumBenefit ? `<small>Évite au prochain tour: ${entry.recommendedBeyondMinimumBenefit.nextTurnAvoidance}; ${entry.recommendedBeyondMinimumBenefit.avoids}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalActionAcceptableUntil ? `<small>Seuil: minimale jusqu’à ${entry.minimalActionAcceptableUntil}; recommandé: ${entry.recommendedAction}; tardif risqué: ${entry.lateRiskyAction}</small>` : ''}


### PR DESCRIPTION
Gamma: Implements #1508.

Summary:
- Adds an `expiryWarning` to immediate cultural synergies only when the linked visible priority has explicit expiration data.
- Keeps stable synergies unchanged with no extra warning when expiration data is absent.
- Renders a short “Synergie temporaire” line in the culture turn report for expiring synergies.

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: PR prête pour validation avant merge.