### PR TITLE
Epsilon: Show climate priority instability trigger

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -35,6 +35,11 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /unrearmedReviewConsequence/);
   assert.match(webAppSource, /nextWatchPriorityImpact/);
   assert.match(webAppSource, /nextPriorityStability/);
+  assert.match(webAppSource, /priorityInstabilityTrigger/);
+  assert.match(webAppSource, /Stable jusqu’à/);
+  assert.match(webAppSource, /stable sauf si/);
+  assert.match(webAppSource, /instable tant que/);
+  assert.match(webAppSource, /la marge tombe courte ou une consequence unrearmed revient/);
   assert.match(webAppSource, /Fin changement priorité/);
   assert.match(webAppSource, /stabilise après review/);
   assert.match(webAppSource, /déjà stable/);
@@ -124,6 +129,8 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__priority--secondary-after-mitigation/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__stability/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__stability--already-stable/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__instability/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__instability--stable-until/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
@@ -259,4 +266,15 @@ test('atlas shows when next climate watch priority will stop changing', () => {
   assert.match(webAppSource, /Fin changement priorité/);
   assert.match(webAppSource, /view\.watchItem\.nextPriorityStability \?/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__stability--stabilizes-after-rearm/);
+});
+
+test('atlas explains what can make stable climate priority unstable again', () => {
+  assert.match(webAppSource, /const priorityInstabilityTrigger = nextPriorityStability\?\.state === 'already-stable'/);
+  assert.match(webAppSource, /state: 'stable-until'/);
+  assert.match(webAppSource, /label: 'stable sauf si'/);
+  assert.match(webAppSource, /la marge tombe courte ou une consequence unrearmed revient sur \$\{watchGap\.nearestRiskLabel\}/);
+  assert.match(webAppSource, /state: 'watch-until-rearmed'/);
+  assert.match(webAppSource, /Stable jusqu’à/);
+  assert.match(webAppSource, /view\.watchItem\.priorityInstabilityTrigger \?/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__instability--watch-until-rearmed/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14429,6 +14429,19 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
           detail: 'cesse de changer si la mitigation tient au prochain check climat',
         }
         : null;
+  const priorityInstabilityTrigger = nextPriorityStability?.state === 'already-stable'
+    ? {
+      state: 'stable-until',
+      label: 'stable sauf si',
+      detail: `la marge tombe courte ou une consequence unrearmed revient sur ${watchGap.nearestRiskLabel}`,
+    }
+    : nextPriorityStability?.state === 'stabilizes-after-rearm'
+      ? {
+        state: 'watch-until-rearmed',
+        label: 'instable tant que',
+        detail: `la review reste non réarmée avant ${progress.deadline}`,
+      }
+      : null;
   const minimalProtection = coverageView.secondaryProtections?.[0]
     ?? coverageView.activeProtections?.[0]
     ?? (gapActionView.recommendation
@@ -14543,6 +14556,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       unrearmedReviewConsequence,
       nextWatchPriorityImpact,
       nextPriorityStability,
+      priorityInstabilityTrigger,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14589,6 +14603,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       ${view.watchItem.unrearmedReviewConsequence ? `<small class="map-world-climate-post-gap-watch__consequence map-world-climate-post-gap-watch__consequence--${view.watchItem.unrearmedReviewConsequence.state}"><b>Si non réarmé</b> · ${view.watchItem.unrearmedReviewConsequence.label}: ${view.watchItem.unrearmedReviewConsequence.detail}</small>` : ''}
       ${view.watchItem.nextWatchPriorityImpact ? `<small class="map-world-climate-post-gap-watch__priority map-world-climate-post-gap-watch__priority--${view.watchItem.nextWatchPriorityImpact.state}"><b>Prochaine priorité</b> · ${view.watchItem.nextWatchPriorityImpact.label}: ${view.watchItem.nextWatchPriorityImpact.detail}</small>` : ''}
       ${view.watchItem.nextPriorityStability ? `<small class="map-world-climate-post-gap-watch__stability map-world-climate-post-gap-watch__stability--${view.watchItem.nextPriorityStability.state}"><b>Fin changement priorité</b> · ${view.watchItem.nextPriorityStability.label}: ${view.watchItem.nextPriorityStability.detail}</small>` : ''}
+      ${view.watchItem.priorityInstabilityTrigger ? `<small class="map-world-climate-post-gap-watch__instability map-world-climate-post-gap-watch__instability--${view.watchItem.priorityInstabilityTrigger.state}"><b>Stable jusqu’à</b> · ${view.watchItem.priorityInstabilityTrigger.label}: ${view.watchItem.priorityInstabilityTrigger.detail}</small>` : ''}
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13782,6 +13782,14 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__stability--stabilizes-after-rearm { border: 1px solid rgba(251, 191, 36, 0.34); }
 .map-world-climate-post-gap-watch__stability--already-stable { border: 1px solid rgba(74, 222, 128, 0.34); }
 .map-world-climate-post-gap-watch__stability--stabilizes-after-mitigation { border: 1px solid rgba(125, 211, 252, 0.28); }
+.map-world-climate-post-gap-watch__instability {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.24);
+}
+.map-world-climate-post-gap-watch__instability--stable-until { border: 1px solid rgba(74, 222, 128, 0.3); }
+.map-world-climate-post-gap-watch__instability--watch-until-rearmed { border: 1px solid rgba(251, 191, 36, 0.32); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon:

Fixes #1600.

Summary:
- adds a compact stable-until hint for the climate next-priority card
- explains what can make an already-stable priority unstable again using existing margin/unrearmed signals
- preserves the existing priority/stability wording and does not change climate progression rules

Validation:
- node --check web/app.js
- npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check