### PR TITLE
Delta: Show missed residual cleanup fallback

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1297,6 +1297,35 @@ export function buildMiniPlanPrematureReengagementRisk(miniPlanFirstSafeReengage
   };
 }
 
+function buildMissedTimingFallback(topChoice, followUpChoices, firstCleanupPayoff) {
+  if (!topChoice) return null;
+
+  const fallbackChoice = followUpChoices.find((choice) => choice.cleanupOrderId !== topChoice.cleanupOrderId
+    && choice.residualRiskKey !== topChoice.residualRiskKey) ?? null;
+
+  if (!fallbackChoice) {
+    return {
+      available: false,
+      secondary: true,
+      label: 'Fallback non prioritaire',
+      timing: 'si la fenêtre sûre est manquée, relire au prochain tour/action',
+      action: 'recontrôler le risque résiduel avant nouvelle escalade',
+      reason: 'aucun second cleanup sûr classé',
+      targetId: topChoice.targetId ?? firstCleanupPayoff?.targetId ?? null,
+    };
+  }
+
+  return {
+    available: true,
+    secondary: true,
+    label: 'Fallback si fenêtre manquée',
+    timing: 'après la fenêtre sûre, avant nouvelle action majeure',
+    action: fallbackChoice.cleanupOrderLabel ?? 'cleanup de secours',
+    reason: fallbackChoice.expectedBenefit ?? fallbackChoice.rankReason ?? 'réduit un risque résiduel secondaire',
+    targetId: fallbackChoice.targetId ?? topChoice.targetId ?? firstCleanupPayoff?.targetId ?? null,
+  };
+}
+
 function cleanupTimingFallback() {
   return {
     empty: true,
@@ -1315,6 +1344,7 @@ function cleanupTimingFallback() {
       targetId: null,
     },
     fallbackMessage: 'Fallback: aucune fenêtre sûre de cleanup résiduel n’est déterminable.',
+    missedTimingFallback: null,
   };
 }
 
@@ -1331,6 +1361,7 @@ export function buildResidualIntrigueCleanupTiming(
     'StrategicMapShell followUpCleanupChoices',
   );
   const topChoice = normalizedChoices[0] ?? null;
+  const missedTimingFallback = buildMissedTimingFallback(topChoice, normalizedChoices, firstCleanupPayoff);
   const readinessState = String(topFollowUpReadiness?.state ?? '').trim();
   const prematureState = String(miniPlanPrematureReengagementRisk?.state ?? '').trim();
   const consequence = firstCleanupPayoff.remainingRiskState === 'no-visible-risk'
@@ -1355,6 +1386,7 @@ export function buildResidualIntrigueCleanupTiming(
         targetId: firstCleanupPayoff.targetId ?? null,
       },
       fallbackMessage: null,
+      missedTimingFallback: null,
     };
   }
 
@@ -1376,6 +1408,7 @@ export function buildResidualIntrigueCleanupTiming(
         targetId: firstCleanupPayoff.targetId ?? null,
       },
       fallbackMessage: 'Fallback: aucune fenêtre sûre précise n’est déterminable; relire au prochain signal.',
+      missedTimingFallback: null,
     };
   }
 
@@ -1402,6 +1435,7 @@ export function buildResidualIntrigueCleanupTiming(
         targetId: topChoice.targetId ?? firstCleanupPayoff.targetId ?? null,
       },
       fallbackMessage: null,
+      missedTimingFallback,
     };
   }
 
@@ -1423,6 +1457,7 @@ export function buildResidualIntrigueCleanupTiming(
         targetId: topChoice.targetId ?? firstCleanupPayoff.targetId ?? null,
       },
       fallbackMessage: null,
+      missedTimingFallback,
     };
   }
 
@@ -1443,6 +1478,7 @@ export function buildResidualIntrigueCleanupTiming(
       targetId: topChoice.targetId ?? firstCleanupPayoff.targetId ?? null,
     },
     fallbackMessage: null,
+    missedTimingFallback,
   };
 }
 

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -1353,6 +1353,7 @@ test('StrategicMapShell shows the safest residual intrigue cleanup timing', () =
     residualRisks: [
       { key: 'supply-pressure:front-a', label: 'pression ravitaillement', reason: 'approvisionnement tendu' },
       { key: 'watch:front-a', label: 'attention résiduelle', reason: 'alerte diffuse' },
+      { key: 'low-loyalty:front-a', label: 'loyauté basse', reason: 'liaison locale fragile' },
     ],
     cleanupOrders: [
       {
@@ -1369,6 +1370,14 @@ test('StrategicMapShell shows the safest residual intrigue cleanup timing', () =
         expectedBenefit: 'retire le signal sans escalade',
         safetyScore: 50,
       },
+      {
+        id: 'cleanup:liaison',
+        label: 'Liaison locale de secours',
+        residualRiskKey: 'low-loyalty:front-a',
+        riskReduced: 'loyauté basse',
+        expectedBenefit: 'contient le résiduel si le timing idéal passe',
+        safetyScore: 44,
+      },
     ],
   });
 
@@ -1381,7 +1390,7 @@ test('StrategicMapShell shows the safest residual intrigue cleanup timing', () =
     nextSafeWindow: 'maintenant, avant de consommer une autre action majeure',
     timingHint: 'Dissiper attention résiduelle: retire le signal sans escalade.',
     recommendation: 'nettoyer maintenant',
-    sourceConsequence: '1 risque résiduel après Nettoyer convoi initial.',
+    sourceConsequence: '2 risques résiduels après Nettoyer convoi initial.',
     mapSignal: {
       visible: true,
       badge: 'cleanup sûr',
@@ -1389,6 +1398,15 @@ test('StrategicMapShell shows the safest residual intrigue cleanup timing', () =
       targetId: 'front-a',
     },
     fallbackMessage: null,
+    missedTimingFallback: {
+      available: true,
+      secondary: true,
+      label: 'Fallback si fenêtre manquée',
+      timing: 'après la fenêtre sûre, avant nouvelle action majeure',
+      action: 'Liaison locale de secours',
+      reason: 'contient le résiduel si le timing idéal passe',
+      targetId: 'front-a',
+    },
   });
 });
 
@@ -1432,6 +1450,15 @@ test('StrategicMapShell marks residual intrigue cleanup as premature until the b
       targetId: 'front-b',
     },
     fallbackMessage: null,
+    missedTimingFallback: {
+      available: false,
+      secondary: true,
+      label: 'Fallback non prioritaire',
+      timing: 'si la fenêtre sûre est manquée, relire au prochain tour/action',
+      action: 'recontrôler le risque résiduel avant nouvelle escalade',
+      reason: 'aucun second cleanup sûr classé',
+      targetId: 'front-b',
+    },
   });
 });
 
@@ -1453,6 +1480,7 @@ test('StrategicMapShell provides a clear fallback when no cleanup timing is dete
       targetId: null,
     },
     fallbackMessage: 'Fallback: aucune fenêtre sûre de cleanup résiduel n’est déterminable.',
+    missedTimingFallback: null,
   });
 });
 


### PR DESCRIPTION
Delta: Implements #1629.

Summary:
- Adds a secondary `missedTimingFallback` cue to residual intrigue cleanup timing.
- Shows a next-best fallback only when a cleanup timing choice exists, keeping it marked as secondary.
- Preserves existing safest timing, deferral consequence, and unknown fallback wording.

Tests:
- npm test