### PR TITLE
Beta: MAP-B43 show route slack consumers

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1195,11 +1195,35 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
       summary,
       route: exposedRoute?.route ?? opportunityCost?.delayedRoute ?? null,
     });
-    const buildRouteSlack = (state, summary, bottleneck) => ({
+    const buildSlackConsumerHint = (consumers) => {
+      const rankedConsumers = consumers
+        .filter((consumer) => consumer?.label && consumer.reason)
+        .sort((left, right) => right.weight - left.weight || left.label.localeCompare(right.label));
+
+      if (rankedConsumers.length === 0) {
+        return {
+          state: 'preserved',
+          label: 'Slack conservé',
+          primaryConsumer: null,
+          summary: 'Slack conservé: aucun coût immédiat ne consomme la marge restante.',
+        };
+      }
+
+      const primaryConsumer = rankedConsumers[0];
+      return {
+        state: primaryConsumer.tone ?? 'watch',
+        label: 'Slack consommé par',
+        primaryConsumer: primaryConsumer.label,
+        summary: `${primaryConsumer.label} consomme d’abord le slack: ${primaryConsumer.reason}`,
+        secondaryConsumers: rankedConsumers.slice(1, 3).map((consumer) => consumer.label),
+      };
+    };
+    const buildRouteSlack = (state, summary, bottleneck, slackConsumerHint) => ({
       state,
       label: 'Marge route reprise',
       summary,
       bottleneck,
+      slackConsumerHint,
     });
 
     if (opportunityCost?.state === 'competing') {
@@ -1222,6 +1246,10 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             ? `Route reprise mais serrée: ${priorityAction.resource} reste le goulot avant confort.`
             : 'Route reprise mais serrée: capacité locale encore partagée.',
           priorityAction.resource ?? 'capacité locale',
+          buildSlackConsumerHint([
+            { label: priorityAction.resource ?? 'capacité locale', reason: `partagée avec ${opportunityCost.delayedRoute}`, weight: 3, tone: 'tight' },
+            exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
+          ]),
         ),
       };
     }
@@ -1245,6 +1273,12 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
               ? `Route reprise confortable: ${margin} points de marge avant le prochain goulot.`
               : `Route reprise mais serrée: ${margin} point de marge avant nouveau goulot.`,
             stopMarker.route,
+            buildSlackConsumerHint(margin >= 2
+              ? []
+              : [
+                { label: stopMarker.route, reason: `il ne reste que ${margin} point de marge`, weight: 2, tone: 'tight' },
+                exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
+              ]),
           ),
         }
         : {
@@ -1260,6 +1294,10 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             'blocked',
             `Route non confortable: ${stopMarker.route} reste le goulot avec ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}.`,
             stopMarker.route,
+            buildSlackConsumerHint([
+              { label: stopMarker.route, reason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, weight: 3, tone: 'blocked' },
+              exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
+            ]),
           ),
         };
     }

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -149,6 +149,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.residualConstraint.summary, /Route primaire reprise, contrainte restante: Outils/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.state, 'tight');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.summary, /Route reprise mais serrée: Outils/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.primaryConsumer, 'Outils');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.summary, /Outils consomme d’abord le slack/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -250,6 +252,8 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.residualConstraint.summary, /Route primaire reprise plus tard: Safe Road manque encore/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.state, 'blocked');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.summary, /Route non confortable: Safe Road reste le goulot/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.primaryConsumer, 'Safe Road');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.summary, /Safe Road consomme d’abord le slack/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -128,6 +128,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /residualConstraint/);
   assert.match(webAppSource, /province-logistics-spillover-route-slack/);
   assert.match(webAppSource, /routeSlack/);
+  assert.match(webAppSource, /province-logistics-spillover-slack-consumer/);
+  assert.match(webAppSource, /slackConsumerHint/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8823,6 +8823,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                     ` : ''}
                     ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack ? `
                       <small class="province-logistics-spillover-route-slack province-logistics-spillover-route-slack--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.summary}</small>
+                      ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint ? `
+                        <small class="province-logistics-spillover-slack-consumer province-logistics-spillover-slack-consumer--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.summary}</small>
+                      ` : ''}
                     ` : ''}
                   ` : ''}
                 ` : ''}


### PR DESCRIPTION
Beta: Implements #1577.\n\nSummary:\n- Adds a compact slack consumer hint to the returned logistics route slack cue.\n- Highlights the primary consumer and keeps secondary consumers ordered using existing resource, exposed route, and guard margin signals.\n- Shows a clear slack-preserved state when no immediate consumer applies.\n- Renders the cue in the economy logistics map panel without changing route selection behavior.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test