### PR TITLE
Beta: MAP-B41 show primary return residual constraint

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1187,6 +1187,15 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       return null;
     }
 
+    const exposure = fallbackAction.residualExposure ?? opportunityCost?.residualExposure ?? null;
+    const exposedRoute = exposure?.exposedRoutes?.[0] ?? null;
+    const buildResidualConstraint = (state, summary) => ({
+      state,
+      label: 'Contrainte restante',
+      summary,
+      route: exposedRoute?.route ?? opportunityCost?.delayedRoute ?? null,
+    });
+
     if (opportunityCost?.state === 'competing') {
       return {
         state: 'stay-fallback',
@@ -1195,6 +1204,12 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           ? `Retour vers ${opportunityCost.delayedRoute} possible quand ${priorityAction.resource} n’est plus la ressource limitante de ${priorityAction.route}.`
           : `Retour vers ${opportunityCost.delayedRoute} possible quand la route principale ne partage plus la capacité locale.`,
         reason: nextChoiceTrigger.trigger,
+        residualConstraint: buildResidualConstraint(
+          'resource',
+          priorityAction.resource
+            ? `Route primaire reprise, contrainte restante: ${priorityAction.resource} doit rester disponible avant de rouvrir ${opportunityCost.delayedRoute}.`
+            : `Route primaire reprise, contrainte restante: capacité locale encore partagée avec ${opportunityCost.delayedRoute}.`,
+        ),
       };
     }
 
@@ -1207,12 +1222,20 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           label: 'Retour possible',
           summary: `${stopMarker.route} redevient sûre: bénéfice ${stopMarker.expectedBenefit} couvre coût ${stopMarker.cumulativeCost}.`,
           reason: nextChoiceTrigger.trigger,
+          residualConstraint: buildResidualConstraint(
+            'watch',
+            `Route primaire reprise, contrainte restante: surveiller ${stopMarker.route} tant que la marge reste à ${margin}.`,
+          ),
         }
         : {
           state: 'stay-fallback',
           label: 'Rester en fallback',
           summary: `Retour vers ${stopMarker.route} après ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge de garde récupéré${Math.abs(margin) > 1 ? 's' : ''}.`,
           reason: nextChoiceTrigger.trigger,
+          residualConstraint: buildResidualConstraint(
+            'margin',
+            `Route primaire reprise plus tard: ${stopMarker.route} manque encore ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge de garde.`,
+          ),
         };
     }
 

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -145,6 +145,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.nextChoiceTrigger.trigger, /Outils|ressource|devient le risque critique/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.state, 'stay-fallback');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.summary, /Retour vers .* possible quand Outils/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint.state, 'resource');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint.summary, /Route primaire reprise, contrainte restante: Outils/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -242,6 +244,8 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.nextChoiceTrigger.reason, /coût .* contre bénéfice/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.state, 'stay-fallback');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.summary, /Retour vers Safe Road après .* marge/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.residualConstraint.state, 'margin');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.residualConstraint.summary, /Route primaire reprise plus tard: Safe Road manque encore/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -124,6 +124,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /Prochain déclencheur:/);
   assert.match(webAppSource, /province-logistics-spillover-primary-return/);
   assert.match(webAppSource, /primaryReturnSignal/);
+  assert.match(webAppSource, /province-logistics-spillover-return-residual/);
+  assert.match(webAppSource, /residualConstraint/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8762,6 +8762,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                   ` : ''}
                   ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal ? `
                     <small class="province-logistics-spillover-primary-return province-logistics-spillover-primary-return--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.label}: ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.summary}</small>
+                    ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint ? `
+                      <small class="province-logistics-spillover-return-residual province-logistics-spillover-return-residual--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint.summary}</small>
+                    ` : ''}
                   ` : ''}
                 ` : ''}
               ` : ''}


### PR DESCRIPTION
Beta: Implements #1557.\n\nSummary:\n- Adds a compact residual constraint after the logistics guard primary-return signal.\n- Reuses existing fallback, return, trigger, margin, resource, and exposed-route signals; no new dependency or heavy recalculation.\n- Keeps the residual line absent when no reliable primary-return signal exists.\n- Renders the remaining constraint in the economy logistics map panel.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test