### PR TITLE
Epsilon: Show climate upkeep reminder exit

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -30,6 +30,12 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /secondaryUpkeep/);
   assert.match(webAppSource, /primaryPromotionMargin/);
   assert.match(webAppSource, /watchMargin/);
+  assert.match(webAppSource, /upkeepReminder/);
+  assert.match(webAppSource, /Rappel upkeep/);
+  assert.match(webAppSource, /rappel proche/);
+  assert.match(webAppSource, /rappel inutile/);
+  assert.match(webAppSource, /sécurité suffisante: attendre un nouveau signal avant de relancer l’upkeep/);
+  assert.match(webAppSource, /surveiller au prochain check car le secondaire peut encore remonter vite/);
   assert.match(webAppSource, /Marge avant primaire/);
   assert.match(webAppSource, /marge faible/);
   assert.match(webAppSource, /marge confortable/);
@@ -87,6 +93,9 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__margin/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__margin--tight/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__margin--comfortable/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__reminder/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__reminder--monitor/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__reminder--skip/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
@@ -170,4 +179,14 @@ test('atlas shows remaining margin before secondary climate watch becomes primar
   assert.match(webAppSource, /Marge avant primaire/);
   assert.match(webAppSource, /view\.watchItem\.watchMargin \? `<small class="map-world-climate-post-gap-watch__margin/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__margin--short/);
+});
+
+test('atlas shows when climate watch margin can stop immediate upkeep reminders', () => {
+  assert.match(webAppSource, /const upkeepReminder = watchMargin/);
+  assert.match(webAppSource, /watchMargin\.state === 'comfortable'/);
+  assert.match(webAppSource, /state: 'skip'/);
+  assert.match(webAppSource, /state: 'monitor'/);
+  assert.match(webAppSource, /Rappel upkeep/);
+  assert.match(webAppSource, /view\.watchItem\.upkeepReminder \?/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__reminder--skip/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14266,6 +14266,19 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
         ? 'déjà au seuil de promotion primaire après cet upkeep'
         : `reste ${primaryPromotionMargin} point${primaryPromotionMargin > 1 ? 's' : ''} avant la promotion primaire`,
     };
+  const upkeepReminder = watchMargin
+    ? watchMargin.state === 'comfortable'
+      ? {
+        state: 'skip',
+        label: 'rappel inutile',
+        detail: 'sécurité suffisante: attendre un nouveau signal avant de relancer l’upkeep',
+      }
+      : {
+        state: 'monitor',
+        label: 'rappel proche',
+        detail: 'surveiller au prochain check car le secondaire peut encore remonter vite',
+      }
+    : null;
   const minimalProtection = coverageView.secondaryProtections?.[0]
     ?? coverageView.activeProtections?.[0]
     ?? (gapActionView.recommendation
@@ -14375,6 +14388,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       secondaryProtectionGuard,
       secondaryUpkeep,
       watchMargin,
+      upkeepReminder,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14416,6 +14430,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small class="map-world-climate-post-gap-watch__upkeep map-world-climate-post-gap-watch__upkeep--${view.watchItem.secondaryUpkeep.state}"><b>Entretien minimal</b> · ${view.watchItem.secondaryUpkeep.label}: ${view.watchItem.secondaryUpkeep.action}; ${view.watchItem.secondaryUpkeep.reason}</small>
       ${view.watchItem.secondaryUpkeep.smallestUpkeepReason ? `<small class="map-world-climate-post-gap-watch__why"><b>Pourquoi cet upkeep</b> · ${view.watchItem.secondaryUpkeep.smallestUpkeepReason.summary}</small>` : '<small class="map-world-climate-post-gap-watch__why"><b>Sans upkeep immédiat</b> · la veille peut rester secondaire tant que le signal ne se rapproche pas.</small>'}
       ${view.watchItem.watchMargin ? `<small class="map-world-climate-post-gap-watch__margin map-world-climate-post-gap-watch__margin--${view.watchItem.watchMargin.state}"><b>Marge avant primaire</b> · ${view.watchItem.watchMargin.label}: ${view.watchItem.watchMargin.detail}</small>` : ''}
+      ${view.watchItem.upkeepReminder ? `<small class="map-world-climate-post-gap-watch__reminder map-world-climate-post-gap-watch__reminder--${view.watchItem.upkeepReminder.state}"><b>Rappel upkeep</b> · ${view.watchItem.upkeepReminder.label}: ${view.watchItem.upkeepReminder.detail}</small>` : ''}
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13673,6 +13673,14 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__margin--tight { border: 1px solid rgba(248, 113, 113, 0.36); }
 .map-world-climate-post-gap-watch__margin--short { border: 1px solid rgba(251, 191, 36, 0.34); }
 .map-world-climate-post-gap-watch__margin--comfortable { border: 1px solid rgba(74, 222, 128, 0.34); }
+.map-world-climate-post-gap-watch__reminder {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.28);
+}
+.map-world-climate-post-gap-watch__reminder--monitor { border: 1px solid rgba(251, 191, 36, 0.34); }
+.map-world-climate-post-gap-watch__reminder--skip { border: 1px solid rgba(74, 222, 128, 0.34); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon:

Fixes #1550.

Summary:
- adds a compact upkeep reminder hint derived from the existing climate watch margin
- distinguishes close monitoring from safe-enough-to-skip immediate reminders without duplicating margin labels
- hides the hint when the margin cannot be determined

Validation:
- node --check web/app.js
- npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check