### PR TITLE
Epsilon: Suggest minimal stabilization for fragile climate priority

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -51,6 +51,11 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /Pourquoi premier/);
   assert.match(webAppSource, /priorityRankingChangeCue/);
   assert.match(webAppSource, /Ce qui changerait/);
+  assert.match(webAppSource, /minimalStabilizationAction/);
+  assert.match(webAppSource, /Stabilisation minimale/);
+  assert.match(webAppSource, /stabiliser par/);
+  assert.match(webAppSource, /stabilisation neutre/);
+  assert.match(webAppSource, /aucune action minimale fiable à ajouter/);
   assert.match(webAppSource, /bascule proche/);
   assert.match(webAppSource, /classement stable/);
   assert.match(webAppSource, /aucun basculement proche/);
@@ -164,6 +169,11 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rank-change--rival-close/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rank-change--margin-fragile/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__rank-change--stable-ranking/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__minimal-stabilization/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__minimal-stabilization--action-readable/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__minimal-stabilization--review-readable/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__minimal-stabilization--stable-neutral/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__minimal-stabilization--watch-neutral/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);

--- a/web/app.js
+++ b/web/app.js
@@ -14744,6 +14744,29 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
         label: 'classement stable',
         detail: `aucun basculement proche: ${orderingRunnerUp} ne menace pas ${watchGap.label} sans nouveau signal`,
       };
+  const minimalStabilizationAction = priorityRankingChangeCue.state === 'stable-ranking'
+    ? {
+      state: 'stable-neutral',
+      label: 'stabilisation neutre',
+      detail: 'aucune action minimale fiable à ajouter tant que le classement reste stable',
+    }
+    : secondaryUpkeep.state === 'available'
+      ? {
+        state: 'action-readable',
+        label: 'stabiliser par',
+        detail: `${secondaryUpkeep.action}; garde ${watchGap.label} premier sans transformer la veille en prévention complète`,
+      }
+      : marginRearmReview
+        ? {
+          state: 'review-readable',
+          label: 'stabiliser par',
+          detail: `réarmer review; ${marginRearmReview.detail}`,
+        }
+        : {
+          state: 'watch-neutral',
+          label: 'stabilisation à surveiller',
+          detail: 'aucune action minimale lisible: attendre le prochain check avant de promettre une stabilisation',
+        };
 
   return {
     state: 'watch',
@@ -14769,6 +14792,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       afterStabilizationPriority,
       priorityOrderingRationale,
       priorityRankingChangeCue,
+      minimalStabilizationAction,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14820,6 +14844,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small class="map-world-climate-post-gap-watch__after-stabilization map-world-climate-post-gap-watch__after-stabilization--${view.watchItem.afterStabilizationPriority.state}"><b>Après stabilisation</b> · ${view.watchItem.afterStabilizationPriority.label}: ${view.watchItem.afterStabilizationPriority.detail}</small>
       <small class="map-world-climate-post-gap-watch__ordering map-world-climate-post-gap-watch__ordering--${view.watchItem.priorityOrderingRationale.state}"><b>Pourquoi premier</b> · ${view.watchItem.priorityOrderingRationale.label}: ${view.watchItem.priorityOrderingRationale.detail}</small>
       <small class="map-world-climate-post-gap-watch__rank-change map-world-climate-post-gap-watch__rank-change--${view.watchItem.priorityRankingChangeCue.state}"><b>Ce qui changerait</b> · ${view.watchItem.priorityRankingChangeCue.label}: ${view.watchItem.priorityRankingChangeCue.detail}</small>
+      <small class="map-world-climate-post-gap-watch__minimal-stabilization map-world-climate-post-gap-watch__minimal-stabilization--${view.watchItem.minimalStabilizationAction.state}"><b>Stabilisation minimale</b> · ${view.watchItem.minimalStabilizationAction.label}: ${view.watchItem.minimalStabilizationAction.detail}</small>
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13826,6 +13826,16 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__rank-change--rival-close { border: 1px solid rgba(251, 191, 36, 0.36); }
 .map-world-climate-post-gap-watch__rank-change--margin-fragile { border: 1px solid rgba(248, 113, 113, 0.34); }
 .map-world-climate-post-gap-watch__rank-change--stable-ranking { border: 1px solid rgba(74, 222, 128, 0.3); }
+.map-world-climate-post-gap-watch__minimal-stabilization {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.3);
+}
+.map-world-climate-post-gap-watch__minimal-stabilization--action-readable { border: 1px solid rgba(74, 222, 128, 0.34); }
+.map-world-climate-post-gap-watch__minimal-stabilization--review-readable { border: 1px solid rgba(125, 211, 252, 0.34); }
+.map-world-climate-post-gap-watch__minimal-stabilization--stable-neutral,
+.map-world-climate-post-gap-watch__minimal-stabilization--watch-neutral { border: 1px solid rgba(148, 163, 184, 0.28); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
## Summary
- add a compact "Stabilisation minimale" cue to the climate post-gap watch when ranking is fragile
- reuse existing close-rival, fragile-margin, upkeep, and review signals without changing climate rules
- keep a neutral stable state when no reliable pivot risk exists

## Tests
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check
- npm test

Closes #1650