### PR TITLE
Gamma: Summarize cultural defer ladder

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1395,12 +1395,13 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
         ? `${candidate.deadlineHint}: la petite action cesse de suffire si ${candidate.turningSignal}.`
         : `payoff ${candidate.payoffScore}: la petite action reste seulement valable jusqu’à la ${candidate.nextReviewWindow}.`)
       : null;
-    const recommendedBeyondMinimumBenefit = minimalSafeAction && missedWindowConsequence
+    const recommendedBeyondMinimumBenefit = missedWindowConsequence
       ? buildCulturalBeyondMinimumBenefit(candidate, missedFallout, missedWindowConsequence)
       : null;
     const immediateSynergy = recommendedBeyondMinimumBenefit
       ? buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedCandidates, missedWindowConsequence)
       : null;
+    const deferLadderSummary = buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBenefit, immediateSynergy);
 
     return {
       ...candidate,
@@ -1421,6 +1422,7 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
       minimalActionThresholdReason,
       recommendedBeyondMinimumBenefit,
       immediateSynergy,
+      deferLadderSummary,
     };
   });
   const top = rankedCandidates[0] ?? null;
@@ -1449,6 +1451,37 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
       ? 'Priorité par pression de délai, puis payoff culturel.'
       : 'Fallback: aucune fenêtre de délai calculable, garder l’ordre stable par risque faible puis culture.',
     entries: rankedCandidates,
+  };
+}
+
+function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBenefit, immediateSynergy) {
+  if (!recommendedBeyondMinimumBenefit || !immediateSynergy) {
+    return null;
+  }
+
+  if (immediateSynergy.expiryWarning) {
+    return {
+      state: 'act-now',
+      label: 'Agir maintenant',
+      decision: 'agir maintenant pour capturer la synergie avant expiration',
+      summary: `Agir maintenant: ${immediateSynergy.expiryWarning.summary}`,
+    };
+  }
+
+  if (candidate.deadlineStatus === 'near-deadline') {
+    return {
+      state: 'minimum-sufficient',
+      label: 'Minimum suffisant',
+      decision: 'faire le minimum garde la fenêtre sans perdre la synergie visible',
+      summary: `Minimum suffisant: ${candidate.minimalRevisitAction}; ${immediateSynergy.summary}`,
+    };
+  }
+
+  return {
+    state: 'safe-defer',
+    label: 'Report sûr',
+    decision: 'reporter sans perdre la synergie visible',
+    summary: `Report sûr: ${candidate.deadlineHint}; ${immediateSynergy.summary}`,
   };
 }
 

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -925,6 +925,9 @@ test('buildCultureTurnReportDeltas explains the benefit of acting beyond the cul
     entry.immediateSynergy?.expiryWarning?.label ?? null,
     entry.immediateSynergy?.expiryWarning?.reviewWindow ?? null,
     entry.immediateSynergy?.expiryWarning?.lostBenefit ?? null,
+    entry.deferLadderSummary?.state ?? null,
+    entry.deferLadderSummary?.label ?? null,
+    entry.deferLadderSummary?.summary ?? null,
   ]), [
     [
       'Compact d’Aurora',
@@ -941,8 +944,11 @@ test('buildCultureTurnReportDeltas explains the benefit of acting beyond the cul
       null,
       null,
       null,
+      'minimum-sufficient',
+      'Minimum suffisant',
+      'Minimum suffisant: confirmer Ouvrir le récit d’expansion; synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.',
     ],
-    ['Harbor Compact', 'later', null, null, null, null, null, null, null, null, null, null, null, null],
+    ['Harbor Compact', 'later', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null],
   ]);
 });
 
@@ -1019,7 +1025,8 @@ test('buildCultureTurnReportDeltas warns when immediate cultural synergy expires
     ],
   });
 
-  const expiringSynergy = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries[0].immediateSynergy;
+  const expiringEntry = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries[0];
+  const expiringSynergy = expiringEntry.immediateSynergy;
   assert.deepEqual(expiringSynergy.expiryWarning, {
     state: 'expires-before-review',
     label: 'expire avant revue',
@@ -1027,6 +1034,80 @@ test('buildCultureTurnReportDeltas warns when immediate cultural synergy expires
     expiryCause: 'expire avant la prochaine revue',
     lostBenefit: 'archive-routes ne renforcera plus Compact d’Aurora de façon sûre',
     summary: 'expire avant revue: expire avant la prochaine revue; agir maintenant capture archive-routes.',
+  });
+  assert.deepEqual(expiringEntry.deferLadderSummary, {
+    state: 'act-now',
+    label: 'Agir maintenant',
+    decision: 'agir maintenant pour capturer la synergie avant expiration',
+    summary: 'Agir maintenant: expire avant revue: expire avant la prochaine revue; agir maintenant capture archive-routes.',
+  });
+});
+
+test('buildCultureTurnReportDeltas summarizes a safe defer ladder without expiring synergy', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 9,
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'opportunity',
+        microAction: 'amplifier',
+      },
+    },
+    activeRecommendations: [
+      {
+        recommendationId: 'river-gate:aurora:stable-discovery',
+        regionId: 'river-gate',
+        cultureName: 'Compact d’Aurora',
+        action: 'amplifier',
+        tone: 'opportunity',
+        level: 'surging',
+        discoveryId: 'archive-routes',
+        confidence: 'high',
+        supportKey: 'amplifier',
+        markerIds: ['aurora-marker'],
+        rank: 1,
+      },
+    ],
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit',
+        promptLabel: 'Ouvrir le récit',
+        choiceState: 'deferred',
+        outcome: 'risque stabilisé',
+      },
+      {
+        decisionId: 'turn-8-harbor-calm',
+        turn: 8,
+        regionId: 'harbor',
+        clusterLabel: 'Harbor Compact',
+        theme: 'Calmer le port',
+        promptLabel: 'Calmer le port',
+        choiceState: 'deferred',
+        outcome: 'risque stabilisé',
+      },
+    ],
+  });
+
+  const safeEntry = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries[0];
+  assert.equal(safeEntry.deadlineStatus, 'safe-this-turn');
+  assert.equal(safeEntry.immediateSynergy.expiryWarning, null);
+  assert.deepEqual(safeEntry.deferLadderSummary, {
+    state: 'safe-defer',
+    label: 'Report sûr',
+    decision: 'reporter sans perdre la synergie visible',
+    summary: 'Report sûr: sûr ce tour; synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.',
   });
 });
 

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -183,6 +183,8 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Si manqué:/);
   assert.match(webAppSource, /Action minimale:/);
   assert.match(webAppSource, /Au-delà du minimum:/);
+  assert.match(webAppSource, /Arbitrage:/);
+  assert.match(webAppSource, /deferLadderSummary/);
   assert.match(webAppSource, /Synergie ce tour:/);
   assert.match(webAppSource, /Synergie temporaire:/);
   assert.match(webAppSource, /expiryWarning/);

--- a/web/app.js
+++ b/web/app.js
@@ -7724,13 +7724,14 @@ function renderCultureTurnReport(report) {
                   ${entry.revisitPriority === 'next' ? '<small>Priorité: à revisiter en premier</small>' : ''}
                   <small>Délai: ${entry.deadlineHint ?? 'fenêtre non calculable'}</small>
                   <small>Payoff: ${entry.payoffScore ?? 0}</small>
-                  ${entry.revisitPriority === 'next' && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
-                  ${entry.revisitPriority === 'next' && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
-                  ${entry.revisitPriority === 'next' && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}
-                  ${entry.revisitPriority === 'next' && entry.immediateSynergy ? `<small>Synergie ce tour: ${entry.immediateSynergy.summary}</small>` : ''}
-                  ${entry.revisitPriority === 'next' && entry.immediateSynergy?.expiryWarning ? `<small>Synergie temporaire: ${entry.immediateSynergy.expiryWarning.summary}</small>` : ''}
-                  ${entry.revisitPriority === 'next' && entry.immediateSynergy ? `<small>Bénéfice: ${entry.immediateSynergy.benefit}; risque évité: ${entry.immediateSynergy.avoidedRisk}</small>` : ''}
-                  ${entry.revisitPriority === 'next' && entry.recommendedBeyondMinimumBenefit ? `<small>Évite au prochain tour: ${entry.recommendedBeyondMinimumBenefit.nextTurnAvoidance}; ${entry.recommendedBeyondMinimumBenefit.avoids}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.deferLadderSummary ? `<small>Arbitrage: ${entry.deferLadderSummary.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.immediateSynergy ? `<small>Synergie ce tour: ${entry.immediateSynergy.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.immediateSynergy?.expiryWarning ? `<small>Synergie temporaire: ${entry.immediateSynergy.expiryWarning.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.immediateSynergy ? `<small>Bénéfice: ${entry.immediateSynergy.benefit}; risque évité: ${entry.immediateSynergy.avoidedRisk}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.recommendedBeyondMinimumBenefit ? `<small>Évite au prochain tour: ${entry.recommendedBeyondMinimumBenefit.nextTurnAvoidance}; ${entry.recommendedBeyondMinimumBenefit.avoids}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalActionAcceptableUntil ? `<small>Seuil: minimale jusqu’à ${entry.minimalActionAcceptableUntil}; recommandé: ${entry.recommendedAction}; tardif risqué: ${entry.lateRiskyAction}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.minimalActionThresholdReason ? `<small>Pourquoi: ${entry.minimalActionThresholdReason}</small>` : ''}
                   <small>Condition: ${entry.condition}</small>


### PR DESCRIPTION
Gamma: Implements #1518.

Summary:
- Adds a single cultural defer ladder summary combining deadline, payoff, immediate synergy, and expiry cues.
- Shows “Agir maintenant”, “Minimum suffisant”, or “Report sûr” only when visible/fog-safe synergy data exists.
- Collapses the existing MAP-G34/G35/G36 detail lines behind the new arbitration line when the ladder summary is available, avoiding duplicate cues.

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: PR prête pour validation avant merge.