### PR TITLE
Epsilon: Show post-stabilization climate priority

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -45,6 +45,11 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /instable tant que/);
   assert.match(webAppSource, /la marge tombe courte ou une consequence unrearmed revient/);
   assert.match(webAppSource, /Fin changement priorité/);
+  assert.match(webAppSource, /afterStabilizationPriority/);
+  assert.match(webAppSource, /Après stabilisation/);
+  assert.match(webAppSource, /après stabilisation: surveiller/);
+  assert.match(webAppSource, /aucune priorité suivante fiable sans nouveau signal climat/);
+  assert.match(webAppSource, /attendre un signal mesurable avant de promettre la prochaine priorité/);
   assert.match(webAppSource, /stabilise après review/);
   assert.match(webAppSource, /déjà stable/);
   assert.match(webAppSource, /stable après mitigation/);
@@ -137,6 +142,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__instability--stable-until/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__window/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__window--next-check/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-stabilization/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-stabilization--watch-next/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-stabilization--neutral-stable/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-stabilization--unknown/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);

--- a/web/app.js
+++ b/web/app.js
@@ -14620,6 +14620,23 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
         reason: 'protection déjà active',
       }
       : null;
+  const afterStabilizationPriority = nextSecondaryRisk
+    ? {
+      state: 'watch-next',
+      label: `surveiller ${nextSecondaryRisk.label}`,
+      detail: `après stabilisation: surveiller ${nextSecondaryRisk.label}; ${nextSecondaryRisk.reason}`,
+    }
+    : nextPriorityStability?.state === 'already-stable'
+      ? {
+        state: 'neutral-stable',
+        label: 'priorité stable',
+        detail: 'après stabilisation: aucune priorité suivante fiable sans nouveau signal climat',
+      }
+      : {
+        state: 'unknown',
+        label: 'priorité indéterminée',
+        detail: 'après stabilisation: attendre un signal mesurable avant de promettre la prochaine priorité',
+      };
 
   return {
     state: 'watch',
@@ -14642,6 +14659,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       nextPriorityStability,
       priorityInstabilityTrigger,
       priorityInstabilityWindow,
+      afterStabilizationPriority,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14690,6 +14708,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       ${view.watchItem.nextPriorityStability ? `<small class="map-world-climate-post-gap-watch__stability map-world-climate-post-gap-watch__stability--${view.watchItem.nextPriorityStability.state}"><b>Fin changement priorité</b> · ${view.watchItem.nextPriorityStability.label}: ${view.watchItem.nextPriorityStability.detail}</small>` : ''}
       ${view.watchItem.priorityInstabilityTrigger ? `<small class="map-world-climate-post-gap-watch__instability map-world-climate-post-gap-watch__instability--${view.watchItem.priorityInstabilityTrigger.state}"><b>Stable jusqu’à</b> · ${view.watchItem.priorityInstabilityTrigger.label}: ${view.watchItem.priorityInstabilityTrigger.detail}</small>` : ''}
       <small class="map-world-climate-post-gap-watch__window map-world-climate-post-gap-watch__window--${view.watchItem.priorityInstabilityWindow.state}"><b>Fenêtre instabilité</b> · ${view.watchItem.priorityInstabilityWindow.label}: ${view.watchItem.priorityInstabilityWindow.detail}</small>
+      <small class="map-world-climate-post-gap-watch__after-stabilization map-world-climate-post-gap-watch__after-stabilization--${view.watchItem.afterStabilizationPriority.state}"><b>Après stabilisation</b> · ${view.watchItem.afterStabilizationPriority.label}: ${view.watchItem.afterStabilizationPriority.detail}</small>
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13799,6 +13799,15 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__window--next-check { border: 1px solid rgba(125, 211, 252, 0.32); }
 .map-world-climate-post-gap-watch__window--before-review { border: 1px solid rgba(251, 191, 36, 0.34); }
 .map-world-climate-post-gap-watch__window--none-close { border: 1px solid rgba(148, 163, 184, 0.28); }
+.map-world-climate-post-gap-watch__after-stabilization {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.28);
+}
+.map-world-climate-post-gap-watch__after-stabilization--watch-next { border: 1px solid rgba(125, 211, 252, 0.34); }
+.map-world-climate-post-gap-watch__after-stabilization--neutral-stable { border: 1px solid rgba(74, 222, 128, 0.32); }
+.map-world-climate-post-gap-watch__after-stabilization--unknown { border: 1px solid rgba(148, 163, 184, 0.28); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon: Résout #1620.

Résumé:
- ajoute une ligne "Après stabilisation" à la veille climat post-action pour indiquer la prochaine priorité surveillable quand elle est fiable;
- garde un état neutre/stable ou indéterminé quand la priorité suivante ne peut pas être promise;
- ajoute les styles et assertions UI associées.

Validations:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check
- npm test