### PR TITLE
Beta: MAP-B37 summarize logistics guard ladder

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -850,6 +850,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: aucune garde concrète à classer.' },
       guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Capacité de garde indisponible sans récupération locale.' },
       guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune chaîne de garde à prolonger.', stopChain: false, residualExposure: { state: 'unknown', exposedRoutes: [], benefit: 'Bénéfice du fallback non calculable sans chaîne de garde.', residualRisk: 'Exposition restante non traçable précisément avec les signaux actuels.' } },
+      guardDecisionSummary: { state: 'unknown', action: 'wait-for-signals', label: 'Comparer au prochain signal', summary: 'Exposition restante non traçable précisément avec les signaux actuels.', reason: 'Bénéfice du fallback non calculable sans chaîne de garde.' },
     };
   }
 
@@ -896,6 +897,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: coût de garde non comparable sans route exposée.' },
       guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Aucune route exposée ne permet de comparer la capacité de garde.' },
       guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune route adjacente exposée à comparer.', stopChain: false, residualExposure: { state: 'unknown', exposedRoutes: [], benefit: 'Bénéfice du fallback non calculable sans route exposée.', residualRisk: 'Exposition restante non traçable précisément avec les signaux actuels.' } },
+      guardDecisionSummary: { state: 'unknown', action: 'wait-for-signals', label: 'Comparer au prochain signal', summary: 'Exposition restante non traçable précisément avec les signaux actuels.', reason: 'Bénéfice du fallback non calculable sans route exposée.' },
     };
   }
 
@@ -1137,6 +1139,61 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           },
           canContinueWithoutCriticalDelay: false,
         };
+  const buildGuardDecisionSummary = (opportunityCost) => {
+    if (!opportunityCost) {
+      return {
+        state: 'unknown',
+        action: 'wait-for-signals',
+        label: 'Décision garde inconnue',
+        summary: 'Synthèse indisponible: les signaux de garde ne sont pas comparables.',
+        reason: 'Aucun coût d’opportunité exploitable.',
+      };
+    }
+
+    if (opportunityCost.canContinueWithoutCriticalDelay || opportunityCost.state === 'continue') {
+      return {
+        state: 'continue',
+        action: 'continue-guard',
+        label: 'Continuer la garde',
+        summary: `Continuer vers ${opportunityCost.delayedRoute ?? 'le segment suivant'}: aucune route critique retardée.`,
+        reason: opportunityCost.stopReason ?? 'Le coût reste couvert par le bénéfice attendu.',
+      };
+    }
+
+    const exposure = opportunityCost.fallbackAction?.residualExposure ?? opportunityCost.residualExposure ?? null;
+    const exposedRoutes = exposure?.exposedRoutes ?? [];
+    const comparableExposure = exposure?.state === 'traced' && exposedRoutes.length > 0;
+    const urgentExposure = comparableExposure && exposedRoutes.some((route) => route.tone === 'high');
+
+    if (opportunityCost.fallbackAction && urgentExposure) {
+      return {
+        state: 'fallback',
+        action: 'use-fallback',
+        label: 'Basculer sur le fallback',
+        summary: `${opportunityCost.fallbackAction.label}: réduit le risque principal sans rouvrir la chaîne.`,
+        reason: exposure.residualRisk,
+      };
+    }
+
+    if (comparableExposure) {
+      return {
+        state: 'watch',
+        action: 'accept-exposure',
+        label: 'Accepter l’exposition ce tour',
+        summary: `${exposedRoutes.map((route) => route.route).join(', ')} reste à surveiller après le bénéfice principal.`,
+        reason: exposure.benefit,
+      };
+    }
+
+    return {
+      state: 'watch',
+      action: 'accept-exposure',
+      label: 'Accepter l’exposition à surveiller',
+      summary: exposure?.residualRisk ?? 'Exposition restante non comparable avec les signaux actuels.',
+      reason: exposure?.benefit ?? 'Fallback neutre: aucune route restante traçable précisément.',
+    };
+  };
+  const guardDecisionSummary = buildGuardDecisionSummary(guardOpportunityCost);
 
   return {
     state: secondaryRoutes.length > 0 ? 'chain' : 'single',
@@ -1148,6 +1205,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
     guardComparison,
     guardSequencing,
     guardOpportunityCost,
+    guardDecisionSummary,
   };
 }
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -133,6 +133,9 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopChain, true);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.summary, /Protège .*retarde/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.stopReason, /Ne pas prolonger|remplace déjà/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.state, 'fallback');
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.action, 'use-fallback');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.summary, /Différer|fallback/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -217,6 +220,9 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.exposedRoutes[0].reason, /au-delà du point d’arrêt/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.benefit, /protège Ember Line/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.residualRisk, /Safe Road.*reste exposé/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.state, 'watch');
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.action, 'accept-exposure');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.summary, /Safe Road.*reste à surveiller/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
@@ -258,6 +264,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.residualExposure.state, 'unknown');
   assert.deepEqual(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.residualExposure.exposedRoutes, []);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.residualExposure.residualRisk, /non traçable précisément/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.state, 'unknown');
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.action, 'wait-for-signals');
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -113,6 +113,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /province-logistics-spillover-residual-benefit/);
   assert.match(webAppSource, /province-logistics-spillover-residual-risk/);
   assert.match(webAppSource, /Reste exposé:/);
+  assert.match(webAppSource, /province-logistics-spillover-ladder/);
+  assert.match(webAppSource, /guardDecisionSummary/);
+  assert.match(webAppSource, /Synthèse garde:/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8634,6 +8634,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                   <small class="province-logistics-spillover-residual-risk">Reste exposé: ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.residualExposure.residualRisk}</small>
                 ` : ''}
               ` : ''}
+              ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary ? `
+                <small class="province-logistics-spillover-ladder province-logistics-spillover-ladder--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.state}">Synthèse garde: ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.label} — ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.summary}</small>
+              ` : ''}
               ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost?.canContinueWithoutCriticalDelay ? '<small>Continuer la chaîne reste acceptable: aucune route critique n’est retardée.</small>' : ''}
             </div>
           ` : ''}


### PR DESCRIPTION
Beta: Implements #1517.\n\nSummary:\n- Adds a compact guard decision summary that reuses existing stop marker, fallback, and residual exposure preview signals.\n- Surfaces continue, fallback, and accepted residual exposure states for the map panel without recalculating economy.\n- Renders the ladder summary in the province logistics spillover card.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test