### PR TITLE
[MAP-E36] Summarize climate watch ladder

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -17,6 +17,7 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /Transfert attention/);
   assert.match(webAppSource, /Reste secondaire si/);
   assert.match(webAppSource, /Entretien minimal/);
+  assert.match(webAppSource, /Synthèse watch/);
   assert.match(webAppSource, /Secondaire suivant/);
   assert.match(webAppSource, /nextSecondaryRisk/);
   assert.match(webAppSource, /devient action primaire si la pression reste ≥80 au prochain check/);
@@ -27,6 +28,8 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /minimalProtection/);
   assert.match(webAppSource, /secondaryProtectionGuard/);
   assert.match(webAppSource, /secondaryUpkeep/);
+  assert.match(webAppSource, /watchLadderSummary/);
+  assert.match(webAppSource, /remainingWatchItems\.length > 1/);
   assert.match(webAppSource, /state: 'available'/);
   assert.match(webAppSource, /state: 'impossible'/);
   assert.match(webAppSource, /state: 'fallback'/);
@@ -64,6 +67,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--available/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--impossible/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--fallback/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--watch-only/);
 });
 
 test('atlas keeps a quiet fallback when no secondary climate watch is close enough', () => {
@@ -94,4 +101,26 @@ test('atlas keeps a readable upkeep fallback without adding climate mechanics', 
   assert.match(webAppSource, /label: 'fallback entretien'/);
   assert.match(webAppSource, /relire la veille secondaire au prochain signal climat avant d’investir/);
   assert.match(webAppSource, /aucune mitigation minimale disponible pour maintenir ce statut/);
+});
+
+
+test('atlas summarizes the watch ladder when the primary remains first', () => {
+  assert.match(webAppSource, /state: 'primary-first'/);
+  assert.match(webAppSource, /decision: 'traiter le primaire'/);
+  assert.match(webAppSource, /Traiter le primaire: \$\{watchGap\.label\}/);
+  assert.match(webAppSource, /ne pas rendre le secondaire plus urgent que le primaire/);
+});
+
+test('atlas summarizes the ladder with secondary upkeep when useful', () => {
+  assert.match(webAppSource, /state: 'upkeep-secondary'/);
+  assert.match(webAppSource, /decision: 'entretenir un secondaire'/);
+  assert.match(webAppSource, /Entretenir un secondaire: \$\{secondaryUpkeep\.action\}/);
+  assert.match(webAppSource, /plus petit upkeep utile, pas une prévention complète/);
+});
+
+test('atlas summarizes the ladder as watch-only when thresholds are uncertain', () => {
+  assert.match(webAppSource, /state: 'watch-only'/);
+  assert.match(webAppSource, /decision: 'surveiller sans action immédiate'/);
+  assert.match(webAppSource, /Surveiller sans action immédiate: \$\{watchGap\.label\}/);
+  assert.match(webAppSource, /fallback robuste quand les seuils ou protections ne sont pas connus/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14138,9 +14138,33 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
         action: 'relire la veille secondaire au prochain signal climat avant d’investir',
         reason: 'aucune mitigation minimale disponible pour maintenir ce statut',
       };
-  const nextSecondaryGap = (coverageView.blindSpots ?? [])
-    .filter((gap) => !gap.nearest && gap.label !== gapActionView.recommendation.target && gap.label !== watchGap.label)
+  const remainingWatchItems = (coverageView.blindSpots ?? [])
+    .filter((gap) => !gap.nearest && gap.label !== gapActionView.recommendation.target && gap.nearestThresholdScore >= 40);
+  const nextSecondaryGap = remainingWatchItems
+    .filter((gap) => gap.label !== watchGap.label)
     .find((gap) => gap.nearestThresholdScore >= 40) ?? null;
+  const watchLadderSummary = remainingWatchItems.length > 1
+    ? watchGap.nearestThresholdScore >= 80
+      ? {
+        state: 'primary-first',
+        decision: 'traiter le primaire',
+        line: `Traiter le primaire: ${watchGap.label}; garder ${nextSecondaryGap?.label ?? 'le secondaire'} sous veille compacte.`,
+        why: 'promotion proche: ne pas rendre le secondaire plus urgent que le primaire',
+      }
+      : secondaryUpkeep.state === 'available'
+        ? {
+          state: 'upkeep-secondary',
+          decision: 'entretenir un secondaire',
+          line: `Entretenir un secondaire: ${secondaryUpkeep.action}; ${watchGap.label} reste sous le primaire.`,
+          why: 'plus petit upkeep utile, pas une prévention complète',
+        }
+        : {
+          state: 'watch-only',
+          decision: 'surveiller sans action immédiate',
+          line: `Surveiller sans action immédiate: ${watchGap.label}; seuil ou protection encore incertain.`,
+          why: 'fallback robuste quand les seuils ou protections ne sont pas connus',
+        }
+    : null;
   const protectedSecondary = !nextSecondaryGap ? coverageView.secondaryProtections?.[0] ?? coverageView.activeProtections?.[0] ?? null : null;
   const nextSecondaryRisk = nextSecondaryGap
     ? {
@@ -14171,6 +14195,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       shortSecondaryLabel,
       secondaryProtectionGuard,
       secondaryUpkeep,
+      watchLadderSummary,
     },
     nextSecondaryRisk,
     summary: `${watchGap.label}: seul watch item restant après l’action du gap prioritaire.`,
@@ -14209,6 +14234,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small><b>Transfert attention</b> · ${view.watchItem.promotionCue}</small>
       ${view.watchItem.secondaryProtectionGuard ? `<small class="map-world-climate-post-gap-watch__guard"><b>Reste secondaire si</b> · ${view.watchItem.secondaryProtectionGuard.condition}${view.watchItem.secondaryProtectionGuard.minimalAction ? `; action minimale: ${view.watchItem.secondaryProtectionGuard.minimalAction}` : '; action minimale indisponible'}</small>` : ''}
       <small class="map-world-climate-post-gap-watch__upkeep map-world-climate-post-gap-watch__upkeep--${view.watchItem.secondaryUpkeep.state}"><b>Entretien minimal</b> · ${view.watchItem.secondaryUpkeep.label}: ${view.watchItem.secondaryUpkeep.action}; ${view.watchItem.secondaryUpkeep.reason}</small>
+      ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>
       <small><b>Prochain check</b> · ${view.watchItem.nextCheck}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13605,6 +13605,14 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__upkeep--available { border: 1px solid rgba(74, 222, 128, 0.36); }
 .map-world-climate-post-gap-watch__upkeep--impossible { border: 1px solid rgba(251, 191, 36, 0.34); }
 .map-world-climate-post-gap-watch__upkeep--fallback { border: 1px solid rgba(148, 163, 184, 0.28); }
+.map-world-climate-post-gap-watch__ladder {
+  padding: 4px 8px;
+  border-radius: 11px;
+  background: rgba(15, 23, 42, 0.38);
+}
+.map-world-climate-post-gap-watch__ladder--primary-first { border: 1px solid rgba(248, 113, 113, 0.34); }
+.map-world-climate-post-gap-watch__ladder--upkeep-secondary { border: 1px solid rgba(74, 222, 128, 0.34); }
+.map-world-climate-post-gap-watch__ladder--watch-only { border: 1px solid rgba(125, 211, 252, 0.28); }
 
 .province-node--action-available::before {
   border-color: rgba(74, 222, 128, 0.48);


### PR DESCRIPTION
Epsilon: Implements #1520.

- Adds a compact climate watch ladder summary only when multiple watch items are present.
- Combines promotion, protection guard, and upkeep into one decision: treat primary first, upkeep a secondary, or watch without immediate action.
- Keeps the secondary below the primary and leaves existing MAP-E33/E34/E35 detail lines intact without duplicating them.
- Adds robust fallback language for unknown thresholds/protections plus targeted UI climate tests for the three expected cases.

Validations:
- `node --check web/app.js`
- `git diff --check`
- `npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js`

Zeta: ready for validation before merge.