### PR TITLE
Alpha: MAP-A37 summarize front follow-up ladder

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -365,3 +365,24 @@ test('atlas military shows delay cost for blocked front prep actions', () => {
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-alt__delay--risky/);
 });
+
+// MAP-A37: when multiple follow-up signals coexist, add one compact ladder that
+// orders play-now, prep, and delay-risk cues without duplicating each row.
+test('atlas military summarizes the front follow-up ladder', () => {
+  assert.match(webAppSource, /function buildAtlasMilitaryBlockedFollowUpLadder\(alternative, candidates = \[\]\)/);
+  assert.match(webAppSource, /const playableEntry = candidates\.find\(\(entry\) => entry\.viability\.status === 'ready'\)/);
+  assert.match(webAppSource, /jouer maintenant: \$\{playableEntry\.option\.nextAction\}/);
+  assert.match(webAppSource, /jouer maintenant: \$\{alternative\.action\}/);
+  assert.match(webAppSource, /const prepEntry = candidates\.find\(\(entry\) => entry\.viability\.status === 'prep'\)/);
+  assert.match(webAppSource, /préparer: \$\{prepUnlock\.action\}/);
+  assert.match(webAppSource, /attendre: \$\{prepUnlock\.delayCost\.label\.toLowerCase\(\)\}/);
+  assert.match(webAppSource, /if \(steps\.length < 2\)/);
+  assert.match(webAppSource, /label: 'Échelle suivi front'/);
+  assert.match(webAppSource, /detail: steps\.join\(' → '\)/);
+  assert.match(webAppSource, /const blockedFollowUpLadder = buildAtlasMilitaryBlockedFollowUpLadder\(blockedFollowUpAlternative, candidates\)/);
+  assert.match(webAppSource, /renderAtlasMilitaryBlockedFollowUpLadder\(preview\.blockedFollowUpLadder, ladderY\)/);
+  assert.match(webAppSource, /Synthèse échelle de suivi de front/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder--ready/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder--prep/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder--risky/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2768,6 +2768,49 @@ function getAtlasMilitaryBlockedFollowUpPrepUnlock(option, checklistItem) {
   };
 }
 
+function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = []) {
+  if (!alternative?.visible || alternative.viabilityStatus === 'avoid') {
+    return {
+      visible: false,
+      tone: 'quiet',
+      label: 'Synthèse suivi front indisponible',
+      detail: 'pas assez de signaux fiables',
+    };
+  }
+  const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
+  const prepEntry = candidates.find((entry) => entry.viability.status === 'prep') ?? null;
+  const prepUnlock = prepEntry
+    ? getAtlasMilitaryBlockedFollowUpPrepUnlock({ ...prepEntry.option, viabilityStatus: prepEntry.viability.status }, prepEntry.checklistItem)
+    : alternative.prepUnlock;
+  const steps = [];
+  if (playableEntry) {
+    steps.push(`jouer maintenant: ${playableEntry.option.nextAction}`);
+  } else if (alternative.viabilityStatus === 'ready') {
+    steps.push(`jouer maintenant: ${alternative.action}`);
+  }
+  if (prepUnlock) {
+    steps.push(`préparer: ${prepUnlock.action}`);
+  }
+  if (prepUnlock?.delayCost) {
+    steps.push(`attendre: ${prepUnlock.delayCost.label.toLowerCase()}`);
+  }
+  if (steps.length < 2) {
+    return {
+      visible: false,
+      tone: 'quiet',
+      label: 'Synthèse suivi front masquée',
+      detail: 'un seul signal, ligne dédiée suffisante',
+    };
+  }
+  const delayCost = prepUnlock?.delayCost ?? null;
+  return {
+    visible: true,
+    tone: delayCost?.tone === 'risky' ? 'risky' : alternative.viabilityStatus === 'ready' ? 'ready' : 'prep',
+    label: 'Échelle suivi front',
+    detail: steps.join(' → '),
+  };
+}
+
 function buildAtlasMilitaryBlockedResidualFollowUpAlternative(followUp, conflict, recommendation, checklist) {
   if (!followUp?.visible || !conflict?.visible || conflict.tone === 'safe') {
     return {
@@ -2853,6 +2896,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       residualFollowUpOrder: buildAtlasMilitaryNeighborResidualFollowUpOrder(buildAtlasMilitaryNeighborSharedResidualRisk(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])), buildAtlasMilitaryNeighborSharedHandlingHint(buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), [])))), buildAtlasMilitaryNeighborFrontUrgencyCluster([], buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewChangeExplanation(buildAtlasMilitaryNeighborReviewStaleness(recommendation, []), buildAtlasMilitaryNeighborReviewPriority([]), []))),
       residualFollowUpConflict: buildAtlasMilitaryNeighborResidualFollowUpConflict(null, recommendation, checklist),
       blockedFollowUpAlternative: buildAtlasMilitaryBlockedResidualFollowUpAlternative(null, buildAtlasMilitaryNeighborResidualFollowUpConflict(null, recommendation, checklist), recommendation, checklist),
+      blockedFollowUpLadder: buildAtlasMilitaryBlockedFollowUpLadder(buildAtlasMilitaryBlockedResidualFollowUpAlternative(null, buildAtlasMilitaryNeighborResidualFollowUpConflict(null, recommendation, checklist), recommendation, checklist)),
       summary: 'Prévision voisins indisponible: aucun ordre de province en focus.',
       empty: true,
     };
@@ -2887,6 +2931,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
   const residualFollowUpOrder = buildAtlasMilitaryNeighborResidualFollowUpOrder(sharedResidualRisk, urgencyCluster);
   const residualFollowUpConflict = buildAtlasMilitaryNeighborResidualFollowUpConflict(residualFollowUpOrder, recommendation, checklist);
   const blockedFollowUpAlternative = buildAtlasMilitaryBlockedResidualFollowUpAlternative(residualFollowUpOrder, residualFollowUpConflict, recommendation, checklist);
+  const blockedFollowUpLadder = buildAtlasMilitaryBlockedFollowUpLadder(blockedFollowUpAlternative, candidates);
 
   if (!shifts.length) {
     return {
@@ -2903,6 +2948,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
       residualFollowUpOrder,
       residualFollowUpConflict,
       blockedFollowUpAlternative,
+      blockedFollowUpLadder,
       summary: `${focusProvince}: aucun front voisin lisible après engagement.`,
       empty: true,
     };
@@ -2922,7 +2968,8 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
     residualFollowUpOrder,
     residualFollowUpConflict,
     blockedFollowUpAlternative,
-    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}; ${reviewStaleness.label}; ${reviewChange.label}${urgencyCluster.visible ? `; ${urgencyCluster.label}; ${sharedHandlingHint.label}${sharedResidualRisk.visible ? `; ${sharedResidualRisk.label}${residualFollowUpOrder.visible ? `; ${residualFollowUpOrder.label}; ${residualFollowUpConflict.label}${blockedFollowUpAlternative.visible ? `; ${blockedFollowUpAlternative.label}` : ''}` : ''}` : ''}` : contestedPriority.visible ? `; ${contestedPriority.label}` : ''}.`,
+    blockedFollowUpLadder,
+    summary: `${focusProvince}: ${shifts.length} front${shifts.length > 1 ? 's' : ''} voisin${shifts.length > 1 ? 's' : ''} à prévisualiser après ${focus?.nextAction ?? 'ordre'}; ${reviewPriority.label}; ${reviewStaleness.label}; ${reviewChange.label}${urgencyCluster.visible ? `; ${urgencyCluster.label}; ${sharedHandlingHint.label}${sharedResidualRisk.visible ? `; ${sharedResidualRisk.label}${residualFollowUpOrder.visible ? `; ${residualFollowUpOrder.label}; ${residualFollowUpConflict.label}${blockedFollowUpAlternative.visible ? `; ${blockedFollowUpAlternative.label}${blockedFollowUpLadder.visible ? `; ${blockedFollowUpLadder.label}` : ''}` : ''}` : ''}` : ''}` : contestedPriority.visible ? `; ${contestedPriority.label}` : ''}.`,
     empty: false,
   };
 }
@@ -3014,6 +3061,16 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
   `;
 }
 
+function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
+  if (!ladder?.visible) return '';
+  return `
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}">
+      <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
+      <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
+    </g>
+  `;
+}
+
 function renderAtlasMilitaryBlockedResidualFollowUpAlternative(alternative, y) {
   if (!alternative?.visible) return '';
   const delayCost = alternative.prepUnlock?.delayCost ?? null;
@@ -3046,7 +3103,9 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
   const alternativeBlockHeight = preview.blockedFollowUpAlternative?.visible
     ? preview.blockedFollowUpAlternative?.prepUnlock?.delayCost ? 5.2 : preview.blockedFollowUpAlternative?.prepUnlock ? 3.85 : 2.5
     : 0;
-  const contestedY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
+  const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
+  const ladderHeight = preview.blockedFollowUpLadder?.visible ? 2.5 : 0;
+  const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? 2.75 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;
   const hintHeight = preview.sharedHandlingHint?.visible ? 2.5 : 0;
   const residualHeight = preview.sharedResidualRisk?.visible ? 2.5 : 0;
@@ -3054,7 +3113,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
   const conflictHeight = preview.residualFollowUpConflict?.visible ? 2.5 : 0;
   const alternativeHeight = alternativeBlockHeight;
   const contestedHeight = preview.contestedPriority?.visible ? 2.5 : 0;
-  const height = (preview.empty ? 13.6 : 13.6 + (preview.shifts.length * 3.45)) + clusterHeight + hintHeight + residualHeight + followUpHeight + conflictHeight + alternativeHeight + contestedHeight;
+  const height = (preview.empty ? 13.6 : 13.6 + (preview.shifts.length * 3.45)) + clusterHeight + hintHeight + residualHeight + followUpHeight + conflictHeight + alternativeHeight + ladderHeight + contestedHeight;
   return `
     <g class="atlas-military-neighbor-front-shift atlas-military-neighbor-front-shift--${preview.empty ? 'empty' : 'active'}" aria-label="Prévisualisation des fronts voisins après engagement: ${preview.summary}">
       <rect class="atlas-military-neighbor-front-shift__panel" x="43" y="157" width="35" height="${height}" rx="2.1"></rect>
@@ -3076,6 +3135,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
       ${renderAtlasMilitaryNeighborResidualFollowUpOrder(preview.residualFollowUpOrder, followUpY)}
       ${renderAtlasMilitaryNeighborResidualFollowUpConflict(preview.residualFollowUpConflict, conflictY)}
       ${renderAtlasMilitaryBlockedResidualFollowUpAlternative(preview.blockedFollowUpAlternative, alternativeY)}
+      ${renderAtlasMilitaryBlockedFollowUpLadder(preview.blockedFollowUpLadder, ladderY)}
       ${renderAtlasMilitaryNeighborContestedHandlingPriority(preview.contestedPriority, contestedY)}
     </g>
   `;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14565,7 +14565,8 @@ button { font: inherit; }
 .atlas-military-neighbor-residual-follow-up-conflict__detail,
 .atlas-military-neighbor-blocked-follow-up-alt__detail,
 .atlas-military-neighbor-blocked-follow-up-alt__prep,
-.atlas-military-neighbor-blocked-follow-up-alt__delay {
+.atlas-military-neighbor-blocked-follow-up-alt__delay,
+.atlas-military-neighbor-blocked-follow-up-ladder__detail {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14581,7 +14582,8 @@ button { font: inherit; }
 .atlas-military-neighbor-shared-residual__label,
 .atlas-military-neighbor-residual-follow-up__label,
 .atlas-military-neighbor-residual-follow-up-conflict__label,
-.atlas-military-neighbor-blocked-follow-up-alt__label {
+.atlas-military-neighbor-blocked-follow-up-alt__label,
+.atlas-military-neighbor-blocked-follow-up-ladder__label {
   fill: #f5f3ff;
   font-size: 0.55px;
   font-weight: 900;
@@ -14620,7 +14622,10 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-alt--blocked .atlas-military-neighbor-blocked-follow-up-alt__label { fill: #fecdd3; }
 .atlas-military-neighbor-blocked-follow-up-alt--cost .atlas-military-neighbor-blocked-follow-up-alt__label,
 .atlas-military-neighbor-blocked-follow-up-alt--dependency .atlas-military-neighbor-blocked-follow-up-alt__label,
-.atlas-military-neighbor-blocked-follow-up-alt--preparation .atlas-military-neighbor-blocked-follow-up-alt__label { fill: #fde68a; }
+.atlas-military-neighbor-blocked-follow-up-alt--preparation .atlas-military-neighbor-blocked-follow-up-alt__label,
+.atlas-military-neighbor-blocked-follow-up-ladder--prep .atlas-military-neighbor-blocked-follow-up-ladder__label { fill: #fde68a; }
+.atlas-military-neighbor-blocked-follow-up-ladder--ready .atlas-military-neighbor-blocked-follow-up-ladder__label { fill: #bbf7d0; }
+.atlas-military-neighbor-blocked-follow-up-ladder--risky .atlas-military-neighbor-blocked-follow-up-ladder__label { fill: #fecdd3; }
 .atlas-military-neighbor-front-shift-row circle {
   fill: rgba(167, 139, 250, 0.84);
   stroke: rgba(245, 243, 255, 0.72);


### PR DESCRIPTION
Alpha: Implements #1516.\n\nSummary:\n- adds a compact fog-safe follow-up ladder when multiple blocked-front cues coexist\n- orders current playable action, minimal prep, and delay cost/risks without duplicating the existing MAP-A34/A35/A36 rows\n- styles the ladder for ready/prep/risky tones and includes coverage for playable, prep, and delay-risk cues\n\nValidation:\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test\n\nZeta: ready for validation before merge.