### PR TITLE
Epsilon: Show backup climate action when stabilization is insufficient

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -53,6 +53,11 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /Ce qui changerait/);
   assert.match(webAppSource, /minimalStabilizationAction/);
   assert.match(webAppSource, /Stabilisation minimale/);
+  assert.match(webAppSource, /backupClimateActionIfInsufficient/);
+  assert.match(webAppSource, /Si insuffisant/);
+  assert.match(webAppSource, /basculer la veille courte sur/);
+  assert.match(webAppSource, /secours neutre/);
+  assert.match(webAppSource, /aucun secours fiable à préparer/);
   assert.match(webAppSource, /stabiliser par/);
   assert.match(webAppSource, /stabilisation neutre/);
   assert.match(webAppSource, /aucune action minimale fiable à ajouter/);
@@ -174,6 +179,12 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__minimal-stabilization--review-readable/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__minimal-stabilization--stable-neutral/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__minimal-stabilization--watch-neutral/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-action/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-action--watch-backup/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-action--review-backup/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-action--check-backup/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-action--stable-neutral/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-action--unknown-neutral/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);

--- a/web/app.js
+++ b/web/app.js
@@ -14803,6 +14803,35 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
           label: 'stabilisation à surveiller',
           detail: 'aucune action minimale lisible: attendre le prochain check avant de promettre une stabilisation',
         };
+  const backupClimateActionIfInsufficient = minimalStabilizationAction.state === 'stable-neutral'
+    ? {
+      state: 'stable-neutral',
+      label: 'secours neutre',
+      detail: 'si insuffisant: aucun secours fiable à préparer tant que la stabilisation minimale suffit',
+    }
+    : nextSecondaryRisk
+      ? {
+        state: 'watch-backup',
+        label: 'si insuffisant',
+        detail: `basculer la veille courte sur ${nextSecondaryRisk.label}; ${priorityRankingChangeCue.detail}`,
+      }
+      : marginRearmReview
+        ? {
+          state: 'review-backup',
+          label: 'si insuffisant',
+          detail: `réarmer review puis confirmer ${watchGap.label}; ${marginRearmReview.detail}`,
+        }
+        : priorityRankingChangeCue.state !== 'stable-ranking'
+          ? {
+            state: 'check-backup',
+            label: 'si insuffisant',
+            detail: `attendre ${progress.deadline} et appliquer la première bascule mesurable; ${priorityInstabilityWindow.detail}`,
+          }
+          : {
+            state: 'unknown-neutral',
+            label: 'secours indéterminé',
+            detail: 'si insuffisant: aucun secours lisible sans nouveau rival ou marge mesurable',
+          };
 
   return {
     state: 'watch',
@@ -14829,6 +14858,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       priorityOrderingRationale,
       priorityRankingChangeCue,
       minimalStabilizationAction,
+      backupClimateActionIfInsufficient,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14881,6 +14911,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small class="map-world-climate-post-gap-watch__ordering map-world-climate-post-gap-watch__ordering--${view.watchItem.priorityOrderingRationale.state}"><b>Pourquoi premier</b> · ${view.watchItem.priorityOrderingRationale.label}: ${view.watchItem.priorityOrderingRationale.detail}</small>
       <small class="map-world-climate-post-gap-watch__rank-change map-world-climate-post-gap-watch__rank-change--${view.watchItem.priorityRankingChangeCue.state}"><b>Ce qui changerait</b> · ${view.watchItem.priorityRankingChangeCue.label}: ${view.watchItem.priorityRankingChangeCue.detail}</small>
       <small class="map-world-climate-post-gap-watch__minimal-stabilization map-world-climate-post-gap-watch__minimal-stabilization--${view.watchItem.minimalStabilizationAction.state}"><b>Stabilisation minimale</b> · ${view.watchItem.minimalStabilizationAction.label}: ${view.watchItem.minimalStabilizationAction.detail}</small>
+      <small class="map-world-climate-post-gap-watch__backup-action map-world-climate-post-gap-watch__backup-action--${view.watchItem.backupClimateActionIfInsufficient.state}"><b>Si insuffisant</b> · ${view.watchItem.backupClimateActionIfInsufficient.label}: ${view.watchItem.backupClimateActionIfInsufficient.detail}</small>
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13836,6 +13836,17 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__minimal-stabilization--review-readable { border: 1px solid rgba(125, 211, 252, 0.34); }
 .map-world-climate-post-gap-watch__minimal-stabilization--stable-neutral,
 .map-world-climate-post-gap-watch__minimal-stabilization--watch-neutral { border: 1px solid rgba(148, 163, 184, 0.28); }
+.map-world-climate-post-gap-watch__backup-action {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.3);
+}
+.map-world-climate-post-gap-watch__backup-action--watch-backup { border: 1px solid rgba(251, 191, 36, 0.36); }
+.map-world-climate-post-gap-watch__backup-action--review-backup { border: 1px solid rgba(125, 211, 252, 0.34); }
+.map-world-climate-post-gap-watch__backup-action--check-backup { border: 1px solid rgba(248, 113, 113, 0.34); }
+.map-world-climate-post-gap-watch__backup-action--stable-neutral,
+.map-world-climate-post-gap-watch__backup-action--unknown-neutral { border: 1px solid rgba(148, 163, 184, 0.28); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
## Summary
- add a compact "Si insuffisant" cue for fragile climate priority stabilization
- derive backup watch/review/check actions from existing ranking, margin, rival, trigger, and minimal stabilization signals
- keep stable/unknown neutral fallbacks when no reliable backup is readable

## Tests
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check
- npm test

Closes #1660