### PR TITLE
Epsilon: Explain climate watch upkeep choice

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -28,14 +28,21 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /minimalProtection/);
   assert.match(webAppSource, /secondaryProtectionGuard/);
   assert.match(webAppSource, /secondaryUpkeep/);
+  assert.match(webAppSource, /smallestUpkeepReason/);
+  assert.match(webAppSource, /upkeepPromotionRisk/);
+  assert.match(webAppSource, /Pourquoi cet upkeep/);
+  assert.match(webAppSource, /Sans upkeep immédiat/);
+  assert.match(webAppSource, /cible \$\{secondaryProtectionGuard\.label\}; signal \$\{watchGap\.nearestRiskLabel\}; coût minimal/);
+  assert.match(webAppSource, /risque de promotion seulement si la protection échoue/);
+  assert.match(webAppSource, /risque de promotion au prochain tour/);
   assert.match(webAppSource, /watchLadderSummary/);
   assert.match(webAppSource, /remainingWatchItems\.length > 1/);
   assert.match(webAppSource, /state: 'available'/);
   assert.match(webAppSource, /state: 'impossible'/);
-  assert.match(webAppSource, /state: 'fallback'/);
+  assert.match(webAppSource, /state: 'stable-without-upkeep'/);
   assert.match(webAppSource, /garde \$\{watchGap\.label\} secondaire sans lancer une prévention complète/);
   assert.match(webAppSource, /aucune action minimale calculable depuis la protection visible/);
-  assert.match(webAppSource, /relire la veille secondaire au prochain signal climat avant d’investir/);
+  assert.match(webAppSource, /surveiller sans entretien immédiat tant que la protection tient/);
   assert.match(webAppSource, /ne pas confondre avec une prévention complète ou une action primaire/);
   assert.match(webAppSource, /coverageView\.secondaryProtections\?\.\[0\]/);
   assert.match(webAppSource, /coverageView\.activeProtections\?\.\[0\]/);
@@ -66,7 +73,8 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--available/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--impossible/);
-  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--fallback/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--stable-without-upkeep/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__why/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
@@ -96,11 +104,11 @@ test('atlas marks secondary climate upkeep impossible when no minimal action is 
   assert.match(webAppSource, /aucune action minimale calculable depuis la protection visible/);
 });
 
-test('atlas keeps a readable upkeep fallback without adding climate mechanics', () => {
-  assert.match(webAppSource, /state: 'fallback'/);
-  assert.match(webAppSource, /label: 'fallback entretien'/);
-  assert.match(webAppSource, /relire la veille secondaire au prochain signal climat avant d’investir/);
-  assert.match(webAppSource, /aucune mitigation minimale disponible pour maintenir ce statut/);
+test('atlas keeps a readable no-upkeep state without adding climate mechanics', () => {
+  assert.match(webAppSource, /state: 'stable-without-upkeep'/);
+  assert.match(webAppSource, /label: 'veille stable sans upkeep'/);
+  assert.match(webAppSource, /surveiller sans entretien immédiat tant que la protection tient/);
+  assert.match(webAppSource, /la veille peut rester secondaire sans upkeep immédiat/);
 });
 
 
@@ -123,4 +131,20 @@ test('atlas summarizes the ladder as watch-only when thresholds are uncertain', 
   assert.match(webAppSource, /decision: 'surveiller sans action immédiate'/);
   assert.match(webAppSource, /Surveiller sans action immédiate: \$\{watchGap\.label\}/);
   assert.match(webAppSource, /fallback robuste quand les seuils ou protections ne sont pas connus/);
+});
+
+
+test('atlas explains why the smallest climate upkeep was picked', () => {
+  assert.match(webAppSource, /smallestUpkeepReason = secondaryProtectionGuard\?\.minimalAction/);
+  assert.match(webAppSource, /region: secondaryProtectionGuard\.label/);
+  assert.match(webAppSource, /signal: watchGap\.nearestRiskLabel/);
+  assert.match(webAppSource, /coût minimal: garder la mitigation existante plutôt qu’une prévention complète/);
+  assert.match(webAppSource, /promotionRisk: upkeepPromotionRisk/);
+});
+
+test('atlas clearly marks when secondary watch can stay secondary without upkeep', () => {
+  assert.match(webAppSource, /state: 'stable-without-upkeep'/);
+  assert.match(webAppSource, /label: 'veille stable sans upkeep'/);
+  assert.match(webAppSource, /Sans upkeep immédiat/);
+  assert.match(webAppSource, /la veille peut rester secondaire tant que le signal ne se rapproche pas/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14206,12 +14206,25 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       minimalAction: minimalProtection.action ?? null,
     }
     : null;
+  const upkeepPromotionRisk = watchGap.nearestThresholdScore >= 65
+    ? 'risque de promotion au prochain tour'
+    : 'risque de promotion seulement si la protection échoue';
+  const smallestUpkeepReason = secondaryProtectionGuard?.minimalAction
+    ? {
+      region: secondaryProtectionGuard.label,
+      signal: watchGap.nearestRiskLabel,
+      cost: 'coût minimal: garder la mitigation existante plutôt qu’une prévention complète',
+      promotionRisk: upkeepPromotionRisk,
+      summary: `cible ${secondaryProtectionGuard.label}; signal ${watchGap.nearestRiskLabel}; coût minimal; ${upkeepPromotionRisk}`,
+    }
+    : null;
   const secondaryUpkeep = secondaryProtectionGuard?.minimalAction
     ? {
       state: 'available',
       label: 'entretien minimal',
       action: secondaryProtectionGuard.minimalAction,
       reason: `garde ${watchGap.label} secondaire sans lancer une prévention complète`,
+      smallestUpkeepReason,
     }
     : secondaryProtectionGuard
       ? {
@@ -14219,12 +14232,14 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
         label: 'entretien impossible',
         action: 'aucune action minimale calculable depuis la protection visible',
         reason: 'ne pas confondre avec une prévention complète ou une action primaire',
+        smallestUpkeepReason: null,
       }
       : {
-        state: 'fallback',
-        label: 'fallback entretien',
-        action: 'relire la veille secondaire au prochain signal climat avant d’investir',
-        reason: 'aucune mitigation minimale disponible pour maintenir ce statut',
+        state: 'stable-without-upkeep',
+        label: 'veille stable sans upkeep',
+        action: 'surveiller sans entretien immédiat tant que la protection tient',
+        reason: 'la veille peut rester secondaire sans upkeep immédiat',
+        smallestUpkeepReason: null,
       };
   const remainingWatchItems = (coverageView.blindSpots ?? [])
     .filter((gap) => !gap.nearest && gap.label !== gapActionView.recommendation.target && gap.nearestThresholdScore >= 40);
@@ -14244,7 +14259,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
           state: 'upkeep-secondary',
           decision: 'entretenir un secondaire',
           line: `Entretenir un secondaire: ${secondaryUpkeep.action}; ${watchGap.label} reste sous le primaire.`,
-          why: 'plus petit upkeep utile, pas une prévention complète',
+          why: secondaryUpkeep.smallestUpkeepReason?.summary ?? 'plus petit upkeep utile, pas une prévention complète',
         }
         : {
           state: 'watch-only',
@@ -14322,6 +14337,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small><b>Transfert attention</b> · ${view.watchItem.promotionCue}</small>
       ${view.watchItem.secondaryProtectionGuard ? `<small class="map-world-climate-post-gap-watch__guard"><b>Reste secondaire si</b> · ${view.watchItem.secondaryProtectionGuard.condition}${view.watchItem.secondaryProtectionGuard.minimalAction ? `; action minimale: ${view.watchItem.secondaryProtectionGuard.minimalAction}` : '; action minimale indisponible'}</small>` : ''}
       <small class="map-world-climate-post-gap-watch__upkeep map-world-climate-post-gap-watch__upkeep--${view.watchItem.secondaryUpkeep.state}"><b>Entretien minimal</b> · ${view.watchItem.secondaryUpkeep.label}: ${view.watchItem.secondaryUpkeep.action}; ${view.watchItem.secondaryUpkeep.reason}</small>
+      ${view.watchItem.secondaryUpkeep.smallestUpkeepReason ? `<small class="map-world-climate-post-gap-watch__why"><b>Pourquoi cet upkeep</b> · ${view.watchItem.secondaryUpkeep.smallestUpkeepReason.summary}</small>` : '<small class="map-world-climate-post-gap-watch__why"><b>Sans upkeep immédiat</b> · la veille peut rester secondaire tant que le signal ne se rapproche pas.</small>'}
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13642,7 +13642,12 @@ button { font: inherit; }
 }
 .map-world-climate-post-gap-watch__upkeep--available { border: 1px solid rgba(74, 222, 128, 0.36); }
 .map-world-climate-post-gap-watch__upkeep--impossible { border: 1px solid rgba(251, 191, 36, 0.34); }
-.map-world-climate-post-gap-watch__upkeep--fallback { border: 1px solid rgba(148, 163, 184, 0.28); }
+.map-world-climate-post-gap-watch__upkeep--fallback,
+.map-world-climate-post-gap-watch__upkeep--stable-without-upkeep { border: 1px solid rgba(148, 163, 184, 0.28); }
+.map-world-climate-post-gap-watch__why {
+  padding-left: 8px;
+  border-left: 2px solid rgba(125, 211, 252, 0.34);
+}
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon:

Fixes #1530.

Summary:
- adds a short ‘Pourquoi cet upkeep’ explanation for the climate watch ladder’s smallest upkeep choice
- includes target region, secondary signal, minimal-cost framing, and primary-promotion risk
- adds a clear no-upkeep-immediate state when the watch can remain secondary

Validation:
- node --check web/app.js
- npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check