### PR TITLE
Gamma: Show cultural review exit signal

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1461,6 +1461,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
 
   const firstFollowUpReason = buildCulturalFirstFollowUpReason(candidate, recommendedBeyondMinimumBenefit, immediateSynergy);
   const followUpRobustness = buildCulturalFollowUpRobustness(candidate, immediateSynergy);
+  const reviewExitSignal = buildCulturalReviewExitSignal(candidate, immediateSynergy, followUpRobustness);
   const sourceAction = normalizeText(immediateSynergy.sourceAction ?? '');
 
   if (/attendre|observer/.test(sourceAction)) {
@@ -1471,6 +1472,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       summary: `Observer: ${candidate.deadlineHint}; ${immediateSynergy.summary}`,
       firstFollowUpReason,
       followUpRobustness,
+      reviewExitSignal,
     };
   }
 
@@ -1482,6 +1484,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       summary: `Agir maintenant: ${immediateSynergy.expiryWarning.summary}`,
       firstFollowUpReason,
       followUpRobustness,
+      reviewExitSignal,
     };
   }
 
@@ -1493,6 +1496,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       summary: `Minimum suffisant: ${candidate.minimalRevisitAction}; ${immediateSynergy.summary}`,
       firstFollowUpReason,
       followUpRobustness,
+      reviewExitSignal,
     };
   }
 
@@ -1503,6 +1507,27 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
     summary: `Report sûr: ${candidate.deadlineHint}; ${immediateSynergy.summary}`,
     firstFollowUpReason,
     followUpRobustness,
+    reviewExitSignal,
+  };
+}
+
+function buildCulturalReviewExitSignal(candidate, immediateSynergy, followUpRobustness) {
+  if (followUpRobustness.state !== 'stable-until-review') {
+    return null;
+  }
+
+  const exitCondition = immediateSynergy.sourceAction
+    ? `${immediateSynergy.sourceAction} reste visible sans expiration`
+    : `${immediateSynergy.sourceLabel} reste visible sans expiration`;
+  const localAnchor = candidate.minimalSafeAction ?? candidate.condition;
+
+  return {
+    state: 'exit-on-stable-signal',
+    label: 'Sortie de revue',
+    reviewWindow: followUpRobustness.reviewWindow,
+    signal: exitCondition,
+    localAnchor,
+    summary: `Sortie de revue: ${exitCondition} jusqu’à ${followUpRobustness.reviewWindow}; ${localAnchor}.`,
   };
 }
 

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -1059,6 +1059,7 @@ test('buildCultureTurnReportDeltas warns when immediate cultural synergy expires
       reason: 'expire avant la prochaine revue',
       summary: 'Fragile avant revue: expire avant la prochaine revue; archive-routes expire avant prochaine rotation culturelle.',
     },
+    reviewExitSignal: null,
   });
 });
 
@@ -1143,6 +1144,14 @@ test('buildCultureTurnReportDeltas summarizes a safe defer ladder without expiri
       reviewWindow: 'prochaine rotation culturelle',
       reason: 'sûr ce tour',
       summary: 'Stable jusqu’à la prochaine revue: prochaine rotation culturelle; aucune expiration de synergie visible.',
+    },
+    reviewExitSignal: {
+      state: 'exit-on-stable-signal',
+      label: 'Sortie de revue',
+      reviewWindow: 'prochaine rotation culturelle',
+      signal: 'amplifier reste visible sans expiration',
+      localAnchor: 'risque stabilisé par l’historique lisible',
+      summary: 'Sortie de revue: amplifier reste visible sans expiration jusqu’à prochaine rotation culturelle; risque stabilisé par l’historique lisible.',
     },
   });
 });

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -186,8 +186,10 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Arbitrage:/);
   assert.match(webAppSource, /Pourquoi ce suivi:/);
   assert.match(webAppSource, /Robustesse:/);
+  assert.match(webAppSource, /Stabilisation:/);
   assert.match(webAppSource, /firstFollowUpReason/);
   assert.match(webAppSource, /followUpRobustness/);
+  assert.match(webAppSource, /reviewExitSignal/);
   assert.match(webAppSource, /deferLadderSummary/);
   assert.match(webAppSource, /Synergie ce tour:/);
   assert.match(webAppSource, /Synergie temporaire:/);

--- a/web/app.js
+++ b/web/app.js
@@ -7817,6 +7817,7 @@ function renderCultureTurnReport(report) {
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary ? `<small>Arbitrage: ${entry.deferLadderSummary.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.firstFollowUpReason ? `<small>Pourquoi ce suivi: ${entry.deferLadderSummary.firstFollowUpReason.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.followUpRobustness ? `<small>Robustesse: ${entry.deferLadderSummary.followUpRobustness.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewExitSignal ? `<small>Stabilisation: ${entry.deferLadderSummary.reviewExitSignal.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}


### PR DESCRIPTION
Gamma: Implements #1548.

Summary:
- adds a reviewExitSignal to stable cultural defer ladder summaries
- keeps expiring/fragile follow-ups from repeating a stabilization signal
- renders the first visible stabilization cue in the culture report

Validation:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- node --check web/app.js
- git diff --check
- npm test
