### PR TITLE
Alpha: MAP-A42 show light recheck unlock

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -432,3 +432,15 @@ test('atlas military shows the next light front check after watch drop', () => {
   assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.nextLightCheck \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 7\.9 : 6\.55/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__recheck/);
 });
+
+// MAP-A42: a passed light recheck should unlock a safe next action or
+// confirmation state, while making condition changes the only reason to re-arm.
+test('atlas military shows what a passed light front recheck unlocks next', () => {
+  assert.match(webAppSource, /const lightRecheckUnlock = nextLightCheck/);
+  assert.match(webAppSource, /label: 'Recheck OK: sortie confirmée'/);
+  assert.match(webAppSource, /procéder sans watch active · observer léger · réarmer si \$\{residualRisk\?\.provinceLabel \?\? alternative\.provinceLabel \?\? 'front'\} change/);
+  assert.match(webAppSource, /lightRecheckUnlock,/);
+  assert.match(webAppSource, /ladder\.lightRecheckUnlock \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__unlock"/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightRecheckUnlock \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 9\.25 : 7\.9/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__unlock/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2779,6 +2779,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       remainingWatch: null,
       watchDrop: null,
       nextLightCheck: null,
+      lightRecheckUnlock: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2842,6 +2843,12 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
   const nextLightCheck = watchDrop?.tone === 'stable'
     ? `Contrôle léger: prochain tour, vérifier ${residualRisk?.provinceLabel ?? alternative.provinceLabel ?? 'front'} sans relancer d’alerte`
     : null;
+  const lightRecheckUnlock = nextLightCheck
+    ? {
+      label: 'Recheck OK: sortie confirmée',
+      detail: `procéder sans watch active · observer léger · réarmer si ${residualRisk?.provinceLabel ?? alternative.provinceLabel ?? 'front'} change`,
+    }
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -2852,6 +2859,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       remainingWatch: null,
       watchDrop: null,
       nextLightCheck: null,
+      lightRecheckUnlock: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2864,6 +2872,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     remainingWatch,
     watchDrop,
     nextLightCheck,
+    lightRecheckUnlock,
   };
 }
 
@@ -3120,13 +3129,14 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
       ${ladder.remainingWatch ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__watch" x="44.2" y="${y + 4.05}">${ladder.remainingWatch}</text>` : ''}
       ${ladder.watchDrop ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__drop atlas-military-neighbor-blocked-follow-up-ladder__drop--${ladder.watchDrop.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 5.4 : 4.05)}">${ladder.watchDrop.label}: ${ladder.watchDrop.detail}</text>` : ''}
       ${ladder.nextLightCheck ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__recheck" x="44.2" y="${y + (ladder.remainingWatch ? 6.75 : 5.4)}">${ladder.nextLightCheck}</text>` : ''}
+      ${ladder.lightRecheckUnlock ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__unlock" x="44.2" y="${y + (ladder.remainingWatch ? 8.1 : 6.75)}">${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3165,7 +3175,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14691,7 +14691,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__reason,
 .atlas-military-neighbor-blocked-follow-up-ladder__watch,
 .atlas-military-neighbor-blocked-follow-up-ladder__drop,
-.atlas-military-neighbor-blocked-follow-up-ladder__recheck {
+.atlas-military-neighbor-blocked-follow-up-ladder__recheck,
+.atlas-military-neighbor-blocked-follow-up-ladder__unlock {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14701,6 +14702,7 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__drop--watch { fill: #fde68a; }
 .atlas-military-neighbor-blocked-follow-up-ladder__drop--stable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-ladder__recheck { fill: #c4b5fd; }
+.atlas-military-neighbor-blocked-follow-up-ladder__unlock { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1566.\n\nSummary:\n- adds a compact outcome cue for a passed light front recheck after watch drop\n- shows that the player can proceed without active watch, keep only light observation, and re-arm watch only if conditions change\n- keeps existing front ladder, watch-drop, and light-recheck behavior intact\n\nValidation:\n- git diff --check\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test\n\nZeta: ready for validation before merge.