### PR TITLE
Gamma: Show cultural follow-up robustness

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1460,6 +1460,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
   }
 
   const firstFollowUpReason = buildCulturalFirstFollowUpReason(candidate, recommendedBeyondMinimumBenefit, immediateSynergy);
+  const followUpRobustness = buildCulturalFollowUpRobustness(candidate, immediateSynergy);
   const sourceAction = normalizeText(immediateSynergy.sourceAction ?? '');
 
   if (/attendre|observer/.test(sourceAction)) {
@@ -1469,6 +1470,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       decision: 'attendre/observer reste le meilleur premier suivi visible',
       summary: `Observer: ${candidate.deadlineHint}; ${immediateSynergy.summary}`,
       firstFollowUpReason,
+      followUpRobustness,
     };
   }
 
@@ -1479,6 +1481,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       decision: 'agir maintenant pour capturer la synergie avant expiration',
       summary: `Agir maintenant: ${immediateSynergy.expiryWarning.summary}`,
       firstFollowUpReason,
+      followUpRobustness,
     };
   }
 
@@ -1489,6 +1492,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       decision: 'faire le minimum garde la fenêtre sans perdre la synergie visible',
       summary: `Minimum suffisant: ${candidate.minimalRevisitAction}; ${immediateSynergy.summary}`,
       firstFollowUpReason,
+      followUpRobustness,
     };
   }
 
@@ -1498,6 +1502,29 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
     decision: 'reporter sans perdre la synergie visible',
     summary: `Report sûr: ${candidate.deadlineHint}; ${immediateSynergy.summary}`,
     firstFollowUpReason,
+    followUpRobustness,
+  };
+}
+
+function buildCulturalFollowUpRobustness(candidate, immediateSynergy) {
+  if (immediateSynergy.expiryWarning) {
+    return {
+      state: 'fragile-before-review',
+      label: 'Fragile avant revue',
+      reviewWindow: immediateSynergy.expiryWarning.reviewWindow,
+      reason: immediateSynergy.expiryWarning.expiryCause,
+      summary: `Fragile avant revue: ${immediateSynergy.expiryWarning.expiryCause}; ${immediateSynergy.sourceLabel} expire avant ${immediateSynergy.expiryWarning.reviewWindow}.`,
+    };
+  }
+
+  return {
+    state: 'stable-until-review',
+    label: 'Stable jusqu’à la prochaine revue',
+    reviewWindow: candidate.nextReviewWindow,
+    reason: candidate.deadlineStatus === 'near-deadline'
+      ? 'la synergie visible ne signale pas d’expiration avant la revue'
+      : candidate.deadlineHint,
+    summary: `Stable jusqu’à la prochaine revue: ${candidate.nextReviewWindow}; aucune expiration de synergie visible.`,
   };
 }
 

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -1052,6 +1052,13 @@ test('buildCultureTurnReportDeltas warns when immediate cultural synergy expires
       summary: 'synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.; expiration: expire avant revue: expire avant la prochaine revue; agir maintenant capture archive-routes.; piste différée: confirmer Ouvrir le récit d’expansion; signal local: perte du soutien actif.',
       payoffCue: 'gain concret: sécurise payoff 3 sans attendre la bascule',
     },
+    followUpRobustness: {
+      state: 'fragile-before-review',
+      label: 'Fragile avant revue',
+      reviewWindow: 'prochaine rotation culturelle',
+      reason: 'expire avant la prochaine revue',
+      summary: 'Fragile avant revue: expire avant la prochaine revue; archive-routes expire avant prochaine rotation culturelle.',
+    },
   });
 });
 
@@ -1129,6 +1136,13 @@ test('buildCultureTurnReportDeltas summarizes a safe defer ladder without expiri
       localSignal: 'signal local: fallout en hausse',
       summary: 'synergie ce tour: archive-routes + Compact d’Aurora; amplifier sécurisé.; expiration: aucune expiration visible; piste différée: risque stabilisé par l’historique lisible; signal local: fallout en hausse.',
       payoffCue: 'gain concret: sécurise payoff 2 sans attendre la bascule',
+    },
+    followUpRobustness: {
+      state: 'stable-until-review',
+      label: 'Stable jusqu’à la prochaine revue',
+      reviewWindow: 'prochaine rotation culturelle',
+      reason: 'sûr ce tour',
+      summary: 'Stable jusqu’à la prochaine revue: prochaine rotation culturelle; aucune expiration de synergie visible.',
     },
   });
 });

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -185,7 +185,9 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Au-delà du minimum:/);
   assert.match(webAppSource, /Arbitrage:/);
   assert.match(webAppSource, /Pourquoi ce suivi:/);
+  assert.match(webAppSource, /Robustesse:/);
   assert.match(webAppSource, /firstFollowUpReason/);
+  assert.match(webAppSource, /followUpRobustness/);
   assert.match(webAppSource, /deferLadderSummary/);
   assert.match(webAppSource, /Synergie ce tour:/);
   assert.match(webAppSource, /Synergie temporaire:/);

--- a/web/app.js
+++ b/web/app.js
@@ -7801,6 +7801,7 @@ function renderCultureTurnReport(report) {
                   <small>Payoff: ${entry.payoffScore ?? 0}</small>
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary ? `<small>Arbitrage: ${entry.deferLadderSummary.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.firstFollowUpReason ? `<small>Pourquoi ce suivi: ${entry.deferLadderSummary.firstFollowUpReason.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.followUpRobustness ? `<small>Robustesse: ${entry.deferLadderSummary.followUpRobustness.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}


### PR DESCRIPTION
Gamma: Implements #1538.

Summary:
- Adds `followUpRobustness` to the cultural defer ladder using existing synergy/expiry cues.
- Marks follow-ups as “Fragile avant revue” only when an explicit expiry warning is visible.
- Marks durable visible synergies as “Stable jusqu’à la prochaine revue” without pessimistic warnings.
- Renders a compact “Robustesse” line in the culture report.

Tests:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- node --check web/app.js
- git diff --check
- npm test

Zeta: PR prête pour validation avant merge.