### PR TITLE
Alpha: MAP-A44 explain light follow-up defer buffer

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -458,3 +458,17 @@ test('atlas military shows the first follow-up after a light front unlock is use
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__post-unlock--ready/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__post-unlock--quiet/);
 });
+
+// MAP-A44: when the unlocked light front follow-up is below the urgent
+// threshold, show the concrete buffer that makes it safe to defer.
+test('atlas military explains why a light front follow-up can wait', () => {
+  assert.match(webAppSource, /const lightFollowUpPriority = Math\.max/);
+  assert.match(webAppSource, /const lightFollowUpIsUrgent = lightFollowUpPriority >= 72 \|\| prepUnlock\?\.delayCost\?\.tone === 'risky'/);
+  assert.match(webAppSource, /const lightFollowUpDeferReason = lightUnlockFollowUp && !lightFollowUpIsUrgent/);
+  assert.match(webAppSource, /label: 'Peut attendre'/);
+  assert.match(webAppSource, /tampon: \$\{residualRisk\.label\} déjà couvert/);
+  assert.match(webAppSource, /lightFollowUpDeferReason,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpDeferReason \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__defer/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpDeferReason \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 11\.95 : 10\.6/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__defer--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2781,6 +2781,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       nextLightCheck: null,
       lightRecheckUnlock: null,
       lightUnlockFollowUp: null,
+      lightFollowUpDeferReason: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2882,6 +2883,19 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       };
     })()
     : null;
+  const lightFollowUpPriority = Math.max(playableEntry?.option?.score ?? 0, alternative.score ?? 0);
+  const lightFollowUpIsUrgent = lightFollowUpPriority >= 72 || prepUnlock?.delayCost?.tone === 'risky';
+  const lightFollowUpDeferReason = lightUnlockFollowUp && !lightFollowUpIsUrgent
+    ? {
+      tone: lightUnlockFollowUp.tone === 'ready' ? 'ready' : 'quiet',
+      label: 'Peut attendre',
+      detail: residualRisk?.visible && residualRisk.tone === 'covered'
+        ? `tampon: ${residualRisk.label} déjà couvert · ${residualRisk.action}`
+        : prepUnlock?.delayCost?.tone === 'acceptable'
+          ? `tampon: ${prepUnlock.delayCost.detail}`
+          : `condition stable: ${residualRisk?.provinceLabel ?? alternative.provinceLabel ?? 'front'} sans changement visible`,
+    }
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -2894,6 +2908,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       nextLightCheck: null,
       lightRecheckUnlock: null,
       lightUnlockFollowUp: null,
+      lightFollowUpDeferReason: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2908,6 +2923,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     nextLightCheck,
     lightRecheckUnlock,
     lightUnlockFollowUp,
+    lightFollowUpDeferReason,
   };
 }
 
@@ -3164,7 +3180,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3173,6 +3189,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.nextLightCheck ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__recheck" x="44.2" y="${y + (ladder.remainingWatch ? 6.75 : 5.4)}">${ladder.nextLightCheck}</text>` : ''}
       ${ladder.lightRecheckUnlock ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__unlock" x="44.2" y="${y + (ladder.remainingWatch ? 8.1 : 6.75)}">${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}</text>` : ''}
       ${ladder.lightUnlockFollowUp ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__post-unlock atlas-military-neighbor-blocked-follow-up-ladder__post-unlock--${ladder.lightUnlockFollowUp.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 9.45 : 8.1)}">${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}</text>` : ''}
+      ${ladder.lightFollowUpDeferReason ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__defer atlas-military-neighbor-blocked-follow-up-ladder__defer--${ladder.lightFollowUpDeferReason.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 10.8 : 9.45)}">${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3211,7 +3228,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14748,7 +14748,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__drop,
 .atlas-military-neighbor-blocked-follow-up-ladder__recheck,
 .atlas-military-neighbor-blocked-follow-up-ladder__unlock,
-.atlas-military-neighbor-blocked-follow-up-ladder__post-unlock {
+.atlas-military-neighbor-blocked-follow-up-ladder__post-unlock,
+.atlas-military-neighbor-blocked-follow-up-ladder__defer {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14762,6 +14763,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__post-unlock--ready { fill: #86efac; }
 .atlas-military-neighbor-blocked-follow-up-ladder__post-unlock--prep { fill: #fde68a; }
 .atlas-military-neighbor-blocked-follow-up-ladder__post-unlock--quiet { fill: #cbd5e1; }
+.atlas-military-neighbor-blocked-follow-up-ladder__defer--ready { fill: #bae6fd; }
+.atlas-military-neighbor-blocked-follow-up-ladder__defer--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1586.\n\nSummary:\n- adds a compact safe-to-defer hint for unlocked light front follow-ups below the urgent threshold\n- names the concrete buffer/condition keeping the follow-up safe instead of only saying it is safe\n- suppresses the defer hint when priority or risky delay makes urgent wording win\n\nValidation:\n- git diff --check\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test\n\nZeta: ready for validation before merge.