### PR TITLE
Alpha: MAP-A52 show minimal light-front recovery cue

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -584,3 +584,22 @@ test('atlas military shows delay effect for chosen light front countermeasure', 
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--watch/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--quiet/);
 });
+
+
+// MAP-A52: once delaying the chosen light-front countermeasure starts to cost,
+// show the smallest recovery move without changing the main recommendation.
+test('atlas military shows minimal recovery after delayed light front countermeasure', () => {
+  assert.match(webAppSource, /const lightFollowUpCountermeasureRecovery = lightFollowUpCountermeasureDelayEffect/);
+  assert.match(webAppSource, /label: 'Rattrapage minimal: agir maintenant'/);
+  assert.match(webAppSource, /label: 'Rattrapage minimal: préparer vite'/);
+  assert.match(webAppSource, /label: 'Rattrapage minimal: alternative viable'/);
+  assert.match(webAppSource, /label: 'Rattrapage minimal: trop tardif'/);
+  assert.match(webAppSource, /label: 'Rattrapage minimal: information insuffisante'/);
+  assert.match(webAppSource, /aucun geste de récupération fiable à afficher/);
+  assert.match(webAppSource, /lightFollowUpCountermeasureRecovery,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpCountermeasureRecovery \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpCountermeasureRecovery \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 22\.75 : 21\.4/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--possible/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--late/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2789,6 +2789,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpCountermeasure: null,
       lightFollowUpCountermeasureComparison: null,
       lightFollowUpCountermeasureDelayEffect: null,
+      lightFollowUpCountermeasureRecovery: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -3066,6 +3067,57 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       };
     })()
     : null;
+  const lightFollowUpCountermeasureRecovery = lightFollowUpCountermeasureDelayEffect
+    ? (() => {
+      const readyAction = playableEntry?.option?.nextAction ?? (alternative.viabilityStatus === 'ready' ? alternative.action : null);
+      const viablePrepAction = prepUnlock?.action
+        ? `${prepUnlock.action}${prepUnlock.unlocks ? ` · ${prepUnlock.unlocks}` : ''}`
+        : null;
+      const viableAlternative = candidates
+        .filter((entry) => entry.viability.status === 'ready' || entry.viability.status === 'prep')
+        .sort((a, b) => (a.option.score ?? 0) - (b.option.score ?? 0))[0] ?? null;
+      if (lightFollowUpCountermeasureDelayEffect.tone === 'quiet') {
+        return {
+          tone: 'quiet',
+          label: 'Rattrapage minimal: information insuffisante',
+          detail: 'aucun geste de récupération fiable à afficher',
+        };
+      }
+      if (readyAction) {
+        return {
+          tone: 'possible',
+          label: 'Rattrapage minimal: agir maintenant',
+          detail: readyAction,
+        };
+      }
+      if (viablePrepAction) {
+        return {
+          tone: 'possible',
+          label: 'Rattrapage minimal: préparer vite',
+          detail: viablePrepAction,
+        };
+      }
+      if (viableAlternative) {
+        return {
+          tone: 'possible',
+          label: 'Rattrapage minimal: alternative viable',
+          detail: viableAlternative.option.nextAction ?? viableAlternative.option.action ?? viableAlternative.option.provinceLabel,
+        };
+      }
+      if (lightFollowUpCountermeasureDelayEffect.tone === 'risky' || residualRisk?.tone === 'watch') {
+        return {
+          tone: 'late',
+          label: 'Rattrapage minimal: trop tardif',
+          detail: residualRisk?.action ?? 'front léger redevenu prioritaire',
+        };
+      }
+      return {
+        tone: 'quiet',
+        label: 'Rattrapage minimal: information insuffisante',
+        detail: 'alternatives encore viables non calculables',
+      };
+    })()
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -3086,6 +3138,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpCountermeasure: null,
       lightFollowUpCountermeasureComparison: null,
       lightFollowUpCountermeasureDelayEffect: null,
+      lightFollowUpCountermeasureRecovery: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -3108,6 +3161,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     lightFollowUpCountermeasure,
     lightFollowUpCountermeasureComparison,
     lightFollowUpCountermeasureDelayEffect,
+    lightFollowUpCountermeasureRecovery,
   };
 }
 
@@ -3364,7 +3418,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}${ladder.lightFollowUpCountermeasure ? `; ${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}` : ''}${ladder.lightFollowUpCountermeasureComparison ? `; ${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}` : ''}${ladder.lightFollowUpCountermeasureDelayEffect ? `; ${ladder.lightFollowUpCountermeasureDelayEffect.label}: ${ladder.lightFollowUpCountermeasureDelayEffect.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}${ladder.lightFollowUpCountermeasure ? `; ${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}` : ''}${ladder.lightFollowUpCountermeasureComparison ? `; ${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}` : ''}${ladder.lightFollowUpCountermeasureDelayEffect ? `; ${ladder.lightFollowUpCountermeasureDelayEffect.label}: ${ladder.lightFollowUpCountermeasureDelayEffect.detail}` : ''}${ladder.lightFollowUpCountermeasureRecovery ? `; ${ladder.lightFollowUpCountermeasureRecovery.label}: ${ladder.lightFollowUpCountermeasureRecovery.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3381,6 +3435,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.lightFollowUpCountermeasure ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure atlas-military-neighbor-blocked-follow-up-ladder__countermeasure--${ladder.lightFollowUpCountermeasure.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 17.55 : 16.2)}">${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}</text>` : ''}
       ${ladder.lightFollowUpCountermeasureComparison ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--${ladder.lightFollowUpCountermeasureComparison.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 18.9 : 17.55)}">${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}</text>` : ''}
       ${ladder.lightFollowUpCountermeasureDelayEffect ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--${ladder.lightFollowUpCountermeasureDelayEffect.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 20.25 : 18.9)}">${ladder.lightFollowUpCountermeasureDelayEffect.label}: ${ladder.lightFollowUpCountermeasureDelayEffect.detail}</text>` : ''}
+      ${ladder.lightFollowUpCountermeasureRecovery ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--${ladder.lightFollowUpCountermeasureRecovery.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 21.6 : 20.25)}">${ladder.lightFollowUpCountermeasureRecovery.label}: ${ladder.lightFollowUpCountermeasureRecovery.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3419,7 +3474,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightFollowUpCountermeasureDelayEffect ? preview.blockedFollowUpLadder?.remainingWatch ? 21.4 : 20.05 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasureComparison ? preview.blockedFollowUpLadder?.remainingWatch ? 20.05 : 18.7 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasure ? preview.blockedFollowUpLadder?.remainingWatch ? 18.7 : 17.35 : preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpCountermeasureRecovery ? preview.blockedFollowUpLadder?.remainingWatch ? 22.75 : 21.4 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasureDelayEffect ? preview.blockedFollowUpLadder?.remainingWatch ? 21.4 : 20.05 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasureComparison ? preview.blockedFollowUpLadder?.remainingWatch ? 20.05 : 18.7 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasure ? preview.blockedFollowUpLadder?.remainingWatch ? 18.7 : 17.35 : preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14830,7 +14830,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__pressure-source,
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure,
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison,
-.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay {
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay,
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14866,6 +14867,9 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--prep { fill: #fde68a; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--watch { fill: #fdba74; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--quiet { fill: #cbd5e1; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--possible { fill: #bbf7d0; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--late { fill: #fca5a5; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements #1666.

Summary:
- Adds a compact `Rattrapage minimal` cue after the delayed light-front countermeasure risk.
- Reuses existing light pressure, delay consequence, prep delay, residual risk, and viable alternative signals without changing the main recommendation.
- Distinguishes recovery possible, too late, and insufficient-information fallback states.

Validation:
- git diff --check
- node --check web/app.js
- node --test test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test

Zeta, this Alpha PR is ready for validation before merge.