### PR TITLE
Beta: Explain safe delivery route slack

### DIFF
--- a/src/ui/economy/buildProvinceLogisticsChoicePreview.js
+++ b/src/ui/economy/buildProvinceLogisticsChoicePreview.js
@@ -1225,6 +1225,10 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             state: 'safe',
             label: 'Livraison déjà sûre',
             summary: 'Route déjà sûre: aucune récupération de slack requise pour la prochaine livraison.',
+            nextSafeDelivery: 'prochaine livraison sûre',
+            decisiveSlackSource: 'slack conservé',
+            routeConstraint: 'aucun coût immédiat ne consomme la marge de route',
+            invalidationCondition: 'un nouveau goulot devient prioritaire ou consomme la marge conservée',
           },
         };
       }
@@ -1264,6 +1268,14 @@ function buildAdjacentRouteSpilloverRisk(priorityAction, routeChoices) {
             ? `Lever ${primaryConsumer.label} d’abord: ${primaryConsumer.blockerReason ?? primaryConsumer.reason} empêche encore la prochaine livraison sûre.`
             : `Récupérer ${primaryConsumer.label} rend la prochaine livraison sûre avant ${nextConsumer?.label ?? 'une autre contrainte'}.`),
           recovery: primaryConsumer.label,
+          nextSafeDelivery: nextConsumer?.label ?? 'prochaine livraison sûre',
+          decisiveSlackSource: primaryConsumer.label,
+          routeConstraint: primaryConsumer.tone === 'blocked'
+            ? `${primaryConsumer.label} reste sous le seuil de slack: ${primaryConsumer.blockerReason ?? primaryConsumer.reason}`
+            : `${primaryConsumer.label} garde assez de slack avant ${nextConsumer?.label ?? 'la prochaine contrainte'}`,
+          invalidationCondition: nextConsumer
+            ? `${nextConsumer.label} consomme la marge suivante ou passe critique avant ${primaryConsumer.label}`
+            : `${primaryConsumer.label} redevient bloquant ou un nouveau consommateur apparaît avant la livraison`,
         },
       };
     };

--- a/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/buildProvinceLogisticsChoicePreview.test.js
@@ -158,6 +158,9 @@ test('buildProvinceLogisticsChoicePreview ranks the most constrained route as re
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.summary, /Hill Spur consommerait ensuite le slack/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.state, 'recoverable');
   assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.summary, /Récupérer Outils libère Hill Spur/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.decisiveSlackSource, 'Outils');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.routeConstraint, /Outils garde assez de slack avant Hill Spur/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.invalidationCondition, /Hill Spur consomme la marge suivante|passe critique/);
   assert.ok(Array.isArray(preview.adjacentRouteSpilloverRisk.secondaryRoutes));
   assert.equal(preview.primaryLogisticsAction.actionId, preview.priorityActions[0].actionId);
   assert.match(preview.primaryLogisticsAction.label, /Ember Line|Hill Spur|Safe Road/);
@@ -268,6 +271,9 @@ test('buildProvinceLogisticsChoicePreview marks multi-guard spillover as chainab
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.nextLikelyConsumer.summary, /aucun choix logistique significatif/);
   assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.state, 'insufficient');
   assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.summary, /Lever Safe Road d’abord/);
+  assert.equal(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.decisiveSlackSource, 'Safe Road');
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.routeConstraint, /Safe Road reste sous le seuil de slack/);
+  assert.match(preview.adjacentRouteSpilloverRisk.guardOpportunityCost.fallbackAction.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.invalidationCondition, /Safe Road redevient bloquant|nouveau consommateur/);
 });
 
 test('buildProvinceLogisticsChoicePreview returns an empty state when no route is linked', () => {

--- a/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
+++ b/test/ui/economy/webProvinceLogisticsChoicePreview.test.js
@@ -138,6 +138,9 @@ test('playable province detail renders compact logistics route causes', () => {
   assert.match(webAppSource, /nextLikelyConsumer/);
   assert.match(webAppSource, /province-logistics-spillover-safe-delivery-unlock/);
   assert.match(webAppSource, /safeDeliveryUnlock/);
+  assert.match(webAppSource, /province-logistics-spillover-safe-delivery-rationale/);
+  assert.match(webAppSource, /Slack décisif:/);
+  assert.match(webAppSource, /invalidationCondition/);
   assert.match(webAppSource, /Continuer la chaîne reste acceptable/);
   assert.match(webAppSource, /province-logistics-queue-action/);
   assert.match(webAppSource, /Action carte/);

--- a/web/app.js
+++ b/web/app.js
@@ -8912,6 +8912,7 @@ function renderProvinceLogisticsChoicePreview(province, economyView) {
                         ` : ''}
                         ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock ? `
                           <small class="province-logistics-spillover-safe-delivery-unlock province-logistics-spillover-safe-delivery-unlock--${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.state}">${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.summary}</small>
+                          <small class="province-logistics-spillover-safe-delivery-rationale">Slack décisif: ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.decisiveSlackSource} · Contrainte: ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.routeConstraint} · Invalide si ${preview.adjacentRouteSpilloverRisk.guardDecisionSummary.fallbackJustification.primaryReturnSignal.routeSlack.slackConsumerHint.safeDeliveryUnlock.invalidationCondition}</small>
                         ` : ''}
                       ` : ''}
                     ` : ''}

--- a/web/styles.css
+++ b/web/styles.css
@@ -14875,3 +14875,9 @@ button { font: inherit; }
 .atlas-military-neighbor-front-shift-row--rechute circle { fill: rgba(251, 113, 133, 0.88); }
 .atlas-military-neighbor-front-shift-row--fragilise .atlas-military-neighbor-front-shift-row__reason,
 .atlas-military-neighbor-front-shift-row--rechute .atlas-military-neighbor-front-shift-row__reason { fill: #fecdd3; }
+
+.province-logistics-spillover-safe-delivery-rationale {
+  display: block;
+  margin-top: 0.25rem;
+  color: #bae6fd;
+}


### PR DESCRIPTION
Beta: ## Summary
- Add explicit safe-delivery rationale fields for route slack: decisive slack source, remaining constraint, and first invalidation condition.
- Render the rationale on the province logistics map cue so the player sees why the next delivery is still safe without opening extra panels.
- Cover recoverable and insufficient slack cases in focused economy UI tests.

Fixes #1627

## Validation
- node --check src/ui/economy/buildProvinceLogisticsChoicePreview.js
- node --check web/app.js
- node --test test/ui/economy/buildProvinceLogisticsChoicePreview.test.js test/ui/economy/webProvinceLogisticsChoicePreview.test.js
- git diff --check
- npm test
