### PR TITLE
Beta: MAP-B47 show slack recovery safe delivery

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1221,6 +1221,11 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             label: 'Aucun consommateur suivant',
             summary: 'Aucun choix logistique significatif ne consommerait le slack ensuite.',
           },
+          safeDeliveryUnlock: {
+            state: 'safe',
+            label: 'Livraison déjà sûre',
+            summary: 'Route déjà sûre: aucune récupération de slack requise pour la prochaine livraison.',
+          },
         };
       }
 
@@ -1251,6 +1256,14 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
           summary: nextConsumer
             ? `${nextConsumer.label} consommerait ensuite le slack: ${nextConsumer.reason}.`
             : `Après ${primaryConsumer.label}, aucun choix logistique significatif ne consommerait le slack ensuite.`,
+        },
+        safeDeliveryUnlock: {
+          state: primaryConsumer.tone === 'blocked' ? 'insufficient' : 'recoverable',
+          label: primaryConsumer.tone === 'blocked' ? 'Slack insuffisant' : 'Slack récupérable',
+          summary: primaryConsumer.recoverySummary ?? (primaryConsumer.tone === 'blocked'
+            ? `Lever ${primaryConsumer.label} d’abord: ${primaryConsumer.blockerReason ?? primaryConsumer.reason} empêche encore la prochaine livraison sûre.`
+            : `Récupérer ${primaryConsumer.label} rend la prochaine livraison sûre avant ${nextConsumer?.label ?? 'une autre contrainte'}.`),
+          recovery: primaryConsumer.label,
         },
       };
     };
@@ -1283,7 +1296,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             : 'Route reprise mais serrée: capacité locale encore partagée.',
           priorityAction.resource ?? 'capacité locale',
           buildSlackConsumerHint([
-            { label: priorityAction.resource ?? 'capacité locale', reason: `partagée avec ${opportunityCost.delayedRoute}`, blockerReason: `la ressource reste partagée avec ${opportunityCost.delayedRoute}`, afterHandledSummary: exposedRoute ? `Après ${priorityAction.resource ?? 'capacité locale'}, slack restant surveillé par ${exposedRoute.route}.` : `Après ${priorityAction.resource ?? 'capacité locale'}, aucune autre contrainte immédiate ne consomme le slack.`, weight: 3, tone: 'tight' },
+            { label: priorityAction.resource ?? 'capacité locale', reason: `partagée avec ${opportunityCost.delayedRoute}`, blockerReason: `la ressource reste partagée avec ${opportunityCost.delayedRoute}`, afterHandledSummary: exposedRoute ? `Après ${priorityAction.resource ?? 'capacité locale'}, slack restant surveillé par ${exposedRoute.route}.` : `Après ${priorityAction.resource ?? 'capacité locale'}, aucune autre contrainte immédiate ne consomme le slack.`, recoverySummary: `Récupérer ${priorityAction.resource ?? 'capacité locale'} libère ${opportunityCost.delayedRoute} pour la prochaine livraison sûre.`, weight: 3, tone: 'tight' },
             exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, blockerReason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
           ]),
         ),
@@ -1312,7 +1325,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             buildSlackConsumerHint(margin >= 2
               ? []
               : [
-                { label: stopMarker.route, reason: `il ne reste que ${margin} point de marge`, blockerReason: `marge restante ${margin}`, afterHandledSummary: exposedRoute ? `Après ${stopMarker.route}, il reste ${margin} point de marge et ${exposedRoute.route} à surveiller.` : `Après ${stopMarker.route}, il reste ${margin} point de marge sans autre bloqueur immédiat.`, weight: 2, tone: 'tight' },
+                { label: stopMarker.route, reason: `il ne reste que ${margin} point de marge`, blockerReason: `marge restante ${margin}`, afterHandledSummary: exposedRoute ? `Après ${stopMarker.route}, il reste ${margin} point de marge et ${exposedRoute.route} à surveiller.` : `Après ${stopMarker.route}, il reste ${margin} point de marge sans autre bloqueur immédiat.`, recoverySummary: `Récupérer ${stopMarker.route} sécurise la prochaine livraison avec ${margin} point de marge.`, weight: 2, tone: 'tight' },
                 exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, blockerReason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
               ]),
           ),
@@ -1331,7 +1344,7 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             `Route non confortable: ${stopMarker.route} reste le goulot avec ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}.`,
             stopMarker.route,
             buildSlackConsumerHint([
-              { label: stopMarker.route, reason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, blockerReason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, afterHandledSummary: exposedRoute ? `Après ${stopMarker.route}, la marge revient à 0 et ${exposedRoute.route} reste à surveiller.` : `Après ${stopMarker.route}, la marge revient à 0 sans autre bloqueur immédiat.`, weight: 3, tone: 'blocked' },
+              { label: stopMarker.route, reason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, blockerReason: `${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} de marge manquant${Math.abs(margin) > 1 ? 's' : ''}`, afterHandledSummary: exposedRoute ? `Après ${stopMarker.route}, la marge revient à 0 et ${exposedRoute.route} reste à surveiller.` : `Après ${stopMarker.route}, la marge revient à 0 sans autre bloqueur immédiat.`, recoverySummary: `Lever ${stopMarker.route} d’abord: ${Math.abs(margin)} point${Math.abs(margin) > 1 ? 's' : ''} manque${Math.abs(margin) > 1 ? 'nt' : ''} encore avant livraison sûre.`, weight: 3, tone: 'blocked' },
               exposedRoute ? { label: exposedRoute.route, reason: exposure.residualRisk, blockerReason: exposure.residualRisk, weight: exposedRoute.tone === 'high' ? 2 : 1, tone: exposedRoute.tone } : null,
             ]),
           ),

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -156,6 +156,8 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.summary, /Après Outils, slack restant surveillé/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.label, 'Prochain consommateur: Hill Spur');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.summary, /Hill Spur consommerait ensuite le slack/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.state, 'recoverable');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.summary, /Récupérer Outils libère Hill Spur/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -264,6 +266,8 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.afterFirstBlockerHandled.summary, /Après Safe Road, la marge revient à 0/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.label, 'Aucun consommateur suivant');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.summary, /aucun choix logistique significatif/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.state, 'insufficient');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.summary, /Lever Safe Road d’abord/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -136,6 +136,8 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /afterFirstBlockerHandled/);
   assert.match(webAppSource, /province-logistics-spillover-next-slack-consumer/);
   assert.match(webAppSource, /nextLikelyConsumer/);
+  assert.match(webAppSource, /province-logistics-spillover-safe-delivery-unlock/);
+  assert.match(webAppSource, /safeDeliveryUnlock/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8888,6 +8888,9 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                         ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer ? `
                           <small class="province-logistics-spillover-next-slack-consumer province-logistics-spillover-next-slack-consumer--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.summary}</small>
                         ` : ''}
+                        ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock ? `
+                          <small class="province-logistics-spillover-safe-delivery-unlock province-logistics-spillover-safe-delivery-unlock--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.summary}</small>
+                        ` : ''}
                       ` : ''}
                     ` : ''}
                   ` : ''}


### PR DESCRIPTION
Beta: Implements #1617.\n\nSummary:\n- Adds a safe-delivery unlock cue to the existing route slack consumer hint.\n- Distinguishes slack insufficient, slack recoverable, and already-safe states.\n- Points to the first recovery/constraint to lift using existing ranked slack consumer signals.\n- Renders the cue in the logistics spillover panel without changing economic or route selection logic.\n\nValidation:\n- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js\n- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js\n- node --check web/app.js\n- git diff --check\n- npm test