### PR TITLE
Alpha: MAP-A53 show light recovery buffer outcome

### DIFF
--- a/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
+++ b/test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
@@ -603,3 +603,22 @@ test('atlas military shows minimal recovery after delayed light front countermea
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--late/);
   assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--quiet/);
 });
+
+// MAP-A53: after the minimal light-front recovery cue, show whether it restores
+// the buffer, only stops the immediate relapse, or lacks enough information.
+test('atlas military shows whether minimal light front recovery restores buffer', () => {
+  assert.match(webAppSource, /const lightFollowUpCountermeasureRecoveryOutcome = lightFollowUpCountermeasureRecovery/);
+  assert.match(webAppSource, /label: 'Après rattrapage: buffer restauré'/);
+  assert.match(webAppSource, /label: 'Après rattrapage: rechute stoppée'/);
+  assert.match(webAppSource, /label: 'Après rattrapage: information insuffisante'/);
+  assert.match(webAppSource, /label: 'Après rattrapage: neutre'/);
+  assert.match(webAppSource, /aucun retard coûteux lisible/);
+  assert.match(webAppSource, /recommandation principale inchangée/);
+  assert.match(webAppSource, /lightFollowUpCountermeasureRecoveryOutcome,/);
+  assert.match(webAppSource, /ladder\.lightFollowUpCountermeasureRecoveryOutcome \? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome/);
+  assert.match(webAppSource, /preview\.blockedFollowUpLadder\?\.lightFollowUpCountermeasureRecoveryOutcome \? preview\.blockedFollowUpLadder\?\.remainingWatch \? 24\.1 : 22\.75/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome--restored/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome--stopped/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome--late/);
+  assert.match(stylesSource, /\.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome--quiet/);
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2790,6 +2790,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpCountermeasureComparison: null,
       lightFollowUpCountermeasureDelayEffect: null,
       lightFollowUpCountermeasureRecovery: null,
+      lightFollowUpCountermeasureRecoveryOutcome: null,
     };
   }
   const playableEntry = candidates.find((entry) => entry.viability.status === 'ready') ?? null;
@@ -3118,6 +3119,52 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       };
     })()
     : null;
+  const lightFollowUpCountermeasureRecoveryOutcome = lightFollowUpCountermeasureRecovery
+    ? (() => {
+      const costlyDelayReadable = lightFollowUpCountermeasureDelayEffect?.tone === 'risky'
+        || lightFollowUpCountermeasureDelayEffect?.tone === 'prep'
+        || prepUnlock?.delayCost?.tone === 'risky';
+      const bufferRestored = residualRisk?.visible && residualRisk.tone === 'covered' && !costlyDelayReadable;
+      const viableAlternativeCount = candidates
+        .filter((entry) => entry.viability.status === 'ready' || entry.viability.status === 'prep')
+        .length;
+      if (!costlyDelayReadable && lightFollowUpCountermeasureRecovery.tone === 'quiet') {
+        return {
+          tone: 'quiet',
+          label: 'Après rattrapage: neutre',
+          detail: 'aucun retard coûteux lisible',
+        };
+      }
+      if (lightFollowUpCountermeasureRecovery.tone === 'quiet') {
+        return {
+          tone: 'quiet',
+          label: 'Après rattrapage: information insuffisante',
+          detail: 'buffer restant non calculable après le geste minimal',
+        };
+      }
+      if (bufferRestored) {
+        return {
+          tone: 'restored',
+          label: 'Après rattrapage: buffer restauré',
+          detail: `${residualRisk.label} repris · recommandation principale inchangée`,
+        };
+      }
+      if (lightFollowUpCountermeasureRecovery.tone === 'possible') {
+        return {
+          tone: 'stopped',
+          label: 'Après rattrapage: rechute stoppée',
+          detail: viableAlternativeCount > 1
+            ? `retard contenu · ${viableAlternativeCount - 1} alternative${viableAlternativeCount > 2 ? 's' : ''} encore viable${viableAlternativeCount > 2 ? 's' : ''}`
+            : `retard contenu · buffer non restauré`,
+        };
+      }
+      return {
+        tone: 'late',
+        label: 'Après rattrapage: insuffisant',
+        detail: 'la pression reste prioritaire malgré le geste minimal',
+      };
+    })()
+    : null;
   if (steps.length < 2) {
     return {
       visible: false,
@@ -3139,6 +3186,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
       lightFollowUpCountermeasureComparison: null,
       lightFollowUpCountermeasureDelayEffect: null,
       lightFollowUpCountermeasureRecovery: null,
+      lightFollowUpCountermeasureRecoveryOutcome: null,
     };
   }
   const delayCost = prepUnlock?.delayCost ?? null;
@@ -3162,6 +3210,7 @@ function buildAtlasMilitaryBlockedFollowUpLadder(alternative, candidates = [], r
     lightFollowUpCountermeasureComparison,
     lightFollowUpCountermeasureDelayEffect,
     lightFollowUpCountermeasureRecovery,
+    lightFollowUpCountermeasureRecoveryOutcome,
   };
 }
 
@@ -3418,7 +3467,7 @@ function renderAtlasMilitaryNeighborResidualFollowUpConflict(conflict, y) {
 function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
   if (!ladder?.visible) return '';
   return `
-    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}${ladder.lightFollowUpCountermeasure ? `; ${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}` : ''}${ladder.lightFollowUpCountermeasureComparison ? `; ${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}` : ''}${ladder.lightFollowUpCountermeasureDelayEffect ? `; ${ladder.lightFollowUpCountermeasureDelayEffect.label}: ${ladder.lightFollowUpCountermeasureDelayEffect.detail}` : ''}${ladder.lightFollowUpCountermeasureRecovery ? `; ${ladder.lightFollowUpCountermeasureRecovery.label}: ${ladder.lightFollowUpCountermeasureRecovery.detail}` : ''}">
+    <g class="atlas-military-neighbor-blocked-follow-up-ladder atlas-military-neighbor-blocked-follow-up-ladder--${ladder.tone}" aria-label="Synthèse échelle de suivi de front: ${ladder.label}; ${ladder.detail}; ${ladder.firstActionReason}${ladder.remainingWatch ? `; ${ladder.remainingWatch}` : ''}${ladder.watchDrop ? `; ${ladder.watchDrop.label}: ${ladder.watchDrop.detail}` : ''}${ladder.nextLightCheck ? `; ${ladder.nextLightCheck}` : ''}${ladder.lightRecheckUnlock ? `; ${ladder.lightRecheckUnlock.label}: ${ladder.lightRecheckUnlock.detail}` : ''}${ladder.lightUnlockFollowUp ? `; ${ladder.lightUnlockFollowUp.label}: ${ladder.lightUnlockFollowUp.detail}` : ''}${ladder.lightFollowUpDeferReason ? `; ${ladder.lightFollowUpDeferReason.label}: ${ladder.lightFollowUpDeferReason.detail}` : ''}${ladder.lightFollowUpPressure ? `; ${ladder.lightFollowUpPressure.label}: ${ladder.lightFollowUpPressure.detail}` : ''}${ladder.lightFollowUpRiskWindow ? `; ${ladder.lightFollowUpRiskWindow.label}: ${ladder.lightFollowUpRiskWindow.detail}` : ''}${ladder.lightFollowUpNextRisk ? `; ${ladder.lightFollowUpNextRisk.label}: ${ladder.lightFollowUpNextRisk.detail}` : ''}${ladder.lightFollowUpPressureSource ? `; ${ladder.lightFollowUpPressureSource.label}: ${ladder.lightFollowUpPressureSource.detail}` : ''}${ladder.lightFollowUpCountermeasure ? `; ${ladder.lightFollowUpCountermeasure.label}: ${ladder.lightFollowUpCountermeasure.detail}` : ''}${ladder.lightFollowUpCountermeasureComparison ? `; ${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}` : ''}${ladder.lightFollowUpCountermeasureDelayEffect ? `; ${ladder.lightFollowUpCountermeasureDelayEffect.label}: ${ladder.lightFollowUpCountermeasureDelayEffect.detail}` : ''}${ladder.lightFollowUpCountermeasureRecovery ? `; ${ladder.lightFollowUpCountermeasureRecovery.label}: ${ladder.lightFollowUpCountermeasureRecovery.detail}` : ''}${ladder.lightFollowUpCountermeasureRecoveryOutcome ? `; ${ladder.lightFollowUpCountermeasureRecoveryOutcome.label}: ${ladder.lightFollowUpCountermeasureRecoveryOutcome.detail}` : ''}">
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__label" x="44.2" y="${y}">${ladder.label}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__detail" x="44.2" y="${y + 1.35}">${ladder.detail}</text>
       <text class="atlas-military-neighbor-blocked-follow-up-ladder__reason" x="44.2" y="${y + 2.7}">${ladder.firstActionReason}</text>
@@ -3436,6 +3485,7 @@ function renderAtlasMilitaryBlockedFollowUpLadder(ladder, y) {
       ${ladder.lightFollowUpCountermeasureComparison ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison--${ladder.lightFollowUpCountermeasureComparison.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 18.9 : 17.55)}">${ladder.lightFollowUpCountermeasureComparison.label}: ${ladder.lightFollowUpCountermeasureComparison.detail}</text>` : ''}
       ${ladder.lightFollowUpCountermeasureDelayEffect ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay--${ladder.lightFollowUpCountermeasureDelayEffect.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 20.25 : 18.9)}">${ladder.lightFollowUpCountermeasureDelayEffect.label}: ${ladder.lightFollowUpCountermeasureDelayEffect.detail}</text>` : ''}
       ${ladder.lightFollowUpCountermeasureRecovery ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--${ladder.lightFollowUpCountermeasureRecovery.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 21.6 : 20.25)}">${ladder.lightFollowUpCountermeasureRecovery.label}: ${ladder.lightFollowUpCountermeasureRecovery.detail}</text>` : ''}
+      ${ladder.lightFollowUpCountermeasureRecoveryOutcome ? `<text class="atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome--${ladder.lightFollowUpCountermeasureRecoveryOutcome.tone}" x="44.2" y="${y + (ladder.remainingWatch ? 22.95 : 21.6)}">${ladder.lightFollowUpCountermeasureRecoveryOutcome.label}: ${ladder.lightFollowUpCountermeasureRecoveryOutcome.detail}</text>` : ''}
     </g>
   `;
 }
@@ -3474,7 +3524,7 @@ function renderAtlasMilitaryNeighborFrontShiftPreview(preview) {
     : 0;
   const ladderY = alternativeY + (preview.blockedFollowUpAlternative?.visible ? alternativeBlockHeight + 0.25 : 0);
   const ladderHeight = preview.blockedFollowUpLadder?.visible
-    ? preview.blockedFollowUpLadder?.lightFollowUpCountermeasureRecovery ? preview.blockedFollowUpLadder?.remainingWatch ? 22.75 : 21.4 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasureDelayEffect ? preview.blockedFollowUpLadder?.remainingWatch ? 21.4 : 20.05 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasureComparison ? preview.blockedFollowUpLadder?.remainingWatch ? 20.05 : 18.7 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasure ? preview.blockedFollowUpLadder?.remainingWatch ? 18.7 : 17.35 : preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
+    ? preview.blockedFollowUpLadder?.lightFollowUpCountermeasureRecoveryOutcome ? preview.blockedFollowUpLadder?.remainingWatch ? 24.1 : 22.75 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasureRecovery ? preview.blockedFollowUpLadder?.remainingWatch ? 22.75 : 21.4 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasureDelayEffect ? preview.blockedFollowUpLadder?.remainingWatch ? 21.4 : 20.05 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasureComparison ? preview.blockedFollowUpLadder?.remainingWatch ? 20.05 : 18.7 : preview.blockedFollowUpLadder?.lightFollowUpCountermeasure ? preview.blockedFollowUpLadder?.remainingWatch ? 18.7 : 17.35 : preview.blockedFollowUpLadder?.lightFollowUpPressureSource ? preview.blockedFollowUpLadder?.remainingWatch ? 17.35 : 16 : preview.blockedFollowUpLadder?.lightFollowUpNextRisk ? preview.blockedFollowUpLadder?.remainingWatch ? 16 : 14.65 : preview.blockedFollowUpLadder?.lightFollowUpRiskWindow ? preview.blockedFollowUpLadder?.remainingWatch ? 14.65 : 13.3 : preview.blockedFollowUpLadder?.lightFollowUpPressure ? preview.blockedFollowUpLadder?.remainingWatch ? 13.3 : 11.95 : preview.blockedFollowUpLadder?.lightFollowUpDeferReason ? preview.blockedFollowUpLadder?.remainingWatch ? 11.95 : 10.6 : preview.blockedFollowUpLadder?.lightUnlockFollowUp ? preview.blockedFollowUpLadder?.remainingWatch ? 10.6 : 9.25 : preview.blockedFollowUpLadder?.lightRecheckUnlock ? preview.blockedFollowUpLadder?.remainingWatch ? 9.25 : 7.9 : preview.blockedFollowUpLadder?.nextLightCheck ? preview.blockedFollowUpLadder?.remainingWatch ? 7.9 : 6.55 : preview.blockedFollowUpLadder?.watchDrop ? preview.blockedFollowUpLadder?.remainingWatch ? 6.55 : 5.2 : preview.blockedFollowUpLadder?.remainingWatch ? 5.2 : 3.85
     : 0;
   const contestedY = ladderY + (preview.blockedFollowUpLadder?.visible ? ladderHeight + 0.25 : 0);
   const clusterHeight = preview.urgencyCluster?.visible ? 2.5 : 0;

--- a/web/styles.css
+++ b/web/styles.css
@@ -14840,7 +14840,8 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure,
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-comparison,
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-delay,
-.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery {
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery,
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome {
   fill: #ddd6fe;
   font-size: 0.42px;
 }
@@ -14879,6 +14880,10 @@ button { font: inherit; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--possible { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--late { fill: #fca5a5; }
 .atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery--quiet { fill: #cbd5e1; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome--restored { fill: #86efac; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome--stopped { fill: #fde68a; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome--late { fill: #fca5a5; }
+.atlas-military-neighbor-blocked-follow-up-ladder__countermeasure-recovery-outcome--quiet { fill: #cbd5e1; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--acceptable { fill: #bbf7d0; }
 .atlas-military-neighbor-blocked-follow-up-alt__delay--risky { fill: #fecdd3; }
 .atlas-military-neighbor-review-priority__label,


### PR DESCRIPTION
Alpha: Implements MAP-A53.

Summary:
- Adds an “Après rattrapage” cue after the minimal light-front recovery line.
- Distinguishes restored buffer, immediate relapse stopped, insufficient information, and neutral/no costly delay states.
- Keeps the main recommendation unchanged and only extends the compact ladder/readout.

Tests:
- npm test -- test/ui/war/webAtlasMilitaryNextBestClosureRecommendation.test.js
- npm test

Closes #1677
