### PR TITLE
Epsilon: Show next climate watch after backup

### DIFF
--- a/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
+++ b/test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
@@ -55,11 +55,16 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(webAppSource, /Stabilisation minimale/);
   assert.match(webAppSource, /backupClimateActionIfInsufficient/);
   assert.match(webAppSource, /backupClimateScopeCue/);
+  assert.match(webAppSource, /nextWatchAfterLimitedBackupCue/);
   assert.match(webAppSource, /Si insuffisant/);
   assert.match(webAppSource, /Portée du secours/);
+  assert.match(webAppSource, /Ensuite surveiller/);
   assert.match(webAppSource, /protège la prochaine fenêtre/);
   assert.match(webAppSource, /protège seulement l’urgence actuelle/);
   assert.match(webAppSource, /portée incertaine/);
+  assert.match(webAppSource, /fenêtre suivante couverte/);
+  assert.match(webAppSource, /prochaine watch fragile/);
+  assert.match(webAppSource, /information insuffisante/);
   assert.match(webAppSource, /nextClimateWindow/);
   assert.match(webAppSource, /basculer la veille courte sur/);
   assert.match(webAppSource, /secours neutre/);
@@ -195,6 +200,10 @@ test('atlas shows one remaining climate watch item after the smallest gap action
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-scope--protects-next-window/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-scope--current-emergency-only/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__backup-scope--scope-uncertain/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-backup/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-backup--fragile-watch/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-backup--window-covered/);
+  assert.match(stylesSource, /\.map-world-climate-post-gap-watch__after-backup--insufficient-info/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--primary-first/);
   assert.match(stylesSource, /\.map-world-climate-post-gap-watch__ladder--upkeep-secondary/);

--- a/web/app.js
+++ b/web/app.js
@@ -14960,6 +14960,24 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
           label: 'portée incertaine',
           detail: 'aucun secours de repli lisible: ne pas promettre la prochaine fenêtre climat',
         };
+  const nextWatchAfterBackupCandidate = nextSecondaryGap ?? watchGap;
+  const nextWatchAfterLimitedBackupCue = backupClimateScopeCue.state === 'protects-next-window'
+    ? {
+      state: 'window-covered',
+      label: 'fenêtre suivante couverte',
+      detail: `ensuite surveiller: ${nextSecondaryRisk?.label ?? nextWatchAfterBackupCandidate.label} reste couvert par le secours jusqu’à ${nextClimateWindow}`,
+    }
+    : backupClimateScopeCue.state === 'current-emergency-only'
+      ? {
+        state: 'fragile-watch',
+        label: `prochaine watch fragile: ${nextWatchAfterBackupCandidate.label}`,
+        detail: `ensuite surveiller ${nextWatchAfterBackupCandidate.label} après le secours; ${nextClimateWindow} n’est pas couvert par cette action limitée`,
+      }
+      : {
+        state: 'insufficient-info',
+        label: 'information insuffisante',
+        detail: `ensuite surveiller: attendre ${progress.deadline} ou un signal mesurable avant de dire quelle watch suit le secours`,
+      };
 
   return {
     state: 'watch',
@@ -14988,6 +15006,7 @@ function buildAtlasClimatePostGapActionWatch(coverageView, gapActionView, thresh
       minimalStabilizationAction,
       backupClimateActionIfInsufficient,
       backupClimateScopeCue,
+      nextWatchAfterLimitedBackupCue,
       watchLadderSummary,
     },
     nextSecondaryRisk,
@@ -15042,6 +15061,7 @@ function renderAtlasClimatePostGapActionWatch(view) {
       <small class="map-world-climate-post-gap-watch__minimal-stabilization map-world-climate-post-gap-watch__minimal-stabilization--${view.watchItem.minimalStabilizationAction.state}"><b>Stabilisation minimale</b> · ${view.watchItem.minimalStabilizationAction.label}: ${view.watchItem.minimalStabilizationAction.detail}</small>
       <small class="map-world-climate-post-gap-watch__backup-action map-world-climate-post-gap-watch__backup-action--${view.watchItem.backupClimateActionIfInsufficient.state}"><b>Si insuffisant</b> · ${view.watchItem.backupClimateActionIfInsufficient.label}: ${view.watchItem.backupClimateActionIfInsufficient.detail}</small>
       <small class="map-world-climate-post-gap-watch__backup-scope map-world-climate-post-gap-watch__backup-scope--${view.watchItem.backupClimateScopeCue.state}"><b>Portée du secours</b> · ${view.watchItem.backupClimateScopeCue.label}: ${view.watchItem.backupClimateScopeCue.detail}</small>
+      <small class="map-world-climate-post-gap-watch__after-backup map-world-climate-post-gap-watch__after-backup--${view.watchItem.nextWatchAfterLimitedBackupCue.state}"><b>Ensuite surveiller</b> · ${view.watchItem.nextWatchAfterLimitedBackupCue.label}: ${view.watchItem.nextWatchAfterLimitedBackupCue.detail}</small>
       ${view.watchItem.watchLadderSummary ? `<small class="map-world-climate-post-gap-watch__ladder map-world-climate-post-gap-watch__ladder--${view.watchItem.watchLadderSummary.state}"><b>Synthèse watch</b> · ${view.watchItem.watchLadderSummary.decision}: ${view.watchItem.watchLadderSummary.line} ${view.watchItem.watchLadderSummary.why}</small>` : ''}
       ${view.nextSecondaryRisk ? `<small><b>Secondaire suivant</b> · ${view.nextSecondaryRisk.phrase} ${view.nextSecondaryRisk.reason}</small>` : '<small><b>Secondaire suivant</b> · aucun second risque assez lisible sans créer une file.</small>'}
       <small><b>Pression</b> · ${view.watchItem.thresholdPressure}</small>

--- a/web/styles.css
+++ b/web/styles.css
@@ -13856,6 +13856,15 @@ button { font: inherit; }
 .map-world-climate-post-gap-watch__backup-scope--protects-next-window { border: 1px solid rgba(34, 197, 94, 0.34); }
 .map-world-climate-post-gap-watch__backup-scope--current-emergency-only { border: 1px solid rgba(251, 191, 36, 0.34); }
 .map-world-climate-post-gap-watch__backup-scope--scope-uncertain { border: 1px solid rgba(148, 163, 184, 0.28); }
+.map-world-climate-post-gap-watch__after-backup {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.3);
+}
+.map-world-climate-post-gap-watch__after-backup--fragile-watch { border: 1px solid rgba(251, 191, 36, 0.36); }
+.map-world-climate-post-gap-watch__after-backup--window-covered { border: 1px solid rgba(74, 222, 128, 0.32); }
+.map-world-climate-post-gap-watch__after-backup--insufficient-info { border: 1px solid rgba(148, 163, 184, 0.28); }
 .map-world-climate-post-gap-watch__ladder {
   padding: 4px 8px;
   border-radius: 11px;


### PR DESCRIPTION
Epsilon: Implements #1681.

Summary:
- adds a compact “Ensuite surveiller” cue after the backup climate scope cue
- separates backup scope from the next watch to monitor: fragile next watch, covered next window, or insufficient information
- reuses the existing climate priority, backup action/scope, remaining watch, and next climate window data without changing climate rules or thresholds

Validation:
- node --check web/app.js
- node --test test/ui/climate/webAtlasClimatePostGapActionWatch.test.js
- git diff --check
- npm test
