### PR TITLE
Alpha: MAP-A49 show light pressure countermeasure

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -528,3 +528,21 @@ test('atlas military shows the next pressure source after light front buffer is 
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--watch/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--quiet/);
 });
+
+// MAP-A49: once a next light-front pressure source is visible, show the first
+// direct countermeasure or a quiet fallback if none is reliable.
+test('atlas military shows first countermeasure for next light front pressure source', () => {
+  assert.match(webAppSource, /const lightFollowUpCountermeasure = lightFollowUpPressureSource/);
+  assert.match(webAppSource, /label: 'Contre-mesure: agir'/);
+  assert.match(webAppSource, /label: 'Contre-mesure: préparer'/);
+  assert.match(webAppSource, /label: 'Contre-mesure: veille'/);
+  assert.match(webAppSource, /label: 'Contre-mesure: non fiable'/);
+  assert.match(webAppSource, /label: 'Contre-mesure: en attente'/);
+  assert.match(webAppSource, /lightFollowUpCountermeasure,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpCountermeasure \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpCountermeasure \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 18\.7 : 17\.35/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--ready/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--prep/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--watch/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2786,6 +2786,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpRiskWindow: null,
       lightFollowUpNextRisk: null,
       lightFollowUpPressureSource: null,
+      lightFollowUpCountermeasure: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2961,6 +2962,43 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
         detail: `état sûr tant que ${residualRisk?.provinceLabel ?? alternative.provinceLabel ?? 'front voisin'} reste stable`,
       }
     : null;
+  const lightFollowUpCountermeasure = lightFollowUpPressureSource
+    ? lightFollowUpPressureSource.tone === 'watch'
+      ? (() => {
+        const readyAction = playableEntry?.option?.nextAction ?? (alternative.viabilityStatus === 'ready' ? alternative.action : null);
+        if (readyAction) {
+          return {
+            tone: 'ready',
+            label: 'Contre-mesure: agir',
+            detail: readyAction,
+          };
+        }
+        if (prepUnlock?.action) {
+          return {
+            tone: 'prep',
+            label: 'Contre-mesure: préparer',
+            detail: `${prepUnlock.action} · ${prepUnlock.unlocks}`,
+          };
+        }
+        if (residualRisk?.action) {
+          return {
+            tone: 'watch',
+            label: 'Contre-mesure: veille',
+            detail: residualRisk.action,
+          };
+        }
+        return {
+          tone: 'quiet',
+          label: 'Contre-mesure: non fiable',
+          detail: 'aucune action courte calculable',
+        };
+      })()
+      : {
+        tone: 'quiet',
+        label: 'Contre-mesure: en attente',
+        detail: 'aucune préparation requise tant que la source reste stable',
+      }
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -2978,6 +3016,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpRiskWindow: null,
       lightFollowUpNextRisk: null,
       lightFollowUpPressureSource: null,
+      lightFollowUpCountermeasure: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -2997,6 +3036,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     lightFollowUpRiskWindow,
     lightFollowUpNextRisk,
     lightFollowUpPressureSource,
+    lightFollowUpCountermeasure,
   };
 }
 
@@ -3253,7 +3293,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}${ladder.lightFollowUpCountermeasure ? `; ${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3267,6 +3307,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.lightFollowUpRiskWindow ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__risk-window atlas-military-neighbor-blocked-follow-up-ladder__risk-window--${ladder.lightFollowUpRiskWindow.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 13.5 : 12.15)}">${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}</text>` : ''}
       ${ladder.lightFollowUpNextRisk ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__next-risk atlas-military-neighbor-blocked-follow-up-ladder__next-risk--${ladder.lightFollowUpNextRisk.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 14.85 : 13.5)}">${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}</text>` : ''}
       ${ladder.lightFollowUpPressureSource ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure-source atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--${ladder.lightFollowUpPressureSource.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 16.2 : 14.85)}">${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}</text>` : ''}
+      ${ladder.lightFollowUpCountermeasure ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--${ladder.lightFollowUpCountermeasure.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 17.55 : 16.2)}">${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3305,7 +3346,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpCountermeasure ? preview.blockedFollowUpLadder?.remainingWatch ? 18.7 : 17.35 : preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14797,7 +14797,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure,
 .atlas-military-neighbor-blocked-follow-up-ladder__risk-window,
 .atlas-military-neighbor-blocked-follow-up-ladder__next-risk,
-.atlas-military-neighbor-blocked-follow-up-ladder__pressure-source {
+.atlas-military-neighbor-blocked-follow-up-ladder__pressure-source,
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14821,6 +14822,10 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__next-risk--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--watch { fill: #fdba74; }
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--quiet { fill: #bbf7d0; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--ready { fill: #86efac; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--prep { fill: #fde68a; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--watch { fill: #fdba74; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements MAP-A49 for issue #1636.

Summary:
- Adds a compact countermeasure cue for the next light-front pressure source.
- Distinguishes immediately available action, prep/watch follow-up, and quiet fallback states.
- Extends map rendering, aria copy, sizing, styles, and the source-level UI contract test.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test