### PR TITLE
Beta: MAP-B45 show slack after first blocker

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1211,10 +1211,16 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             label: 'Aucun bloqueur immédiat',
             summary: 'Aucun consommateur proche ne bloque la route pour l’instant.',
           },
+          afterFirstBlockerHandled: {
+            state: 'preserved',
+            label: 'Slack après bloqueur',
+            summary: 'Après action, le slack reste disponible: aucun bloqueur immédiat à traiter.',
+          },
         };
       }
 
       const primaryConsumer = rankedConsumers[0];
+      const nextConsumer = rankedConsumers[1] ?? null;
       return {
         state: primaryConsumer.tone ?? 'watch',
         label: 'Slack consommé par',
@@ -1225,6 +1231,14 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           state: primaryConsumer.tone ?? 'watch',
           label: `Premier bloqueur: ${primaryConsumer.label}`,
           summary: `${primaryConsumer.label} deviendrait bloquant en premier: ${primaryConsumer.blockerReason ?? primaryConsumer.reason}.`,
+        },
+        afterFirstBlockerHandled: {
+          state: nextConsumer ? nextConsumer.tone ?? 'watch' : 'spare',
+          label: 'Slack après bloqueur',
+          summary: primaryConsumer.afterHandledSummary ?? (nextConsumer
+            ? `Après ${primaryConsumer.label}, marge restante à surveiller: ${nextConsumer.label} (${nextConsumer.reason}).`
+            : `Après ${primaryConsumer.label}, aucune autre contrainte immédiate ne consomme le slack.`),
+          nextConsumer: nextConsumer?.label ?? null,
         },
       };
     };
@@ -1257,7 +1271,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             : 'Route reprise mais serrée: capacité locale encore partagée.',
           priorityAction.resource ?? 'capacité locale',
           buildSlackConsumerHint([
-            { label: priorityAction.resource ?? 'capacité locale', reason: `partagée avec ${opportunityCost.delayedRoute}`, blockerReason: `la ressource reste partagée avec ${opportunityCost.delayedRoute}`, weight: 3, tone: 'tight' },
+            { label: priorityAction.resource ?? 'capacité locale', reason: `partagée avec ${opportunityCost.delayedRoute}`, blockerReason: `la ressource reste partagée avec ${opportunityCost.delayedRoute}`, afterHandledSummary: exposedRoute ? `Après ${priorityAction.resource ?? 'capacité locale'}, slack restant surveillé par ${exposedRoute.route}.` : `Après ${priorityAction.resource ?? 'capacité locale'}, aucune autre contrainte immédiate ne consomme le slack.`, weight: 3, tone: 'tight' },
             exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, blockerReason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
           ]),
         ),
@@ -1286,7 +1300,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             buildSlackConsumerHint(margin >= 2
               ? []
               : [
-                { label: stopMarker.route, reason: `il ne reste que ${margin} point de marge`, blockerReason: `marge restante ${margin}`, weight: 2, tone: 'tight' },
+                { label: stopMarker.route, reason: `il ne reste que ${margin} point de marge`, blockerReason: `marge restante ${margin}`, afterHandledSummary: exposedRoute ? `Après ${stopMarker.route}, il reste ${margin} point de marge et ${exposedRoute.route} à surveiller.` : `Après ${stopMarker.route}, il reste ${margin} point de marge sans autre bloqueur immédiat.`, weight: 2, tone: 'tight' },
                 exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, blockerReason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
               ]),
           ),
@@ -1305,7 +1319,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             `Route non confortable: ${stopMarker.route} reste le goulot avec ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}.`,
             stopMarker.route,
             buildSlackConsumerHint([
-              { label: stopMarker.route, reason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, blockerReason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, weight: 3, tone: 'blocked' },
+              { label: stopMarker.route, reason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, blockerReason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, afterHandledSummary: exposedRoute ? `Après ${stopMarker.route}, la marge revient à 0 et ${exposedRoute.route} reste à surveiller.` : `Après ${stopMarker.route}, la marge revient à 0 sans autre bloqueur immédiat.`, weight: 3, tone: 'blocked' },
               exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, blockerReason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
             ]),
           ),

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -153,6 +153,7 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.summary, /Outils consomme d’abord le slack/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.label, 'Premier bloqueur: Outils');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.summary, /Outils deviendrait bloquant en premier/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.summary, /Après Outils, slack restant surveillé/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -258,6 +259,7 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.summary, /Safe Road consomme d’abord le slack/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.label, 'Premier bloqueur: Safe Road');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.summary, /Safe Road deviendrait bloquant en premier/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.summary, /Après Safe Road, la marge revient à 0/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -132,6 +132,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /slackConsumerHint/);
   assert.match(webAppSource, /province-logistics-spillover-slack-blocker/);
   assert.match(webAppSource, /nextBlocker/);
+  assert.match(webAppSource, /province-logistics-spillover-slack-after-blocker/);
+  assert.match(webAppSource, /afterFirstBlockerHandled/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8846,6 +8846,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                         ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker ? `
                           <small class="province-logistics-spillover-slack-blocker province-logistics-spillover-slack-blocker--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.summary}</small>
                         ` : ''}
+                        ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled ? `
+                          <small class="province-logistics-spillover-slack-after-blocker province-logistics-spillover-slack-after-blocker--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.summary}</small>
+                        ` : ''}
                       ` : ''}
                     ` : ''}
                   ` : ''}


### PR DESCRIPTION
Beta: Implements #1597.\n\nSummary:\n- Adds a compact after-first-blocker slack cue to the existing route slack consumer hint.\n- Keeps the current first blocker visible while showing whether another constraint follows or the slack is spare.\n- Reuses existing ranked consumer, margin, resource, and exposed route signals without changing logistics selection.\n- Renders the residual slack cue in the logistics spillover panel.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test