### PR TITLE
Epsilon: Show climate priority stability condition

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -34,6 +34,11 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /marginRearmReview/);
   assert.match(webAppSource, /unrearmedReviewConsequence/);
   assert.match(webAppSource, /nextWatchPriorityImpact/);
+  assert.match(webAppSource, /nextPriorityStability/);
+  assert.match(webAppSource, /Fin changement priorité/);
+  assert.match(webAppSource, /stabilise après review/);
+  assert.match(webAppSource, /déjà stable/);
+  assert.match(webAppSource, /stable après mitigation/);
   assert.match(webAppSource, /Prochaine priorité/);
   assert.match(webAppSource, /priorité monte/);
   assert.match(webAppSource, /priorité stable/);
@@ -117,6 +122,8 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__priority/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__priority--rises/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__priority--secondary-after-mitigation/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__stability/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__stability--already-stable/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
@@ -239,4 +246,17 @@ test('atlas links unrearmed climate consequence to next watch priority', () => {
   assert.match(webAppSource, /label: 'priorité indéterminée'/);
   assert.match(webAppSource, /view\.watchItem\.nextWatchPriorityImpact \?/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__priority--fallback/);
+});
+
+test('atlas shows when next climate watch priority will stop changing', () => {
+  assert.match(webAppSource, /const nextPriorityStability = nextWatchPriorityImpact\.state === 'rises'/);
+  assert.match(webAppSource, /state: 'stabilizes-after-rearm'/);
+  assert.match(webAppSource, /label: 'stabilise après review'/);
+  assert.match(webAppSource, /cesse de changer quand la review est réarmée/);
+  assert.match(webAppSource, /state: 'already-stable'/);
+  assert.match(webAppSource, /label: 'déjà stable'/);
+  assert.match(webAppSource, /state: 'stabilizes-after-mitigation'/);
+  assert.match(webAppSource, /Fin changement priorité/);
+  assert.match(webAppSource, /view\.watchItem\.nextPriorityStability \?/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__stability--stabilizes-after-rearm/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14409,6 +14409,25 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
         label: 'priorité indéterminée',
         detail: 'relire la prochaine watch climat quand le signal secondaire redevient mesurable',
       };
+  const nextPriorityStability = nextWatchPriorityImpact.state === 'rises'
+    ? {
+      state: 'stabilizes-after-rearm',
+      label: 'stabilise après review',
+      detail: `cesse de changer quand la review est réarmée ou quand ${progress.deadline} confirme une marge encore confortable`,
+    }
+    : nextWatchPriorityImpact.state === 'stable'
+      ? {
+        state: 'already-stable',
+        label: 'déjà stable',
+        detail: 'aucun changement attendu tant que la marge confortable reste lisible',
+      }
+      : nextWatchPriorityImpact.state === 'secondary-after-mitigation'
+        ? {
+          state: 'stabilizes-after-mitigation',
+          label: 'stable après mitigation',
+          detail: 'cesse de changer si la mitigation tient au prochain check climat',
+        }
+        : null;
   const minimalProtection = coverageView.secondaryProtections?.[0]
     ?? coverageView.activeProtections?.[0]
     ?? (gapActionView.recommendation
@@ -14522,6 +14541,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       marginRearmReview,
       unrearmedReviewConsequence,
       nextWatchPriorityImpact,
+      nextPriorityStability,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14567,6 +14587,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       ${view.watchItem.marginRearmReview ? `<small class="map-world-climate-post-gap-watch__rearm map-world-climate-post-gap-watch__rearm--${view.watchItem.marginRearmReview.state}"><b>Réarmer review</b> · ${view.watchItem.marginRearmReview.label}: ${view.watchItem.marginRearmReview.detail}</small>` : ''}
       ${view.watchItem.unrearmedReviewConsequence ? `<small class="map-world-climate-post-gap-watch__consequence map-world-climate-post-gap-watch__consequence--${view.watchItem.unrearmedReviewConsequence.state}"><b>Si non réarmé</b> · ${view.watchItem.unrearmedReviewConsequence.label}: ${view.watchItem.unrearmedReviewConsequence.detail}</small>` : ''}
       ${view.watchItem.nextWatchPriorityImpact ? `<small class="map-world-climate-post-gap-watch__priority map-world-climate-post-gap-watch__priority--${view.watchItem.nextWatchPriorityImpact.state}"><b>Prochaine priorité</b> · ${view.watchItem.nextWatchPriorityImpact.label}: ${view.watchItem.nextWatchPriorityImpact.detail}</small>` : ''}
+      ${view.watchItem.nextPriorityStability ? `<small class="map-world-climate-post-gap-watch__stability map-world-climate-post-gap-watch__stability--${view.watchItem.nextPriorityStability.state}"><b>Fin changement priorité</b> · ${view.watchItem.nextPriorityStability.label}: ${view.watchItem.nextPriorityStability.detail}</small>` : ''}
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13773,6 +13773,15 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__priority--stable { border: 1px solid rgba(74, 222, 128, 0.34); }
 .map-world-climate-post-gap-watch__priority--secondary-after-mitigation,
 .map-world-climate-post-gap-watch__priority--fallback { border: 1px solid rgba(125, 211, 252, 0.28); }
+.map-world-climate-post-gap-watch__stability {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(8, 47, 73, 0.24);
+}
+.map-world-climate-post-gap-watch__stability--stabilizes-after-rearm { border: 1px solid rgba(251, 191, 36, 0.34); }
+.map-world-climate-post-gap-watch__stability--already-stable { border: 1px solid rgba(74, 222, 128, 0.34); }
+.map-world-climate-post-gap-watch__stability--stabilizes-after-mitigation { border: 1px solid rgba(125, 211, 252, 0.28); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon:

Fixes #1590.

Summary:
- adds a compact stability hint for the next climate watch priority
- explains when rising priority stops changing after an unrearmed consequence
- uses clear already-stable / post-mitigation labels without changing climate progression rules

Validation:
- node --check web/app.js
- npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check