### PR TITLE
Beta: MAP-B40 show logistics guard primary return

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1181,12 +1181,50 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
 
     return null;
   };
+  const buildGuardPrimaryReturnSignal = (opportunityCost, nextChoiceTrigger) => {
+    const fallbackAction = opportunityCost?.fallbackAction ?? null;
+    if (!fallbackAction || !nextChoiceTrigger) {
+      return null;
+    }
+
+    if (opportunityCost?.state === 'competing') {
+      return {
+        state: 'stay-fallback',
+        label: 'Rester en fallback',
+        summary: priorityAction.resource
+          ? `Retour vers ${opportunityCost.delayedRoute} possible quand ${priorityAction.resource} n’est plus la ressource limitante de ${priorityAction.route}.`
+          : `Retour vers ${opportunityCost.delayedRoute} possible quand la route principale ne partage plus la capacité locale.`,
+        reason: nextChoiceTrigger.trigger,
+      };
+    }
+
+    const stopMarker = opportunityCost?.stopMarker ?? null;
+    if (stopMarker?.cumulativeCost && stopMarker?.expectedBenefit) {
+      const margin = stopMarker.expectedBenefit - stopMarker.cumulativeCost;
+      return margin >= 0
+        ? {
+          state: 'return-possible',
+          label: 'Retour possible',
+          summary: `${stopMarker.route} redevient sûre: bénéfice ${stopMarker.expectedBenefit} couvre coût ${stopMarker.cumulativeCost}.`,
+          reason: nextChoiceTrigger.trigger,
+        }
+        : {
+          state: 'stay-fallback',
+          label: 'Rester en fallback',
+          summary: `Retour vers ${stopMarker.route} après ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge de garde récupéré${Math.abs(margin) > 1 ? 's' : ''}.`,
+          reason: nextChoiceTrigger.trigger,
+        };
+    }
+
+    return null;
+  };
   const buildGuardFallbackJustification = (opportunityCost) => {
     const fallbackAction = opportunityCost?.fallbackAction ?? null;
     const exposure = fallbackAction?.residualExposure ?? opportunityCost?.residualExposure ?? null;
     const exposedRoutes = exposure?.exposedRoutes ?? [];
     const firstExposedRoute = exposedRoutes[0] ?? null;
     const nextChoiceTrigger = buildGuardNextChoiceTrigger(opportunityCost);
+    const primaryReturnSignal = buildGuardPrimaryReturnSignal(opportunityCost, nextChoiceTrigger);
 
     if (!fallbackAction) {
       return {
@@ -1213,6 +1251,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         ? `Ignorer ce repli laisse ${exposedLabel} critique et peut retarder le bénéfice principal.`
         : `Ignorer ce repli risque de relancer une garde moins rentable sur ${exposedLabel}.`,
       nextChoiceTrigger,
+      primaryReturnSignal,
     };
   };
   if (guardOpportunityCost.fallbackAction) {

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -143,6 +143,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.ignoredRisk, /Ignorer/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.nextChoiceTrigger.state, 'resource');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.nextChoiceTrigger.trigger, /Outils|ressource|devient le risque critique/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.state, 'stay-fallback');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.summary, /Retour vers .* possible quand Outils/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -238,6 +240,8 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.nextChoiceTrigger.state, 'watch');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.nextChoiceTrigger.trigger, /bénéfice attendu de Safe Road/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.nextChoiceTrigger.reason, /coût .* contre bénéfice/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.state, 'stay-fallback');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.summary, /Retour vers Safe Road après .* marge/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {
@@ -284,6 +288,7 @@ test('buildProvinceLogisticsChoicePreview returns an empty state when no route i
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.state, 'unavailable');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.label, /Aucun fallback sûr/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.nextChoiceTrigger, undefined);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal, undefined);
   assert.equal(preview.primaryLogisticsAction.status, 'empty');
   assert.equal(preview.primaryLogisticsAction.disabled, true);
   assert.match(preview.timelineSummary, /timeline vide/);

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -122,6 +122,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /province-logistics-spillover-next-trigger/);
   assert.match(webAppSource, /nextChoiceTrigger/);
   assert.match(webAppSource, /Prochain déclencheur:/);
+  assert.match(webAppSource, /province-logistics-spillover-primary-return/);
+  assert.match(webAppSource, /primaryReturnSignal/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8734,6 +8734,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                   ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.nextChoiceTrigger ? `
                     <small class="province-logistics-spillover-next-trigger province-logistics-spillover-next-trigger--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.nextChoiceTrigger.state}">Prochain déclencheur: ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.nextChoiceTrigger.trigger} ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.nextChoiceTrigger.reason}</small>
                   ` : ''}
+                  ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal ? `
+                    <small class="province-logistics-spillover-primary-return province-logistics-spillover-primary-return--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.label}: ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.summary}</small>
+                  ` : ''}
                 ` : ''}
               ` : ''}
               ${preview.adjacentRouteSpilloverRisk.guardOpportunityCost?.canContinueWithoutCriticalDelay ? '<small>Continuer la chaîne reste acceptable: aucune route critique n’est retardée.</small>' : ''}


### PR DESCRIPTION
Beta: Implements #1547.\n\nSummary:\n- Adds a compact primary-return signal after logistics guard fallbacks.\n- Reuses the existing next-choice trigger, resource limit, and guard margin signals; no new dependency or heavy recalculation.\n- Keeps the return line absent when no reliable fallback trigger exists.\n- Renders stay-fallback / return-possible guidance in the economy logistics map panel.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test