### PR TITLE
Beta: MAP-B38 explain logistics guard fallback

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -850,7 +850,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: aucune garde concrète à classer.' },
       guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Capacité de garde indisponible sans récupération locale.' },
       guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune chaîne de garde à prolonger.', stopChain: false, residualExposure: { state: 'unknown', exposedRoutes: [], benefit: 'Bénéfice du fallback non calculable sans chaîne de garde.', residualRisk: 'Exposition restante non traçable précisément avec les signaux actuels.' } },
-      guardDecisionSummary: { state: 'unknown', action: 'wait-for-signals', label: 'Comparer au prochain signal', summary: 'Exposition restante non traçable précisément avec les signaux actuels.', reason: 'Bénéfice du fallback non calculable sans chaîne de garde.' },
+      guardDecisionSummary: { state: 'unknown', action: 'wait-for-signals', label: 'Comparer au prochain signal', summary: 'Exposition restante non traçable précisément avec les signaux actuels.', reason: 'Bénéfice du fallback non calculable sans chaîne de garde.', fallbackJustification: { state: 'unavailable', label: 'Aucun fallback sûr', protectedMargin: 'Marge protégée non calculable sans fallback confirmé.', limitingResource: 'Ressource limitante non identifiée par les signaux actuels.', residualExposure: 'Exposition restante non traçable précisément avec les signaux actuels.', ignoredRisk: 'Attendre un signal comparable avant de rouvrir la chaîne de garde.' } },
     };
   }
 
@@ -897,7 +897,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       guardComparison: { state: 'fallback', candidates: [], summary: 'Comparaison impossible: coût de garde non comparable sans route exposée.' },
       guardSequencing: { state: 'unknown', phrase: 'enchaînement inconnu', reason: 'Aucune route exposée ne permet de comparer la capacité de garde.' },
       guardOpportunityCost: { state: 'fallback', summary: 'Coût d’opportunité indisponible: aucune route adjacente exposée à comparer.', stopChain: false, residualExposure: { state: 'unknown', exposedRoutes: [], benefit: 'Bénéfice du fallback non calculable sans route exposée.', residualRisk: 'Exposition restante non traçable précisément avec les signaux actuels.' } },
-      guardDecisionSummary: { state: 'unknown', action: 'wait-for-signals', label: 'Comparer au prochain signal', summary: 'Exposition restante non traçable précisément avec les signaux actuels.', reason: 'Bénéfice du fallback non calculable sans route exposée.' },
+      guardDecisionSummary: { state: 'unknown', action: 'wait-for-signals', label: 'Comparer au prochain signal', summary: 'Exposition restante non traçable précisément avec les signaux actuels.', reason: 'Bénéfice du fallback non calculable sans route exposée.', fallbackJustification: { state: 'unavailable', label: 'Aucun fallback sûr', protectedMargin: 'Marge protégée non calculable sans fallback confirmé.', limitingResource: priorityAction.resource ? `${priorityAction.resource} reste la ressource limitante, mais aucun relais sûr n’est classé.` : 'Ressource limitante non identifiée par les signaux actuels.', residualExposure: 'Exposition restante non traçable précisément avec les signaux actuels.', ignoredRisk: 'Attendre un signal comparable avant de rouvrir la chaîne de garde.' } },
     };
   }
 
@@ -1139,7 +1139,43 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           },
           canContinueWithoutCriticalDelay: false,
         };
+  const buildGuardFallbackJustification = (opportunityCost) => {
+    const fallbackAction = opportunityCost?.fallbackAction ?? null;
+    const exposure = fallbackAction?.residualExposure ?? opportunityCost?.residualExposure ?? null;
+    const exposedRoutes = exposure?.exposedRoutes ?? [];
+    const firstExposedRoute = exposedRoutes[0] ?? null;
+
+    if (!fallbackAction) {
+      return {
+        state: 'unavailable',
+        label: 'Aucun fallback sûr',
+        protectedMargin: 'Marge protégée non calculable sans fallback confirmé.',
+        limitingResource: priorityAction.resource ? `${priorityAction.resource} reste la ressource limitante, mais aucun relais sûr n’est classé.` : 'Ressource limitante non identifiée par les signaux actuels.',
+        residualExposure: exposure?.residualRisk ?? 'Exposition restante non comparable avec les signaux actuels.',
+        ignoredRisk: 'Attendre un signal comparable avant de rouvrir la chaîne de garde.',
+      };
+    }
+
+    const protectedTarget = fallbackAction.target ?? opportunityCost?.protectedRoute ?? guardAction.route ?? criticalRoute.city;
+    const protectedRoute = opportunityCost?.protectedRoute ?? guardAction.route ?? protectedTarget;
+    const exposedLabel = firstExposedRoute ? `${firstExposedRoute.route}/${firstExposedRoute.city}` : opportunityCost?.delayedRoute ?? 'la route suivante';
+
+    return {
+      state: 'available',
+      label: `Pourquoi ${fallbackAction.label}`,
+      protectedMargin: `${protectedTarget} garde la marge utile via ${protectedRoute} sans rouvrir toute la chaîne.`,
+      limitingResource: priorityAction.resource ? `${priorityAction.resource} reste la ressource limitante; ${fallbackAction.label} évite de la consommer au-delà du premier relais.` : 'Ressource limitante non identifiée par les signaux actuels.',
+      residualExposure: exposure?.residualRisk ?? `${exposedLabel} reste à surveiller après ce repli.`,
+      ignoredRisk: firstExposedRoute?.tone === 'high'
+        ? `Ignorer ce repli laisse ${exposedLabel} critique et peut retarder le bénéfice principal.`
+        : `Ignorer ce repli risque de relancer une garde moins rentable sur ${exposedLabel}.`,
+    };
+  };
+  if (guardOpportunityCost.fallbackAction) {
+    guardOpportunityCost.fallbackAction.fallbackJustification = buildGuardFallbackJustification(guardOpportunityCost);
+  }
   const buildGuardDecisionSummary = (opportunityCost) => {
+    const fallbackJustification = buildGuardFallbackJustification(opportunityCost);
     if (!opportunityCost) {
       return {
         state: 'unknown',
@@ -1147,6 +1183,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         label: 'Décision garde inconnue',
         summary: 'Synthèse indisponible: les signaux de garde ne sont pas comparables.',
         reason: 'Aucun coût d’opportunité exploitable.',
+        fallbackJustification,
       };
     }
 
@@ -1157,6 +1194,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         label: 'Continuer la garde',
         summary: `Continuer vers ${opportunityCost.delayedRoute ?? 'le segment suivant'}: aucune route critique retardée.`,
         reason: opportunityCost.stopReason ?? 'Le coût reste couvert par le bénéfice attendu.',
+        fallbackJustification,
       };
     }
 
@@ -1172,6 +1210,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         label: 'Basculer sur le fallback',
         summary: `${opportunityCost.fallbackAction.label}: réduit le risque principal sans rouvrir la chaîne.`,
         reason: exposure.residualRisk,
+        fallbackJustification,
       };
     }
 
@@ -1182,6 +1221,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         label: 'Accepter l’exposition ce tour',
         summary: `${exposedRoutes.map((route) => route.route).join(', ')} reste à surveiller après le bénéfice principal.`,
         reason: exposure.benefit,
+        fallbackJustification,
       };
     }
 
@@ -1191,6 +1231,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       label: 'Accepter l’exposition à surveiller',
       summary: exposure?.residualRisk ?? 'Exposition restante non comparable avec les signaux actuels.',
       reason: exposure?.benefit ?? 'Fallback neutre: aucune route restante traçable précisément.',
+      fallbackJustification,
     };
   };
   const guardDecisionSummary = buildGuardDecisionSummary(guardOpportunityCost);

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -136,6 +136,11 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.state, 'fallback');
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.action, 'use-fallback');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.summary, /Différer|fallback/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.state, 'available');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.protectedMargin, /Ember Line|Hill Spur|marge utile/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.limitingResource, /Outils|ressource limitante/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.residualExposure, /reste exposée|reste exposé/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.ignoredRisk, /Ignorer/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -223,6 +228,11 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.state, 'watch');
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.action, 'accept-exposure');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.summary, /Safe Road.*reste à surveiller/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.state, 'available');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.protectedMargin, /Iron Plain|Ember Line|marge utile/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.limitingResource, /Outils|ressource limitante/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.residualExposure, /Safe Road/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.ignoredRisk, /Ignorer/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
@@ -266,6 +276,8 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.residualExposure.residualRisk, /non traçable précisément/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.state, 'unknown');
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.action, 'wait-for-signals');
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.state, 'unavailable');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.label, /Aucun fallback sûr/);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -116,6 +116,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /province-logistics-spillover-ladder/);
   assert.match(webAppSource, /guardDecisionSummary/);
   assert.match(webAppSource, /Synthèse garde:/);
+  assert.match(webAppSource, /province-logistics-spillover-fallback-why/);
+  assert.match(webAppSource, /fallbackJustification/);
+  assert.match(webAppSource, /Pourquoi fallback:/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8697,6 +8697,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
               ` : ''}
               ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary ? `
                 <small class="province-logistics-spillover-ladder province-logistics-spillover-ladder--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.state}">Synthèse garde: ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.label} — ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.summary}</small>
+                ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification ? `
+                  <small class="province-logistics-spillover-fallback-why province-logistics-spillover-fallback-why--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.state}">Pourquoi fallback: ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.protectedMargin} ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.limitingResource} ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.residualExposure} Risque: ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.ignoredRisk}</small>
+                ` : ''}
               ` : ''}
               ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost?.canContinueWithoutCriticalDelay ? '<small>Continuer la chaîne reste acceptable: aucune route critique n’est retardée.</small>' : ''}
             </div>


### PR DESCRIPTION
Beta: Implements #1527.\n\nSummary:\n- Adds a compact fallback justification to the logistics guard ladder preview.\n- Explains protected margin, limiting resource, residual exposure, and risk if ignored using existing MAP-B34/B37 signals.\n- Surfaces a clear no-safe-fallback state when guard fallback signals are unavailable.\n- Renders the justification in the economy/logistics map panel.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test