### PR TITLE
Alpha: MAP-A50 compare light countermeasures

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -546,3 +546,22 @@ test('atlas military shows first countermeasure for next light front pressure so
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--watch/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--quiet/);
 });
+
+// MAP-A50: compare visible light-front countermeasures by urgency and cost so
+// the recommended action explains why it beats alternatives.
+test('atlas military compares light front countermeasures by urgency and cost', () => {
+  assert.match(webAppSource, /const lightFollowUpCountermeasureComparison = lightFollowUpCountermeasure/);
+  assert.match(webAppSource, /candidatesForComparison = \[/);
+  assert.match(webAppSource, /label: 'Comparaison: meilleur ratio'/);
+  assert.match(webAppSource, /label: 'Comparaison: neutre'/);
+  assert.match(webAppSource, /pas assez d’alternatives fiables à comparer/);
+  assert.match(webAppSource, /urgence haute, \$\{runnerUp\?\.label \?\? 'alternative'\} coûte plus de temps/);
+  assert.match(webAppSource, /meilleur coût\/urgence avant \$\{runnerUp\?\.label \?\? 'veille'\}/);
+  assert.match(webAppSource, /lightFollowUpCountermeasureComparison,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpCountermeasureComparison \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpCountermeasureComparison \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 20\.05 : 18\.7/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--ready/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--prep/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--watch/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2787,6 +2787,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpNextRisk: null,
       lightFollowUpPressureSource: null,
       lightFollowUpCountermeasure: null,
+      lightFollowUpCountermeasureComparison: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -2999,6 +3000,34 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
         detail: 'aucune préparation requise tant que la source reste stable',
       }
     : null;
+  const lightFollowUpCountermeasureComparison = lightFollowUpCountermeasure
+    ? (() => {
+      const readyAction = playableEntry?.option?.nextAction ?? (alternative.viabilityStatus === 'ready' ? alternative.action : null);
+      const candidatesForComparison = [
+        readyAction ? { tone: 'ready', label: 'action immédiate', cost: 'coût nul' } : null,
+        prepUnlock?.action ? { tone: 'prep', label: 'préparation', cost: prepUnlock.delayCost?.label?.toLowerCase() ?? 'coût de prep' } : null,
+        residualRisk?.action ? { tone: 'watch', label: 'veille', cost: residualRisk.tone === 'covered' ? 'risque couvert' : 'risque à surveiller' } : null,
+      ].filter(Boolean);
+      if (lightFollowUpCountermeasure.tone === 'quiet' || candidatesForComparison.length < 2) {
+        return {
+          tone: 'quiet',
+          label: 'Comparaison: neutre',
+          detail: 'pas assez d’alternatives fiables à comparer',
+        };
+      }
+      const runnerUp = candidatesForComparison.find((candidate) => candidate.tone !== lightFollowUpCountermeasure.tone) ?? candidatesForComparison[1];
+      const reasonByTone = {
+        ready: `urgence haute, ${runnerUp?.label ?? 'alternative'} coûte plus de temps`,
+        prep: `meilleur coût/urgence avant ${runnerUp?.label ?? 'veille'} · ${runnerUp?.cost ?? 'coût incertain'}`,
+        watch: `veille prioritaire, action directe non fiable`,
+      };
+      return {
+        tone: lightFollowUpCountermeasure.tone,
+        label: 'Comparaison: meilleur ratio',
+        detail: reasonByTone[lightFollowUpCountermeasure.tone] ?? 'priorité conservée faute de meilleure option',
+      };
+    })()
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -3017,6 +3046,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpNextRisk: null,
       lightFollowUpPressureSource: null,
       lightFollowUpCountermeasure: null,
+      lightFollowUpCountermeasureComparison: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -3037,6 +3067,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     lightFollowUpNextRisk,
     lightFollowUpPressureSource,
     lightFollowUpCountermeasure,
+    lightFollowUpCountermeasureComparison,
   };
 }
 
@@ -3293,7 +3324,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}${ladder.lightFollowUpCountermeasure ? `; ${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}${ladder.lightFollowUpCountermeasure ? `; ${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}` : ''}${ladder.lightFollowUpCountermeasureComparison ? `; ${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3308,6 +3339,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.lightFollowUpNextRisk ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__next-risk atlas-military-neighbor-blocked-follow-up-ladder__next-risk--${ladder.lightFollowUpNextRisk.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 14.85 : 13.5)}">${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}</text>` : ''}
       ${ladder.lightFollowUpPressureSource ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure-source atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--${ladder.lightFollowUpPressureSource.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 16.2 : 14.85)}">${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}</text>` : ''}
       ${ladder.lightFollowUpCountermeasure ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--${ladder.lightFollowUpCountermeasure.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 17.55 : 16.2)}">${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}</text>` : ''}
+      ${ladder.lightFollowUpCountermeasureComparison ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--${ladder.lightFollowUpCountermeasureComparison.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 18.9 : 17.55)}">${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3346,7 +3378,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightFollowUpCountermeasure ? preview.blockedFollowUpLadder?.remainingWatch ? 18.7 : 17.35 : preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpCountermeasureComparison ? preview.blockedFollowUpLadder?.remainingWatch ? 20.05 : 18.7 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasure ? preview.blockedFollowUpLadder?.remainingWatch ? 18.7 : 17.35 : preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14817,7 +14817,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__risk-window,
 .atlas-military-neighbor-blocked-follow-up-ladder__next-risk,
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure-source,
-.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure {
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure,
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14845,6 +14846,10 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--prep { fill: #fde68a; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--watch { fill: #fdba74; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--quiet { fill: #cbd5e1; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--ready { fill: #86efac; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--prep { fill: #fde68a; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--watch { fill: #fdba74; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1646.

Summary:
- Adds a compact comparison cue for the selected light-front countermeasure.
- Compares ready/prep/watch alternatives using existing pressure, prep, buffer, and residual-risk signals only.
- Renders a neutral comparison state when there are not enough reliable alternatives.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test

Zeta, this Alpha PR is ready for validation before merge.