### PR TITLE
Gamma: Show cultural review outcome threshold

### DIFF
--- a/src/ui/culture/buildCultureTurnReportDeltas.js
+++ b/src/ui/culture/buildCultureTurnReportDeltas.js
@@ -1544,13 +1544,25 @@ function buildCulturalReviewReopenSignal(immediateSynergy, reviewExitSignal) {
 
 function buildCulturalReopenedReviewPreview(immediateSynergy, reviewExitSignal, sourceCue) {
   const actionCue = immediateSynergy.sourceAction ?? 'le suivi culturel';
+  const outcomeThreshold = buildCulturalReopenedReviewOutcomeThreshold(actionCue, reviewExitSignal, sourceCue);
 
   return {
     state: 'preview-reopened-review',
     label: 'Si réouvert',
     question: `vérifier si ${sourceCue} justifie encore ${actionCue}`,
     anchor: reviewExitSignal.localAnchor,
+    outcomeThreshold,
     summary: `Si réouvert: vérifier si ${sourceCue} justifie encore ${actionCue}, puis comparer avec ${reviewExitSignal.localAnchor}.`,
+  };
+}
+
+function buildCulturalReopenedReviewOutcomeThreshold(actionCue, reviewExitSignal, sourceCue) {
+  return {
+    state: 'stable-if-synergy-still-supports-anchor',
+    label: 'Seuil stable',
+    criterion: `${sourceCue} soutient encore ${actionCue} sans contredire ${reviewExitSignal.localAnchor}`,
+    fallback: `si ce seuil n’est pas lisible, garder ${reviewExitSignal.localAnchor} comme repère calme`,
+    summary: `Stable si ${sourceCue} soutient encore ${actionCue} sans contredire ${reviewExitSignal.localAnchor}; sinon revoir activement.`,
   };
 }
 

--- a/test/ui/culture/buildCultureTurnReportDeltas.test.js
+++ b/test/ui/culture/buildCultureTurnReportDeltas.test.js
@@ -1164,6 +1164,13 @@ test('buildCultureTurnReportDeltas summarizes a safe defer ladder without expiri
         label: 'Si réouvert',
         question: 'vérifier si archive-routes justifie encore amplifier',
         anchor: 'risque stabilisé par l’historique lisible',
+        outcomeThreshold: {
+          state: 'stable-if-synergy-still-supports-anchor',
+          label: 'Seuil stable',
+          criterion: 'archive-routes soutient encore amplifier sans contredire risque stabilisé par l’historique lisible',
+          fallback: 'si ce seuil n’est pas lisible, garder risque stabilisé par l’historique lisible comme repère calme',
+          summary: 'Stable si archive-routes soutient encore amplifier sans contredire risque stabilisé par l’historique lisible; sinon revoir activement.',
+        },
         summary: 'Si réouvert: vérifier si archive-routes justifie encore amplifier, puis comparer avec risque stabilisé par l’historique lisible.',
       },
       summary: 'Réouvrir la revue: amplifier ne reste plus aligné avec archive-routes, expire, ou contredit risque stabilisé par l’historique lisible.',

--- a/test/ui/culture/webCultureWorldMapAtlas.test.js
+++ b/test/ui/culture/webCultureWorldMapAtlas.test.js
@@ -189,11 +189,13 @@ test('world map atlas exposes discovery sites without adding a new culture sourc
   assert.match(webAppSource, /Stabilisation:/);
   assert.match(webAppSource, /Réouverture:/);
   assert.match(webAppSource, /Si réouvert:/);
+  assert.match(webAppSource, /Seuil:/);
   assert.match(webAppSource, /firstFollowUpReason/);
   assert.match(webAppSource, /followUpRobustness/);
   assert.match(webAppSource, /reviewExitSignal/);
   assert.match(webAppSource, /reviewReopenSignal/);
   assert.match(webAppSource, /reviewQuestionPreview/);
+  assert.match(webAppSource, /outcomeThreshold/);
   assert.match(webAppSource, /deferLadderSummary/);
   assert.match(webAppSource, /Synergie ce tour:/);
   assert.match(webAppSource, /Synergie temporaire:/);

--- a/web/app.js
+++ b/web/app.js
@@ -7862,6 +7862,7 @@ function renderCultureTurnReport(report) {
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewExitSignal ? `<small>Stabilisation: ${entry.deferLadderSummary.reviewExitSignal.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewReopenSignal ? `<small>Réouverture: ${entry.deferLadderSummary.reviewReopenSignal.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewReopenSignal?.reviewQuestionPreview ? `<small>Si réouvert: ${entry.deferLadderSummary.reviewReopenSignal.reviewQuestionPreview.summary}</small>` : ''}
+                  ${entry.revisitPriority === 'next' && entry.deferLadderSummary?.reviewReopenSignal?.reviewQuestionPreview?.outcomeThreshold ? `<small>Seuil: ${entry.deferLadderSummary.reviewReopenSignal.reviewQuestionPreview.outcomeThreshold.summary}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.missedWindowConsequence ? `<small>Si manqué: ${entry.missedWindowConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.minimalSafeAction ? `<small>Action minimale: ${entry.minimalSafeAction} — ${entry.preventedConsequence}</small>` : ''}
                   ${entry.revisitPriority === 'next' && !entry.deferLadderSummary && entry.recommendedBeyondMinimumBenefit ? `<small>Au-delà du minimum: ${entry.recommendedBeyondMinimumBenefit.summary}</small>` : ''}


### PR DESCRIPTION
Gamma: Implements #1578.

Summary:
- adds a compact outcomeThreshold to the reopened cultural review preview
- separates the review question from the stable-if threshold/fallback criterion
- renders the threshold near the existing reopened-review cue without adding new scoring mechanics

Validation:
- node --test test/ui/culture/buildCultureTurnReportDeltas.test.js
- node --test test/ui/culture/webCultureWorldMapAtlas.test.js
- node --check src/ui/culture/buildCultureTurnReportDeltas.js
- node --check web/app.js
- git diff --check
- npm test
