### PR TITLE
Alpha: MAP-A39 show remaining front follow-up watch

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -391,3 +391,17 @@ test('atlas military summarizes the front follow-up ladder', () => {
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder--risky/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__reason/);
 });
+
+// MAP-A39: after the chosen follow-up action, show the most useful remaining
+// watch item without adding noise when nothing relevant remains.
+test('atlas military shows what remains to watch after the front follow-up action', () => {
+  assert.match(webAppSource, /const watchParts = \[\]/);
+  assert.match(webAppSource, /watchParts\.push\(`\$\{residualRisk\.label\}: \$\{residualRisk\.detail\}`\)/);
+  assert.match(webAppSource, /watchParts\.push\(`condition \$\{alternative\.minimumCondition\}`\)/);
+  assert.match(webAppSource, /watchParts\.push\(`\$\{prepUnlock\.delayCost\.label\.toLowerCase\(\)\}: \$\{prepUnlock\.delayCost\.detail\}`\)/);
+  assert.match(webAppSource, /const remainingWatch = watchParts\.length \? `Reste à surveiller: \$\{watchParts\.slice\(0, 2\)\.join\(' · '\)\}` : null/);
+  assert.match(webAppSource, /remainingWatch,/);
+  assert.match(webAppSource, /ladder\.remainingWatch \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__watch"/);
+  assert.match(webAppSource, /ladderHeight = preview\.blockedFollowUpLadder\?\.visible \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 5\.2 : 3\.85 : 0/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__watch/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2776,6 +2776,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       label: 'Synthèse suivi front indisponible',
       detail: 'pas assez de signaux fiables',
       firstActionReason: 'raison masquée: signaux insuffisants',
+      remainingWatch: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2806,6 +2807,17 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
   if (residualRisk?.visible) {
     reasonParts.push(`risque restant: ${residualRisk.label}`);
   }
+  const watchParts = [];
+  if (residualRisk?.visible) {
+    watchParts.push(`${residualRisk.label}: ${residualRisk.detail}`);
+  }
+  if (alternative.viabilityStatus !== 'ready') {
+    watchParts.push(`condition ${alternative.minimumCondition}`);
+  }
+  if (!watchParts.length && prepUnlock?.delayCost?.tone === 'risky') {
+    watchParts.push(`${prepUnlock.delayCost.label.toLowerCase()}: ${prepUnlock.delayCost.detail}`);
+  }
+  const remainingWatch = watchParts.length ? `Reste à surveiller: ${watchParts.slice(0, 2).join(' · ')}` : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -2813,6 +2825,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       label: 'Synthèse suivi front masquée',
       detail: 'un seul signal, ligne dédiée suffisante',
       firstActionReason: 'raison masquée: un seul signal utile',
+      remainingWatch: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2822,6 +2835,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     label: 'Échelle suivi front',
     detail: steps.join(' → '),
     firstActionReason: `Pourquoi d’abord: ${reasonParts.slice(0, 4).join(' · ')}`,
+    remainingWatch,
   };
 }
 
@@ -3078,10 +3092,11 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
+      ${ladder.remainingWatch ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__watch" x="44.2" y="${y + 4.05}">${ladder.remainingWatch}</text>` : ''}
     </g>
   `;
 }
@@ -3119,8 +3134,8 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     ? preview.blockedFollowUpAlternative?.prepUnlock?.delayCost ? 5.2 : preview.blockedFollowUpAlternative?.prepUnlock ? 3.85 : 2.5
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
-  const ladderHeight = preview.blockedFollowUpLadder?.visible ? 3.85 : 0;
-  const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? 4.1 : 0);
+  const ladderHeight = preview.blockedFollowUpLadder?.visible ? preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85 : 0;
+  const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;
   const hintHeight = preview.sharedHandlingHint?.visible ? 2.5 : 0;
   const residualHeight = preview.sharedResidualRisk?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14618,12 +14618,14 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-alt__prep,
 .atlas-military-neighbor-blocked-follow-up-alt__delay,
 .atlas-military-neighbor-blocked-follow-up-ladder__detail,
-.atlas-military-neighbor-blocked-follow-up-ladder__reason {
+.atlas-military-neighbor-blocked-follow-up-ladder__reason,
+.atlas-military-neighbor-blocked-follow-up-ladder__watch {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
 .atlas-military-neighbor-blocked-follow-up-alt__prep { fill: #bfdbfe; }
 .atlas-military-neighbor-blocked-follow-up-ladder__reason { fill: #bfdbfe; }
+.atlas-military-neighbor-blocked-follow-up-ladder__watch { fill: #fecdd3; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1536.\n\nSummary:\n- adds a compact remaining-watch line to the front follow-up ladder when useful residual context exists\n- reuses already-computed residual risk, blocked condition, and risky delay signals without adding a row when nothing remains to watch\n- keeps the existing MAP-A36..A38 ladder and cue rows intact\n\nValidation:\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test\n\nZeta: ready for validation before merge.