### PR TITLE
Epsilon: Show climate priority destabilization window

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -36,6 +36,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /nextWatchPriorityImpact/);
   assert.match(webAppSource, /nextPriorityStability/);
   assert.match(webAppSource, /priorityInstabilityTrigger/);
+  assert.match(webAppSource, /priorityInstabilityWindow/);
+  assert.match(webAppSource, /Fenêtre instabilité/);
+  assert.match(webAppSource, /première fenêtre: vérifier/);
+  assert.match(webAppSource, /aucune fenêtre proche/);
   assert.match(webAppSource, /Stable jusqu’à/);
   assert.match(webAppSource, /stable sauf si/);
   assert.match(webAppSource, /instable tant que/);
@@ -131,6 +135,8 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__stability--already-stable/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__instability/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__instability--stable-until/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__window/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__window--next-check/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);
@@ -277,4 +283,17 @@ test('atlas explains what can make stable climate priority unstable again', () =
   assert.match(webAppSource, /Stable jusqu’à/);
   assert.match(webAppSource, /view\.watchItem\.priorityInstabilityTrigger \?/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__instability--watch-until-rearmed/);
+});
+
+test('atlas shows the first window where climate priority can destabilize', () => {
+  assert.match(webAppSource, /const priorityInstabilityWindow = priorityInstabilityTrigger\?\.state === 'stable-until'/);
+  assert.match(webAppSource, /state: 'next-check'/);
+  assert.match(webAppSource, /label: progress\.deadline/);
+  assert.match(webAppSource, /première fenêtre: vérifier si \$\{watchGap\.nearestRiskLabel\} réduit la marge au prochain check/);
+  assert.match(webAppSource, /state: 'before-review'/);
+  assert.match(webAppSource, /fenêtre ouverte tant que la review reste non réarmée/);
+  assert.match(webAppSource, /state: 'none-close'/);
+  assert.match(webAppSource, /attendre un nouveau signal climat mesurable avant de reclasser la priorité/);
+  assert.match(webAppSource, /Fenêtre instabilité/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__window--none-close/);
 });

--- a/web/app.js
+++ b/web/app.js
@@ -14483,6 +14483,23 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
         detail: `la review reste non réarmée avant ${progress.deadline}`,
       }
       : null;
+  const priorityInstabilityWindow = priorityInstabilityTrigger?.state === 'stable-until'
+    ? {
+      state: 'next-check',
+      label: progress.deadline,
+      detail: `première fenêtre: vérifier si ${watchGap.nearestRiskLabel} réduit la marge au prochain check`,
+    }
+    : priorityInstabilityTrigger?.state === 'watch-until-rearmed'
+      ? {
+        state: 'before-review',
+        label: `avant ${progress.deadline}`,
+        detail: `fenêtre ouverte tant que la review reste non réarmée`,
+      }
+      : {
+        state: 'none-close',
+        label: 'aucune fenêtre proche',
+        detail: 'attendre un nouveau signal climat mesurable avant de reclasser la priorité',
+      };
   const minimalProtection = coverageView.secondaryProtections?.[0]
     ?? coverageView.activeProtections?.[0]
     ?? (gapActionView.recommendation
@@ -14598,6 +14615,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       nextWatchPriorityImpact,
       nextPriorityStability,
       priorityInstabilityTrigger,
+      priorityInstabilityWindow,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14645,6 +14663,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       ${view.watchItem.nextWatchPriorityImpact ? `<small class="map-world-climate-post-gap-watch__priority map-world-climate-post-gap-watch__priority--${view.watchItem.nextWatchPriorityImpact.state}"><b>Prochaine priorité</b> · ${view.watchItem.nextWatchPriorityImpact.label}: ${view.watchItem.nextWatchPriorityImpact.detail}</small>` : ''}
       ${view.watchItem.nextPriorityStability ? `<small class="map-world-climate-post-gap-watch__stability map-world-climate-post-gap-watch__stability--${view.watchItem.nextPriorityStability.state}"><b>Fin changement priorité</b> · ${view.watchItem.nextPriorityStability.label}: ${view.watchItem.nextPriorityStability.detail}</small>` : ''}
       ${view.watchItem.priorityInstabilityTrigger ? `<small class="map-world-climate-post-gap-watch__instability map-world-climate-post-gap-watch__instability--${view.watchItem.priorityInstabilityTrigger.state}"><b>Stable jusqu’à</b> · ${view.watchItem.priorityInstabilityTrigger.label}: ${view.watchItem.priorityInstabilityTrigger.detail}</small>` : ''}
+      <small class="map-world-climate-post-gap-watch__window map-world-climate-post-gap-watch__window--${view.watchItem.priorityInstabilityWindow.state}"><b>Fenêtre instabilité</b> · ${view.watchItem.priorityInstabilityWindow.label}: ${view.watchItem.priorityInstabilityWindow.detail}</small>
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13790,6 +13790,15 @@ button { font: inherit; }
 }
 .map-world-climate-post-gap-watch__instability--stable-until { border: 1px solid rgba(74, 222, 128, 0.3); }
 .map-world-climate-post-gap-watch__instability--watch-until-rearmed { border: 1px solid rgba(251, 191, 36, 0.32); }
+.map-world-climate-post-gap-watch__window {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(30, 41, 59, 0.28);
+}
+.map-world-climate-post-gap-watch__window--next-check { border: 1px solid rgba(125, 211, 252, 0.32); }
+.map-world-climate-post-gap-watch__window--before-review { border: 1px solid rgba(251, 191, 36, 0.34); }
+.map-world-climate-post-gap-watch__window--none-close { border: 1px solid rgba(148, 163, 184, 0.28); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon:

Fixes #1610.

Summary:
- adds a compact climate priority destabilization-window line
- shows the first existing check/review window where instability can return
- keeps the change UI-only, with no climate calendar or catastrophe rule changes

Validation:
- node --check web/app.js
- npm test -- test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check