### PR TITLE
Epsilon: Explain climate priority ordering

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -47,6 +47,11 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /Fin changement priorité/);
   assert.match(webAppSource, /afterStabilizationPriority/);
   assert.match(webAppSource, /Après stabilisation/);
+  assert.match(webAppSource, /priorityOrderingRationale/);
+  assert.match(webAppSource, /Pourquoi premier/);
+  assert.match(webAppSource, /seuil primaire atteint/);
+  assert.match(webAppSource, /passe devant: pression/);
+  assert.match(webAppSource, /dauphin/);
   assert.match(webAppSource, /après stabilisation: surveiller/);
   assert.match(webAppSource, /aucune priorité suivante fiable sans nouveau signal climat/);
   assert.match(webAppSource, /attendre un signal mesurable avant de promettre la prochaine priorité/);
@@ -146,6 +151,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-stabilization--watch-next/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-stabilization--neutral-stable/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-stabilization--unknown/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ordering/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ordering--threshold-first/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ordering--margin-first/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ordering--runner-up-clear/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);

--- a/web/app.js
+++ b/web/app.js
@@ -14660,6 +14660,24 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
         label: 'priorité indéterminée',
         detail: 'après stabilisation: attendre un signal mesurable avant de promettre la prochaine priorité',
       };
+  const orderingRunnerUp = nextSecondaryGap
+    ? `${nextSecondaryGap.label} (${nextSecondaryGap.nearestThresholdScore})`
+    : protectedSecondary
+      ? `${protectedSecondary.label} protégé`
+      : 'aucun watch proche';
+  const priorityOrderingRationale = {
+    state: watchGap.nearestThresholdScore >= 80
+      ? 'threshold-first'
+      : watchMargin?.state === 'tight' || watchMargin?.state === 'short'
+        ? 'margin-first'
+        : 'runner-up-clear',
+    label: watchGap.nearestThresholdScore >= 80
+      ? 'seuil primaire atteint'
+      : `marge ${primaryPromotionMargin ?? 'inconnue'}`,
+    detail: Number.isFinite(primaryPromotionMargin)
+      ? `${watchGap.label} passe devant: pression ${watchGap.nearestThresholdScore}, marge ${primaryPromotionMargin} avant primaire; dauphin ${orderingRunnerUp}`
+      : `${watchGap.label} passe devant: pression lisible, dauphin ${orderingRunnerUp}`,
+  };
 
   return {
     state: 'watch',
@@ -14683,6 +14701,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       priorityInstabilityTrigger,
       priorityInstabilityWindow,
       afterStabilizationPriority,
+      priorityOrderingRationale,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14732,6 +14751,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       ${view.watchItem.priorityInstabilityTrigger ? `<small class="map-world-climate-post-gap-watch__instability map-world-climate-post-gap-watch__instability--${view.watchItem.priorityInstabilityTrigger.state}"><b>Stable jusqu’à</b> · ${view.watchItem.priorityInstabilityTrigger.label}: ${view.watchItem.priorityInstabilityTrigger.detail}</small>` : ''}
       <small class="map-world-climate-post-gap-watch__window map-world-climate-post-gap-watch__window--${view.watchItem.priorityInstabilityWindow.state}"><b>Fenêtre instabilité</b> · ${view.watchItem.priorityInstabilityWindow.label}: ${view.watchItem.priorityInstabilityWindow.detail}</small>
       <small class="map-world-climate-post-gap-watch__after-stabilization map-world-climate-post-gap-watch__after-stabilization--${view.watchItem.afterStabilizationPriority.state}"><b>Après stabilisation</b> · ${view.watchItem.afterStabilizationPriority.label}: ${view.watchItem.afterStabilizationPriority.detail}</small>
+      <small class="map-world-climate-post-gap-watch__ordering map-world-climate-post-gap-watch__ordering--${view.watchItem.priorityOrderingRationale.state}"><b>Pourquoi premier</b> · ${view.watchItem.priorityOrderingRationale.label}: ${view.watchItem.priorityOrderingRationale.detail}</small>
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13808,6 +13808,15 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__after-stabilization--watch-next { border: 1px solid rgba(125, 211, 252, 0.34); }
 .map-world-climate-post-gap-watch__after-stabilization--neutral-stable { border: 1px solid rgba(74, 222, 128, 0.32); }
 .map-world-climate-post-gap-watch__after-stabilization--unknown { border: 1px solid rgba(148, 163, 184, 0.28); }
+.map-world-climate-post-gap-watch__ordering {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(8, 47, 73, 0.26);
+}
+.map-world-climate-post-gap-watch__ordering--threshold-first { border: 1px solid rgba(251, 191, 36, 0.36); }
+.map-world-climate-post-gap-watch__ordering--margin-first { border: 1px solid rgba(125, 211, 252, 0.34); }
+.map-world-climate-post-gap-watch__ordering--runner-up-clear { border: 1px solid rgba(74, 222, 128, 0.32); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon: Résout #1630.

Résumé:
- ajoute un cue compact "Pourquoi premier" distinct du message MAP-E46 "Après stabilisation";
- expose le seuil ou la marge décisive qui place la prochaine priorité climat devant les autres watches;
- affiche seulement le dauphin le plus proche pour éviter une liste longue.

Validations:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check
- npm test