### PR TITLE
Gamma: Preview reopened cultural review

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1530,12 +1530,27 @@ function buildCulturalReviewReopenSignal(immediateSynergy, reviewExitSignal) {
     ? `${immediateSynergy.sourceAction} ne reste plus aligné avec ${sourceCue}`
     : `${sourceCue} ne reste plus visible`;
 
+  const reviewQuestionPreview = buildCulturalReopenedReviewPreview(immediateSynergy, reviewExitSignal, sourceCue);
+
   return {
     state: 'reopen-on-synergy-change',
     label: 'Réouvrir la revue',
     trigger: actionCue,
     reviewWindow: reviewExitSignal.reviewWindow,
+    reviewQuestionPreview,
     summary: `Réouvrir la revue: ${actionCue}, expire, ou contredit ${reviewExitSignal.localAnchor}.`,
+  };
+}
+
+function buildCulturalReopenedReviewPreview(immediateSynergy, reviewExitSignal, sourceCue) {
+  const actionCue = immediateSynergy.sourceAction ?? 'le suivi culturel';
+
+  return {
+    state: 'preview-reopened-review',
+    label: 'Si réouvert',
+    question: `vérifier si ${sourceCue} justifie encore ${actionCue}`,
+    anchor: reviewExitSignal.localAnchor,
+    summary: `Si réouvert: vérifier si ${sourceCue} justifie encore ${actionCue}, puis comparer avec ${reviewExitSignal.localAnchor}.`,
   };
 }
 

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -1159,6 +1159,13 @@ test('buildCultureTurnReportDeltas summarizes a safe defer ladder without expiri
       label: 'Réouvrir la revue',
       trigger: 'amplifier ne reste plus aligné avec archive-routes',
       reviewWindow: 'prochaine rotation culturelle',
+      reviewQuestionPreview: {
+        state: 'preview-reopened-review',
+        label: 'Si réouvert',
+        question: 'vérifier si archive-routes justifie encore amplifier',
+        anchor: 'risque stabilisé par l’historique lisible',
+        summary: 'Si réouvert: vérifier si archive-routes justifie encore amplifier, puis comparer avec risque stabilisé par l’historique lisible.',
+      },
       summary: 'Réouvrir la revue: amplifier ne reste plus aligné avec archive-routes, expire, ou contredit risque stabilisé par l’historique lisible.',
     },
   });

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -188,10 +188,12 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Robustesse:/);
   assert.match(webAppSource, /Stabilisation:/);
   assert.match(webAppSource, /Réouverture:/);
+  assert.match(webAppSource, /Si réouvert:/);
   assert.match(webAppSource, /firstFollowUpReason/);
   assert.match(webAppSource, /followUpRobustness/);
   assert.match(webAppSource, /reviewExitSignal/);
   assert.match(webAppSource, /reviewReopenSignal/);
+  assert.match(webAppSource, /reviewQuestionPreview/);
   assert.match(webAppSource, /deferLadderSummary/);
   assert.match(webAppSource, /Synergie ce tour:/);
   assert.match(webAppSource, /Synergie temporaire:/);

--- a/web/app.js
+++ b/web/app.js
@@ -7861,6 +7861,7 @@ function renderCultureTurnReport(report) {
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.followUpRobustness ? `<small>Robustesse: ${entry.deferLadderSummary.followUpRobustness.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewExitSignal ? `<small>Stabilisation: ${entry.deferLadderSummary.reviewExitSignal.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewReopenSignal ? `<small>Réouverture: ${entry.deferLadderSummary.reviewReopenSignal.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewReopenSignal?.reviewQuestionPreview ? `<small>Si réouvert: ${entry.deferLadderSummary.reviewReopenSignal.reviewQuestionPreview.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}


### PR DESCRIPTION
Gamma: Implements #1568.

Summary:
- adds a compact reviewQuestionPreview under stable cultural review reopen signals
- distinguishes the reopen trigger from what the reopened review will evaluate
- renders the preview near the existing stabilization/reopen cues without adding urgency

Validation:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- node --check web/app.js
- git diff --check
- npm test
