### PR TITLE
Epsilon: Show unrearmed climate review consequence

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -32,6 +32,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /watchMargin/);
   assert.match(webAppSource, /upkeepReminder/);
   assert.match(webAppSource, /marginRearmReview/);
+  assert.match(webAppSource, /unrearmedReviewConsequence/);
+  assert.match(webAppSource, /Si non réarmé/);
+  assert.match(webAppSource, /premier effet sans review/);
+  assert.match(webAppSource, /risque d’être lu tard, même avec une marge encore confortable/);
   assert.match(webAppSource, /Réarmer review/);
   assert.match(webAppSource, /review différée/);
   assert.match(webAppSource, /réarmer si \$\{watchGap\.nearestRiskLabel\} revient avant \$\{progress\.deadline\} ou si la marge repasse courte/);
@@ -102,6 +106,8 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__reminder--skip/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rearm/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rearm--deferred/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__consequence/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__consequence--informative/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
@@ -204,4 +210,13 @@ test('atlas shows when comfortable climate margin should be rearmed for review',
   assert.match(webAppSource, /Réarmer review/);
   assert.match(webAppSource, /view\.watchItem\.marginRearmReview \?/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rearm--deferred/);
+});
+
+test('atlas shows first consequence of leaving climate review unrearmed', () => {
+  assert.match(webAppSource, /const unrearmedReviewConsequence = marginRearmReview/);
+  assert.match(webAppSource, /state: 'informative'/);
+  assert.match(webAppSource, /label: 'premier effet sans review'/);
+  assert.match(webAppSource, /le prochain signal \$\{watchGap\.nearestRiskLabel\} risque d’être lu tard/);
+  assert.match(webAppSource, /view\.watchItem\.unrearmedReviewConsequence \?/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__consequence--informative/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14319,6 +14319,13 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       detail: `réarmer si ${watchGap.nearestRiskLabel} revient avant ${progress.deadline} ou si la marge repasse courte`,
     }
     : null;
+  const unrearmedReviewConsequence = marginRearmReview
+    ? {
+      state: 'informative',
+      label: 'premier effet sans review',
+      detail: `le prochain signal ${watchGap.nearestRiskLabel} risque d’être lu tard, même avec une marge encore confortable`,
+    }
+    : null;
   const minimalProtection = coverageView.secondaryProtections?.[0]
     ?? coverageView.activeProtections?.[0]
     ?? (gapActionView.recommendation
@@ -14430,6 +14437,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       watchMargin,
       upkeepReminder,
       marginRearmReview,
+      unrearmedReviewConsequence,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14473,6 +14481,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       ${view.watchItem.watchMargin ? `<small class="map-world-climate-post-gap-watch__margin map-world-climate-post-gap-watch__margin--${view.watchItem.watchMargin.state}"><b>Marge avant primaire</b> · ${view.watchItem.watchMargin.label}: ${view.watchItem.watchMargin.detail}</small>` : ''}
       ${view.watchItem.upkeepReminder ? `<small class="map-world-climate-post-gap-watch__reminder map-world-climate-post-gap-watch__reminder--${view.watchItem.upkeepReminder.state}"><b>Rappel upkeep</b> · ${view.watchItem.upkeepReminder.label}: ${view.watchItem.upkeepReminder.detail}</small>` : ''}
       ${view.watchItem.marginRearmReview ? `<small class="map-world-climate-post-gap-watch__rearm map-world-climate-post-gap-watch__rearm--${view.watchItem.marginRearmReview.state}"><b>Réarmer review</b> · ${view.watchItem.marginRearmReview.label}: ${view.watchItem.marginRearmReview.detail}</small>` : ''}
+      ${view.watchItem.unrearmedReviewConsequence ? `<small class="map-world-climate-post-gap-watch__consequence map-world-climate-post-gap-watch__consequence--${view.watchItem.unrearmedReviewConsequence.state}"><b>Si non réarmé</b> · ${view.watchItem.unrearmedReviewConsequence.label}: ${view.watchItem.unrearmedReviewConsequence.detail}</small>` : ''}
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13737,6 +13737,13 @@ button { font: inherit; }
   background: rgba(8, 47, 73, 0.24);
 }
 .map-world-climate-post-gap-watch__rearm--deferred { border: 1px solid rgba(125, 211, 252, 0.34); }
+.map-world-climate-post-gap-watch__consequence {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.26);
+}
+.map-world-climate-post-gap-watch__consequence--informative { border: 1px solid rgba(125, 211, 252, 0.3); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon:

Fixes #1570.

Summary:
- adds a proportional consequence cue beside the comfortable-margin review rearm message
- explains the first visible effect of leaving review unrearmed without changing climate watch mechanics
- keeps the cue hidden unless the existing rearm hint is reliable

Validation:
- node --check web/app.js
- npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check