### PR TITLE
Alpha: MAP-A46 show light buffer risk window

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -485,3 +485,17 @@ test('atlas military compares light front defer buffer with upcoming pressure', 
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__pressure--watch/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__pressure--quiet/);
 });
+
+// MAP-A46: show the next threshold where a deferred light front follow-up
+// becomes risky, or explicitly state that it can remain deferred.
+test('atlas military shows when light front defer buffer becomes risky', () => {
+  assert.match(webAppSource, /const lightFollowUpRiskWindow = lightFollowUpPressure/);
+  assert.match(webAppSource, /label: 'Devient risqué: prochain signal'/);
+  assert.match(webAppSource, /label: 'Report maintenu'/);
+  assert.match(webAppSource, /reste différable tant que \$\{residualRisk\?\.provinceLabel \?\? alternative\.provinceLabel \?\? 'front'\} ne change pas/);
+  assert.match(webAppSource, /lightFollowUpRiskWindow,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpRiskWindow \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__risk-window/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpRiskWindow \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 14\.65 : 13\.3/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__risk-window--risky/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__risk-window--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2783,6 +2783,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightUnlockFollowUp: null,
       lightFollowUpDeferReason: null,
       lightFollowUpPressure: null,
+      lightFollowUpRiskWindow: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2908,6 +2909,21 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
           : `buffer: léger · pression: changement visible sur ${alternative.provinceLabel ?? 'front'}`,
     }
     : null;
+  const lightFollowUpRiskWindow = lightFollowUpPressure
+    ? lightFollowUpPressure.tone === 'watch' || lightFollowUpPriority >= 60
+      ? {
+        tone: 'risky',
+        label: 'Devient risqué: prochain signal',
+        detail: residualRisk?.visible
+          ? `si ${residualRisk.detail}`
+          : `si ${prepUnlock?.unlocks ?? `pression revient sur ${alternative.provinceLabel ?? 'front'}`}`,
+      }
+      : {
+        tone: 'quiet',
+        label: 'Report maintenu',
+        detail: `reste différable tant que ${residualRisk?.provinceLabel ?? alternative.provinceLabel ?? 'front'} ne change pas`,
+      }
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -2922,6 +2938,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightUnlockFollowUp: null,
       lightFollowUpDeferReason: null,
       lightFollowUpPressure: null,
+      lightFollowUpRiskWindow: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2938,6 +2955,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     lightUnlockFollowUp,
     lightFollowUpDeferReason,
     lightFollowUpPressure,
+    lightFollowUpRiskWindow,
   };
 }
 
@@ -3194,7 +3212,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3205,6 +3223,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.lightUnlockFollowUp ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__post-unlock atlas-military-neighbor-blocked-follow-up-ladder__post-unlock--${ladder.lightUnlockFollowUp.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 9.45 : 8.1)}">${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}</text>` : ''}
       ${ladder.lightFollowUpDeferReason ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__defer atlas-military-neighbor-blocked-follow-up-ladder__defer--${ladder.lightFollowUpDeferReason.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 10.8 : 9.45)}">${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}</text>` : ''}
       ${ladder.lightFollowUpPressure ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure atlas-military-neighbor-blocked-follow-up-ladder__pressure--${ladder.lightFollowUpPressure.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 12.15 : 10.8)}">${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}</text>` : ''}
+      ${ladder.lightFollowUpRiskWindow ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__risk-window atlas-military-neighbor-blocked-follow-up-ladder__risk-window--${ladder.lightFollowUpRiskWindow.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 13.5 : 12.15)}">${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3243,7 +3262,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14767,7 +14767,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__unlock,
 .atlas-military-neighbor-blocked-follow-up-ladder__post-unlock,
 .atlas-military-neighbor-blocked-follow-up-ladder__defer,
-.atlas-military-neighbor-blocked-follow-up-ladder__pressure {
+.atlas-military-neighbor-blocked-follow-up-ladder__pressure,
+.atlas-military-neighbor-blocked-follow-up-ladder__risk-window {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14785,6 +14786,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__defer--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure--watch { fill: #fde68a; }
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure--quiet { fill: #cbd5e1; }
+.atlas-military-neighbor-blocked-follow-up-ladder__risk-window--risky { fill: #fecdd3; }
+.atlas-military-neighbor-blocked-follow-up-ladder__risk-window--quiet { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1606.\n\nSummary:\n- adds a compact risk-window cue for deferred light front follow-ups\n- shows when the defer buffer becomes risky on the next signal/threshold\n- explicitly keeps the follow-up deferable when no nearby risk threshold is visible\n\nValidation:\n- git diff --check\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test\n\nZeta: ready for validation before merge.