### PR TITLE
Alpha: MAP-A40 show front watch drop condition

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -402,6 +402,22 @@ test('atlas military shows what remains to watch after the front follow-up actio
   assert.match(webAppSource, /const remainingWatch = watchParts\.length \? `Reste à surveiller: \$\{watchParts\.slice\(0, 2\)\.join\(' · '\)\}` : null/);
   assert.match(webAppSource, /remainingWatch,/);
   assert.match(webAppSource, /ladder\.remainingWatch \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__watch"/);
-  assert.match(webAppSource, /ladderHeight = preview\.blockedFollowUpLadder\?\.visible \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 5\.2 : 3\.85 : 0/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.remainingWatch \? 5\.2 : 3\.85/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__watch/);
+});
+
+// MAP-A40: show when residual front follow-up surveillance is still useful or
+// can be dropped, using the same visible risk/condition signals.
+test('atlas military shows when the front follow-up watch can be dropped', () => {
+  assert.match(webAppSource, /let watchDrop = null/);
+  assert.match(webAppSource, /residualRisk\?\.visible && residualRisk\.tone === 'covered'/);
+  assert.match(webAppSource, /label: 'Suivi stabilisé'/);
+  assert.match(webAppSource, /peut être lâché après confirmation: \$\{residualRisk\.action\}/);
+  assert.match(webAppSource, /label: 'Surveillance encore utile'/);
+  assert.match(webAppSource, /detail: `lâcher quand \$\{exitCondition\}`/);
+  assert.match(webAppSource, /ladder\.watchDrop \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__drop/);
+  assert.match(webAppSource, /ladder\.watchDrop\.label\}: \$\{ladder\.watchDrop\.detail\}/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.watchDrop \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 6\.55 : 5\.2/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__drop--watch/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__drop--stable/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -2777,6 +2777,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       detail: 'pas assez de signaux fiables',
       firstActionReason: 'raison masquée: signaux insuffisants',
       remainingWatch: null,
+      watchDrop: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2818,6 +2819,25 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     watchParts.push(`${prepUnlock.delayCost.label.toLowerCase()}: ${prepUnlock.delayCost.detail}`);
   }
   const remainingWatch = watchParts.length ? `Reste à surveiller: ${watchParts.slice(0, 2).join(' · ')}` : null;
+  let watchDrop = null;
+  if (residualRisk?.visible && residualRisk.tone === 'covered') {
+    watchDrop = {
+      tone: 'stable',
+      label: 'Suivi stabilisé',
+      detail: `peut être lâché après confirmation: ${residualRisk.action}`,
+    };
+  } else if (remainingWatch) {
+    const exitCondition = alternative.viabilityStatus !== 'ready'
+      ? alternative.minimumCondition
+      : residualRisk?.action ?? prepUnlock?.delayCost?.detail;
+    if (exitCondition) {
+      watchDrop = {
+        tone: 'watch',
+        label: 'Surveillance encore utile',
+        detail: `lâcher quand ${exitCondition}`,
+      };
+    }
+  }
   if (steps.length < 2) {
     return {
       visible: false,
@@ -2826,6 +2846,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       detail: 'un seul signal, ligne dédiée suffisante',
       firstActionReason: 'raison masquée: un seul signal utile',
       remainingWatch: null,
+      watchDrop: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2836,6 +2857,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     detail: steps.join(' → '),
     firstActionReason: `Pourquoi d’abord: ${reasonParts.slice(0, 4).join(' · ')}`,
     remainingWatch,
+    watchDrop,
   };
 }
 
@@ -3092,11 +3114,12 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
       ${ladder.remainingWatch ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__watch" x="44.2" y="${y + 4.05}">${ladder.remainingWatch}</text>` : ''}
+      ${ladder.watchDrop ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__drop atlas-military-neighbor-blocked-follow-up-ladder__drop--${ladder.watchDrop.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 5.4 : 4.05)}">${ladder.watchDrop.label}: ${ladder.watchDrop.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3134,7 +3157,9 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     ? preview.blockedFollowUpAlternative?.prepUnlock?.delayCost ? 5.2 : preview.blockedFollowUpAlternative?.prepUnlock ? 3.85 : 2.5
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
-  const ladderHeight = preview.blockedFollowUpLadder?.visible ? preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85 : 0;
+  const ladderHeight = preview.blockedFollowUpLadder?.visible
+    ? preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;
   const hintHeight = preview.sharedHandlingHint?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14644,13 +14644,16 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay,
 .atlas-military-neighbor-blocked-follow-up-ladder__detail,
 .atlas-military-neighbor-blocked-follow-up-ladder__reason,
-.atlas-military-neighbor-blocked-follow-up-ladder__watch {
+.atlas-military-neighbor-blocked-follow-up-ladder__watch,
+.atlas-military-neighbor-blocked-follow-up-ladder__drop {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
 .atlas-military-neighbor-blocked-follow-up-alt__prep { fill: #bfdbfe; }
 .atlas-military-neighbor-blocked-follow-up-ladder__reason { fill: #bfdbfe; }
 .atlas-military-neighbor-blocked-follow-up-ladder__watch { fill: #fecdd3; }
+.atlas-military-neighbor-blocked-follow-up-ladder__drop--watch { fill: #fde68a; }
+.atlas-military-neighbor-blocked-follow-up-ladder__drop--stable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1546.\n\nSummary:\n- adds a compact drop/keep watching cue to the front follow-up ladder\n- distinguishes stable covered follow-up from active residual surveillance using existing residual risk, minimum condition, and delay-cost signals\n- keeps the cue absent when no reliable drop condition is available and avoids duplicating MAP-A36..A39 rows\n\nValidation:\n- git diff --check\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test\n\nZeta: ready for validation before merge.