### PR TITLE
Alpha: MAP-A38 explain front ladder first action

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -369,7 +369,7 @@ test('atlas military shows delay cost for blocked front prep actions', () => {
 // MAP-A37: when multiple follow-up signals coexist, add one compact ladder that
 // orders play-now, prep, and delay-risk cues without duplicating each row.
 test('atlas military summarizes the front follow-up ladder', () => {
-  assert.match(webAppSource, /function buildAtlasMilitaryBlockedFollowUpLadder\(alternative, candidates = \[\]\)/);
+  assert.match(webAppSource, /function buildAtlasMilitaryBlockedFollowUpLadder\(alternative, candidates = \[\], residualRisk = null\)/);
   assert.match(webAppSource, /const playableEntry = candidates\.find\(\(entry\) => entry\.viability\.status === 'ready'\)/);
   assert.match(webAppSource, /jouer maintenant: \$\{playableEntry\.option\.nextAction\}/);
   assert.match(webAppSource, /jouer maintenant: \$\{alternative\.action\}/);
@@ -379,10 +379,15 @@ test('atlas military summarizes the front follow-up ladder', () => {
   assert.match(webAppSource, /if \(steps\.length < 2\)/);
   assert.match(webAppSource, /label: 'Échelle suivi front'/);
   assert.match(webAppSource, /detail: steps\.join\(' → '\)/);
-  assert.match(webAppSource, /const blockedFollowUpLadder = buildAtlasMilitaryBlockedFollowUpLadder\(blockedFollowUpAlternative, candidates\)/);
+  assert.match(webAppSource, /firstActionReason: `Pourquoi d’abord: \$\{reasonParts\.slice\(0, 4\)\.join\(' · '\)\}`/);
+  assert.match(webAppSource, /préparation minimale: \$\{prepUnlock\.unlocks\}/);
+  assert.match(webAppSource, /alternative bloquée: \$\{alternative\.viabilityLabel\}/);
+  assert.match(webAppSource, /risque restant: \$\{residualRisk\.label\}/);
+  assert.match(webAppSource, /const blockedFollowUpLadder = buildAtlasMilitaryBlockedFollowUpLadder\(blockedFollowUpAlternative, candidates, sharedResidualRisk\)/);
   assert.match(webAppSource, /renderAtlasMilitaryBlockedFollowUpLadder\(preview\.blockedFollowUpLadder, ladderY\)/);
   assert.match(webAppSource, /Synthèse échelle de suivi de front/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder--ready/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder--prep/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder--risky/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__reason/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -2768,13 +2768,14 @@ function getAtlasMilitaryBlockedFollowUpPrepUnlock(option, checklistItem) {
   };
 }
 
-function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = []) {
+function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], residualRisk = null) {
   if (!alternative?.visible || alternative.viabilityStatus === 'avoid') {
     return {
       visible: false,
       tone: 'quiet',
       label: 'Synthèse suivi front indisponible',
       detail: 'pas assez de signaux fiables',
+      firstActionReason: 'raison masquée: signaux insuffisants',
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2783,16 +2784,27 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = []) {
     ? getAtlasMilitaryBlockedFollowUpPrepUnlock({ ...prepEntry.option, viabilityStatus: prepEntry.viability.status }, prepEntry.checklistItem)
     : alternative.prepUnlock;
   const steps = [];
+  const reasonParts = [];
   if (playableEntry) {
     steps.push(`jouer maintenant: ${playableEntry.option.nextAction}`);
+    reasonParts.push(`action jouable ${playableEntry.option.provinceLabel} avant préparation`);
   } else if (alternative.viabilityStatus === 'ready') {
     steps.push(`jouer maintenant: ${alternative.action}`);
+    reasonParts.push(`alternative ${alternative.provinceLabel ?? 'front'} déjà jouable`);
   }
   if (prepUnlock) {
     steps.push(`préparer: ${prepUnlock.action}`);
+    reasonParts.push(`préparation minimale: ${prepUnlock.unlocks}`);
   }
   if (prepUnlock?.delayCost) {
     steps.push(`attendre: ${prepUnlock.delayCost.label.toLowerCase()}`);
+    reasonParts.push(`${prepUnlock.delayCost.label.toLowerCase()}: ${prepUnlock.delayCost.detail}`);
+  }
+  if (alternative.viabilityStatus !== 'ready') {
+    reasonParts.push(`alternative bloquée: ${alternative.viabilityLabel}`);
+  }
+  if (residualRisk?.visible) {
+    reasonParts.push(`risque restant: ${residualRisk.label}`);
   }
   if (steps.length < 2) {
     return {
@@ -2800,6 +2812,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = []) {
       tone: 'quiet',
       label: 'Synthèse suivi front masquée',
       detail: 'un seul signal, ligne dédiée suffisante',
+      firstActionReason: 'raison masquée: un seul signal utile',
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2808,6 +2821,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = []) {
     tone: delayCost?.tone === 'risky' ? 'risky' : alternative.viabilityStatus === 'ready' ? 'ready' : 'prep',
     label: 'Échelle suivi front',
     detail: steps.join(' → '),
+    firstActionReason: `Pourquoi d’abord: ${reasonParts.slice(0, 4).join(' · ')}`,
   };
 }
 
@@ -2931,7 +2945,7 @@ function buildAtlasMilitaryNeighborFrontShiftPreview(recommendation, checklist, 
   const residualFollowUpOrder = buildAtlasMilitaryNeighborResidualFollowUpOrder(sharedResidualRisk, urgencyCluster);
   const residualFollowUpConflict = buildAtlasMilitaryNeighborResidualFollowUpConflict(residualFollowUpOrder, recommendation, checklist);
   const blockedFollowUpAlternative = buildAtlasMilitaryBlockedResidualFollowUpAlternative(residualFollowUpOrder, residualFollowUpConflict, recommendation, checklist);
-  const blockedFollowUpLadder = buildAtlasMilitaryBlockedFollowUpLadder(blockedFollowUpAlternative, candidates);
+  const blockedFollowUpLadder = buildAtlasMilitaryBlockedFollowUpLadder(blockedFollowUpAlternative, candidates, sharedResidualRisk);
 
   if (!shifts.length) {
     return {
@@ -3064,9 +3078,10 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
+      <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
     </g>
   `;
 }
@@ -3104,8 +3119,8 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     ? preview.blockedFollowUpAlternative?.prepUnlock?.delayCost ? 5.2 : preview.blockedFollowUpAlternative?.prepUnlock ? 3.85 : 2.5
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
-  const ladderHeight = preview.blockedFollowUpLadder?.visible ? 2.5 : 0;
-  const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? 2.75 : 0);
+  const ladderHeight = preview.blockedFollowUpLadder?.visible ? 3.85 : 0;
+  const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? 4.1 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;
   const hintHeight = preview.sharedHandlingHint?.visible ? 2.5 : 0;
   const residualHeight = preview.sharedResidualRisk?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14593,11 +14593,13 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-alt__detail,
 .atlas-military-neighbor-blocked-follow-up-alt__prep,
 .atlas-military-neighbor-blocked-follow-up-alt__delay,
-.atlas-military-neighbor-blocked-follow-up-ladder__detail {
+.atlas-military-neighbor-blocked-follow-up-ladder__detail,
+.atlas-military-neighbor-blocked-follow-up-ladder__reason {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
 .atlas-military-neighbor-blocked-follow-up-alt__prep { fill: #bfdbfe; }
+.atlas-military-neighbor-blocked-follow-up-ladder__reason { fill: #bfdbfe; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1526.\n\nSummary:\n- adds a short deterministic explanation for why the front follow-up ladder starts with its first action\n- folds in already-computed prep unlocks, delay cost, blocked-alternative status, and residual risk when visible\n- renders the reason line in the existing ladder without changing the separate MAP-A34/A35/A36 cue rows\n\nValidation:\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test\n\nZeta: ready for validation before merge.