### PR TITLE
Epsilon: Show climate watch primary margin

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -28,6 +28,15 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /minimalProtection/);
   assert.match(webAppSource, /secondaryProtectionGuard/);
   assert.match(webAppSource, /secondaryUpkeep/);
+  assert.match(webAppSource, /primaryPromotionMargin/);
+  assert.match(webAppSource, /watchMargin/);
+  assert.match(webAppSource, /Marge avant primaire/);
+  assert.match(webAppSource, /marge faible/);
+  assert.match(webAppSource, /marge confortable/);
+  assert.match(webAppSource, /reste \$\{primaryPromotionMargin\} point/);
+  assert.match(webAppSource, /Number\.isFinite\(watchGap\.nearestThresholdScore\)/);
+  assert.match(webAppSource, /view\.watchItem\.watchMargin \?/);
+  assert.match(webAppSource, /secondaryUpkeep/);
   assert.match(webAppSource, /smallestUpkeepReason/);
   assert.match(webAppSource, /upkeepPromotionRisk/);
   assert.match(webAppSource, /Pourquoi cet upkeep/);
@@ -75,6 +84,9 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--impossible/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__upkeep--stable-without-upkeep/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__why/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__margin/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__margin--tight/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__margin--comfortable/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
@@ -147,4 +159,15 @@ test('atlas clearly marks when secondary watch can stay secondary without upkeep
   assert.match(webAppSource, /label: 'veille stable sans upkeep'/);
   assert.match(webAppSource, /Sans upkeep immédiat/);
   assert.match(webAppSource, /la veille peut rester secondaire tant que le signal ne se rapproche pas/);
+});
+
+test('atlas shows remaining margin before secondary climate watch becomes primary', () => {
+  assert.match(webAppSource, /const primaryPromotionMargin = Number\.isFinite\(watchGap\.nearestThresholdScore\)/);
+  assert.match(webAppSource, /Math\.max\(0, 80 - watchGap\.nearestThresholdScore\)/);
+  assert.match(webAppSource, /label: primaryPromotionMargin <= 0/);
+  assert.match(webAppSource, /marge nulle/);
+  assert.match(webAppSource, /marge courte/);
+  assert.match(webAppSource, /Marge avant primaire/);
+  assert.match(webAppSource, /view\.watchItem\.watchMargin \? `<small class="map-world-climate-post-gap-watch__margin/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__margin--short/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14210,6 +14210,30 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
     : watchGap.nearestThresholdScore >= 65
       ? 'veille tour+1'
       : 'veille conditionnelle';
+  const primaryPromotionMargin = Number.isFinite(watchGap.nearestThresholdScore)
+    ? Math.max(0, 80 - watchGap.nearestThresholdScore)
+    : null;
+  const watchMargin = primaryPromotionMargin === null
+    ? null
+    : {
+      state: primaryPromotionMargin <= 0
+        ? 'none'
+        : primaryPromotionMargin <= 5
+          ? 'tight'
+          : primaryPromotionMargin <= 15
+            ? 'short'
+            : 'comfortable',
+      label: primaryPromotionMargin <= 0
+        ? 'marge nulle'
+        : primaryPromotionMargin <= 5
+          ? 'marge faible'
+          : primaryPromotionMargin <= 15
+            ? 'marge courte'
+            : 'marge confortable',
+      detail: primaryPromotionMargin <= 0
+        ? 'déjà au seuil de promotion primaire après cet upkeep'
+        : `reste ${primaryPromotionMargin} point${primaryPromotionMargin > 1 ? 's' : ''} avant la promotion primaire`,
+    };
   const minimalProtection = coverageView.secondaryProtections?.[0]
     ?? coverageView.activeProtections?.[0]
     ?? (gapActionView.recommendation
@@ -14318,6 +14342,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       shortSecondaryLabel,
       secondaryProtectionGuard,
       secondaryUpkeep,
+      watchMargin,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14358,6 +14383,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       ${view.watchItem.secondaryProtectionGuard ? `<small class="map-world-climate-post-gap-watch__guard"><b>Reste secondaire si</b> · ${view.watchItem.secondaryProtectionGuard.condition}${view.watchItem.secondaryProtectionGuard.minimalAction ? `; action minimale: ${view.watchItem.secondaryProtectionGuard.minimalAction}` : '; action minimale indisponible'}</small>` : ''}
       <small class="map-world-climate-post-gap-watch__upkeep map-world-climate-post-gap-watch__upkeep--${view.watchItem.secondaryUpkeep.state}"><b>Entretien minimal</b> · ${view.watchItem.secondaryUpkeep.label}: ${view.watchItem.secondaryUpkeep.action}; ${view.watchItem.secondaryUpkeep.reason}</small>
       ${view.watchItem.secondaryUpkeep.smallestUpkeepReason ? `<small class="map-world-climate-post-gap-watch__why"><b>Pourquoi cet upkeep</b> · ${view.watchItem.secondaryUpkeep.smallestUpkeepReason.summary}</small>` : '<small class="map-world-climate-post-gap-watch__why"><b>Sans upkeep immédiat</b> · la veille peut rester secondaire tant que le signal ne se rapproche pas.</small>'}
+      ${view.watchItem.watchMargin ? `<small class="map-world-climate-post-gap-watch__margin map-world-climate-post-gap-watch__margin--${view.watchItem.watchMargin.state}"><b>Marge avant primaire</b> · ${view.watchItem.watchMargin.label}: ${view.watchItem.watchMargin.detail}</small>` : ''}
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13648,6 +13648,16 @@ button { font: inherit; }
   padding-left: 8px;
   border-left: 2px solid rgba(125, 211, 252, 0.34);
 }
+.map-world-climate-post-gap-watch__margin {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.32);
+}
+.map-world-climate-post-gap-watch__margin--none,
+.map-world-climate-post-gap-watch__margin--tight { border: 1px solid rgba(248, 113, 113, 0.36); }
+.map-world-climate-post-gap-watch__margin--short { border: 1px solid rgba(251, 191, 36, 0.34); }
+.map-world-climate-post-gap-watch__margin--comfortable { border: 1px solid rgba(74, 222, 128, 0.34); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon:

Fixes #1540.

Summary:
- adds a compact margin line after the chosen climate watch upkeep
- labels remaining distance before primary promotion as null/weak/short/comfortable without new mechanics
- hides the margin when the threshold score is not determinable

Validation:
- node --check web/app.js
- npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check