### PR TITLE
Delta: Show residual fallback safety cutoff

### DIFF
--- a/src/ui/war/StrategicMapShell.js
+++ b/src/ui/war/StrategicMapShell.js
@@ -1388,6 +1388,45 @@ function buildResidualFallbackWaitCost(topChoice, missedTimingFallback, topFollo
   };
 }
 
+function buildResidualFallbackSafetyCutoff(fallbackWaitCost, missedTimingFallback, topChoice) {
+  if (!fallbackWaitCost || fallbackWaitCost.level === 'unknown-cost') return null;
+
+  if (fallbackWaitCost.level === 'minor-loss') {
+    return {
+      state: 'acceptable-wait',
+      label: 'Attente encore acceptable',
+      summary: `fallback encore sûr, mais ${fallbackWaitCost.summary}`,
+      cutoff: 'avant la prochaine action majeure',
+      primaryAction: topChoice?.cleanupOrderLabel ?? null,
+      secondary: true,
+    };
+  }
+
+  if (fallbackWaitCost.level === 'recheck-risk') {
+    return {
+      state: 'recheck-before-wait',
+      label: 'Recheck requis avant attente',
+      summary: 'le fallback cesse d’être assez sûr sans nouvelle lecture du risque',
+      cutoff: 'au prochain tour/action',
+      primaryAction: topChoice?.cleanupOrderLabel ?? null,
+      secondary: true,
+    };
+  }
+
+  if (fallbackWaitCost.level === 'blocks-next-action') {
+    return {
+      state: 'clean-now',
+      label: 'Nettoyer maintenant',
+      summary: fallbackWaitCost.summary,
+      cutoff: 'avant de confirmer l’action suivante',
+      primaryAction: topChoice?.cleanupOrderLabel ?? missedTimingFallback?.action ?? null,
+      secondary: true,
+    };
+  }
+
+  return null;
+}
+
 function cleanupTimingFallback() {
   return {
     empty: true,
@@ -1408,6 +1447,7 @@ function cleanupTimingFallback() {
     fallbackMessage: 'Fallback: aucune fenêtre sûre de cleanup résiduel n’est déterminable.',
     missedTimingFallback: null,
     fallbackWaitCost: null,
+    fallbackSafetyCutoff: null,
   };
 }
 
@@ -1430,6 +1470,11 @@ export function buildResidualIntrigueCleanupTiming(
     missedTimingFallback,
     topFollowUpReadiness,
     miniPlanPrematureReengagementRisk,
+  );
+  const fallbackSafetyCutoff = buildResidualFallbackSafetyCutoff(
+    fallbackWaitCost,
+    missedTimingFallback,
+    topChoice,
   );
   const readinessState = String(topFollowUpReadiness?.state ?? '').trim();
   const prematureState = String(miniPlanPrematureReengagementRisk?.state ?? '').trim();
@@ -1457,6 +1502,7 @@ export function buildResidualIntrigueCleanupTiming(
       fallbackMessage: null,
       missedTimingFallback: null,
       fallbackWaitCost: null,
+      fallbackSafetyCutoff: null,
     };
   }
 
@@ -1480,6 +1526,7 @@ export function buildResidualIntrigueCleanupTiming(
       fallbackMessage: 'Fallback: aucune fenêtre sûre précise n’est déterminable; relire au prochain signal.',
       missedTimingFallback: null,
       fallbackWaitCost: null,
+      fallbackSafetyCutoff: null,
     };
   }
 
@@ -1508,6 +1555,7 @@ export function buildResidualIntrigueCleanupTiming(
       fallbackMessage: null,
       missedTimingFallback,
       fallbackWaitCost,
+      fallbackSafetyCutoff,
     };
   }
 
@@ -1531,6 +1579,7 @@ export function buildResidualIntrigueCleanupTiming(
       fallbackMessage: null,
       missedTimingFallback,
       fallbackWaitCost,
+      fallbackSafetyCutoff,
     };
   }
 
@@ -1553,6 +1602,7 @@ export function buildResidualIntrigueCleanupTiming(
     fallbackMessage: null,
     missedTimingFallback,
     fallbackWaitCost,
+    fallbackSafetyCutoff,
   };
 }
 

--- a/test/ui/war/StrategicMapShell.test.js
+++ b/test/ui/war/StrategicMapShell.test.js
@@ -1413,6 +1413,14 @@ test('StrategicMapShell shows the safest residual intrigue cleanup timing', () =
       summary: 'attendre le fallback perd le meilleur score sûr (50)',
       secondary: true,
     },
+    fallbackSafetyCutoff: {
+      state: 'acceptable-wait',
+      label: 'Attente encore acceptable',
+      summary: 'fallback encore sûr, mais attendre le fallback perd le meilleur score sûr (50)',
+      cutoff: 'avant la prochaine action majeure',
+      primaryAction: 'Dissiper attention résiduelle',
+      secondary: true,
+    },
   });
 });
 
@@ -1471,6 +1479,14 @@ test('StrategicMapShell marks residual intrigue cleanup as premature until the b
       summary: 'attendre force une relecture avant nouvelle escalade',
       secondary: true,
     },
+    fallbackSafetyCutoff: {
+      state: 'recheck-before-wait',
+      label: 'Recheck requis avant attente',
+      summary: 'le fallback cesse d’être assez sûr sans nouvelle lecture du risque',
+      cutoff: 'au prochain tour/action',
+      primaryAction: 'Scanner axe détour',
+      secondary: true,
+    },
   });
 });
 
@@ -1498,7 +1514,7 @@ test('StrategicMapShell distinguishes blocked and unknown residual fallback wait
     },
   ];
 
-  assert.equal(buildResidualIntrigueCleanupTiming(
+  const blockedTiming = buildResidualIntrigueCleanupTiming(
     basePayoff,
     choices,
     {
@@ -1506,19 +1522,32 @@ test('StrategicMapShell distinguishes blocked and unknown residual fallback wait
       blocker: 'éclaireurs disponibles',
       action: 'sécuriser le corridor court avant exécution',
     },
-  ).fallbackWaitCost.summary, 'attendre le fallback laisse éclaireurs disponibles bloquer sécuriser le corridor court avant exécution');
+  );
 
-  assert.deepEqual(buildResidualIntrigueCleanupTiming(
+  assert.equal(blockedTiming.fallbackWaitCost.summary, 'attendre le fallback laisse éclaireurs disponibles bloquer sécuriser le corridor court avant exécution');
+  assert.deepEqual(blockedTiming.fallbackSafetyCutoff, {
+    state: 'clean-now',
+    label: 'Nettoyer maintenant',
+    summary: 'attendre le fallback laisse éclaireurs disponibles bloquer sécuriser le corridor court avant exécution',
+    cutoff: 'avant de confirmer l’action suivante',
+    primaryAction: 'Scanner axe détour',
+    secondary: true,
+  });
+
+  const unknownTiming = buildResidualIntrigueCleanupTiming(
     basePayoff,
     choices,
     { state: 'ready-now' },
     { state: 'ready' },
-  ).fallbackWaitCost, {
+  );
+
+  assert.deepEqual(unknownTiming.fallbackWaitCost, {
     level: 'unknown-cost',
     label: 'Coût inconnu',
     summary: 'coût relatif non déterminable avec les signaux actuels',
     secondary: true,
   });
+  assert.equal(unknownTiming.fallbackSafetyCutoff, null);
 });
 
 test('StrategicMapShell provides a clear fallback when no cleanup timing is determinable', () => {
@@ -1541,6 +1570,7 @@ test('StrategicMapShell provides a clear fallback when no cleanup timing is dete
     fallbackMessage: 'Fallback: aucune fenêtre sûre de cleanup résiduel n’est déterminable.',
     missedTimingFallback: null,
     fallbackWaitCost: null,
+    fallbackSafetyCutoff: null,
   });
 });
 


### PR DESCRIPTION
Delta: Implements #1649.

Summary:
- Adds a secondary `fallbackSafetyCutoff` cue to residual intrigue cleanup timing.
- Reuses `missedTimingFallback` and `fallbackWaitCost` to distinguish acceptable wait, recheck-needed, and clean-now states.
- Keeps the cue silent when relative fallback cost is unknown, without changing intrigue rules or exposure budgets.

Tests:
- node --test test/ui/war/StrategicMapShell.test.js
- npm test
- git diff --check