### PR TITLE
Alpha: MAP-A45 compare light buffer pressure

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -472,3 +472,16 @@ test('atlas military explains why a light front follow-up can wait', () => {
   assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpDeferReason \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 11\.95 : 10\.6/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__defer--quiet/);
 });
+
+// MAP-A45: compare the safe defer buffer with the next pressure that could
+// consume it, without changing urgent-priority behavior.
+test('atlas military compares light front defer buffer with upcoming pressure', () => {
+  assert.match(webAppSource, /const lightFollowUpPressure = lightFollowUpDeferReason/);
+  assert.match(webAppSource, /label: lightFollowUpPriority >= 46 \|\| residualRisk\?\.tone === 'watch' \? 'Sûr si pas de pression' : 'Buffer restant'/);
+  assert.match(webAppSource, /buffer: \$\{residualRisk\.label\} · pression: \$\{residualRisk\.detail\}/);
+  assert.match(webAppSource, /lightFollowUpPressure,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpPressure \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpPressure \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 13\.3 : 11\.95/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__pressure--watch/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__pressure--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2782,6 +2782,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightRecheckUnlock: null,
       lightUnlockFollowUp: null,
       lightFollowUpDeferReason: null,
+      lightFollowUpPressure: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2896,6 +2897,17 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
           : `condition stable: ${residualRisk?.provinceLabel ?? alternative.provinceLabel ?? 'front'} sans changement visible`,
     }
     : null;
+  const lightFollowUpPressure = lightFollowUpDeferReason
+    ? {
+      tone: lightFollowUpPriority >= 46 || residualRisk?.tone === 'watch' ? 'watch' : 'quiet',
+      label: lightFollowUpPriority >= 46 || residualRisk?.tone === 'watch' ? 'Sûr si pas de pression' : 'Buffer restant',
+      detail: residualRisk?.visible
+        ? `buffer: ${residualRisk.label} · pression: ${residualRisk.detail}`
+        : prepUnlock?.delayCost?.detail
+          ? `buffer: ${prepUnlock.delayCost.detail} · pression: ${prepUnlock.unlocks}`
+          : `buffer: léger · pression: changement visible sur ${alternative.provinceLabel ?? 'front'}`,
+    }
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -2909,6 +2921,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightRecheckUnlock: null,
       lightUnlockFollowUp: null,
       lightFollowUpDeferReason: null,
+      lightFollowUpPressure: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2924,6 +2937,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     lightRecheckUnlock,
     lightUnlockFollowUp,
     lightFollowUpDeferReason,
+    lightFollowUpPressure,
   };
 }
 
@@ -3180,7 +3194,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3190,6 +3204,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.lightRecheckUnlock ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__unlock" x="44.2" y="${y + (ladder.remainingWatch ? 8.1 : 6.75)}">${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}</text>` : ''}
       ${ladder.lightUnlockFollowUp ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__post-unlock atlas-military-neighbor-blocked-follow-up-ladder__post-unlock--${ladder.lightUnlockFollowUp.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 9.45 : 8.1)}">${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}</text>` : ''}
       ${ladder.lightFollowUpDeferReason ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__defer atlas-military-neighbor-blocked-follow-up-ladder__defer--${ladder.lightFollowUpDeferReason.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 10.8 : 9.45)}">${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}</text>` : ''}
+      ${ladder.lightFollowUpPressure ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure atlas-military-neighbor-blocked-follow-up-ladder__pressure--${ladder.lightFollowUpPressure.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 12.15 : 10.8)}">${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3228,7 +3243,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14758,7 +14758,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__recheck,
 .atlas-military-neighbor-blocked-follow-up-ladder__unlock,
 .atlas-military-neighbor-blocked-follow-up-ladder__post-unlock,
-.atlas-military-neighbor-blocked-follow-up-ladder__defer {
+.atlas-military-neighbor-blocked-follow-up-ladder__defer,
+.atlas-military-neighbor-blocked-follow-up-ladder__pressure {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14774,6 +14775,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__post-unlock--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-ladder__defer--ready { fill: #bae6fd; }
 .atlas-military-neighbor-blocked-follow-up-ladder__defer--quiet { fill: #cbd5e1; }
+.atlas-military-neighbor-blocked-follow-up-ladder__pressure--watch { fill: #fde68a; }
+.atlas-military-neighbor-blocked-follow-up-ladder__pressure--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1596.\n\nSummary:\n- adds a compact pressure comparison for deferred light front follow-ups\n- distinguishes the stable buffer state from cases that are safe only while no new pressure arrives\n- keeps urgent/risky wording ahead of the defer/pressure hint without changing simulation rules\n\nValidation:\n- git diff --check\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test\n\nZeta: ready for validation before merge.