### PR TITLE
Alpha: MAP-A51 show light countermeasure delay effect

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -565,3 +565,22 @@ test('atlas military compares light front countermeasures by urgency and cost', 
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--watch/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--quiet/);
 });
+
+// MAP-A51: after comparing light-front countermeasures, show what changes if
+// the recommended countermeasure is delayed without recalculating war rules.
+test('atlas military shows delay effect for chosen light front countermeasure', () => {
+  assert.match(webAppSource, /const lightFollowUpCountermeasureDelayEffect = lightFollowUpCountermeasureComparison/);
+  assert.match(webAppSource, /label: 'Si retardée: pression revient'/);
+  assert.match(webAppSource, /label: 'Si retardée: coût augmente'/);
+  assert.match(webAppSource, /label: 'Si retardée: préparation manquée'/);
+  assert.match(webAppSource, /label: 'Si retardée: veille exposée'/);
+  assert.match(webAppSource, /label: 'Si retardée: neutre'/);
+  assert.match(webAppSource, /conséquence du report non fiable/);
+  assert.match(webAppSource, /lightFollowUpCountermeasureDelayEffect,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpCountermeasureDelayEffect \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpCountermeasureDelayEffect \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 21\.4 : 20\.05/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--risky/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--prep/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--watch/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2788,6 +2788,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpPressureSource: null,
       lightFollowUpCountermeasure: null,
       lightFollowUpCountermeasureComparison: null,
+      lightFollowUpCountermeasureDelayEffect: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -3028,6 +3029,43 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       };
     })()
     : null;
+  const lightFollowUpCountermeasureDelayEffect = lightFollowUpCountermeasureComparison
+    ? (() => {
+      if (lightFollowUpCountermeasure.tone === 'ready') {
+        return {
+          tone: 'risky',
+          label: 'Si retardée: pression revient',
+          detail: residualRisk?.detail ?? lightFollowUpPressureSource?.detail ?? 'la fenêtre d’action se referme',
+        };
+      }
+      if (lightFollowUpCountermeasure.tone === 'prep' && prepUnlock?.delayCost) {
+        return {
+          tone: prepUnlock.delayCost.tone === 'risky' ? 'risky' : 'prep',
+          label: 'Si retardée: coût augmente',
+          detail: `${prepUnlock.delayCost.label} · ${prepUnlock.delayCost.detail}`,
+        };
+      }
+      if (lightFollowUpCountermeasure.tone === 'prep' && prepUnlock?.unlocks) {
+        return {
+          tone: 'prep',
+          label: 'Si retardée: préparation manquée',
+          detail: prepUnlock.unlocks,
+        };
+      }
+      if (lightFollowUpCountermeasure.tone === 'watch' && residualRisk?.action) {
+        return {
+          tone: residualRisk.tone === 'covered' ? 'watch' : 'risky',
+          label: 'Si retardée: veille exposée',
+          detail: residualRisk.detail ?? residualRisk.action,
+        };
+      }
+      return {
+        tone: 'quiet',
+        label: 'Si retardée: neutre',
+        detail: 'conséquence du report non fiable',
+      };
+    })()
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -3047,6 +3085,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpPressureSource: null,
       lightFollowUpCountermeasure: null,
       lightFollowUpCountermeasureComparison: null,
+      lightFollowUpCountermeasureDelayEffect: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -3068,6 +3107,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     lightFollowUpPressureSource,
     lightFollowUpCountermeasure,
     lightFollowUpCountermeasureComparison,
+    lightFollowUpCountermeasureDelayEffect,
   };
 }
 
@@ -3324,7 +3364,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}${ladder.lightFollowUpCountermeasure ? `; ${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}` : ''}${ladder.lightFollowUpCountermeasureComparison ? `; ${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}${ladder.lightFollowUpCountermeasure ? `; ${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}` : ''}${ladder.lightFollowUpCountermeasureComparison ? `; ${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}` : ''}${ladder.lightFollowUpCountermeasureDelayEffect ? `; ${ladder.lightFollowUpCountermeasureDelayEffect.label}: ${ladder.lightFollowUpCountermeasureDelayEffect.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3340,6 +3380,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.lightFollowUpPressureSource ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__pressure-source atlas-military-neighbor-blocked-follow-up-ladder__pressure-source--${ladder.lightFollowUpPressureSource.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 16.2 : 14.85)}">${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}</text>` : ''}
       ${ladder.lightFollowUpCountermeasure ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--${ladder.lightFollowUpCountermeasure.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 17.55 : 16.2)}">${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}</text>` : ''}
       ${ladder.lightFollowUpCountermeasureComparison ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--${ladder.lightFollowUpCountermeasureComparison.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 18.9 : 17.55)}">${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}</text>` : ''}
+      ${ladder.lightFollowUpCountermeasureDelayEffect ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--${ladder.lightFollowUpCountermeasureDelayEffect.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 20.25 : 18.9)}">${ladder.lightFollowUpCountermeasureDelayEffect.label}: ${ladder.lightFollowUpCountermeasureDelayEffect.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3378,7 +3419,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightFollowUpCountermeasureComparison ? preview.blockedFollowUpLadder?.remainingWatch ? 20.05 : 18.7 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasure ? preview.blockedFollowUpLadder?.remainingWatch ? 18.7 : 17.35 : preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpCountermeasureDelayEffect ? preview.blockedFollowUpLadder?.remainingWatch ? 21.4 : 20.05 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasureComparison ? preview.blockedFollowUpLadder?.remainingWatch ? 20.05 : 18.7 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasure ? preview.blockedFollowUpLadder?.remainingWatch ? 18.7 : 17.35 : preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14818,7 +14818,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__next-risk,
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure-source,
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure,
-.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison {
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison,
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14850,6 +14851,10 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--prep { fill: #fde68a; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--watch { fill: #fdba74; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--quiet { fill: #cbd5e1; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--risky { fill: #fecaca; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--prep { fill: #fde68a; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--watch { fill: #fdba74; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1656.

Summary:
- Adds a compact “Si retardée” cue after the light-front countermeasure comparison.
- Reuses existing light pressure, source, chosen countermeasure, prep delay, and residual-risk signals.
- Keeps the main recommendation unchanged and falls back quietly when delay consequences are not reliable.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test

Zeta, this Alpha PR is ready for validation before merge.