### PR TITLE
Epsilon: Show climate margin review rearm

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -31,6 +31,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /primaryPromotionMargin/);
   assert.match(webAppSource, /watchMargin/);
   assert.match(webAppSource, /upkeepReminder/);
+  assert.match(webAppSource, /marginRearmReview/);
+  assert.match(webAppSource, /Réarmer review/);
+  assert.match(webAppSource, /review différée/);
+  assert.match(webAppSource, /réarmer si \$\{watchGap\.nearestRiskLabel\} revient avant \$\{progress\.deadline\} ou si la marge repasse courte/);
   assert.match(webAppSource, /Rappel upkeep/);
   assert.match(webAppSource, /rappel proche/);
   assert.match(webAppSource, /rappel inutile/);
@@ -96,6 +100,8 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__reminder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__reminder--monitor/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__reminder--skip/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rearm/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rearm--deferred/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
@@ -189,4 +195,13 @@ test('atlas shows when climate watch margin can stop immediate upkeep reminders'
   assert.match(webAppSource, /Rappel upkeep/);
   assert.match(webAppSource, /view\.watchItem\.upkeepReminder \?/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__reminder--skip/);
+});
+
+test('atlas shows when comfortable climate margin should be rearmed for review', () => {
+  assert.match(webAppSource, /const marginRearmReview = watchMargin\?\.state === 'comfortable'/);
+  assert.match(webAppSource, /watchGap\.nearestRiskLabel && progress\.deadline/);
+  assert.match(webAppSource, /label: 'review différée'/);
+  assert.match(webAppSource, /Réarmer review/);
+  assert.match(webAppSource, /view\.watchItem\.marginRearmReview \?/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rearm--deferred/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14282,6 +14282,13 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
         detail: 'surveiller au prochain check car le secondaire peut encore remonter vite',
       }
     : null;
+  const marginRearmReview = watchMargin?.state === 'comfortable' && watchGap.nearestRiskLabel && progress.deadline
+    ? {
+      state: 'deferred',
+      label: 'review différée',
+      detail: `réarmer si ${watchGap.nearestRiskLabel} revient avant ${progress.deadline} ou si la marge repasse courte`,
+    }
+    : null;
   const minimalProtection = coverageView.secondaryProtections?.[0]
     ?? coverageView.activeProtections?.[0]
     ?? (gapActionView.recommendation
@@ -14392,6 +14399,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       secondaryUpkeep,
       watchMargin,
       upkeepReminder,
+      marginRearmReview,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14434,6 +14442,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       ${view.watchItem.secondaryUpkeep.smallestUpkeepReason ? `<small class="map-world-climate-post-gap-watch__why"><b>Pourquoi cet upkeep</b> · ${view.watchItem.secondaryUpkeep.smallestUpkeepReason.summary}</small>` : '<small class="map-world-climate-post-gap-watch__why"><b>Sans upkeep immédiat</b> · la veille peut rester secondaire tant que le signal ne se rapproche pas.</small>'}
       ${view.watchItem.watchMargin ? `<small class="map-world-climate-post-gap-watch__margin map-world-climate-post-gap-watch__margin--${view.watchItem.watchMargin.state}"><b>Marge avant primaire</b> · ${view.watchItem.watchMargin.label}: ${view.watchItem.watchMargin.detail}</small>` : ''}
       ${view.watchItem.upkeepReminder ? `<small class="map-world-climate-post-gap-watch__reminder map-world-climate-post-gap-watch__reminder--${view.watchItem.upkeepReminder.state}"><b>Rappel upkeep</b> · ${view.watchItem.upkeepReminder.label}: ${view.watchItem.upkeepReminder.detail}</small>` : ''}
+      ${view.watchItem.marginRearmReview ? `<small class="map-world-climate-post-gap-watch__rearm map-world-climate-post-gap-watch__rearm--${view.watchItem.marginRearmReview.state}"><b>Réarmer review</b> · ${view.watchItem.marginRearmReview.label}: ${view.watchItem.marginRearmReview.detail}</small>` : ''}
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13696,6 +13696,13 @@ button { font: inherit; }
 }
 .map-world-climate-post-gap-watch__reminder--monitor { border: 1px solid rgba(251, 191, 36, 0.34); }
 .map-world-climate-post-gap-watch__reminder--skip { border: 1px solid rgba(74, 222, 128, 0.34); }
+.map-world-climate-post-gap-watch__rearm {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(8, 47, 73, 0.24);
+}
+.map-world-climate-post-gap-watch__rearm--deferred { border: 1px solid rgba(125, 211, 252, 0.34); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon:

Fixes #1560.

Summary:
- adds a compact review rearm hint for comfortable climate watch margins
- distinguishes immediate upkeep skip from the future signal that should bring the watch back into attention
- hides the hint unless the margin is comfortable and the rearm signal/deadline are available

Validation:
- node --check web/app.js
- npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check