### PR TITLE
Epsilon: Show climate next watch priority impact

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -33,6 +33,12 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /upkeepReminder/);
   assert.match(webAppSource, /marginRearmReview/);
   assert.match(webAppSource, /unrearmedReviewConsequence/);
+  assert.match(webAppSource, /nextWatchPriorityImpact/);
+  assert.match(webAppSource, /Prochaine priorité/);
+  assert.match(webAppSource, /priorité monte/);
+  assert.match(webAppSource, /priorité stable/);
+  assert.match(webAppSource, /secondaire après mitigation/);
+  assert.match(webAppSource, /priorité indéterminée/);
   assert.match(webAppSource, /Si non réarmé/);
   assert.match(webAppSource, /premier effet sans review/);
   assert.match(webAppSource, /risque d’être lu tard, même avec une marge encore confortable/);
@@ -108,6 +114,9 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rearm--deferred/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__consequence/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__consequence--informative/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__priority/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__priority--rises/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__priority--secondary-after-mitigation/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
@@ -219,4 +228,15 @@ test('atlas shows first consequence of leaving climate review unrearmed', () => 
   assert.match(webAppSource, /le prochain signal \$\{watchGap\.nearestRiskLabel\} risque d’être lu tard/);
   assert.match(webAppSource, /view\.watchItem\.unrearmedReviewConsequence \?/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__consequence--informative/);
+});
+
+test('atlas links unrearmed climate consequence to next watch priority', () => {
+  assert.match(webAppSource, /const nextWatchPriorityImpact = unrearmedReviewConsequence/);
+  assert.match(webAppSource, /state: 'rises'/);
+  assert.match(webAppSource, /label: 'priorité monte'/);
+  assert.match(webAppSource, /prochaine watch: \$\{watchGap\.label\} remonte si la review reste non réarmée/);
+  assert.match(webAppSource, /label: watchMargin\.state === 'comfortable' \? 'priorité stable' : 'secondaire après mitigation'/);
+  assert.match(webAppSource, /label: 'priorité indéterminée'/);
+  assert.match(webAppSource, /view\.watchItem\.nextWatchPriorityImpact \?/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__priority--fallback/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14367,6 +14367,25 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       detail: `le prochain signal ${watchGap.nearestRiskLabel} risque d’être lu tard, même avec une marge encore confortable`,
     }
     : null;
+  const nextWatchPriorityImpact = unrearmedReviewConsequence
+    ? {
+      state: 'rises',
+      label: 'priorité monte',
+      detail: `prochaine watch: ${watchGap.label} remonte si la review reste non réarmée`,
+    }
+    : watchMargin
+      ? {
+        state: watchMargin.state === 'comfortable' ? 'stable' : 'secondary-after-mitigation',
+        label: watchMargin.state === 'comfortable' ? 'priorité stable' : 'secondaire après mitigation',
+        detail: watchMargin.state === 'comfortable'
+          ? `prochaine watch: ${watchGap.label} reste en observation tant que la marge tient`
+          : `prochaine watch: ${watchGap.label} reste secondaire après mitigation`,
+      }
+      : {
+        state: 'fallback',
+        label: 'priorité indéterminée',
+        detail: 'relire la prochaine watch climat quand le signal secondaire redevient mesurable',
+      };
   const minimalProtection = coverageView.secondaryProtections?.[0]
     ?? coverageView.activeProtections?.[0]
     ?? (gapActionView.recommendation
@@ -14479,6 +14498,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       upkeepReminder,
       marginRearmReview,
       unrearmedReviewConsequence,
+      nextWatchPriorityImpact,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14523,6 +14543,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       ${view.watchItem.upkeepReminder ? `<small class="map-world-climate-post-gap-watch__reminder map-world-climate-post-gap-watch__reminder--${view.watchItem.upkeepReminder.state}"><b>Rappel upkeep</b> · ${view.watchItem.upkeepReminder.label}: ${view.watchItem.upkeepReminder.detail}</small>` : ''}
       ${view.watchItem.marginRearmReview ? `<small class="map-world-climate-post-gap-watch__rearm map-world-climate-post-gap-watch__rearm--${view.watchItem.marginRearmReview.state}"><b>Réarmer review</b> · ${view.watchItem.marginRearmReview.label}: ${view.watchItem.marginRearmReview.detail}</small>` : ''}
       ${view.watchItem.unrearmedReviewConsequence ? `<small class="map-world-climate-post-gap-watch__consequence map-world-climate-post-gap-watch__consequence--${view.watchItem.unrearmedReviewConsequence.state}"><b>Si non réarmé</b> · ${view.watchItem.unrearmedReviewConsequence.label}: ${view.watchItem.unrearmedReviewConsequence.detail}</small>` : ''}
+      ${view.watchItem.nextWatchPriorityImpact ? `<small class="map-world-climate-post-gap-watch__priority map-world-climate-post-gap-watch__priority--${view.watchItem.nextWatchPriorityImpact.state}"><b>Prochaine priorité</b> · ${view.watchItem.nextWatchPriorityImpact.label}: ${view.watchItem.nextWatchPriorityImpact.detail}</small>` : ''}
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13763,6 +13763,16 @@ button { font: inherit; }
   background: rgba(15, 23, 42, 0.26);
 }
 .map-world-climate-post-gap-watch__consequence--informative { border: 1px solid rgba(125, 211, 252, 0.3); }
+.map-world-climate-post-gap-watch__priority {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.28);
+}
+.map-world-climate-post-gap-watch__priority--rises { border: 1px solid rgba(251, 191, 36, 0.36); }
+.map-world-climate-post-gap-watch__priority--stable { border: 1px solid rgba(74, 222, 128, 0.34); }
+.map-world-climate-post-gap-watch__priority--secondary-after-mitigation,
+.map-world-climate-post-gap-watch__priority--fallback { border: 1px solid rgba(125, 211, 252, 0.28); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon:

Fixes #1580.

Summary:
- adds a compact next-watch priority hint beside the unrearmed climate review consequence
- shows whether priority rises, stays stable, becomes secondary after mitigation, or falls back when undetermined
- keeps this as derived UI readability only; climate watch/margin mechanics are unchanged

Validation:
- node --check web/app.js
- npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check