### PR TITLE
Beta: MAP-B44 show first route slack blocker

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1206,6 +1206,11 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           label: 'Slack conservé',
           primaryConsumer: null,
           summary: 'Slack conservé: aucun coût immédiat ne consomme la marge restante.',
+          nextBlocker: {
+            state: 'none',
+            label: 'Aucun bloqueur immédiat',
+            summary: 'Aucun consommateur proche ne bloque la route pour l’instant.',
+          },
         };
       }
 
@@ -1216,6 +1221,11 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
         primaryConsumer: primaryConsumer.label,
         summary: `${primaryConsumer.label} consomme d’abord le slack: ${primaryConsumer.reason}`,
         secondaryConsumers: rankedConsumers.slice(1, 3).map((consumer) => consumer.label),
+        nextBlocker: {
+          state: primaryConsumer.tone ?? 'watch',
+          label: `Premier bloqueur: ${primaryConsumer.label}`,
+          summary: `${primaryConsumer.label} deviendrait bloquant en premier: ${primaryConsumer.blockerReason ?? primaryConsumer.reason}.`,
+        },
       };
     };
     const buildRouteSlack = (state, summary, bottleneck, slackConsumerHint) => ({
@@ -1247,8 +1257,8 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             : 'Route reprise mais serrée: capacité locale encore partagée.',
           priorityAction.resource ?? 'capacité locale',
           buildSlackConsumerHint([
-            { label: priorityAction.resource ?? 'capacité locale', reason: `partagée avec ${opportunityCost.delayedRoute}`, weight: 3, tone: 'tight' },
-            exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
+            { label: priorityAction.resource ?? 'capacité locale', reason: `partagée avec ${opportunityCost.delayedRoute}`, blockerReason: `la ressource reste partagée avec ${opportunityCost.delayedRoute}`, weight: 3, tone: 'tight' },
+            exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, blockerReason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
           ]),
         ),
       };
@@ -1276,8 +1286,8 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             buildSlackConsumerHint(margin >= 2
               ? []
               : [
-                { label: stopMarker.route, reason: `il ne reste que ${margin} point de marge`, weight: 2, tone: 'tight' },
-                exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
+                { label: stopMarker.route, reason: `il ne reste que ${margin} point de marge`, blockerReason: `marge restante ${margin}`, weight: 2, tone: 'tight' },
+                exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, blockerReason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
               ]),
           ),
         }
@@ -1295,8 +1305,8 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             `Route non confortable: ${stopMarker.route} reste le goulot avec ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}.`,
             stopMarker.route,
             buildSlackConsumerHint([
-              { label: stopMarker.route, reason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, weight: 3, tone: 'blocked' },
-              exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
+              { label: stopMarker.route, reason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, blockerReason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, weight: 3, tone: 'blocked' },
+              exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, blockerReason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
             ]),
           ),
         };

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -151,6 +151,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.summary, /Route reprise mais serrée: Outils/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.primaryConsumer, 'Outils');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.summary, /Outils consomme d’abord le slack/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.label, 'Premier bloqueur: Outils');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.summary, /Outils deviendrait bloquant en premier/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -254,6 +256,8 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.summary, /Route non confortable: Safe Road reste le goulot/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.primaryConsumer, 'Safe Road');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.summary, /Safe Road consomme d’abord le slack/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.label, 'Premier bloqueur: Safe Road');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.summary, /Safe Road deviendrait bloquant en premier/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -130,6 +130,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /routeSlack/);
   assert.match(webAppSource, /province-logistics-spillover-slack-consumer/);
   assert.match(webAppSource, /slackConsumerHint/);
+  assert.match(webAppSource, /province-logistics-spillover-slack-blocker/);
+  assert.match(webAppSource, /nextBlocker/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8825,6 +8825,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                       <small class="province-logistics-spillover-route-slack province-logistics-spillover-route-slack--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.summary}</small>
                       ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint ? `
                         <small class="province-logistics-spillover-slack-consumer province-logistics-spillover-slack-consumer--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.summary}</small>
+                        ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker ? `
+                          <small class="province-logistics-spillover-slack-blocker province-logistics-spillover-slack-blocker--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.summary}</small>
+                        ` : ''}
                       ` : ''}
                     ` : ''}
                   ` : ''}


### PR DESCRIPTION
Beta: Implements #1587.\n\nSummary:\n- Extends the route slack consumer hint with a compact next-blocker cue.\n- Identifies the consumer closest to becoming blocking using the existing ordered consumer signals.\n- Keeps a clear no-immediate-blocker message when slack is preserved.\n- Renders the blocker cue in the logistics spillover panel without changing route selection.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test