### PR TITLE
Alpha: MAP-A47 show next light buffer risk

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -499,3 +499,17 @@ test('atlas military shows when light front defer buffer becomes risky', () => {
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__risk-window--risky/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__risk-window--quiet/);
 });
+
+// MAP-A47: after the current light-front defer buffer is spent, show the
+// next concrete risk or a neutral no-risk state.
+test('atlas military shows the next light front risk after buffer is spent', () => {
+  assert.match(webAppSource, /const lightFollowUpNextRisk = lightFollowUpRiskWindow/);
+  assert.match(webAppSource, /label: 'Après buffer: risque suivant'/);
+  assert.match(webAppSource, /label: 'Après buffer: risque neutre'/);
+  assert.match(webAppSource, /aucun risque imminent calculable/);
+  assert.match(webAppSource, /lightFollowUpNextRisk,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpNextRisk \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__next-risk/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpNextRisk \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 16 : 14\.65/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__next-risk--risky/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__next-risk--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2784,6 +2784,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpDeferReason: null,
       lightFollowUpPressure: null,
       lightFollowUpRiskWindow: null,
+      lightFollowUpNextRisk: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2924,6 +2925,23 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
         detail: `reste différable tant que ${residualRisk?.provinceLabel ?? alternative.provinceLabel ?? 'front'} ne change pas`,
       }
     : null;
+  const lightFollowUpNextRisk = lightFollowUpRiskWindow
+    ? lightFollowUpRiskWindow.tone === 'risky'
+      ? {
+        tone: 'risky',
+        label: 'Après buffer: risque suivant',
+        detail: prepUnlock?.delayCost?.detail
+          ? `délai: ${prepUnlock.delayCost.detail}`
+          : residualRisk?.action
+            ? `pression: ${residualRisk.action}`
+            : `occasion à reprendre sur ${alternative.provinceLabel ?? 'front'}`,
+      }
+      : {
+        tone: 'quiet',
+        label: 'Après buffer: risque neutre',
+        detail: 'aucun risque imminent calculable',
+      }
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -2939,6 +2957,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpDeferReason: null,
       lightFollowUpPressure: null,
       lightFollowUpRiskWindow: null,
+      lightFollowUpNextRisk: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2956,6 +2975,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     lightFollowUpDeferReason,
     lightFollowUpPressure,
     lightFollowUpRiskWindow,
+    lightFollowUpNextRisk,
   };
 }
 
@@ -3212,7 +3232,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3224,6 +3244,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.lightFollowUpDeferReason ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__defer atlas-military-neighbor-blocked-follow-up-ladder__defer--${ladder.lightFollowUpDeferReason.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 10.8 : 9.45)}">${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}</text>` : ''}
       ${ladder.lightFollowUpPressure ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure atlas-military-neighbor-blocked-follow-up-ladder__pressure--${ladder.lightFollowUpPressure.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 12.15 : 10.8)}">${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}</text>` : ''}
       ${ladder.lightFollowUpRiskWindow ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__risk-window atlas-military-neighbor-blocked-follow-up-ladder__risk-window--${ladder.lightFollowUpRiskWindow.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 13.5 : 12.15)}">${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}</text>` : ''}
+      ${ladder.lightFollowUpNextRisk ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__next-risk atlas-military-neighbor-blocked-follow-up-ladder__next-risk--${ladder.lightFollowUpNextRisk.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 14.85 : 13.5)}">${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3262,7 +3283,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14777,7 +14777,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__post-unlock,
 .atlas-military-neighbor-blocked-follow-up-ladder__defer,
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure,
-.atlas-military-neighbor-blocked-follow-up-ladder__risk-window {
+.atlas-military-neighbor-blocked-follow-up-ladder__risk-window,
+.atlas-military-neighbor-blocked-follow-up-ladder__next-risk {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14797,6 +14798,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-ladder__risk-window--risky { fill: #fecdd3; }
 .atlas-military-neighbor-blocked-follow-up-ladder__risk-window--quiet { fill: #bbf7d0; }
+.atlas-military-neighbor-blocked-follow-up-ladder__next-risk--risky { fill: #fca5a5; }
+.atlas-military-neighbor-blocked-follow-up-ladder__next-risk--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1616.\n\nSummary:\n- adds a compact next-risk cue after the current light-front defer buffer is spent\n- names the concrete follow-on risk when the buffer becomes risky\n- shows a neutral no-risk state when no imminent risk is calculable\n\nValidation:\n- git diff --check\n- node --check web/app.js\n- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js\n- npm test\n\nZeta: ready for validation before merge.