### PR TITLE
Delta: Show residual cleanup fallback wait cost

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1326,6 +1326,68 @@ function buildMissedTimingFallback(topChoice, followUpChoices, firstCleanupPayof
   };
 }
 
+function buildResidualFallbackWaitCost(topChoice, missedTimingFallback, topFollowUpReadiness, miniPlanPrematureReengagementRisk) {
+  if (!topChoice || !missedTimingFallback) return null;
+
+  if (!missedTimingFallback.available) {
+    return {
+      level: 'recheck-risk',
+      label: 'Risque de recheck',
+      summary: 'attendre force une relecture avant nouvelle escalade',
+      secondary: true,
+    };
+  }
+
+  const readinessState = String(topFollowUpReadiness?.state ?? '').trim();
+  const prematureState = String(miniPlanPrematureReengagementRisk?.state ?? '').trim();
+  const blocker = String(topFollowUpReadiness?.blocker ?? '').trim();
+  const action = String(topFollowUpReadiness?.action ?? topChoice.cleanupOrderLabel ?? 'l’action suivante').trim()
+    || 'l’action suivante';
+
+  if (readinessState && readinessState !== 'ready-now') {
+    return {
+      level: 'blocks-next-action',
+      label: 'Action suivante bloquée',
+      summary: `attendre le fallback laisse ${blocker || 'le prérequis'} bloquer ${action}`,
+      secondary: true,
+    };
+  }
+
+  if (prematureState === 'partial-window') {
+    return {
+      level: 'minor-loss',
+      label: 'Perte mineure',
+      summary: 'attendre le fallback réduit la fenêtre principale mais garde un suivi limité',
+      secondary: true,
+    };
+  }
+
+  if (prematureState === 'too-early') {
+    return {
+      level: 'blocks-next-action',
+      label: 'Action suivante bloquée',
+      summary: `attendre le fallback retarde ${miniPlanPrematureReengagementRisk?.nextSafe ?? action}`,
+      secondary: true,
+    };
+  }
+
+  if (Number.isFinite(topChoice.safetyScore) && topChoice.safetyScore > 0) {
+    return {
+      level: 'minor-loss',
+      label: 'Perte mineure',
+      summary: `attendre le fallback perd le meilleur score sûr (${topChoice.safetyScore})`,
+      secondary: true,
+    };
+  }
+
+  return {
+    level: 'unknown-cost',
+    label: 'Coût inconnu',
+    summary: 'coût relatif non déterminable avec les signaux actuels',
+    secondary: true,
+  };
+}
+
 function cleanupTimingFallback() {
   return {
     empty: true,
@@ -1345,6 +1407,7 @@ function cleanupTimingFallback() {
     },
     fallbackMessage: 'Fallback: aucune fenêtre sûre de cleanup résiduel n’est déterminable.',
     missedTimingFallback: null,
+    fallbackWaitCost: null,
   };
 }
 
@@ -1362,6 +1425,12 @@ export function buildResidualIntrigueCleanupTiming(
   );
   const topChoice = normalizedChoices[0] ?? null;
   const missedTimingFallback = buildMissedTimingFallback(topChoice, normalizedChoices, firstCleanupPayoff);
+  const fallbackWaitCost = buildResidualFallbackWaitCost(
+    topChoice,
+    missedTimingFallback,
+    topFollowUpReadiness,
+    miniPlanPrematureReengagementRisk,
+  );
   const readinessState = String(topFollowUpReadiness?.state ?? '').trim();
   const prematureState = String(miniPlanPrematureReengagementRisk?.state ?? '').trim();
   const consequence = firstCleanupPayoff.remainingRiskState === 'no-visible-risk'
@@ -1387,6 +1456,7 @@ export function buildResidualIntrigueCleanupTiming(
       },
       fallbackMessage: null,
       missedTimingFallback: null,
+      fallbackWaitCost: null,
     };
   }
 
@@ -1409,6 +1479,7 @@ export function buildResidualIntrigueCleanupTiming(
       },
       fallbackMessage: 'Fallback: aucune fenêtre sûre précise n’est déterminable; relire au prochain signal.',
       missedTimingFallback: null,
+      fallbackWaitCost: null,
     };
   }
 
@@ -1436,6 +1507,7 @@ export function buildResidualIntrigueCleanupTiming(
       },
       fallbackMessage: null,
       missedTimingFallback,
+      fallbackWaitCost,
     };
   }
 
@@ -1458,6 +1530,7 @@ export function buildResidualIntrigueCleanupTiming(
       },
       fallbackMessage: null,
       missedTimingFallback,
+      fallbackWaitCost,
     };
   }
 
@@ -1479,6 +1552,7 @@ export function buildResidualIntrigueCleanupTiming(
     },
     fallbackMessage: null,
     missedTimingFallback,
+    fallbackWaitCost,
   };
 }
 

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -1407,6 +1407,12 @@ test('StrategicMapShell shows the safest residual intrigue cleanup timing', () =
       reason: 'contient le résiduel si le timing idéal passe',
       targetId: 'front-a',
     },
+    fallbackWaitCost: {
+      level: 'minor-loss',
+      label: 'Perte mineure',
+      summary: 'attendre le fallback perd le meilleur score sûr (50)',
+      secondary: true,
+    },
   });
 });
 
@@ -1459,6 +1465,59 @@ test('StrategicMapShell marks residual intrigue cleanup as premature until the b
       reason: 'aucun second cleanup sûr classé',
       targetId: 'front-b',
     },
+    fallbackWaitCost: {
+      level: 'recheck-risk',
+      label: 'Risque de recheck',
+      summary: 'attendre force une relecture avant nouvelle escalade',
+      secondary: true,
+    },
+  });
+});
+
+test('StrategicMapShell distinguishes blocked and unknown residual fallback wait costs', () => {
+  const basePayoff = {
+    cleanupOrderLabel: 'Nettoyer convoi initial',
+    riskReduced: 'pression ravitaillement',
+    remainingRiskState: 'residual-risk-remains',
+    remainingRiskCount: 2,
+    targetId: 'front-a',
+  };
+  const choices = [
+    {
+      cleanupOrderId: 'cleanup:route',
+      cleanupOrderLabel: 'Scanner axe détour',
+      residualRiskKey: 'route-exposure:front-b',
+      targetId: 'front-b',
+      prerequisite: 'éclaireurs disponibles',
+    },
+    {
+      cleanupOrderId: 'cleanup:liaison',
+      cleanupOrderLabel: 'Liaison locale de secours',
+      residualRiskKey: 'low-loyalty:front-a',
+      targetId: 'front-a',
+    },
+  ];
+
+  assert.equal(buildResidualIntrigueCleanupTiming(
+    basePayoff,
+    choices,
+    {
+      state: 'needs-logistics',
+      blocker: 'éclaireurs disponibles',
+      action: 'sécuriser le corridor court avant exécution',
+    },
+  ).fallbackWaitCost.summary, 'attendre le fallback laisse éclaireurs disponibles bloquer sécuriser le corridor court avant exécution');
+
+  assert.deepEqual(buildResidualIntrigueCleanupTiming(
+    basePayoff,
+    choices,
+    { state: 'ready-now' },
+    { state: 'ready' },
+  ).fallbackWaitCost, {
+    level: 'unknown-cost',
+    label: 'Coût inconnu',
+    summary: 'coût relatif non déterminable avec les signaux actuels',
+    secondary: true,
   });
 });
 
@@ -1481,6 +1540,7 @@ test('StrategicMapShell provides a clear fallback when no cleanup timing is dete
     },
     fallbackMessage: 'Fallback: aucune fenêtre sûre de cleanup résiduel n’est déterminable.',
     missedTimingFallback: null,
+    fallbackWaitCost: null,
   });
 });
 


### PR DESCRIPTION
Delta: Implements #1639.

Summary:
- Adds a secondary `fallbackWaitCost` cue beside the residual cleanup fallback.
- Distinguishes minor loss, recheck risk, blocked next action, and unknown relative cost from existing cleanup/readiness signals.
- Keeps the fallback and cost cue secondary so the safest cleanup timing remains the primary recommendation.

Tests:
- npm test
- git diff --check