### PR TITLE
Beta: MAP-B42 show primary route slack

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1195,6 +1195,12 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       summary,
       route: exposedRoute?.route ?? opportunityCost?.delayedRoute ?? null,
     });
+    const buildRouteSlack = (state, summary, bottleneck) => ({
+      state,
+      label: 'Marge route reprise',
+      summary,
+      bottleneck,
+    });
 
     if (opportunityCost?.state === 'competing') {
       return {
@@ -1209,6 +1215,13 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           priorityAction.resource
             ? `Route primaire reprise, contrainte restante: ${priorityAction.resource} doit rester disponible avant de rouvrir ${opportunityCost.delayedRoute}.`
             : `Route primaire reprise, contrainte restante: capacité locale encore partagée avec ${opportunityCost.delayedRoute}.`,
+        ),
+        routeSlack: buildRouteSlack(
+          'tight',
+          priorityAction.resource
+            ? `Route reprise mais serrée: ${priorityAction.resource} reste le goulot avant confort.`
+            : 'Route reprise mais serrée: capacité locale encore partagée.',
+          priorityAction.resource ?? 'capacité locale',
         ),
       };
     }
@@ -1226,6 +1239,13 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             'watch',
             `Route primaire reprise, contrainte restante: surveiller ${stopMarker.route} tant que la marge reste à ${margin}.`,
           ),
+          routeSlack: buildRouteSlack(
+            margin >= 2 ? 'comfortable' : 'tight',
+            margin >= 2
+              ? `Route reprise confortable: ${margin} points de marge avant le prochain goulot.`
+              : `Route reprise mais serrée: ${margin} point de marge avant nouveau goulot.`,
+            stopMarker.route,
+          ),
         }
         : {
           state: 'stay-fallback',
@@ -1235,6 +1255,11 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           residualConstraint: buildResidualConstraint(
             'margin',
             `Route primaire reprise plus tard: ${stopMarker.route} manque encore ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge de garde.`,
+          ),
+          routeSlack: buildRouteSlack(
+            'blocked',
+            `Route non confortable: ${stopMarker.route} reste le goulot avec ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}.`,
+            stopMarker.route,
           ),
         };
     }

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -147,6 +147,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.summary, /Retour vers .* possible quand Outils/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint.state, 'resource');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint.summary, /Route primaire reprise, contrainte restante: Outils/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.state, 'tight');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.summary, /Route reprise mais serrée: Outils/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -246,6 +248,8 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.summary, /Retour vers Safe Road après .* marge/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.residualConstraint.state, 'margin');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.residualConstraint.summary, /Route primaire reprise plus tard: Safe Road manque encore/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.state, 'blocked');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.summary, /Route non confortable: Safe Road reste le goulot/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -126,6 +126,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /primaryReturnSignal/);
   assert.match(webAppSource, /province-logistics-spillover-return-residual/);
   assert.match(webAppSource, /residualConstraint/);
+  assert.match(webAppSource, /province-logistics-spillover-route-slack/);
+  assert.match(webAppSource, /routeSlack/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8773,6 +8773,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                     ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint ? `
                       <small class="province-logistics-spillover-return-residual province-logistics-spillover-return-residual--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint.summary}</small>
                     ` : ''}
+                    ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack ? `
+                      <small class="province-logistics-spillover-route-slack province-logistics-spillover-route-slack--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.summary}</small>
+                    ` : ''}
                   ` : ''}
                 ` : ''}
               ` : ''}


### PR DESCRIPTION
Beta: Implements #1567.\n\nSummary:\n- Adds a compact route slack cue after logistics primary-return guidance.\n- Distinguishes restored-but-tight, blocked, and comfortable slack states using existing return, resource, margin, and bottleneck signals.\n- Keeps the cue tied to existing primary return signals so it stays absent when the remaining route slack cannot be identified.\n- Renders the slack cue in the economy logistics map panel.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test