### PR TITLE
Epsilon: Show backup climate scope cue

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -54,7 +54,13 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /minimalStabilizationAction/);
   assert.match(webAppSource, /Stabilisation minimale/);
   assert.match(webAppSource, /backupClimateActionIfInsufficient/);
+  assert.match(webAppSource, /backupClimateScopeCue/);
   assert.match(webAppSource, /Si insuffisant/);
+  assert.match(webAppSource, /Portée du secours/);
+  assert.match(webAppSource, /protège la prochaine fenêtre/);
+  assert.match(webAppSource, /protège seulement l’urgence actuelle/);
+  assert.match(webAppSource, /portée incertaine/);
+  assert.match(webAppSource, /nextClimateWindow/);
   assert.match(webAppSource, /basculer la veille courte sur/);
   assert.match(webAppSource, /secours neutre/);
   assert.match(webAppSource, /aucun secours fiable à préparer/);
@@ -185,6 +191,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-action--check-backup/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-action--stable-neutral/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-action--unknown-neutral/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-scope/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-scope--protects-next-window/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-scope--current-emergency-only/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-scope--scope-uncertain/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);

--- a/web/app.js
+++ b/web/app.js
@@ -14877,6 +14877,30 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
             label: 'secours indéterminé',
             detail: 'si insuffisant: aucun secours lisible sans nouveau rival ou marge mesurable',
           };
+  const nextClimateWindow = priorityInstabilityWindow?.label ?? progress.deadline ?? 'prochaine fenêtre climat';
+  const backupClimateScopeCue = backupClimateActionIfInsufficient.state === 'watch-backup' && nextSecondaryRisk
+    ? {
+      state: 'protects-next-window',
+      label: 'protège la prochaine fenêtre',
+      detail: `${backupClimateActionIfInsufficient.detail}; couvre aussi ${nextSecondaryRisk.label} avant ${nextClimateWindow}`,
+    }
+    : backupClimateActionIfInsufficient.state === 'review-backup'
+      ? {
+        state: 'current-emergency-only',
+        label: 'protège seulement l’urgence actuelle',
+        detail: `la review sécurise ${watchGap.label} maintenant; relire ${nextClimateWindow} avant de promettre la fenêtre suivante`,
+      }
+      : backupClimateActionIfInsufficient.state === 'check-backup'
+        ? {
+          state: 'scope-uncertain',
+          label: 'portée incertaine',
+          detail: `attendre ${progress.deadline}: la première bascule mesurable dira si ${nextClimateWindow} est protégée`,
+        }
+        : {
+          state: 'scope-uncertain',
+          label: 'portée incertaine',
+          detail: 'aucun secours de repli lisible: ne pas promettre la prochaine fenêtre climat',
+        };
 
   return {
     state: 'watch',
@@ -14904,6 +14928,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       priorityRankingChangeCue,
       minimalStabilizationAction,
       backupClimateActionIfInsufficient,
+      backupClimateScopeCue,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -14957,6 +14982,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small class="map-world-climate-post-gap-watch__rank-change map-world-climate-post-gap-watch__rank-change--${view.watchItem.priorityRankingChangeCue.state}"><b>Ce qui changerait</b> · ${view.watchItem.priorityRankingChangeCue.label}: ${view.watchItem.priorityRankingChangeCue.detail}</small>
       <small class="map-world-climate-post-gap-watch__minimal-stabilization map-world-climate-post-gap-watch__minimal-stabilization--${view.watchItem.minimalStabilizationAction.state}"><b>Stabilisation minimale</b> · ${view.watchItem.minimalStabilizationAction.label}: ${view.watchItem.minimalStabilizationAction.detail}</small>
       <small class="map-world-climate-post-gap-watch__backup-action map-world-climate-post-gap-watch__backup-action--${view.watchItem.backupClimateActionIfInsufficient.state}"><b>Si insuffisant</b> · ${view.watchItem.backupClimateActionIfInsufficient.label}: ${view.watchItem.backupClimateActionIfInsufficient.detail}</small>
+      <small class="map-world-climate-post-gap-watch__backup-scope map-world-climate-post-gap-watch__backup-scope--${view.watchItem.backupClimateScopeCue.state}"><b>Portée du secours</b> · ${view.watchItem.backupClimateScopeCue.label}: ${view.watchItem.backupClimateScopeCue.detail}</small>
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13847,6 +13847,15 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__backup-action--check-backup { border: 1px solid rgba(248, 113, 113, 0.34); }
 .map-world-climate-post-gap-watch__backup-action--stable-neutral,
 .map-world-climate-post-gap-watch__backup-action--unknown-neutral { border: 1px solid rgba(148, 163, 184, 0.28); }
+.map-world-climate-post-gap-watch__backup-scope {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.3);
+}
+.map-world-climate-post-gap-watch__backup-scope--protects-next-window { border: 1px solid rgba(34, 197, 94, 0.34); }
+.map-world-climate-post-gap-watch__backup-scope--current-emergency-only { border: 1px solid rgba(251, 191, 36, 0.34); }
+.map-world-climate-post-gap-watch__backup-scope--scope-uncertain { border: 1px solid rgba(148, 163, 184, 0.28); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon: Implements #1670.

Summary:
- adds a compact backup climate scope cue to the post-gap watch card
- distinguishes whether the backup protects the next climate window, only the current urgency, or remains uncertain
- reuses existing priority, backup action, remaining watch, and instability window data without changing climate rules

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check
- npm test
