### PR TITLE
Gamma: Explain cultural defer ladder follow-up

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1401,7 +1401,7 @@ function buildCulturalSafeToDeferBundles(groups, cleanupPrompts, falloutPreview,
     const immediateSynergy = recommendedBeyondMinimumBenefit
       ? buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedCandidates, missedWindowConsequence)
       : null;
-    const deferLadderSummary = buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBenefit, immediateSynergy);
+    const deferLadderSummary = buildCulturalDeferLadderSummary({ ...candidate, minimalSafeAction }, recommendedBeyondMinimumBenefit, immediateSynergy);
 
     return {
       ...candidate,
@@ -1459,12 +1459,26 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
     return null;
   }
 
+  const firstFollowUpReason = buildCulturalFirstFollowUpReason(candidate, recommendedBeyondMinimumBenefit, immediateSynergy);
+  const sourceAction = normalizeText(immediateSynergy.sourceAction ?? '');
+
+  if (/attendre|observer/.test(sourceAction)) {
+    return {
+      state: 'observe-first',
+      label: 'Observer',
+      decision: 'attendre/observer reste le meilleur premier suivi visible',
+      summary: `Observer: ${candidate.deadlineHint}; ${immediateSynergy.summary}`,
+      firstFollowUpReason,
+    };
+  }
+
   if (immediateSynergy.expiryWarning) {
     return {
       state: 'act-now',
       label: 'Agir maintenant',
       decision: 'agir maintenant pour capturer la synergie avant expiration',
       summary: `Agir maintenant: ${immediateSynergy.expiryWarning.summary}`,
+      firstFollowUpReason,
     };
   }
 
@@ -1474,6 +1488,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       label: 'Minimum suffisant',
       decision: 'faire le minimum garde la fenêtre sans perdre la synergie visible',
       summary: `Minimum suffisant: ${candidate.minimalRevisitAction}; ${immediateSynergy.summary}`,
+      firstFollowUpReason,
     };
   }
 
@@ -1482,6 +1497,30 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
     label: 'Report sûr',
     decision: 'reporter sans perdre la synergie visible',
     summary: `Report sûr: ${candidate.deadlineHint}; ${immediateSynergy.summary}`,
+    firstFollowUpReason,
+  };
+}
+
+function buildCulturalFirstFollowUpReason(candidate, recommendedBeyondMinimumBenefit, immediateSynergy) {
+  const expiryCue = immediateSynergy.expiryWarning
+    ? `expiration: ${immediateSynergy.expiryWarning.summary}`
+    : 'expiration: aucune expiration visible';
+  const deferredTrack = candidate.minimalSafeAction
+    ? `piste différée: ${candidate.minimalSafeAction}`
+    : `piste différée: ${candidate.condition}`;
+  const localSignal = candidate.turningSignal
+    ? `signal local: ${candidate.turningSignal}`
+    : `signal local: ${candidate.deadlineHint}`;
+
+  return {
+    state: immediateSynergy.expiryWarning ? 'expiry-driven' : candidate.deadlineStatus,
+    label: 'Pourquoi ce suivi',
+    synergy: immediateSynergy.summary,
+    expiryCue,
+    deferredTrack,
+    localSignal,
+    summary: `${immediateSynergy.summary}; ${expiryCue}; ${deferredTrack}; ${localSignal}.`,
+    payoffCue: recommendedBeyondMinimumBenefit.concreteGain,
   };
 }
 
@@ -1499,6 +1538,7 @@ function buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedC
       label: 'Synergie ce tour',
       sourceType: 'discovery',
       sourceLabel: sameClusterPriority.discoveryId,
+      sourceAction: sameClusterPriority.action,
       benefit: `${sameClusterPriority.discoveryId} renforce ${sameClusterPriority.action} avec ${candidate.clusterLabel}`,
       avoidedRisk: `évite de séparer la découverte du suivi reporté: ${missedWindowConsequence}`,
       summary: `synergie ce tour: ${sameClusterPriority.discoveryId} + ${candidate.clusterLabel}; ${sameClusterPriority.action} sécurisé.`,
@@ -1515,6 +1555,7 @@ function buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedC
       label: 'Synergie ce tour',
       sourceType: 'narrative',
       sourceLabel: candidate.minimalRevisitAction ?? candidate.clusterLabel,
+      sourceAction: candidate.minimalRevisitAction ?? 'suivre le récit',
       benefit: `le récit actif devient un suivi culturel immédiat pour ${candidate.clusterLabel}`,
       avoidedRisk: `évite de laisser le récit dépasser la fenêtre sûre: ${missedWindowConsequence}`,
       summary: `synergie ce tour: récit actif + ${candidate.clusterLabel}; suivi narratif sécurisé.`,
@@ -1531,6 +1572,7 @@ function buildCulturalBeyondMinimumSynergy(candidate, visiblePriorities, sortedC
       label: 'Synergie ce tour',
       sourceType: 'neighbor-cluster',
       sourceLabel: neighboringPriority.cultureName,
+      sourceAction: neighboringPriority.action,
       benefit: `${candidate.clusterLabel} reste aligné avec ${neighboringPriority.cultureName}`,
       avoidedRisk: `évite que le cluster voisin reprenne seul la priorité: ${missedWindowConsequence}`,
       summary: `synergie ce tour: ${candidate.clusterLabel} + ${neighboringPriority.cultureName}; priorités proches alignées.`,

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -928,6 +928,7 @@ test('buildCultureTurnReportDeltas explains the benefit of acting beyond the cul
     entry.deferLadderSummary?.state ?? null,
     entry.deferLadderSummary?.label ?? null,
     entry.deferLadderSummary?.summary ?? null,
+    entry.deferLadderSummary?.firstFollowUpReason?.summary ?? null,
   ]), [
     [
       'Compact d’Aurora',
@@ -947,8 +948,9 @@ test('buildCultureTurnReportDeltas explains the benefit of acting beyond the cul
       'minimum-sufficient',
       'Minimum suffisant',
       'Minimum suffisant: confirmer Ouvrir le récit d’expansion; synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.',
+      'synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.; expiration: aucune expiration visible; piste différée: confirmer Ouvrir le récit d’expansion; signal local: perte du soutien actif.',
     ],
-    ['Harbor Compact', 'later', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null],
+    ['Harbor Compact', 'later', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null],
   ]);
 });
 
@@ -1040,6 +1042,16 @@ test('buildCultureTurnReportDeltas warns when immediate cultural synergy expires
     label: 'Agir maintenant',
     decision: 'agir maintenant pour capturer la synergie avant expiration',
     summary: 'Agir maintenant: expire avant revue: expire avant la prochaine revue; agir maintenant capture archive-routes.',
+    firstFollowUpReason: {
+      state: 'expiry-driven',
+      label: 'Pourquoi ce suivi',
+      synergy: 'synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.',
+      expiryCue: 'expiration: expire avant revue: expire avant la prochaine revue; agir maintenant capture archive-routes.',
+      deferredTrack: 'piste différée: confirmer Ouvrir le récit d’expansion',
+      localSignal: 'signal local: perte du soutien actif',
+      summary: 'synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.; expiration: expire avant revue: expire avant la prochaine revue; agir maintenant capture archive-routes.; piste différée: confirmer Ouvrir le récit d’expansion; signal local: perte du soutien actif.',
+      payoffCue: 'gain concret: sécurise payoff 3 sans attendre la bascule',
+    },
   });
 });
 
@@ -1108,7 +1120,94 @@ test('buildCultureTurnReportDeltas summarizes a safe defer ladder without expiri
     label: 'Report sûr',
     decision: 'reporter sans perdre la synergie visible',
     summary: 'Report sûr: sûr ce tour; synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.',
+    firstFollowUpReason: {
+      state: 'safe-this-turn',
+      label: 'Pourquoi ce suivi',
+      synergy: 'synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.',
+      expiryCue: 'expiration: aucune expiration visible',
+      deferredTrack: 'piste différée: risque stabilisé par l’historique lisible',
+      localSignal: 'signal local: fallout en hausse',
+      summary: 'synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.; expiration: aucune expiration visible; piste différée: risque stabilisé par l’historique lisible; signal local: fallout en hausse.',
+      payoffCue: 'gain concret: sécurise payoff 2 sans attendre la bascule',
+    },
   });
+});
+
+test('buildCultureTurnReportDeltas explains when observing is the first cultural follow-up', () => {
+  const report = buildCultureTurnReportDeltas({
+    turn: 9,
+    selectedRegionId: 'river-gate',
+    selectedMarker: {
+      overlayId: 'river-gate:culture-aurora',
+      regionId: 'river-gate',
+      cultureName: 'Compact d’Aurora',
+      influenceTier: 'strong',
+      influenceScore: 82,
+      discoveries: ['archive-routes'],
+      activeResearchCount: 0,
+      unlockedResearchIds: [],
+      narrativePriority: {
+        state: 'watch',
+        microAction: 'attendre',
+      },
+    },
+    activeRecommendations: [
+      {
+        recommendationId: 'river-gate:aurora:observe',
+        regionId: 'river-gate',
+        cultureName: 'Compact d’Aurora',
+        action: 'attendre',
+        tone: 'watch',
+        level: 'steady',
+        discoveryId: 'archive-routes',
+        confidence: 'high',
+        supportKey: 'attendre',
+        markerIds: ['aurora-marker'],
+        rank: 1,
+      },
+    ],
+    localTimeline: {
+      items: [
+        {
+          timelineId: 'harbor:event:quiet-followup',
+          kind: 'event',
+          signal: 'watch',
+          title: 'Suivi calme',
+          summary: 'Risque stabilisé.',
+          regionId: 'harbor',
+          cultureName: 'Harbor Compact',
+        },
+      ],
+    },
+    promptHistory: [
+      {
+        decisionId: 'turn-8-aurora-expansion',
+        turn: 8,
+        regionId: 'river-gate',
+        clusterLabel: 'Compact d’Aurora',
+        theme: 'Ouvrir le récit d’expansion',
+        promptLabel: 'Ouvrir le récit d’expansion',
+        choiceState: 'deferred',
+        outcome: 'soutien actif confirmé',
+      },
+      {
+        decisionId: 'turn-8-harbor-calm',
+        turn: 8,
+        regionId: 'harbor',
+        clusterLabel: 'Harbor Compact',
+        theme: 'Calmer le port',
+        promptLabel: 'Calmer le port',
+        choiceState: 'deferred',
+        outcome: 'risque stabilisé',
+      },
+    ],
+  });
+
+  const observeEntry = report.commitmentBundles.followThroughBundlePlan.safeToDeferBundles.entries[0];
+  assert.equal(observeEntry.deferLadderSummary.state, 'observe-first');
+  assert.equal(observeEntry.deferLadderSummary.label, 'Observer');
+  assert.equal(observeEntry.deferLadderSummary.decision, 'attendre/observer reste le meilleur premier suivi visible');
+  assert.equal(observeEntry.deferLadderSummary.firstFollowUpReason.summary, 'synergie ce tour: archive-routes + Compact d’Aurora; attendre sécurisé.; expiration: aucune expiration visible; piste différée: risque stabilisé par l’historique lisible; signal local: fallout en hausse.');
 });
 
 test('buildCultureTurnReportDeltas breaks safe defer deadline ties by cultural payoff', () => {

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -184,6 +184,8 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Action minimale:/);
   assert.match(webAppSource, /Au-delà du minimum:/);
   assert.match(webAppSource, /Arbitrage:/);
+  assert.match(webAppSource, /Pourquoi ce suivi:/);
+  assert.match(webAppSource, /firstFollowUpReason/);
   assert.match(webAppSource, /deferLadderSummary/);
   assert.match(webAppSource, /Synergie ce tour:/);
   assert.match(webAppSource, /Synergie temporaire:/);

--- a/web/app.js
+++ b/web/app.js
@@ -7800,6 +7800,7 @@ function renderCultureTurnReport(report) {
                   <small>Délai: ${entry.deadlineHint ?? 'fenêtre non calculable'}</small>
                   <small>Payoff: ${entry.payoffScore ?? 0}</small>
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary ? `<small>Arbitrage: ${entry.deferLadderSummary.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.firstFollowUpReason ? `<small>Pourquoi ce suivi: ${entry.deferLadderSummary.firstFollowUpReason.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}


### PR DESCRIPTION
Gamma: Implements #1528.

Summary:
- Adds a `firstFollowUpReason` to the cultural defer ladder to explain why the first follow-up wins.
- Combines visible synergy, expiry cue, deferred track, local signal, and payoff context without exposing non-visible data.
- Adds an observe-first ladder state when the best visible cultural follow-up is to wait/observe.
- Renders a compact “Pourquoi ce suivi” line in the culture report.

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: PR prête pour validation avant merge.