### PR TITLE
Beta: MAP-B46 show next route slack consumer

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1216,11 +1216,16 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             label: 'Slack après bloqueur',
             summary: 'Après action, le slack reste disponible: aucun bloqueur immédiat à traiter.',
           },
+          nextLikelyConsumer: {
+            state: 'none',
+            label: 'Aucun consommateur suivant',
+            summary: 'Aucun choix logistique significatif ne consommerait le slack ensuite.',
+          },
         };
       }
 
       const primaryConsumer = rankedConsumers[0];
-      const nextConsumer = rankedConsumers[1] ?? null;
+      const nextConsumer = rankedConsumers.find((consumer) => consumer.label !== primaryConsumer.label) ?? null;
       return {
         state: primaryConsumer.tone ?? 'watch',
         label: 'Slack consommé par',
@@ -1239,6 +1244,13 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             ? `Après ${primaryConsumer.label}, marge restante à surveiller: ${nextConsumer.label} (${nextConsumer.reason}).`
             : `Après ${primaryConsumer.label}, aucune autre contrainte immédiate ne consomme le slack.`),
           nextConsumer: nextConsumer?.label ?? null,
+        },
+        nextLikelyConsumer: {
+          state: nextConsumer ? nextConsumer.tone ?? 'watch' : 'none',
+          label: nextConsumer ? `Prochain consommateur: ${nextConsumer.label}` : 'Aucun consommateur suivant',
+          summary: nextConsumer
+            ? `${nextConsumer.label} consommerait ensuite le slack: ${nextConsumer.reason}.`
+            : `Après ${primaryConsumer.label}, aucun choix logistique significatif ne consommerait le slack ensuite.`,
         },
       };
     };

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -154,6 +154,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.label, 'Premier bloqueur: Outils');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.summary, /Outils deviendrait bloquant en premier/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.summary, /Après Outils, slack restant surveillé/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.label, 'Prochain consommateur: Hill Spur');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.summary, /Hill Spur consommerait ensuite le slack/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -260,6 +262,8 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.label, 'Premier bloqueur: Safe Road');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextBlocker.summary, /Safe Road deviendrait bloquant en premier/);
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.summary, /Après Safe Road, la marge revient à 0/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.label, 'Aucun consommateur suivant');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.summary, /aucun choix logistique significatif/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -134,6 +134,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /nextBlocker/);
   assert.match(webAppSource, /province-logistics-spillover-slack-after-blocker/);
   assert.match(webAppSource, /afterFirstBlockerHandled/);
+  assert.match(webAppSource, /province-logistics-spillover-next-slack-consumer/);
+  assert.match(webAppSource, /nextLikelyConsumer/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8865,6 +8865,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                         ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled ? `
                           <small class="province-logistics-spillover-slack-after-blocker province-logistics-spillover-slack-after-blocker--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.summary}</small>
                         ` : ''}
+                        ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer ? `
+                          <small class="province-logistics-spillover-next-slack-consumer province-logistics-spillover-next-slack-consumer--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.summary}</small>
+                        ` : ''}
                       ` : ''}
                     ` : ''}
                   ` : ''}


### PR DESCRIPTION
Beta: Implements #1607.\n\nSummary:\n- Adds a compact next-likely slack consumer cue after the first blocker handling state.\n- Reuses existing ranked slack consumer signals and skips duplicate primary consumers.\n- Provides an explicit no-significant-consumer state when no follow-up constraint is available.\n- Renders the cue in the logistics spillover panel without changing economic or route selection logic.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test