### PR TITLE
Gamma: Show cultural review reopen signal

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1462,6 +1462,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
   const firstFollowUpReason = buildCulturalFirstFollowUpReason(candidate, recommendedBeyondMinimumBenefit, immediateSynergy);
   const followUpRobustness = buildCulturalFollowUpRobustness(candidate, immediateSynergy);
   const reviewExitSignal = buildCulturalReviewExitSignal(candidate, immediateSynergy, followUpRobustness);
+  const reviewReopenSignal = buildCulturalReviewReopenSignal(immediateSynergy, reviewExitSignal);
   const sourceAction = normalizeText(immediateSynergy.sourceAction ?? '');
 
   if (/attendre|observer/.test(sourceAction)) {
@@ -1473,6 +1474,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       firstFollowUpReason,
       followUpRobustness,
       reviewExitSignal,
+      reviewReopenSignal,
     };
   }
 
@@ -1485,6 +1487,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       firstFollowUpReason,
       followUpRobustness,
       reviewExitSignal,
+      reviewReopenSignal,
     };
   }
 
@@ -1497,6 +1500,7 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
       firstFollowUpReason,
       followUpRobustness,
       reviewExitSignal,
+      reviewReopenSignal,
     };
   }
 
@@ -1508,6 +1512,30 @@ function buildCulturalDeferLadderSummary(candidate, recommendedBeyondMinimumBene
     firstFollowUpReason,
     followUpRobustness,
     reviewExitSignal,
+    reviewReopenSignal,
+  };
+}
+
+function buildCulturalReviewReopenSignal(immediateSynergy, reviewExitSignal) {
+  if (!reviewExitSignal) {
+    return null;
+  }
+
+  const sourceCue = immediateSynergy.sourceLabel ?? immediateSynergy.sourceAction;
+  if (!sourceCue) {
+    return null;
+  }
+
+  const actionCue = immediateSynergy.sourceAction
+    ? `${immediateSynergy.sourceAction} ne reste plus aligné avec ${sourceCue}`
+    : `${sourceCue} ne reste plus visible`;
+
+  return {
+    state: 'reopen-on-synergy-change',
+    label: 'Réouvrir la revue',
+    trigger: actionCue,
+    reviewWindow: reviewExitSignal.reviewWindow,
+    summary: `Réouvrir la revue: ${actionCue}, expire, ou contredit ${reviewExitSignal.localAnchor}.`,
   };
 }
 

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -1060,6 +1060,7 @@ test('buildCultureTurnReportDeltas warns when immediate cultural synergy expires
       summary: 'Fragile avant revue: expire avant la prochaine revue; archive-routes expire avant prochaine rotation culturelle.',
     },
     reviewExitSignal: null,
+    reviewReopenSignal: null,
   });
 });
 
@@ -1152,6 +1153,13 @@ test('buildCultureTurnReportDeltas summarizes a safe defer ladder without expiri
       signal: 'amplifier reste visible sans expiration',
       localAnchor: 'risque stabilisé par l’historique lisible',
       summary: 'Sortie de revue: amplifier reste visible sans expiration jusqu’à prochaine rotation culturelle; risque stabilisé par l’historique lisible.',
+    },
+    reviewReopenSignal: {
+      state: 'reopen-on-synergy-change',
+      label: 'Réouvrir la revue',
+      trigger: 'amplifier ne reste plus aligné avec archive-routes',
+      reviewWindow: 'prochaine rotation culturelle',
+      summary: 'Réouvrir la revue: amplifier ne reste plus aligné avec archive-routes, expire, ou contredit risque stabilisé par l’historique lisible.',
     },
   });
 });

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -187,9 +187,11 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Pourquoi ce suivi:/);
   assert.match(webAppSource, /Robustesse:/);
   assert.match(webAppSource, /Stabilisation:/);
+  assert.match(webAppSource, /Réouverture:/);
   assert.match(webAppSource, /firstFollowUpReason/);
   assert.match(webAppSource, /followUpRobustness/);
   assert.match(webAppSource, /reviewExitSignal/);
+  assert.match(webAppSource, /reviewReopenSignal/);
   assert.match(webAppSource, /deferLadderSummary/);
   assert.match(webAppSource, /Synergie ce tour:/);
   assert.match(webAppSource, /Synergie temporaire:/);

--- a/web/app.js
+++ b/web/app.js
@@ -7850,6 +7850,7 @@ function renderCultureTurnReport(report) {
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.firstFollowUpReason ? `<small>Pourquoi ce suivi: ${entry.deferLadderSummary.firstFollowUpReason.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.followUpRobustness ? `<small>Robustesse: ${entry.deferLadderSummary.followUpRobustness.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewExitSignal ? `<small>Stabilisation: ${entry.deferLadderSummary.reviewExitSignal.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewReopenSignal ? `<small>Réouverture: ${entry.deferLadderSummary.reviewReopenSignal.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}


### PR DESCRIPTION
Gamma: Implements #1558.

Summary:
- adds a reviewReopenSignal only when the cultural follow-up has a visible stabilization/exit signal
- keeps expiring or fragile follow-ups quiet instead of duplicating existing warnings
- renders the compact future trigger that would bring cultural review back into active attention

Validation:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- node --check web/app.js
- git diff --check
- npm test
