### PR TITLE
Alpha: MAP-A48 show light front pressure source

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -513,3 +513,18 @@ test('atlas military shows the next light front risk after buffer is spent', () 
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__next-risk--risky/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__next-risk--quiet/);
 });
+
+// MAP-A48: after the light-front buffer is spent, name the next pressure
+// source directly on the map instead of repeating the buffer-risk wording.
+test('atlas military shows the next pressure source after light front buffer is spent', () => {
+  assert.match(webAppSource, /const lightFollowUpPressureSource = lightFollowUpNextRisk/);
+  assert.match(webAppSource, /label: `Source suivante: \$\{sourceLabel\}`/);
+  assert.match(webAppSource, /surveiller \$\{sourceTrigger\} · préparer \$\{sourceAction\}/);
+  assert.match(webAppSource, /label: 'Source suivante: aucune pression'/);
+  assert.match(webAppSource, /état sûr tant que \$\{residualRisk\?\.provinceLabel \?\? alternative\.provinceLabel \?\? 'front voisin'\} reste stable/);
+  assert.match(webAppSource, /lightFollowUpPressureSource,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpPressureSource \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure-source/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpPressureSource \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 17\.35 : 16/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--watch/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2785,6 +2785,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpPressure: null,
       lightFollowUpRiskWindow: null,
       lightFollowUpNextRisk: null,
+      lightFollowUpPressureSource: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2942,6 +2943,24 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
         detail: 'aucun risque imminent calculable',
       }
     : null;
+  const lightFollowUpPressureSource = lightFollowUpNextRisk
+    ? lightFollowUpNextRisk.tone === 'risky'
+      ? (() => {
+        const sourceLabel = residualRisk?.provinceLabel ?? prepEntry?.option?.provinceLabel ?? alternative.provinceLabel ?? 'front voisin';
+        const sourceTrigger = residualRisk?.detail ?? prepUnlock?.unlocks ?? alternative.minimumCondition ?? 'nouveau signal visible';
+        const sourceAction = residualRisk?.action ?? prepUnlock?.action ?? alternative.action ?? 'observer léger';
+        return {
+          tone: 'watch',
+          label: `Source suivante: ${sourceLabel}`,
+          detail: `surveiller ${sourceTrigger} · préparer ${sourceAction}`,
+        };
+      })()
+      : {
+        tone: 'quiet',
+        label: 'Source suivante: aucune pression',
+        detail: `état sûr tant que ${residualRisk?.provinceLabel ?? alternative.provinceLabel ?? 'front voisin'} reste stable`,
+      }
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -2958,6 +2977,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpPressure: null,
       lightFollowUpRiskWindow: null,
       lightFollowUpNextRisk: null,
+      lightFollowUpPressureSource: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2976,6 +2996,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     lightFollowUpPressure,
     lightFollowUpRiskWindow,
     lightFollowUpNextRisk,
+    lightFollowUpPressureSource,
   };
 }
 
@@ -3232,7 +3253,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3245,6 +3266,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.lightFollowUpPressure ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure atlas-military-neighbor-blocked-follow-up-ladder__pressure--${ladder.lightFollowUpPressure.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 12.15 : 10.8)}">${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}</text>` : ''}
       ${ladder.lightFollowUpRiskWindow ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__risk-window atlas-military-neighbor-blocked-follow-up-ladder__risk-window--${ladder.lightFollowUpRiskWindow.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 13.5 : 12.15)}">${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}</text>` : ''}
       ${ladder.lightFollowUpNextRisk ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__next-risk atlas-military-neighbor-blocked-follow-up-ladder__next-risk--${ladder.lightFollowUpNextRisk.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 14.85 : 13.5)}">${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}</text>` : ''}
+      ${ladder.lightFollowUpPressureSource ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure-source atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--${ladder.lightFollowUpPressureSource.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 16.2 : 14.85)}">${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3283,7 +3305,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14787,7 +14787,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__defer,
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure,
 .atlas-military-neighbor-blocked-follow-up-ladder__risk-window,
-.atlas-military-neighbor-blocked-follow-up-ladder__next-risk {
+.atlas-military-neighbor-blocked-follow-up-ladder__next-risk,
+.atlas-military-neighbor-blocked-follow-up-ladder__pressure-source {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14809,6 +14810,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__risk-window--quiet { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-ladder__next-risk--risky { fill: #fca5a5; }
 .atlas-military-neighbor-blocked-follow-up-ladder__next-risk--quiet { fill: #cbd5e1; }
+.atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--watch { fill: #fdba74; }
+.atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--quiet { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements MAP-A48 for issue #1626.

Summary:
- Adds a compact map cue naming the next light-front pressure source after the buffer is spent.
- Distinguishes risky next-source pressure from the neutral safe state.
- Extends the ladder rendering, accessible label, sizing, and source-level UI contract test.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test