### PR TITLE
Epsilon: Show climate ranking change trigger

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -49,6 +49,11 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /Après stabilisation/);
   assert.match(webAppSource, /priorityOrderingRationale/);
   assert.match(webAppSource, /Pourquoi premier/);
+  assert.match(webAppSource, /priorityRankingChangeCue/);
+  assert.match(webAppSource, /Ce qui changerait/);
+  assert.match(webAppSource, /bascule proche/);
+  assert.match(webAppSource, /classement stable/);
+  assert.match(webAppSource, /aucun basculement proche/);
   assert.match(webAppSource, /seuil primaire atteint/);
   assert.match(webAppSource, /passe devant: pression/);
   assert.match(webAppSource, /dauphin/);
@@ -155,6 +160,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ordering--threshold-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ordering--margin-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ordering--runner-up-clear/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rank-change/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rank-change--rival-close/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rank-change--margin-fragile/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rank-change--stable-ranking/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);

--- a/web/app.js
+++ b/web/app.js
@@ -14679,6 +14679,26 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       ? `${watchGap.label} passe devant: pression ${watchGap.nearestThresholdScore}, marge ${primaryPromotionMargin} avant primaire; dauphin ${orderingRunnerUp}`
       : `${watchGap.label} passe devant: pression lisible, dauphin ${orderingRunnerUp}`,
   };
+  const runnerUpGap = nextSecondaryGap && Number.isFinite(nextSecondaryGap.nearestThresholdScore)
+    ? Math.max(0, watchGap.nearestThresholdScore - nextSecondaryGap.nearestThresholdScore)
+    : null;
+  const priorityRankingChangeCue = runnerUpGap !== null && runnerUpGap <= 15
+    ? {
+      state: 'rival-close',
+      label: 'bascule proche',
+      detail: `${nextSecondaryGap.label} peut passer premier si l’écart ${runnerUpGap} se ferme au prochain check`,
+    }
+    : Number.isFinite(primaryPromotionMargin) && primaryPromotionMargin <= 5
+      ? {
+        state: 'margin-fragile',
+        label: 'marge fragile',
+        detail: `${watchGap.label} perd sa place si la pression retombe sous le seuil primaire au prochain check`,
+      }
+      : {
+        state: 'stable-ranking',
+        label: 'classement stable',
+        detail: `aucun basculement proche: ${orderingRunnerUp} ne menace pas ${watchGap.label} sans nouveau signal`,
+      };
 
   return {
     state: 'watch',
@@ -14703,6 +14723,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       priorityInstabilityWindow,
       afterStabilizationPriority,
       priorityOrderingRationale,
+      priorityRankingChangeCue,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14753,6 +14774,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small class="map-world-climate-post-gap-watch__window map-world-climate-post-gap-watch__window--${view.watchItem.priorityInstabilityWindow.state}"><b>Fenêtre instabilité</b> · ${view.watchItem.priorityInstabilityWindow.label}: ${view.watchItem.priorityInstabilityWindow.detail}</small>
       <small class="map-world-climate-post-gap-watch__after-stabilization map-world-climate-post-gap-watch__after-stabilization--${view.watchItem.afterStabilizationPriority.state}"><b>Après stabilisation</b> · ${view.watchItem.afterStabilizationPriority.label}: ${view.watchItem.afterStabilizationPriority.detail}</small>
       <small class="map-world-climate-post-gap-watch__ordering map-world-climate-post-gap-watch__ordering--${view.watchItem.priorityOrderingRationale.state}"><b>Pourquoi premier</b> · ${view.watchItem.priorityOrderingRationale.label}: ${view.watchItem.priorityOrderingRationale.detail}</small>
+      <small class="map-world-climate-post-gap-watch__rank-change map-world-climate-post-gap-watch__rank-change--${view.watchItem.priorityRankingChangeCue.state}"><b>Ce qui changerait</b> · ${view.watchItem.priorityRankingChangeCue.label}: ${view.watchItem.priorityRankingChangeCue.detail}</small>
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13817,6 +13817,15 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__ordering--threshold-first { border: 1px solid rgba(251, 191, 36, 0.36); }
 .map-world-climate-post-gap-watch__ordering--margin-first { border: 1px solid rgba(125, 211, 252, 0.34); }
 .map-world-climate-post-gap-watch__ordering--runner-up-clear { border: 1px solid rgba(74, 222, 128, 0.32); }
+.map-world-climate-post-gap-watch__rank-change {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(30, 41, 59, 0.28);
+}
+.map-world-climate-post-gap-watch__rank-change--rival-close { border: 1px solid rgba(251, 191, 36, 0.36); }
+.map-world-climate-post-gap-watch__rank-change--margin-fragile { border: 1px solid rgba(248, 113, 113, 0.34); }
+.map-world-climate-post-gap-watch__rank-change--stable-ranking { border: 1px solid rgba(74, 222, 128, 0.3); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon: Résout #1640.

Résumé:
- ajoute un cue compact "Ce qui changerait" après l’explication MAP-E47;
- indique le rival proche ou la marge fragile qui pourrait faire perdre la première place à la priorité climat;
- garde un état stable quand aucun basculement proche n’est lisible, sans créer de liste de ranking.

Validations:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check
- npm test